### PR TITLE
unit test refactor

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,21 +1,22 @@
 package common
+
 // Common types and constants used by the importer and controller.
 // TODO: maybe the vm cloner can use these common values
 
 const (
 	// host file constants:
-	IMPORTER_WRITE_DIR     = "/data"
-	IMPORTER_WRITE_FILE    = "disk.img"
-	IMPORTER_WRITE_PATH    = IMPORTER_WRITE_DIR+"/"+IMPORTER_WRITE_FILE
+	IMPORTER_WRITE_DIR  = "/data"
+	IMPORTER_WRITE_FILE = "disk.img"
+	IMPORTER_WRITE_PATH = IMPORTER_WRITE_DIR + "/" + IMPORTER_WRITE_FILE
 	// importer container constants:
-	IMPORTER_PODNAME       = "importer"
-	IMPORTER_DATA_DIR      = "/data"
-	IMPORTER_S3_HOST       = "s3.amazonaws.com"
+	IMPORTER_PODNAME  = "importer"
+	IMPORTER_DATA_DIR = "/data"
+	IMPORTER_S3_HOST  = "s3.amazonaws.com"
 	// env var names
 	IMPORTER_ENDPOINT      = "IMPORTER_ENDPOINT"
 	IMPORTER_ACCESS_KEY_ID = "IMPORTER_ACCESS_KEY_ID"
 	IMPORTER_SECRET_KEY    = "IMPORTER_SECRET_KEY"
 	// key names expected in credential secret
-	KeyAccess   	       = "accessKeyId" 
-	KeySecret    	       = "secretKey" 
+	KeyAccess = "accessKeyId"
+	KeySecret = "secretKey"
 )

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 // return a pvc pointer based on the passed-in work queue key.
@@ -37,8 +37,11 @@ func (c *Controller) pvcFromKey(key interface{}) (*v1.PersistentVolumeClaim, err
 func getEndpoint(pvc *v1.PersistentVolumeClaim) (string, error) {
 	ep, found := pvc.Annotations[AnnEndpoint]
 	if !found || ep == "" {
-		// annotation was present and is now missing or is blank
-		return ep, fmt.Errorf("getEndpoint: annotation %q in pvc %s/%s is missing or is blank\n", AnnEndpoint, pvc.Namespace, pvc.Name)
+		verb := "empty"
+		if !found {
+			verb = "missing"
+		}
+		return ep, fmt.Errorf("getEndpoint: annotation %q in pvc \"%s/%s\" is %s\n", AnnEndpoint, pvc.Namespace, pvc.Name, verb)
 	}
 	return ep, nil
 }

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -25,7 +25,7 @@ type DataStreamInterface interface {
 var _ DataStreamInterface = &dataStream{}
 
 type dataStream struct {
-	DataRdr	    io.ReadCloser
+	DataRdr     io.ReadCloser
 	url         *url.URL
 	accessKeyId string
 	secretKey   string
@@ -42,7 +42,7 @@ func NewDataStream(ep *url.URL, accKey, secKey string) (*dataStream, error) {
 		glog.Warningf("NewDataStream: %s and/or %s env variables are empty\n", common.IMPORTER_ACCESS_KEY_ID, common.IMPORTER_SECRET_KEY)
 	}
 	ds := &dataStream{
-		url:	     ep,
+		url:         ep,
 		accessKeyId: accKey,
 		secretKey:   secKey,
 	}


### PR DESCRIPTION
fixes some issues with the unit tests:
.  no `BeforeEach`'s inside `for` loops
.  pvc anno set correctly
.  local assignments in `for` loop containing `It`'s
.  dataStream.DataRdr used for importer tests
.  only pre-create file in importer test when needed.
