### PR TITLE
support multiple namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ A declarative Kubernetes system to import Virtual Machine images for use with [K
 
 ## Purpose
 
-This project is designed with Kubevirt in mind and provides a declarative method of importing VM images into a Kuberenetes cluster. Through this behavior, cluster administrators can build an abstract registry of template images (referred to as "Golden Images" for their role as templates for image clones).
+This project is designed with Kubevirt in mind and provides a declarative method for importing VM images into a Kuberenetes cluster. This approach support two main use-cases:
+-  a cluster administrator can build an abstract registry of immutable images (referred to as "Golden Images") which can be cloned and later consumed by Kubevirt, or
+-  an ad-hoc user (granted access) can import a VM image into their own namespace and feed this image directly to Kubevirt, bypassing the cloning step.
 
 For an in depth look at the system and workflow, see the [Design](/doc/design.md#design) documentation.
 
 ### Data Format
 
-The importer is capable of performing certain functions that streamline its use with Kubevirt.  It will unpackage **gzip** and **tar** archived files automatically, as well as convert **qcow2** images into raw image files.
+The importer is capable of performing certain functions that streamline its use with Kubevirt.  It automatically decompresses **gzip** and **xz** files, and un-tar's **tar** archives. Also, **qcow2** images are converted into a raw image files needed by Kubevirt.
 
-Expected file formats are:
+Supported file formats are:
 
 - .tar
 - .gz
@@ -31,10 +33,10 @@ Expected file formats are:
 ## Deploying CDI
 
 ### Assumptions
-- A running Kubernetes cluster
+- A running Kubernetes cluster with roles and role bindings implementing security necesary for the CDI controller to watch PVCs across all namespaces.
 - A storage class and provisioner.
 - An HTTP or S3 file server hosting VM images
-- A namespace acting as the image registry (`default` is fine for tire kicking)
+- An optional "golden" namespace acting as the image registry. The `default` namespace is fine for tire kicking.
 
 ### Either clone this repo or download the necessary manifests directly:
 
@@ -51,7 +53,8 @@ $ wget https://raw.githubusercontent.com/kubevirt/containerized-data-importer/ku
 
 ### Run the CDI Controller
 
-Deploying the CDI controller is straight forward.  Create the controller in the namespace where VM images are to be stored.  Here, `default` is used, but in a production setup, a namespace that is inaccessible to regular users should be used instead (see [Protecting the Golden Image Namespace](#protecting-the-golden-image-namespace) creating a secure golden namespace).
+Deploying the CDI controller is straight forward. Choose the namespace where the controller will run and ensure that this namespace has cluster-wide permission to watch all PVCs.
+In this document the _default_ namespace is used, but in a production setup a namespace that is inaccessible to regular users should be used instead. See [Protecting the Golden Image Namespace](#protecting-the-golden-image-namespace) on creating a secure CDI controller namespace.
 
 `$ kubectl -n default create -f https://raw.githubusercontent.com/kubevirt/containerized-data-importer/master/manifests/cdi-controller-deployment.yaml`
 
@@ -64,11 +67,11 @@ Make copies of the [example manifests](./manifests/example) for editing. The nec
 - endpoint-secret.yaml
 
 ###### Edit golden-pvc.yaml:
-1.  `storageClassName:` The default StorageClass will be used if not set.  Otherwise, set to a desired StorageClass
+1.  `storageClassName:` The default StorageClass will be used if not set.  Otherwise, set to a desired StorageClass.
 
-1.  `kubevirt.io/storage.import.endpoint:` The full URL to the VM image in the format of: `http://www.myUrl.com/path/of/data` or `s3://bucketName/fileName`
+1.  `kubevirt.io/storage.import.endpoint:` The full URL to the VM image in the format of: `http://www.myUrl.com/path/of/data` or `s3://bucketName/fileName`.
 
-1.  `kubevirt.io/storage.import.secretName:` (Optional) The name of the secret containing the authentication credentials required by the file server
+1.  `kubevirt.io/storage.import.secretName:` (Optional) The name of the secret containing the authentication credentials required by the file server.
 
 ###### Edit endpoint-secret.yaml (Optional):
 
@@ -78,54 +81,54 @@ Make copies of the [example manifests](./manifests/example) for editing. The nec
 
 1.  `accessKeyId:` Contains the endpoint's key and/or user name. This value **must be base64 encoded** with no extraneous linefeeds. Use `echo -n "xyzzy" | base64` or `printf "xyzzy" | base64` to avoid a trailing linefeed
 
-1.  `secretKey:`  the endpoint's secret or password, again **base64 encoded** with no extraneous linefeeds.
+1.  `secretKey:` the endpoint's secret or password, again **base64 encoded** with no extraneous linefeeds.
 
 ### Deploy the API Objects
 
-1. (Optional) Create the "golden" namespace.
+1. (Optional) Create the namespace where the controller will run:
 
-    `$ kubectl create ns <name>`
+    `$ kubectl create ns <CDI-NAMESPACE>`
 
-1. (Optional) Create the endpoint secrets:
+1. (Optional) Create the endpoint secret in the triggering PVC's namespace:
 
-   `$ kubectl -n <target namespace> create -f endpoint-secret.yaml`
+   `$ kubectl -n <NAMESPACE> create -f endpoint-secret.yaml`
 
-1. Create the CDI controller (if not already done):
+1. Deploy the CDI controller:
 
-   `$ kubectl -n <target namespace> create -f manifests/controller/cdi-controller-deployment.yaml`
+   `$ kubectl -n <CDI-NAMESPACE> create -f manifests/controller/cdi-controller-deployment.yaml`
 
-1. Next, create the persistent volume claim to trigger the import process;
+1. Create the persistent volume claim to trigger the import process;
 
-   `$ kubectl -n <target namespace> create -f golden-pvc.yaml`
+   `$ kubectl -n <NAMESPACE> create -f golden-pvc.yaml`
 
 1. Monitor the cdi-controller:
 
-   `$ kubectl -n <target namespace> logs cdi-controller`
+   `$ kubectl -n <CDI-NAMESPACE> logs cdi-deployment-<RANDOM-STRING>`
 
 1. Monitor the importer pod:
 
-   `$ kubectl -n <target namespace> logs importer-<pvc-name>`  # shown in controller log above
+   `$ kubectl -n <NAMESPACE> logs importer-<PVC-NAME>`  # shown in controller log above
 
 ### Security Configurations
 
 #### RBAC Roles
 
-CDI needs certain permissions to be able to execute properly, primarily the `cluster-admin` role should be applied to the service account being used through the [Kubernetes RBAC model](https://kubernetes.io/docs/admin/authorization/rbac/).  For example, if CDI is running in a namespace called `golden-images`, and the `default` service account is being used, then the following RBAC should be applied:
+CDI needs certain permissions to be able to execute properly, primarily the `cluster-admin` role should be applied to the service account being used through the [Kubernetes RBAC model](https://kubernetes.io/docs/admin/authorization/rbac/). For example, if the CDI controller is running in a namespace called `cdi` and the `default` service account is being used, then the following RBAC should be applied:
 
 ```
-  $ kubectl create clusterrolebinding <binding-name> --clusterrole=cluster-admin  --serviceaccount=<namespace>:default
+  $ kubectl create clusterrolebinding <BINDING-NAME> --clusterrole=cluster-admin  --serviceaccount=<NAMESPACE>:default
 
   i.e.
-  $ kubectl create clusterrolebinding c-golden-images-default --clusterrole=cluster-admin  --serviceaccount=golden-images:default
+  $ kubectl create clusterrolebinding c-golden-images-default --clusterrole=cluster-admin  --serviceaccount=cdi:default
 
 ```
 
-> NOTE: This gives full cluster-admin access to this binding
+> NOTE: This gives full cluster-admin access to this binding and may not be appropriate for production environments.
 
 
-#### Protecting the `Golden` Image Namespace
+#### Protecting VM Image Namespaces
 
-Currently there is no support for automatically implementing [Kubernetes ResourceQuotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) and Limits on desired namespaces and resources, therefore administrators need to manually lock down all new namespaces from being able to use the StorageClass associated with CDI/Kubevirt and cloning capabilities. This capability of automatically restricting resources is in the works for a future release. Below are some examples of how one might achieve this level of resource protection:
+Currently there is no support for automatically implementing [Kubernetes ResourceQuotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) and Limits on desired namespaces and resources, therefore administrators need to manually lock down all new namespaces from being able to use the StorageClass associated with CDI/Kubevirt and cloning capabilities. This capability of automatically restricting resources is planned for future releases. Below are some examples of how one might achieve this level of resource protection:
 
 - Lock Down StorageClass Usage for Namespace:
 
@@ -136,10 +139,10 @@ metadata:
   name: protect-mynamespace
 spec:
   hard:
-    <storage-class-name>.storageclass.storage.k8s.io/requests.storage: "0"
+    <STORAGE-CLASS-NAME>.storageclass.storage.k8s.io/requests.storage: "0"
 ```
 
-> NOTE: <storage-class-name>.storageclass.storage.k8s.io/persistentvolumeclaims: "0" would also accomplish the same affect by not allowing any pvc requests against the storageclass for this namespace.
+> NOTE: <STORAGE-CLASS-NAME>.storageclass.storage.k8s.io/persistentvolumeclaims: "0" would also accomplish the same affect by not allowing any pvc requests against the storageclass for this namespace.
 
 
 - Open Up StorageClass Usage for Namespace:
@@ -151,8 +154,8 @@ metadata:
   name: protect-mynamespace
 spec:
   hard:
-    <storage-class-name>.storageclass.storage.k8s.io/requests.storage: "500Gi"
+    <STORAGE-CLASS-NAME>.storageclass.storage.k8s.io/requests.storage: "500Gi"
 ```
 
-> NOTE: <storage-class-name>.storageclass.storage.k8s.io/persistentvolumeclaims: "4" could be used and this would only allow for 4 pvc requests in this namespace, anything over that would be denied.
+> NOTE: <STORAGE-CLASS-NAME>.storageclass.storage.k8s.io/persistentvolumeclaims: "4" could be used and this would only allow for 4 pvc requests in this namespace, anything over that would be denied.
 

--- a/manifests/controller/cdi-controller-deployment.yaml
+++ b/manifests/controller/cdi-controller-deployment.yaml
@@ -16,8 +16,3 @@ spec:
       - name: cdi-controller
         image: jcoperh/import-controller
         imagePullPolicy: Always
-        env:
-          - name: OWN_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -50,13 +50,13 @@ func (c *Controller) getSecretName(pvc *v1.PersistentVolumeClaim) (string, error
 	ns := pvc.Namespace
 	name, found := pvc.Annotations[AnnSecret]
 	if !found || name == "" {
-		msg := ""
+		msg := "getEndpointSecret: "
 		if !found {
-			msg = fmt.Sprintf("getEndpointSecret: annotation %q is missing in pvc %s/%s\n", AnnSecret, ns, pvc.Name)
+			msg += "annotation %q is missing in pvc \"%s/%s\""
 		} else {
-			msg = fmt.Sprintf("getEndpointSecret: secret name is missing from annotation %q in pvc \"%s/%s\n", AnnSecret, ns, pvc.Name)
+			msg += "secret name is missing from annotation %q in pvc \"%s/%s\""
 		}
-		glog.Info(msg)
+		glog.Infof(msg+"\n", AnnSecret, ns, pvc.Name)
 		return "", nil // importer pod will not contain secret credentials
 	}
 	glog.Infof("getEndpointSecret: retrieving Secret \"%s/%s\"\n", ns, name)


### PR DESCRIPTION
Support new use-case which allows a user to import a VM image into their namespace. This image will be consumed by Kubevirt w/o the need to be cloned. This imported image is mutable and not part of a "golden image" repository.