### PR TITLE
Add Functional tests for supported data processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,29 @@
 REPO_ROOT=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-# Binary Output
+# Basenames
+CONTROLLER=controller
+IMPORTER=importer
+F_TEST=datastream-test
+
+# Binary Path
 BIN_DIR=$(REPO_ROOT)/bin
 CONTROLLER_BIN=$(BIN_DIR)/import-controller
-IMPORTER_BIN=$(BIN_DIR)/importer
+IMPORTER_BIN=$(BIN_DIR)/$(IMPORTER)
+F_TEST_BIN=$(BIN_DIR)/$(F_TEST)
 
 # Source dirs
 CMD_DIR=$(REPO_ROOT)/cmd
-CONTROLLER_CMD=$(CMD_DIR)/controller
-IMPORTER_CMD=$(CMD_DIR)/importer
+CONTROLLER_CMD=$(CMD_DIR)/$(CONTROLLER)
+IMPORTER_CMD=$(CMD_DIR)/$(IMPORTER)
+F_TEST_DIR=$(REPO_ROOT)/test/datastream
 
 # Build Dirs
 BUILD_DIR=$(REPO_ROOT)/build
-CONTROLLER_BUILD=$(BUILD_DIR)/controller
-IMPORTER_BUILD=$(BUILD_DIR)/importer
+CONTROLLER_BUILD=$(BUILD_DIR)/$(CONTROLLER)
+IMPORTER_BUILD=$(BUILD_DIR)/$(IMPORTER)
 
 # DOCKER TAG VARS
 REGISTRY=jcoperh
-CONTROLLER_IMAGE=import-controller
-IMPORTER_IMAGE=importer
 GIT_USER=$(shell git config --get user.email | sed 's/@.*//')
 TAG="$(GIT_USER)-latest"
 VERSION=v1
@@ -28,6 +33,8 @@ all: clean controller importer test
 controller: controller-bin controller-image
 importer: importer-bin importer-image
 push: push-importer push-controller
+test: functional-test unit-test
+functional-test: func-test-bin func-test-image func-test-run
 
 GOOS?=linux
 ARCH?=amd64
@@ -36,65 +43,99 @@ LDFLAGS='-extldflags "-static"'
 
 # Compile controller binary
 controller-bin:
+	@echo '********'
+	@echo 'Compiling controller binary'
 	GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=$(CGO_ENABLED) go build -a -ldflags $(LDFLAGS) -o $(CONTROLLER_BIN) $(CONTROLLER_CMD)/*.go
 
 # Compile importer binary
 importer-bin:
+	@echo '********'
+	@echo 'Compiling importer binary'
 	GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=$(CGO_ENABLED) go build -a -ldflags $(LDFLAGS) -o $(IMPORTER_BIN) $(IMPORTER_CMD)/*.go
+
+
+# Compile datastream functional test binary
+func-test-bin:
+	@echo '********'
+	@echo 'Compiling functional test binary'
+	-rm -f $(F_TEST_BIN)
+	GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=$(CGO_ENABLED) go test -a -c -ldflags $(LDFLAGS) -o $(F_TEST_BIN) $(F_TEST_DIR)/*.go
 
 # build the controller image
 controller-image: $(CONTROLLER_BUILD)/Dockerfile
+	@echo '********'
+	@echo 'Building controller image'
 	$(eval TEMP_BUILD_DIR=$(CONTROLLER_BUILD)/tmp)
 	mkdir -p $(TEMP_BUILD_DIR)
 	cp $(CONTROLLER_BIN) $(TEMP_BUILD_DIR)
 	cp $(CONTROLLER_BUILD)/Dockerfile $(TEMP_BUILD_DIR)
-	docker build -t $(CONTROLLER_IMAGE) $(TEMP_BUILD_DIR)
-	docker tag $(CONTROLLER_IMAGE) $(REGISTRY)/$(CONTROLLER_IMAGE):$(TAG)
+	docker build -t $(CONTROLLER) $(TEMP_BUILD_DIR)
+	docker tag $(CONTROLLER) $(REGISTRY)/$(CONTROLLER):$(TAG)
 	-rm -rf $(TEMP_BUILD_DIR)
 
 # build the importer image
 importer-image: $(IMPORTER_BUILD)/Dockerfile
+	@echo '********'
+	@echo 'Building importer image'
 	$(eval TEMP_BUILD_DIR=$(IMPORTER_BUILD)/tmp)
 	mkdir -p $(TEMP_BUILD_DIR)
 	cp $(IMPORTER_BIN) $(TEMP_BUILD_DIR)
 	cp $(IMPORTER_BUILD)/Dockerfile $(TEMP_BUILD_DIR)
-	docker build -t $(IMPORTER_IMAGE) $(TEMP_BUILD_DIR)
-	docker tag $(IMPORTER_IMAGE) $(REGISTRY)/$(IMPORTER_IMAGE):$(TAG)
+	docker build --build-arg entrypoint=$(IMPORTER) --build-arg runArgs='-alsologtostderr' -t $(IMPORTER) $(TEMP_BUILD_DIR)
+	docker tag $(IMPORTER) $(REGISTRY)/$(IMPORTER):$(TAG)
 	-rm -rf $(TEMP_BUILD_DIR)
 
+# build the functional test image.  The importer image is used to provide consistency between test
+# and run environments.
+func-test-image: $(IMPORTER_BUILD)/Dockerfile
+	@echo '********'
+	@echo 'Building functional test image'
+	$(eval TEMP_BUILD_DIR=$(IMPORTER_BUILD)/tmp)
+	mkdir -p $(TEMP_BUILD_DIR)
+	cp $(F_TEST_BIN) $(TEMP_BUILD_DIR)
+	cp $(IMPORTER_BUILD)/Dockerfile $(TEMP_BUILD_DIR)
+	docker build --build-arg entrypoint=$(F_TEST) --build-arg runArgs='-ginkgo.v' -t $(F_TEST) $(TEMP_BUILD_DIR)
+	-rm -rf $(TEMP_BUILD_DIR)
+
+
+func-test-run:
+	@echo '********'
+	@echo 'Running functional tests'
+	docker ps -qa && \
+	docker run --rm $(F_TEST) || echo 'Docker service not detected, skipping functional tests'
+
 push-controller:
-	docker push $(REGISTRY)/$(CONTROLLER_IMAGE):$(TAG)
+	@echo '********'
+	@echo 'Pushing controller image'
+	docker push $(REGISTRY)/$(CONTROLLER):$(TAG)
 
 push-importer:
-	docker push $(REGISTRY)/$(IMPORTER_IMAGE):$(TAG)
+	@echo '********'
+	@echo 'Pushing importer image'
+	docker push $(REGISTRY)/$(IMPORTER):$(TAG)
 
-test:
-	CGO_ENABLED=$(CGO_ENABLED) go test -v ./...
+unit-test:
+	@echo '********'
+	@echo 'Running unit tests'
+	CGO_ENABLED=$(CGO_ENABLED) go test -v ./... -tags=unit
+
 
 clean:
+	@echo '********'
+	@echo 'Cleaning build artifacts'
 	-rm -rf $(BIN_DIR)/*
 	-rm -rf $(CONTROLLER_BUILD)/tmp
 	-rm -rf $(IMPORTER_BUILD)/tmp
 
-# push CONTROLLER_IMAGE:$(VERSION). Intended to release stable image built from master branch.
+# push CONTROLLER:$(VERSION). Intended to release stable image built from master branch.
 release:
-	docker tag $(IMPORTER_IMAGE) $(REGISTRY)/$(IMPORTER_IMAGE):latest
-	docker push $(REGISTRY)/$(IMPORTER_IMAGE):latest
-	docker tag $(CONTROLLER_IMAGE) $(REGISTRY)/$(CONTROLLER_IMAGE):latest
-	docker push $(REGISTRY)/$(CONTROLLER_IMAGE):latest
+	@echo '********'
+	@echo 'Releasing CDI images'
+	docker tag $(IMPORTER) $(REGISTRY)/$(IMPORTER):latest
+	docker push $(REGISTRY)/$(IMPORTER):latest
+	docker tag $(CONTROLLER) $(REGISTRY)/$(CONTROLLER):latest
+	docker push $(REGISTRY)/$(CONTROLLER):latest
 
-#	git fetch origin
-#ifneq ($(shell git rev-parse --abbrev-ref HEAD), master)
-#	$(error Release is intended to be run on master branch. Please checkout master and retry.)
-#endif
-#ifneq ($(shell git rev-list HEAD..origin/master --count), 0)
-#	$(error HEAD is behind origin/master -- $(shell git status -sb --porcelain))
-#endif
-#ifneq ($(shell git rev-list origin/master..HEAD --count), 0)
-#	$(error HEAD is ahead of origin/master --  $(shell git status -sb --porcelain))
-#endif
-#	docker tag $(IMAGE) $(REGISTRY)/$(CONTROLLER_IMAGE):latest
-#	docker push $(REGISTRY)/$(CONTROLLER_IMAGE):latest
 
 my-golden-pvc.yaml: manifests/golden-pvc.yaml
 	sed "s,endpoint:.*,endpoint: \"$(URI)\"," $< > $@

--- a/build/importer/Dockerfile
+++ b/build/importer/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.3
 RUN mkdir /data
-COPY ./importer /importer
+ARG entrypoint
+ARG runArgs
+ENV RUN_ARGS=$runArgs
+COPY ./$entrypoint ./run-binary
 RUN apk update && apk add qemu-img \
+  xz \
   qemu-system-or32 \
   qemu-system-mips64el \
   qemu-system-ppc64 \
@@ -31,4 +35,4 @@ RUN apk update && apk add qemu-img \
   qemu-system-sh4 \
   qemu-system-sparc
 RUN apk add ca-certificates && rm -rf /var/cache/apk/*
-ENTRYPOINT ./importer -alsologtostderr
+ENTRYPOINT ./run-binary $RUN_ARGS

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package controller_test
 
 import (

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -5,13 +5,19 @@ import (
 )
 
 const (
-	ExtImg   = ".img"
-	ExtIso   = ".iso"
-	ExtGz    = ".gz"
-	ExtQcow2 = ".qcow2"
-	ExtTar   = ".tar"
-	ExtXz    = ".xz"
+	ExtImg   string = ".img"
+	ExtIso   string = ".iso"
+	ExtGz    string = ".gz"
+	ExtQcow2 string = ".qcow2"
+	ExtTar   string = ".tar"
+	ExtXz    string = ".xz"
+	ExtTarXz string = ExtTar + ExtXz
+	ExtTarGz string = ExtTar + ExtGz
 )
+
+var SupportedNestedExtensions = []string{
+	ExtTarGz, ExtTarXz,
+}
 
 var SupportedCompressionExtensions = []string{
 	ExtGz, ExtXz,
@@ -25,12 +31,14 @@ var SupportedImageFormats = []string{
 	ExtImg, ExtIso, ExtQcow2,
 }
 
-var SupportedFileExtensions = append(SupportedImageFormats, append(SupportedCompressionExtensions, SupportedArchiveExtensions...)...)
+var SupportedFileExtensions = append(SupportedImageFormats,
+	append(SupportedCompressionExtensions,
+	append(SupportedArchiveExtensions, SupportedNestedExtensions...)...)...)
 
 func IsSupporedFileType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedFileExtensions {
-		if strings.HasSuffix(fn, ext) {
+		if strings.HasSuffix(fn, string(ext)) {
 			return true
 		}
 	}
@@ -40,7 +48,7 @@ func IsSupporedFileType(fn string) bool {
 func IsSupporedCompressionType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedCompressionExtensions {
-		if strings.HasSuffix(fn, ext) {
+		if strings.HasSuffix(fn, string(ext)) {
 			return true
 		}
 	}
@@ -50,7 +58,7 @@ func IsSupporedCompressionType(fn string) bool {
 func IsSupporedArchiveType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedArchiveExtensions {
-		if strings.HasSuffix(fn, ext) {
+		if strings.HasSuffix(fn, string(ext)) {
 			return true
 		}
 	}

--- a/pkg/image/validation_suite_test.go
+++ b/pkg/image/validation_suite_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package image_test
 
 import (

--- a/pkg/importer/importer_suite_test.go
+++ b/pkg/importer/importer_suite_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package importer_test
 
 import (

--- a/test/datastream/datastream_suite_test.go
+++ b/test/datastream/datastream_suite_test.go
@@ -1,0 +1,15 @@
+// +build functional
+
+package datastream
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDatastream(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Datastream Suite")
+}

--- a/test/datastream/datastream_test.go
+++ b/test/datastream/datastream_test.go
@@ -1,0 +1,132 @@
+package datastream
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"strings"
+
+	"github.com/kubevirt/containerized-data-importer/pkg/image"
+	f "github.com/kubevirt/containerized-data-importer/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type testCase struct {
+	testDesc      string
+	srcData       io.Reader
+	inFileName    string
+	expectFormats []string
+}
+
+type Tests []testCase
+
+var _ = Describe("Streaming Data Conversion", func() {
+
+	Context("when data is in a supported file format", func() {
+
+		const (
+			size           = 16000 // 16Kb buf size
+			commonBaseName = "testFile"
+		)
+
+		// Test Table
+		tests := Tests{
+			{
+				testDesc:      "should decompress gzip",
+				inFileName:    commonBaseName,
+				expectFormats: []string{image.ExtGz},
+			},
+			{
+				testDesc:      "should decompress xz",
+				inFileName:    commonBaseName,
+				expectFormats: []string{image.ExtXz},
+			},
+			{
+				testDesc:      "should unarchive tar",
+				inFileName:    commonBaseName,
+				expectFormats: []string{image.ExtTar},
+			},
+			{
+				testDesc:      "should unpack .tar.gz",
+				inFileName:    commonBaseName,
+				expectFormats: []string{image.ExtTar, image.ExtGz},
+			},
+			{
+				testDesc:      "should unpack .tar.xz",
+				inFileName:    commonBaseName,
+				expectFormats: []string{image.ExtTar, image.ExtXz},
+			},
+			{
+				testDesc:      "should pass through unformatted data",
+				inFileName:    commonBaseName,
+				expectFormats: []string{""},
+			},
+		}
+
+		for _, t := range tests {
+
+			desc := t.testDesc
+			ff := t.expectFormats
+			fn := t.inFileName
+
+			It(desc, func() {
+
+				By("Generating some input data")
+				sampleData, err := generateTestFile(size, fn)
+
+				By(fmt.Sprintf("Converting sample file to format: %v", ff))
+				// Generate the expected data format from the random bytes
+				sampleFilename, err := f.FormatTestData(fn, ff...)
+				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
+
+				By(fmt.Sprintf("Confirming sample file name %q matches expected file name %q", sampleFilename, fn+strings.Join(ff, "")))
+				Expect(sampleFilename).To(Equal(fn+strings.Join(ff, "")), "Test data filename doesn't match expected file name.")
+
+				// BEGIN TEST
+				By("Opening sample file for test.")
+				// Finally, open the file for reading
+				sampleFile, err := os.Open(sampleFilename)
+				Expect(err).NotTo(HaveOccurred(), "Failed to open sample file %s", sampleFilename)
+				defer sampleFile.Close()
+
+				By("Passing file reader to the data stream")
+				r, err := image.UnpackData(sampleFilename, sampleFile)
+				Expect(err).NotTo(HaveOccurred())
+				defer r.Close()
+
+				var output bytes.Buffer
+				io.Copy(&output, r)
+				By("Checking the output of the data stream")
+				Expect(err).NotTo(HaveOccurred(), "ioutil.ReadAll erred")
+				Expect(output.Len()).To(Equal(size))
+				Expect(output.Bytes()).To(Equal(sampleData))
+				By("Closing sample test file.")
+			})
+		}
+	})
+})
+
+func generateTestFile(size int, filename string) ([]byte, error){
+	// Create a some random data to compress and/or archive.
+	By("Generating test data")
+	sampleData := make([]byte, size)
+	if _, err := rand.Read(sampleData); err != nil {
+		return nil,fmt.Errorf("error occurred during rand.Read()")
+	}
+
+	// Write the byte slice to a file at /
+	// Trigger the defer Close before calling FormatTestData
+	By("Writing test data to file")
+	file, err := os.Create(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create test file %q", filename)
+	}
+	defer file.Close()
+	if _, err = file.Write(sampleData); err != nil {
+		return nil, fmt.Errorf("failed to write sample data to file")
+	}
+	return sampleData, nil
+}

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -1,0 +1,84 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/kubevirt/containerized-data-importer/pkg/image"
+)
+
+var formatTable = map[string]func(string) (string, error){
+	image.ExtGz:    transformGz,
+	image.ExtXz:    transformXz,
+	image.ExtTar:   transformTar,
+	image.ExtQcow2: transformQcow2,
+	"":             transformNoop,
+}
+
+func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
+
+	var (
+		err     error
+		outFile = srcFile
+	)
+
+	for _, tf := range targetFormats {
+		if err != nil {
+			break
+		}
+		i := 0
+		for ftkey, ffunc := range formatTable {
+			if tf == ftkey {
+				outFile, err = ffunc(outFile)
+				break
+			} else if i == len(formatTable)-1 {
+				err = fmt.Errorf("format extension %q not recognized\n", tf)
+			}
+			i ++
+		}
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("FormatTestData: %v", err)
+	}
+	return outFile, nil
+}
+
+func transformFile(srcFile, ext, osCmd string, osArgs ...string) (string, error) {
+	//osArgs = append(osArgs, srcFile)
+	cmd := exec.Command(osCmd, osArgs...)
+	cout, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("transformFile: command erred: %v\n"+
+			"transformFile: command output: %v", err, string(cout))
+	}
+	f := srcFile + ext
+	_, err = os.Stat(f)
+	if err != nil {
+		return "", fmt.Errorf("transformFile: error stat-ing file: %v\n", err)
+	}
+	return f, nil
+}
+
+func transformTar(srcFile string) (string, error) {
+	args := []string{"-cf", srcFile + image.ExtTar, srcFile}
+	return transformFile(srcFile, image.ExtTar, "tar", args...)
+}
+
+func transformGz(srcFile string) (string, error) {
+	return transformFile(srcFile, image.ExtGz, "gzip", srcFile)
+}
+
+func transformXz(srcFile string) (string, error) {
+	return transformFile(srcFile, image.ExtXz, "xz", srcFile)
+}
+
+func transformQcow2(srcfile string) (string, error) {
+	args := []string{"convert", "-f", "raw", "-O", "qcow2", srcfile, srcfile + image.ExtQcow2}
+	return transformFile(srcfile, image.ExtQcow2, "qemu-img", args...)
+}
+
+func transformNoop(srcFile string) (string, error) {
+	return srcFile, nil
+}


### PR DESCRIPTION
fixes: #77 

Add a functional testing framework of the importer's in-stream data decompression, unarchiving, and qcow2 conversion.
Included tinyCore.iso as a base image for testing
Some basic logic using func stubs to plan file conversion logic.