### PR TITLE
Unique importer names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ push-importer:
 	docker push $(REGISTRY)/$(IMPORTER_IMAGE):$(TAG)
 
 test:
-	GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=$(CGO_ENABLED) go test -v ./...
+	CGO_ENABLED=$(CGO_ENABLED) go test -v ./...
 
 clean:
 	-rm -rf $(BIN_DIR)/*

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,6 +1,8 @@
 package controller_test
 
 import (
+	"fmt"
+
 	. "github.com/kubevirt/containerized-data-importer/pkg/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,9 +18,9 @@ import (
 type operation int
 
 const (
-	opAdd operation = iota
-	opUpdate
-	opDelete
+	opAdd    operation = iota
+	opUpdate 
+	opDelete 
 )
 
 var _ = Describe("Controller", func() {
@@ -79,9 +81,10 @@ var _ = Describe("Controller", func() {
 
 			It(test.descr, func() {
 				Expect(controller.ProcessNextItem()).To(BeTrue())
-				pod, err := fakeClient.CoreV1().Pods("").Get(test.expectPodName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pod.Name).To(Equal(test.expectPodName))
+				pod, err := getTestPod(fakeClient, test.expectPodName)
+				Expect(err).To(BeNil(), fmt.Sprintf("Expected nil err, got: %v", err))
+				Expect(pod).NotTo(BeNil(), fmt.Sprintf("Expected Pod %q was not found.", test.expectPodName))
+				Expect(pod.GenerateName).To(ContainSubstring(test.expectPodName))
 			})
 		}
 	})
@@ -121,3 +124,20 @@ var _ = Describe("Controller", func() {
 		}
 	})
 })
+
+// getTestPod is used to handle pods with generated name by comparing the passed in pod name to a list of pods
+// If a match is found, the pod is returned.
+// If no match is found, a nil pointer is returned.  This should be checked by the caller.
+func getTestPod(fc *fake.Clientset, podName string) (*v1.Pod, error) {
+	podList, err := fc.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var pod *v1.Pod
+	for i, p := range podList.Items {
+		if p.GenerateName == podName {
+			pod = &podList.Items[i]
+		}
+	}
+	return pod, nil
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,8 +19,8 @@ type operation int
 
 const (
 	opAdd    operation = iota
-	opUpdate 
-	opDelete 
+	opUpdate
+	opDelete
 )
 
 var _ = Describe("Controller", func() {
@@ -82,9 +82,9 @@ var _ = Describe("Controller", func() {
 			It(test.descr, func() {
 				Expect(controller.ProcessNextItem()).To(BeTrue())
 				pod, err := getTestPod(fakeClient, test.expectPodName)
-				Expect(err).To(BeNil(), fmt.Sprintf("Expected nil err, got: %v", err))
+				Expect(err).NotTo(HaveOccurred())
 				Expect(pod).NotTo(BeNil(), fmt.Sprintf("Expected Pod %q was not found.", test.expectPodName))
-				Expect(pod.GenerateName).To(ContainSubstring(test.expectPodName))
+				Expect(pod.GenerateName).To(HavePrefix(test.expectPodName))
 			})
 		}
 	})

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -126,7 +126,7 @@ func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVo
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
+			GenerateName: podName,
 			Annotations: map[string]string{
 				AnnCreatedBy: "yes",
 			},


### PR DESCRIPTION
To prevent naming collisions with existing or completed importer pods, use `generateName` for importer pod.

Also removed platform and architecture variables from Makefile `test` recipe.   This allows go test to be run on platforms other than linux