### PR TITLE
travis: Cleaner logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,5 @@ before_script:
   - make func-test-build
 
 script:
-  - make test
+  - make unit-test
+  - make functional-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_script:
   - kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v$K6T_VER/kubevirt.yaml
   - k_wait_all_running pods
 
-script:
-  # Deploy manifests
+  # Deploy CDI
   - kubectl apply -f manifests/example/endpoint-secret.yaml
   - kubectl apply -f manifests/controller/cdi-controller-deployment.yaml
 
@@ -41,4 +40,7 @@ script:
   - k_wait_all_running pods
   - kubectl get pods --all-namespaces
 
+  - make func-test-build
+
+script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ controller: controller-bin controller-image
 importer: importer-bin importer-image
 push: push-importer push-controller
 test: functional-test unit-test
-functional-test: func-test-bin func-test-image func-test-run
+functional-test: func-test-run
+func-test-build: func-test-bin func-test-image
 
 GOOS?=linux
 ARCH?=amd64
@@ -100,7 +101,7 @@ func-test-image: $(IMPORTER_BUILD)/Dockerfile
 	-rm -rf $(TEMP_BUILD_DIR)
 
 
-func-test-run:
+func-test-run: func-test-build
 	@echo '********'
 	@echo 'Running functional tests'
 	docker ps -qa && \


### PR DESCRIPTION
This patch moves some of the steps to prepare the tests into the
pre-scripts.
This has the effect of cleaning up the log display a little bit and
will focus more on the test results.
Even if the logs are hidden, travis would still fail if any of the
steps fails.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>