### PR TITLE
Changed Dockerfile ENTRYPOINT to exec form in controller and importer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ importer-image: $(IMPORTER_BUILD)/Dockerfile
 	mkdir -p $(TEMP_BUILD_DIR)
 	cp $(IMPORTER_BIN) $(TEMP_BUILD_DIR)
 	cp $(IMPORTER_BUILD)/Dockerfile $(TEMP_BUILD_DIR)
-	docker build --build-arg entrypoint=$(IMPORTER) --build-arg runArgs='-alsologtostderr' -t $(IMPT_IMG_NAME) $(TEMP_BUILD_DIR)
+	docker build --build-arg entrypoint=$(IMPORTER) -t $(IMPT_IMG_NAME) $(TEMP_BUILD_DIR)
 	-rm -rf $(TEMP_BUILD_DIR)
 
 # build the functional test image.  The importer image is used to provide consistency between test

--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine
 COPY ./import-controller /import-controller
-ENTRYPOINT /import-controller -alsologtostderr
+ENTRYPOINT [ "/import-controller", "-alsologtostderr"]

--- a/build/importer/Dockerfile
+++ b/build/importer/Dockerfile
@@ -10,4 +10,5 @@ RUN apk update && apk add qemu-img \
   xz \
   gzip
 RUN apk add ca-certificates && rm -rf /var/cache/apk/*
-ENTRYPOINT ./run-binary $RUN_ARGS
+ENTRYPOINT ["./run-binary", "-alsologtostderr"]
+CMD $RUN_ARGS


### PR DESCRIPTION
Formatting ENTRYPOINT's into exec form.

We want to be able to pass custom flags to the importer binary via it's pod definition.  Currently, the controller and importer ENTRYPOINT vars are defined in docker's "shell form".  However, k8s sets the custom flags defined in the `args:` list as "exec form" (a json formatted array).

By design, docker ENTRYPOINTs defined in shell form will ignore CMDs in exec form.  Converted the ENTRYPOINTs to exec form causes docker to perform as expected, passing the exec form args list to the ENTRYPOINT.
