### PR TITLE
refactor Get of pvc to recognize err

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -123,9 +123,9 @@ var _ = Describe("Controller", func() {
 
 		It(test.descr, func() {
 			By(fmt.Sprintf("creating in-mem pvc %q with endpt anno=%q", fullname, annotations))
-			pvcObj := createInMemPVC(ns, pvcName, annotations)
+			pvc := createInMemPVC(ns, pvcName, annotations)
 			By("Creating the controller")
-			setUpInformer(pvcObj, ops)
+			setUpInformer(pvc, ops)
 			controller.ProcessNextPvcItem()
 			//controller.ProcessNextPodItem()
 			By("checking if importer pod is present")


### PR DESCRIPTION
[121](https://github.com/kubevirt/containerized-data-importer/pull/121) added code to Get the latest pvc so that the most recent annotations could be checked. However, an error returned from `Get` was treated as _success_, meaning ok to create the importer pod. 
This pr causes a `Get` error to not create the importer pod and to remember the key so it can be retried.
This also requires controller unit test to populate the fake client with the tested pvc.