### PR TITLE
Refactor readers so Close() is called

### DIFF
--- a/cmd/importer/importer.go
+++ b/cmd/importer/importer.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	glog.Infof("Beginning import from %q\n", ep.Path)
-	err = dataStream.Copy(fn)
+	err = dataStream.Copy(common.IMPORTER_WRITE_PATH)
 	if err != nil {
 		glog.Errorf("main: copy error: %v\n", err)
 		os.Exit(1)

--- a/cmd/importer/importer.go
+++ b/cmd/importer/importer.go
@@ -43,16 +43,8 @@ func main() {
 		glog.Errorf("main: unsupported source file %q. Supported types: %v\n", fn, image.SupportedFileExtensions)
 		os.Exit(1)
 	}
-
-	// Initialize the input io stream (typically http or s3 client)
-	glog.Infof("main: importing file %q\n", fn)
-	dataStream, err := NewDataStream(ep, acc, sec)
-	if err != nil {
-		glog.Errorf("main: %q error: %v\n", ep.Path, err)
-		os.Exit(1)
-	}
-
-	glog.Infof("Beginning import from %q\n", ep.Path)
+	glog.Infof("main: beginning import from %q\n", ep.Path)
+	dataStream := NewDataStream(ep, acc, sec)
 	err = dataStream.Copy(common.IMPORTER_WRITE_PATH)
 	if err != nil {
 		glog.Errorf("main: copy error: %v\n", err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -30,11 +30,11 @@ var _ = Describe("Controller", func() {
 		stop       chan struct{}
 	)
 	type testT struct {
-		descr         string
-		ns            string
-		name          string // name of test pvc
-		annEndpoint   string
-		expectError   bool
+		descr       string
+		ns          string
+		name        string // name of test pvc
+		annEndpoint string
+		expectError bool
 	}
 
 	setUpInformer := func(pvc *v1.PersistentVolumeClaim, op operation) {
@@ -69,25 +69,25 @@ var _ = Describe("Controller", func() {
 
 	tests := []testT{
 		{
-			descr:         "pvc, endpoint, blank ns: controller creates importer pod",
-			ns:            "", // blank used originally in these unit tests
-			name:          "test-pvc",
-			annEndpoint:   "http://www.google.com",
-			expectError:   false,
+			descr:       "pvc, endpoint, blank ns: controller creates importer pod",
+			ns:          "", // blank used originally in these unit tests
+			name:        "test-pvc",
+			annEndpoint: "http://www.google.com",
+			expectError: false,
 		},
 		{
-			descr:         "pvc, endpoint, non-blank ns: controller creates importer pod",
-			ns:            "ns-a",
-			name:          "test-pvc",
-			annEndpoint:   "http://www.google.com",
-			expectError:   false,
+			descr:       "pvc, endpoint, non-blank ns: controller creates importer pod",
+			ns:          "ns-a",
+			name:        "test-pvc",
+			annEndpoint: "http://www.google.com",
+			expectError: false,
 		},
 		{
-			descr:         "pvc, blank endpoint: controller does not create importer pod",
-			ns:            "",
-			name:          "test-pvc",
-			annEndpoint:   "",
-			expectError:   true,
+			descr:       "pvc, blank endpoint: controller does not create importer pod",
+			ns:          "",
+			name:        "test-pvc",
+			annEndpoint: "",
+			expectError: true,
 		},
 	}
 

--- a/pkg/image/decompress.go
+++ b/pkg/image/decompress.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
@@ -18,84 +17,27 @@ func TrimString(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
-// UnpackData combines the decompressing and unarchiving of a data stream and returns the
-// end of the stream for further processing.
-// Note: order of unpacking is hard-coded: 1) decompress, 2) un-archive. This can be changed
-//   to be sensitive to the file's (sub-)extensions.
-func UnpackData(filename string, src io.ReadCloser) (io.ReadCloser, error) {
-	glog.Infof("UnpackData: checking compressed and/or archive for file %q\n", filename)
-	var err error
-	// see if file is compressed
-	filename, src, err = DecompressData(filename, src)
-	if err == nil { // see if file is an archive
-		src, err = DearchiveData(filename, src)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("UnpackData: decompress/un-archive error: %v\n", err)
-	}
-	return src, nil
-}
-
-// DecompressData analyzes the filename extension to decide which decompression function to call.
-// Compression packages return objects that must be closed after reading, hence the need to
-// return a ReadCloser.  It is up to the caller of DecompressData to close the returned stream.
-// If no compression is detected, it is considered a 'noop' and the original stream is returned.
-// Returns trimmed filename string and gzip Reader if gzip compression was used.
-func DecompressData(filename string, src io.ReadCloser) (string, io.ReadCloser, error) {
-	glog.Infof("DecompressData: checking if %q is compressed\n", filename)
-	var err error
-	var r io.ReadCloser
-	ext := filepath.Ext(TrimString(filename))
-	switch ext {
-	case ExtGz:
-		r, err = gzDecompress(src)
-	case ExtXz:
-		r, err = xzDecompress(src)
-	}
-	if err != nil {
-		return filename, nil, fmt.Errorf("DecompressData: %v\n", err)
-	}
-	if r != nil { // have decompress Reader
-		glog.Infof("DecompressData: decompressed %q", filename)
-		src = r
-		filename = strings.TrimSuffix(filename, ext) // trim compression extension
-	}
-	return filename, src, nil // orig filename and orig reader
-}
-
-// DearchiveData analyzes a filename extension to decided which de-archive function to call.
-// If no archive format is detected, it is considered a 'noop' and the original stream is
-// returned.
-func DearchiveData(filename string, src io.ReadCloser) (io.ReadCloser, error) {
-	glog.Infof("DearchiveData: checking if %q is an archive file\n", filename)
-	ext := filepath.Ext(TrimString(filename))
-	switch ext {
-	case ExtTar:
-		glog.Infof("DearchiveData: detected %v archive format\n", ext)
-		return tarPrep(filename, src)
-	}
-	return src, nil // orig reader
-}
-
-func gzDecompress(r io.ReadCloser) (io.ReadCloser, error) {
+func GzReader(r io.ReadCloser) (io.ReadCloser, error) {
+	glog.Infoln("GzReader: gz format")
 	return gzip.NewReader(r)
 }
 
-func xzDecompress(r io.ReadCloser) (io.ReadCloser, error) {
+func XzReader(r io.ReadCloser) (io.ReadCloser, error) {
+	glog.Infoln("XzReader: xz format")
 	rdr, err := xz.NewReader(r, 0) //note: default dict size may be too small
 	if err != nil {
-		return nil, fmt.Errorf("xzDecompress: error creating xz Reader: %v\n", err)
+		return nil, fmt.Errorf("XzReader: error creating xz Reader: %v\n", err)
 	}
 	return ioutil.NopCloser(rdr), nil
 }
 
-// TODO: support other archive formats? This just handles tar.
-func tarPrep(srcFile string, r io.ReadCloser) (io.ReadCloser, error) {
+func TarReader(r io.ReadCloser) (io.ReadCloser, error) {
+	glog.Infoln("TarReader: tar format")
 	tr := tar.NewReader(r)
 	hdr, err := tr.Next() // advance cursor to 1st (and only) file in tarball
 	if err != nil {
-		return r, fmt.Errorf("tarPrep: reading tarfile %q header: %v\n", srcFile, err)
+		return r, fmt.Errorf("TarReader: reading tarfile %q header: %v\n", err)
 	}
-	glog.Infof("tarPrep: extracting %q\n", hdr.Name)
+	glog.Infof("TarReader: extracting %q\n", hdr.Name)
 	return ioutil.NopCloser(tr), nil
 }

--- a/pkg/image/decompress.go
+++ b/pkg/image/decompress.go
@@ -6,16 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/xi2/xz"
 )
-
-// Return string as lowercase with all spaces removed.
-func TrimString(s string) string {
-	return strings.ToLower(strings.TrimSpace(s))
-}
 
 func GzReader(r io.ReadCloser) (io.ReadCloser, error) {
 	glog.Infoln("GzReader: gz format")
@@ -36,7 +30,7 @@ func TarReader(r io.ReadCloser) (io.ReadCloser, error) {
 	tr := tar.NewReader(r)
 	hdr, err := tr.Next() // advance cursor to 1st (and only) file in tarball
 	if err != nil {
-		return r, fmt.Errorf("TarReader: reading tarfile %q header: %v\n", err)
+		return r, fmt.Errorf("TarReader: reading tarfile header: %v\n", err)
 	}
 	glog.Infof("TarReader: extracting %q\n", hdr.Name)
 	return ioutil.NopCloser(tr), nil

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -15,15 +15,15 @@ var QCOW2MagicStrSize = len(QCOW2MagicStr)
 // the passed in file. If the file is too small then an empty magic string is returned.
 // Error is returned if a non-eof io error occurs.
 func GetMagicNumber(f io.Reader) ([]byte, error) {
-        buff := make([]byte, QCOW2MagicStrSize)
-        cnt, err := f.Read(buff)
-        if cnt < QCOW2MagicStrSize {
-                return nil, nil
-        }
-        if err != nil && err != io.EOF {
-                return nil, fmt.Errorf("GetMagicNumber: read error: %v\n", err)
-        }
-        return buff, nil
+	buff := make([]byte, QCOW2MagicStrSize)
+	cnt, err := f.Read(buff)
+	if cnt < QCOW2MagicStrSize {
+		return nil, nil
+	}
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("GetMagicNumber: read error: %v\n", err)
+	}
+	return buff, nil
 }
 
 func MatchQcow2MagicNum(match []byte) bool {

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -31,6 +31,10 @@ var SupportedImageFormats = []string{
 	ExtImg, ExtIso, ExtQcow2,
 }
 
+var FinalImageFormats = []string{ // no more processing if these extensions found, just copy
+	ExtImg, ExtIso,
+}
+
 var SupportedFileExtensions = append(SupportedImageFormats,
 	append(SupportedCompressionExtensions,
 	append(SupportedArchiveExtensions, SupportedNestedExtensions...)...)...)
@@ -58,6 +62,16 @@ func IsSupporedCompressionType(fn string) bool {
 func IsSupporedArchiveType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedArchiveExtensions {
+		if strings.HasSuffix(fn, string(ext)) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsFinalImageFormat(fn string) bool {
+	fn = TrimString(fn)
+	for _, ext := range FinalImageFormats {
 		if strings.HasSuffix(fn, string(ext)) {
 			return true
 		}

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -42,7 +42,7 @@ var SupportedFileExtensions = append(SupportedImageFormats,
 func IsSupporedFileType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedFileExtensions {
-		if strings.HasSuffix(fn, string(ext)) {
+		if strings.HasSuffix(fn, ext) {
 			return true
 		}
 	}
@@ -52,7 +52,7 @@ func IsSupporedFileType(fn string) bool {
 func IsSupporedCompressionType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedCompressionExtensions {
-		if strings.HasSuffix(fn, string(ext)) {
+		if strings.HasSuffix(fn, ext) {
 			return true
 		}
 	}
@@ -62,7 +62,7 @@ func IsSupporedCompressionType(fn string) bool {
 func IsSupporedArchiveType(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range SupportedArchiveExtensions {
-		if strings.HasSuffix(fn, string(ext)) {
+		if strings.HasSuffix(fn, ext) {
 			return true
 		}
 	}
@@ -72,9 +72,14 @@ func IsSupporedArchiveType(fn string) bool {
 func IsFinalImageFormat(fn string) bool {
 	fn = TrimString(fn)
 	for _, ext := range FinalImageFormats {
-		if strings.HasSuffix(fn, string(ext)) {
+		if strings.HasSuffix(fn, ext) {
 			return true
 		}
 	}
 	return false
+}
+
+// Return string as lowercase with all spaces removed.
+func TrimString(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -29,7 +29,7 @@ var SupportedArchiveExtensions = []string{
 
 var SupportedCompressArchiveExtensions = append(
 	SupportedCompressionExtensions,
-	SupportedArchiveExtensions...
+	SupportedArchiveExtensions...,
 )
 
 var SupportedImageFormats = []string{
@@ -40,9 +40,9 @@ var SupportedFileExtensions = append(
 	SupportedImageFormats, append(
 		SupportedCompressionExtensions, append(
 			SupportedArchiveExtensions,
-			SupportedNestedExtensions...
-		)...
-	)...
+			SupportedNestedExtensions...,
+		)...,
+	)...,
 )
 
 func IsSupportedType(fn string, exts []string) bool {

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -27,56 +27,48 @@ var SupportedArchiveExtensions = []string{
 	ExtTar,
 }
 
+var SupportedCompressArchiveExtensions = append(
+	SupportedCompressionExtensions,
+	SupportedArchiveExtensions...
+)
+
 var SupportedImageFormats = []string{
 	ExtImg, ExtIso, ExtQcow2,
 }
 
-var FinalImageFormats = []string{ // no more processing if these extensions found, just copy
-	ExtImg, ExtIso,
-}
+var SupportedFileExtensions = append(
+	SupportedImageFormats, append(
+		SupportedCompressionExtensions, append(
+			SupportedArchiveExtensions,
+			SupportedNestedExtensions...
+		)...
+	)...
+)
 
-var SupportedFileExtensions = append(SupportedImageFormats,
-	append(SupportedCompressionExtensions,
-	append(SupportedArchiveExtensions, SupportedNestedExtensions...)...)...)
-
-func IsSupporedFileType(fn string) bool {
+func IsSupportedType(fn string, exts []string) bool {
 	fn = TrimString(fn)
-	for _, ext := range SupportedFileExtensions {
+	for _, ext := range exts {
 		if strings.HasSuffix(fn, ext) {
 			return true
 		}
 	}
 	return false
+}
+
+func IsSupporedFileType(fn string) bool {
+	return IsSupportedType(fn, SupportedFileExtensions)
 }
 
 func IsSupporedCompressionType(fn string) bool {
-	fn = TrimString(fn)
-	for _, ext := range SupportedCompressionExtensions {
-		if strings.HasSuffix(fn, ext) {
-			return true
-		}
-	}
-	return false
+	return IsSupportedType(fn, SupportedCompressionExtensions)
 }
 
 func IsSupporedArchiveType(fn string) bool {
-	fn = TrimString(fn)
-	for _, ext := range SupportedArchiveExtensions {
-		if strings.HasSuffix(fn, ext) {
-			return true
-		}
-	}
-	return false
+	return IsSupportedType(fn, SupportedArchiveExtensions)
 }
 
-func IsFinalImageFormat(fn string) bool {
-	fn = TrimString(fn)
-	for _, ext := range FinalImageFormats {
-		if strings.HasSuffix(fn, ext) {
-			return true
-		}
-	}
-	return false
+func IsSupporedCompressArchiveType(fn string) bool {
+	return IsSupportedType(fn, SupportedCompressArchiveExtensions)
 }
 
 // Return string as lowercase with all spaces removed.

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -21,39 +21,39 @@ var _ = Describe("Validate file and extensions", func() {
 	Context("various file extensions", func() {
 		tests := []testT{
 			{
-				name: "test.qcow2",
+				name:    "test.qcow2",
 				expctOK: true,
 			},
 			{
-				name: "test.tar",
+				name:    "test.tar",
 				expctOK: true,
 			},
 			{
-				name: "test.gz",
+				name:    "test.gz",
 				expctOK: true,
 			},
 			{
-				name: "test.xz",
+				name:    "test.xz",
 				expctOK: true,
 			},
 			{
-				name: "test.img",
+				name:    "test.img",
 				expctOK: true,
 			},
 			{
-				name: "test.iso",
+				name:    "test.iso",
 				expctOK: true,
 			},
 			{
-				name: "xyz.abc",
+				name:    "xyz.abc",
 				expctOK: false,
 			},
 			{
-				name: "xxx",
+				name:    "xxx",
 				expctOK: false,
 			},
 			{
-				name: "",
+				name:    "",
 				expctOK: false,
 			},
 		}

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -134,6 +134,7 @@ var _ = Describe("Importer", func() {
 			mkFile := test.createFile
 			expt := test.expected
 			expErr := test.expectError
+
 			It(test.descr, func() {
 				By("creating dataStream object")
 				dataStream := NewFakeDataStream(ep, "", "")

--- a/test/datastream/datastream_test.go
+++ b/test/datastream/datastream_test.go
@@ -1,7 +1,6 @@
 package datastream
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math/rand"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/kubevirt/containerized-data-importer/pkg/image"
+	"github.com/kubevirt/containerized-data-importer/pkg/importer"
 	f "github.com/kubevirt/containerized-data-importer/test/framework"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,8 +98,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 			useVSize := t.useVirtSize
 
 			It(desc, func() {
-
-				By("Stating the source image file")
+				By(fmt.Sprintf("Stating the source image file %q", fn))
 				finfo, err := os.Stat(fn)
 				Expect(err).NotTo(HaveOccurred())
 				size := finfo.Size()
@@ -108,35 +107,36 @@ var _ = Describe("Streaming Data Conversion", func() {
 				// Generate the expected data format from the random bytes
 				sampleFilename, err := f.FormatTestData(fn, ff...)
 				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
-
-				By(fmt.Sprintf("Confirming sample file name %q matches expected file name %q", sampleFilename, of))
 				Expect(sampleFilename).To(Equal(of), "Test data filename doesn't match expected file name.")
 
-				// BEGIN TEST
-				By("Opening sample file for test.")
-				// Finally, open the file for reading
-				sampleFile, err := os.Open(sampleFilename)
-				Expect(err).NotTo(HaveOccurred(), "Failed to open sample file %s", sampleFilename)
-				defer sampleFile.Close()
-
-				By("Passing file reader to the data stream")
-				r, err := image.UnpackData(sampleFilename, sampleFile)
+				By("Creating a local dataStream w/o auth credentials")
+				fUrl := "file:/" + sampleFilename
+				ep, err := importer.ParseEndpoint(fUrl)
+fmt.Printf("\n***** ep=%#v\n", *ep)
 				Expect(err).NotTo(HaveOccurred())
-				defer r.Close()
+				ds, err := importer.NewDataStream(ep, "", "")
+fmt.Printf("\n***** ds=%#v\n", *ds)
+				Expect(err).NotTo(HaveOccurred())
 
-				var output bytes.Buffer
-				io.Copy(&output, r)
+				dest := "/tmp/" + of
+				By(fmt.Sprintf("Copying the sample file to %q", dest))
+				err = ds.Copy(dest)
+				Expect(err).NotTo(HaveOccurred())
 
-				By("Checking the output of the data stream")
-				Expect(err).NotTo(HaveOccurred(), "ioutil.ReadAll erred")
+				By(fmt.Sprintf("Checking the output file %q", dest))
 				if useVSize {
-					By("Checking getImageVirtualSize")
-					Expect(getImageVirtualSize(of)).To(Equal(size))
+					By("Checking output image virtual size")
+					Expect(getImageVirtualSize(dest)).To(Equal(size))
 				} else {
-					Expect(int64(output.Len())).To(Equal(size))
+					By("Stating output file") 
+					finfo, err := os.Stat(dest)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(finfo.Size()).To(Equal(size))
 				}
+				By(fmt.Sprintf("Removing the output file %q", dest))
+				err = os.Remove(dest)
+				Expect(err).NotTo(HaveOccurred())
 				//Expect(output.Bytes()).To(Equal(size)) // TODO replace with checksum?
-				By("Closing sample test file.")
 			})
 		}
 	})

--- a/test/datastream/datastream_test.go
+++ b/test/datastream/datastream_test.go
@@ -112,10 +112,8 @@ var _ = Describe("Streaming Data Conversion", func() {
 				By("Creating a local dataStream w/o auth credentials")
 				fUrl := "file:/" + sampleFilename
 				ep, err := importer.ParseEndpoint(fUrl)
-fmt.Printf("\n***** ep=%#v\n", *ep)
 				Expect(err).NotTo(HaveOccurred())
 				ds, err := importer.NewDataStream(ep, "", "")
-fmt.Printf("\n***** ds=%#v\n", *ds)
 				Expect(err).NotTo(HaveOccurred())
 
 				dest := "/tmp/" + of
@@ -128,7 +126,7 @@ fmt.Printf("\n***** ds=%#v\n", *ds)
 					By("Checking output image virtual size")
 					Expect(getImageVirtualSize(dest)).To(Equal(size))
 				} else {
-					By("Stating output file") 
+					By("Stating output file")
 					finfo, err := os.Stat(dest)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(finfo.Size()).To(Equal(size))

--- a/test/datastream/datastream_test.go
+++ b/test/datastream/datastream_test.go
@@ -113,8 +113,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 				fUrl := "file:/" + sampleFilename
 				ep, err := importer.ParseEndpoint(fUrl)
 				Expect(err).NotTo(HaveOccurred())
-				ds, err := importer.NewDataStream(ep, "", "")
-				Expect(err).NotTo(HaveOccurred())
+				ds := importer.NewDataStream(ep, "", "")
 
 				dest := "/tmp/" + of
 				By(fmt.Sprintf("Copying the sample file to %q", dest))

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -36,7 +36,7 @@ func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
 			} else if i == len(formatTable)-1 {
 				err = fmt.Errorf("format extension %q not recognized\n", tf)
 			}
-			i ++
+			i++
 		}
 	}
 
@@ -62,15 +62,15 @@ func transformFile(srcFile, outfileName, osCmd string, osArgs ...string) (string
 
 func transformTar(srcFile string) (string, error) {
 	args := []string{"-cf", srcFile + image.ExtTar, srcFile}
-	return transformFile(srcFile, srcFile + image.ExtTar, "tar", args...)
+	return transformFile(srcFile, srcFile+image.ExtTar, "tar", args...)
 }
 
 func transformGz(srcFile string) (string, error) {
-	return transformFile(srcFile, srcFile + image.ExtGz, "gzip", "-k", srcFile)
+	return transformFile(srcFile, srcFile+image.ExtGz, "gzip", "-k", srcFile)
 }
 
 func transformXz(srcFile string) (string, error) {
-	return transformFile(srcFile, srcFile + image.ExtXz, "xz", "-k", srcFile)
+	return transformFile(srcFile, srcFile+image.ExtXz, "xz", "-k", srcFile)
 }
 
 func transformQcow2(srcfile string) (string, error) {


### PR DESCRIPTION
Fixes #74 
Restructure all Readers so that each reader's close is called within the same scope as the reader's creation.

@copejon @screeley44 