### PR TITLE
refactor cdi controller for modern use of informer factories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ release: all
 	docker tag $(CTRL_IMG_NAME) $(RELEASE_REGISTRY)/$(CTRL_IMG_NAME):$(VERSION)
 	docker push $(RELEASE_REGISTRY)/$(CTRL_IMG_NAME):$(VERSION)
 
-my-golden-pvc.yaml: manifests/golden-pvc.yaml
+my-golden-pvc.yaml: manifests/example/golden-pvc.yaml
 	sed "s,endpoint:.*,endpoint: \"$(URI)\"," $< > $@
 
 .PHONY: my-golden-pvc.yaml

--- a/manifests/controller/cdi-controller-deployment.yaml
+++ b/manifests/controller/cdi-controller-deployment.yaml
@@ -2,15 +2,17 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-deployment
+  labels:
+    app: containerized-data-importer
 spec:
   selector:
     matchLabels:
-      app: cdi-controller
+      app: containerized-data-importer
   replicas: 1
   template:
     metadata:
       labels:
-        app: cdi-controller
+        app: containerized-data-importer
     spec:
       containers:
       - name: cdi-controller

--- a/manifests/example/endpoint-secret.yaml
+++ b/manifests/example/endpoint-secret.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: endpoint-secret
+  labels:
+    app: containerized-data-importer
 type: Opaque
 data:
   accessKeyId: ""  # <optional: your key or user name, base64 encoded>

--- a/manifests/example/golden-pvc.yaml
+++ b/manifests/example/golden-pvc.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "golden-pvc"
+  labels:
+    app: containerized-data-importer
   annotations:
     kubevirt.io/storage.import.endpoint: ""   # Required.  Format: (http||s3)://www.myUrl.com/path/of/data
     kubevirt.io/storage.import.secretName: "" # Optional.  The name of the secret containing credentials for the data source

--- a/manifests/importer/importer-pod.yaml
+++ b/manifests/importer/importer-pod.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: data-importer
+  labels:
+    app: containerized-data-importer
 spec:
   restartPolicy: Never
   containers:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,10 +1,13 @@
 package common
 
+import "time"
+
 // Common types and constants used by the importer and controller.
 // TODO: maybe the vm cloner can use these common values
 
 const (
 	CDI_VERSION = "0.4.0-alpha.0"
+
 	IMPORTER_DEFAULT_IMAGE = "docker.io/kubevirt/cdi-importer:" + CDI_VERSION
 
 	// host file constants:
@@ -22,4 +25,7 @@ const (
 	// key names expected in credential secret
 	KeyAccess = "accessKeyId"
 	KeySecret = "secretKey"
+
+	// Shared informer resync period.
+	DEFAULT_RESYNC_PERIOD = 10 * time.Minute
 )

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -109,8 +109,10 @@ func (c *Controller) setAnnoImportPod(pvc *v1.PersistentVolumeClaim, name string
 // importer pod.
 func (c *Controller) createImporterPod(ep, secretName string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
 	ns := pvc.Namespace
-	pod := c.makeImporterPodSpec(ep, secretName, pvc)
-	var err error
+	pod, err := c.makeImporterPodSpec(ep, secretName, pvc)
+	if err != nil {
+		return nil, fmt.Errorf("createImporterPod: error creating pod spec: %v", err)
+	}
 	pod, err = c.clientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
 		return nil, fmt.Errorf("createImporterPod: Create failed: %v\n", err)
@@ -120,9 +122,10 @@ func (c *Controller) createImporterPod(ep, secretName string, pvc *v1.Persistent
 }
 
 // return the importer pod spec based on the passed-in endpoint, secret and pvc.
-func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVolumeClaim) *v1.Pod {
+func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
 	// importer pod name contains the pvc name
 	podName := fmt.Sprintf("%s-%s", common.IMPORTER_PODNAME, pvc.Name)
+
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -138,7 +141,7 @@ func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVo
 			Containers: []v1.Container{
 				{
 					Name:            common.IMPORTER_PODNAME,
-					Image:          c.importerImage,
+					Image:           c.importerImage,
 					ImagePullPolicy: v1.PullAlways,
 					VolumeMounts: []v1.VolumeMount{
 						{
@@ -163,7 +166,7 @@ func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVo
 		},
 	}
 	pod.Spec.Containers[0].Env = makeEnv(ep, secret)
-	return pod
+	return pod, nil
 }
 
 // return the Env portion for the importer container.


### PR DESCRIPTION
Refactor the SharedInformerFactory to properly use a pvc informer This should be done before addressing  [pod monitoring](#83 )