### PR TITLE
Add .travis.yml for basic CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+---
+sudo: required
+
+env:
+  - CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 K6T_VER=0.3.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
+
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#kubevirt"
+    on_success: change
+    on_failure: always
+
+before_script:
+  # Setup minikube
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v$K8S_VER/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+
+  - sudo minikube start --vm-driver=none --kubernetes-version=v$K8S_VER
+  - minikube update-context
+  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+  - k_wait_all_running() { while [[ "$(kubectl get $1 --all-namespaces --field-selector=status.phase!=Running | wc -l)" -gt 1 ]]; do kubectl get $1 --all-namespaces ; sleep 6; done ; }
+
+  # Deploy kubevirt
+  - kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v$K6T_VER/kubevirt.yaml
+  - k_wait_all_running pods
+
+script:
+  # Deploy manifests
+  - kubectl apply -f manifests/endpoint-secret.yaml
+  - kubectl apply -f manifests/cdi-controller-deployment.yaml
+
+  - make manifests/golden-pvc.yaml URI="$SRC"
+  - kubectl apply -f manifests/golden-pvc.yaml
+
+  - k_wait_all_running pods
+  - kubectl get pods --all-namespaces

--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,8 @@ release:
 #endif
 #	docker tag $(IMAGE) $(REGISTRY)/$(CONTROLLER_IMAGE):latest
 #	docker push $(REGISTRY)/$(CONTROLLER_IMAGE):latest
+
+my-golden-pvc.yaml: manifests/golden-pvc.yaml
+	sed "s,endpoint:.*,endpoint: \"$(URI)\"," $< > $@
+
+.PHONY: my-golden-pvc.yaml


### PR DESCRIPTION
This PR does the following:

- Add .travis.yml
- Hook this repo up to travis
- Setup minikube
- Deploy KubeVirt
- Deploy CDI

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>