### PR TITLE
replace status anno with importPodName, remove UpdateFunc and DeleteFunc

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -64,22 +64,10 @@ func main() {
 
 	informerFactory := informers.NewSharedInformerFactory(client, time.Second*30)
 	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims().Informer()
-	// Bind the Index/Informer to the queue
+	// Bind the Index/Informer to the queue only for new pvcs
 	pvcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
-			if err == nil {
-				queue.AddRateLimited(key)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(new)
-			if err == nil && old != new {
-				queue.AddRateLimited(key)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.AddRateLimited(key)
 			}


### PR DESCRIPTION
controller watch will only pay attention to pvc add events. Update and Delete event are now ignored.
Also, the pvc's status annotation is replaced with the name of the importer pod that was created due to this pvc.