### PR TITLE
WIP - fix qemu functional test

### DIFF
--- a/test/datastream/datastream_test.go
+++ b/test/datastream/datastream_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/kubevirt/containerized-data-importer/pkg/image"
@@ -18,6 +20,8 @@ type testCase struct {
 	testDesc      string
 	srcData       io.Reader
 	inFileName    string
+	outFileName   string
+	useVirtSize   bool
 	expectFormats []string
 }
 
@@ -28,7 +32,8 @@ var _ = Describe("Streaming Data Conversion", func() {
 	Context("when data is in a supported file format", func() {
 
 		const (
-			infilePath = "tinyCore.iso"
+			infilePath  = "tinyCore.iso"
+			outfileBase = "tinyCore"
 		)
 
 		// Test Table
@@ -36,36 +41,50 @@ var _ = Describe("Streaming Data Conversion", func() {
 			{
 				testDesc:      "should decompress gzip",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".iso.gz",
+				useVirtSize:   false,
 				expectFormats: []string{image.ExtGz},
 			},
 			{
 				testDesc:      "should decompress xz",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".iso.xz",
+				useVirtSize:   false,
 				expectFormats: []string{image.ExtXz},
 			},
 			{
 				testDesc:      "should unarchive tar",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".iso.tar",
+				useVirtSize:   false,
 				expectFormats: []string{image.ExtTar},
 			},
 			{
 				testDesc:      "should unpack .tar.gz",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".iso.tar.gz",
+				useVirtSize:   false,
 				expectFormats: []string{image.ExtTar, image.ExtGz},
 			},
 			{
 				testDesc:      "should unpack .tar.xz",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".iso.tar.xz",
+				useVirtSize:   false,
 				expectFormats: []string{image.ExtTar, image.ExtXz},
 			},
 			{
 				testDesc:      "should convert .qcow2",
 				inFileName:    infilePath,
+				outFileName:   outfileBase + ".qcow2",
+				useVirtSize:   true,
 				expectFormats: []string{image.ExtQcow2},
 			},
 			{
 				testDesc:      "should pass through unformatted data",
 				inFileName:    infilePath,
+				outFileName:   infilePath,
+				useVirtSize:   false,
 				expectFormats: []string{""},
 			},
 		}
@@ -75,6 +94,8 @@ var _ = Describe("Streaming Data Conversion", func() {
 			desc := t.testDesc
 			ff := t.expectFormats
 			fn := t.inFileName
+			of := t.outFileName
+			useVSize := t.useVirtSize
 
 			It(desc, func() {
 
@@ -88,8 +109,8 @@ var _ = Describe("Streaming Data Conversion", func() {
 				sampleFilename, err := f.FormatTestData(fn, ff...)
 				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
 
-				By(fmt.Sprintf("Confirming sample file name %q matches expected file name %q", sampleFilename, fn+strings.Join(ff, "")))
-				Expect(sampleFilename).To(Equal(fn+strings.Join(ff, "")), "Test data filename doesn't match expected file name.")
+				By(fmt.Sprintf("Confirming sample file name %q matches expected file name %q", sampleFilename, of))
+				Expect(sampleFilename).To(Equal(of), "Test data filename doesn't match expected file name.")
 
 				// BEGIN TEST
 				By("Opening sample file for test.")
@@ -108,13 +129,40 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 				By("Checking the output of the data stream")
 				Expect(err).NotTo(HaveOccurred(), "ioutil.ReadAll erred")
-				Expect(int64(output.Len())).To(Equal(size))
-				//Expect(output.Bytes()).To(Equal(sampleData)) // TODO replace with checksum?
+				if useVSize {
+					By("Checking getImageVirtualSize")
+					Expect(getImageVirtualSize(of)).To(Equal(size))
+				} else {
+					Expect(int64(output.Len())).To(Equal(size))
+				}
+				//Expect(output.Bytes()).To(Equal(size)) // TODO replace with checksum?
 				By("Closing sample test file.")
 			})
 		}
 	})
 })
+
+func getImageVirtualSize(outFile string) int64 {
+	//call qemu-img info
+	virtSizeParseLen := 8
+
+	//create command
+	cmd := fmt.Sprintf("qemu-img info %s | grep 'virtual size:'", outFile)
+	out, err := exec.Command("sh", "-c", cmd).Output()
+	if err != nil {
+		return 0
+	}
+	sOut := string(out)
+
+	index1 := strings.Index(sOut, "(")
+	sSize := sOut[index1+1 : len(sOut)-virtSizeParseLen]
+
+	vSize, err := strconv.ParseInt(sSize, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return vSize
+}
 
 func generateTestFile(size int, filename string) ([]byte, error) {
 	// Create a some random data to compress and/or archive.


### PR DESCRIPTION
@jeffvance - this is a WIP with initial investigation, It may be my lack of understanding at this point, but I think it might be worth while to add another field into the tests to indicate if the filename should be manipulated or not based on the action that is being taken, right now I'm only manipulating the filename based on the fact that is is `qemu` everything else I leave as is...so it does get by step 3 but fails on the last step now where it is comparing source file size vs output/converted file size ...

```
  should convert .qcow2
  /home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:84
STEP: Stating the source image file
STEP: Converting sample file to format: [.qcow2]
STEP: Confirming sample file name "tinyCore.qcow2" matches expected file name "tinyCore.qcow2" base = "tinyCore"
STEP: Opening sample file for test.
STEP: Passing file reader to the data stream
STEP: Checking the output of the data stream

• Failure [0.086 seconds]
Streaming Data Conversion
/home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:26
  when data is in a supported file format
  /home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:28
    should convert .qcow2 [It]
    /home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:84

    Expected
        <int64>: 18219008
    to equal
        <int64>: 18874368

    /home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:118
------------------------------
Streaming Data Conversion when data is in a supported file format 
  should pass through unformatted data
  /home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_test.go:84
STEP: Stating the source image file
STEP: Converting sample file to format: []
STEP: Confirming sample file name "tinyCore.iso" matches expected file name "tinyCore.iso" base = "tinyCore.iso"
STEP: Opening sample file for test.
STEP: Passing file reader to the data stream
STEP: Checking the output of the data stream
STEP: Closing sample test file.
•

Summarizing 1 Failure:

[Fail] Streaming Data Conversion when data is in a supported file format [It] should convert .qcow2 
/home/screeley/git/go/src/github.com/kubevirt/containerized-data-importer/test/datastream/datastream_t
```