### PR TITLE
Change default pull policy to IfNotPresent to support offline demoing.

### DIFF
--- a/manifests/controller/cdi-controller-deployment.yaml
+++ b/manifests/controller/cdi-controller-deployment.yaml
@@ -17,4 +17,4 @@ spec:
       containers:
       - name: cdi-controller
         image: kubevirt/cdi-controller:0.4.0-alpha.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,17 +1,21 @@
 package common
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/api/core/v1"
+)
 
 // Common types and constants used by the importer and controller.
 // TODO: maybe the vm cloner can use these common values
 
 const (
-	CDI_VERSION = "0.4.0-alpha.0"
+	CDI_VERSION             = "0.4.0-alpha.0"
 
 	IMPORTER_DEFAULT_IMAGE = "docker.io/kubevirt/cdi-importer:" + CDI_VERSION
-	CDI_LABEL_KEY = "app"
-	CDI_LABEL_VALUE = "containerized-data-importer"
-	CDI_LABEL_SELECTOR = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
+	CDI_LABEL_KEY          = "app"
+	CDI_LABEL_VALUE        = "containerized-data-importer"
+	CDI_LABEL_SELECTOR     = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
 
 	// host file constants:
 	IMPORTER_WRITE_DIR  = "/data"
@@ -21,10 +25,12 @@ const (
 	IMPORTER_PODNAME  = "importer"
 	IMPORTER_DATA_DIR = "/data"
 	IMPORTER_S3_HOST  = "s3.amazonaws.com"
+	IMPORTER_DEFAULT_PULL_POLICY = string(v1.PullIfNotPresent)
 	// env var names
-	IMPORTER_ENDPOINT      = "IMPORTER_ENDPOINT"
-	IMPORTER_ACCESS_KEY_ID = "IMPORTER_ACCESS_KEY_ID"
-	IMPORTER_SECRET_KEY    = "IMPORTER_SECRET_KEY"
+	IMPORTER_PULL_POLICY         = "IMPORTER_PULL_POLICY"
+	IMPORTER_ENDPOINT            = "IMPORTER_ENDPOINT"
+	IMPORTER_ACCESS_KEY_ID       = "IMPORTER_ACCESS_KEY_ID"
+	IMPORTER_SECRET_KEY          = "IMPORTER_SECRET_KEY"
 	// key names expected in credential secret
 	KeyAccess = "accessKeyId"
 	KeySecret = "secretKey"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,9 +27,11 @@ type Controller struct {
 	queue         workqueue.RateLimitingInterface
 	pvcInformer   cache.SharedIndexInformer
 	importerImage string
+	pullPolicy    string // Options: IfNotPresent, Always, or Never
 }
 
-func NewController(client kubernetes.Interface, pvcInformer cache.SharedIndexInformer, importerImage string) (*Controller, error) {
+func NewController(client kubernetes.Interface, pvcInformer cache.SharedIndexInformer, importerImage string, pullPolicy string) (*Controller, error) {
+
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	c := &Controller{
@@ -37,6 +39,7 @@ func NewController(client kubernetes.Interface, pvcInformer cache.SharedIndexInf
 		queue:         queue,
 		pvcInformer:   pvcInformer,
 		importerImage: importerImage,
+		pullPolicy:    pullPolicy,
 	}
 
 	// Bind the Index/Informer to the queue only for new pvcs

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Controller", func() {
 		queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 		var err error // declare err here to prevent shadowing `controller`, declared in the outer block
-		controller, err = NewController(fakeClient, pvcInformer, common.IMPORTER_DEFAULT_IMAGE)
+		controller, err = NewController(fakeClient, pvcInformer, common.IMPORTER_DEFAULT_IMAGE, common.IMPORTER_DEFAULT_PULL_POLICY)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("setupInformer failed to create controller: %v", err))
 		if op == opAdd || op == opUpdate {
 			objSource.Add(pvc)

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -251,7 +251,7 @@ func (c *Controller) makeImporterPodSpec(ep, secret string, pvc *v1.PersistentVo
 				{
 					Name:            common.IMPORTER_PODNAME,
 					Image:           c.importerImage,
-					ImagePullPolicy: v1.PullAlways,
+					ImagePullPolicy: v1.PullPolicy(c.pullPolicy),
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "data-path",


### PR DESCRIPTION
Default pull policies to IfNotPreset unless env var CDI_PULL_POLICY is set.  Unfortunately, both the controller pull policy must be set to Always and the env var set to `CDI_PULL_POLICY: Always`; this field is covered by the DownwardApi.