### PR TITLE
Automated Versioning with Git Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ go:
 services:
 - docker
 env:
-  matrix:
-  - CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
   global:
-    - GH_USER='copejon'
-    - GH_EMAIL='jcope@redhat.com'
+    - CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
     - secure: jPx5Nleoi0hidCiLAEWBLr8Wt4GXWzwSwNq9x3uL6WvruxKJwrcyKzYNKqgZoLFazzE+D94vf7jbxC9VgvJVknAsg7BelaOuaG4IJL3ayLAG6oyT1M7l6IRJq9BqSxxnOL8VTsRvYwAGUid98XOo/Lk4H5FF6YbGyP7CXbF1HNLGdBj9xiIUku6gvEs4rP0E61i2ihdP0uKQLCPncsyUvCITTFQNDBrOsHIPdJhVQpf31Xgx0HdOIaOAbVMecXNkWzplx0iyfrkB81hZiWkEKCqftUZrXwwkHK6jSzEt58sxeh8R6oRdLTL7YClrlXusT8wz7fljYbhqTsVN09KDVjJPYWH+3YKP0kT0E9EFmxDvVH6NQzXQGP6jqiU3CcTjK5IwFbowDMx9hjE+UgASSiQajPjKX3DDOCQtFZ1WG2xI+WgagDcp1VH7kcXVoibBoL+I0C+Zkl5UCDNzDwINTg7ox8V4x3W/7KP+dvaAlPN8fS+Y4V4MuXhqoe8Z+PNor7pdamyRPCsfd8Z+Z7EG0Zh1AA0YKOVNaD3e3grsFoS7DFV+I09k5Ec7/HgrIjLm1GjLQ27uWouryM1TnTMTRHiNTwlNkKXBOW/ufWOynrVizg1SlIVRWI+YduKeleFUmM3up2E/nO+FLB0Epvv+jShBfQ35ALYe4osNgzFjt3w=
 notifications:
   irc:
@@ -40,11 +37,10 @@ script:
 - kubectl get pods --all-namespaces
 - make test
 before_deploy:
-- git config --local user.name ${GH_USER}
-- git config --local user.email ${GH_EMAIL}
 - git remote add https://${GH_TOKEN}@github.com/kubevirt/containerized-data-importer.git
 - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
 deploy:
+# Increment version if tagged
 - provider: script
   on:
     branch: master
@@ -52,12 +48,14 @@ deploy:
     tags: true
   script: hack/version-and-deploy.sh $TRAVIS_TAG
   skip_cleanup: true
+# Release new docker images
 - provider: script
   script: make release
   skip_cleanup: true
   on:
     branch: master
     repo: kubevirt/containerized-data-importer
+# Upload the latest files
 - provider: releases
   on:
     repo: kubevirt/containerized-data-importer

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,29 @@ script:
 before_deploy:
 - git config --local user.name "copejon"
 - git config --local user.email "copejon@redhat.com"
-- source version && git tag -f $RELEASE_TAG
+- docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
 deploy:
+# When a git tag is set, propagate the new version throughout CDI and
+# publish new images with the tag
 - provider: script
   on:
     branch: master
     repo: kubevirt/containerized-data-importer
-  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && make release
+  script: hack/version-and-deploy.sh $TRAVIS_TAG
   skip_cleanup: true
+  on:
+    branch: master
+    repo: kubevirt/containerized-data-importer
+    tags: true
+# When a PR is merged into master, build and push fresh CDI
+# images with the current version
+- provider: script
+  script: make release
+  skip_cleanup: true
+  on:
+    branch: master
+    repo: kubevirt/containerized-data-importer
+# When a PR is merged into master, build and upload fresh binaries
 - provider: releases
   on:
     repo: kubevirt/containerized-data-importer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ go:
 services:
 - docker
 env:
-- CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
-notifications:
+matrix:- CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
+
+global:
+  - GH_USER='copejon'
+  - GH_EMAIL='jcope@redhat.com'
+  - secure: jPx5Nleoi0hidCiLAEWBLr8Wt4GXWzwSwNq9x3uL6WvruxKJwrcyKzYNKqgZoLFazzE+D94vf7jbxC9VgvJVknAsg7BelaOuaG4IJL3ayLAG6oyT1M7l6IRJq9BqSxxnOL8VTsRvYwAGUid98XOo/Lk4H5FF6YbGyP7CXbF1HNLGdBj9xiIUku6gvEs4rP0E61i2ihdP0uKQLCPncsyUvCITTFQNDBrOsHIPdJhVQpf31Xgx0HdOIaOAbVMecXNkWzplx0iyfrkB81hZiWkEKCqftUZrXwwkHK6jSzEt58sxeh8R6oRdLTL7YClrlXusT8wz7fljYbhqTsVN09KDVjJPYWH+3YKP0kT0E9EFmxDvVH6NQzXQGP6jqiU3CcTjK5IwFbowDMx9hjE+UgASSiQajPjKX3DDOCQtFZ1WG2xI+WgagDcp1VH7kcXVoibBoL+I0C+Zkl5UCDNzDwINTg7ox8V4x3W/7KP+dvaAlPN8fS+Y4V4MuXhqoe8Z+PNor7pdamyRPCsfd8Z+Z7EG0Zh1AA0YKOVNaD3e3grsFoS7DFV+I09k5Ec7/HgrIjLm1GjLQ27uWouryM1TnTMTRHiNTwlNkKXBOW/ufWOynrVizg1SlIVRWI+YduKeleFUmM3up2E/nO+FLB0Epvv+jShBfQ35ALYe4osNgzFjt3w=
   irc:
     channels:
     - chat.freenode.net#kubevirt
@@ -35,12 +39,11 @@ script:
 - kubectl get pods --all-namespaces
 - make test
 before_deploy:
-- git config --local user.name "copejon"
-- git config --local user.email "copejon@redhat.com"
+- git config --local user.name ${GH_USER}
+- git config --local user.email ${GH_EMAIL}
+- git remote add https://${GH_TOKEN}@github.com/kubevirt/containerized-data-importer.git
 - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
 deploy:
-# When a git tag is set, propagate the new version throughout CDI and
-# publish new images with the tag
 - provider: script
   on:
     branch: master
@@ -51,15 +54,12 @@ deploy:
     branch: master
     repo: kubevirt/containerized-data-importer
     tags: true
-# When a PR is merged into master, build and push fresh CDI
-# images with the current version
 - provider: script
   script: make release
   skip_cleanup: true
   on:
     branch: master
     repo: kubevirt/containerized-data-importer
-# When a PR is merged into master, build and upload fresh binaries
 - provider: releases
   on:
     repo: kubevirt/containerized-data-importer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ go:
 services:
 - docker
 env:
-matrix:- CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
-
-global:
-  - GH_USER='copejon'
-  - GH_EMAIL='jcope@redhat.com'
-  - secure: jPx5Nleoi0hidCiLAEWBLr8Wt4GXWzwSwNq9x3uL6WvruxKJwrcyKzYNKqgZoLFazzE+D94vf7jbxC9VgvJVknAsg7BelaOuaG4IJL3ayLAG6oyT1M7l6IRJq9BqSxxnOL8VTsRvYwAGUid98XOo/Lk4H5FF6YbGyP7CXbF1HNLGdBj9xiIUku6gvEs4rP0E61i2ihdP0uKQLCPncsyUvCITTFQNDBrOsHIPdJhVQpf31Xgx0HdOIaOAbVMecXNkWzplx0iyfrkB81hZiWkEKCqftUZrXwwkHK6jSzEt58sxeh8R6oRdLTL7YClrlXusT8wz7fljYbhqTsVN09KDVjJPYWH+3YKP0kT0E9EFmxDvVH6NQzXQGP6jqiU3CcTjK5IwFbowDMx9hjE+UgASSiQajPjKX3DDOCQtFZ1WG2xI+WgagDcp1VH7kcXVoibBoL+I0C+Zkl5UCDNzDwINTg7ox8V4x3W/7KP+dvaAlPN8fS+Y4V4MuXhqoe8Z+PNor7pdamyRPCsfd8Z+Z7EG0Zh1AA0YKOVNaD3e3grsFoS7DFV+I09k5Ec7/HgrIjLm1GjLQ27uWouryM1TnTMTRHiNTwlNkKXBOW/ufWOynrVizg1SlIVRWI+YduKeleFUmM3up2E/nO+FLB0Epvv+jShBfQ35ALYe4osNgzFjt3w=
+  matrix:
+  - CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
+  global:
+    - GH_USER='copejon'
+    - GH_EMAIL='jcope@redhat.com'
+    - secure: jPx5Nleoi0hidCiLAEWBLr8Wt4GXWzwSwNq9x3uL6WvruxKJwrcyKzYNKqgZoLFazzE+D94vf7jbxC9VgvJVknAsg7BelaOuaG4IJL3ayLAG6oyT1M7l6IRJq9BqSxxnOL8VTsRvYwAGUid98XOo/Lk4H5FF6YbGyP7CXbF1HNLGdBj9xiIUku6gvEs4rP0E61i2ihdP0uKQLCPncsyUvCITTFQNDBrOsHIPdJhVQpf31Xgx0HdOIaOAbVMecXNkWzplx0iyfrkB81hZiWkEKCqftUZrXwwkHK6jSzEt58sxeh8R6oRdLTL7YClrlXusT8wz7fljYbhqTsVN09KDVjJPYWH+3YKP0kT0E9EFmxDvVH6NQzXQGP6jqiU3CcTjK5IwFbowDMx9hjE+UgASSiQajPjKX3DDOCQtFZ1WG2xI+WgagDcp1VH7kcXVoibBoL+I0C+Zkl5UCDNzDwINTg7ox8V4x3W/7KP+dvaAlPN8fS+Y4V4MuXhqoe8Z+PNor7pdamyRPCsfd8Z+Z7EG0Zh1AA0YKOVNaD3e3grsFoS7DFV+I09k5Ec7/HgrIjLm1GjLQ27uWouryM1TnTMTRHiNTwlNkKXBOW/ufWOynrVizg1SlIVRWI+YduKeleFUmM3up2E/nO+FLB0Epvv+jShBfQ35ALYe4osNgzFjt3w=
+notifications:
   irc:
     channels:
     - chat.freenode.net#kubevirt
@@ -48,12 +49,9 @@ deploy:
   on:
     branch: master
     repo: kubevirt/containerized-data-importer
+    tags: true
   script: hack/version-and-deploy.sh $TRAVIS_TAG
   skip_cleanup: true
-  on:
-    branch: master
-    repo: kubevirt/containerized-data-importer
-    tags: true
 - provider: script
   script: make release
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-include version # Provides `RELEASE_TAG` variable for versioning
-
 REPO_ROOT=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Basenames
@@ -28,6 +26,7 @@ IMPORTER_BUILD=$(BUILD_DIR)/$(IMPORTER)
 # DOCKER TAG VARS
 REGISTRY=jcoperh
 RELEASE_REGISTRY=kubevirt
+RELEASE_TAG=$(shell cat $(REPO_ROOT)/version)
 CTRL_IMG_NAME=cdi-$(CONTROLLER)
 IMPT_IMG_NAME=cdi-$(IMPORTER)
 GIT_USER=$(shell git config --get user.email | sed 's/@.*//')
@@ -134,7 +133,7 @@ clean:
 	-rm -rf $(IMPORTER_BUILD)/tmp
 
 # push cdi-importer and cdi-controller images to kubevirt repo for general use. Intended to release stable image built from master branch.
-release: controller importer
+release:
 	@echo '********'
 	@echo 'Releasing CDI images'
 	docker tag $(IMPT_IMG_NAME) $(RELEASE_REGISTRY)/$(IMPT_IMG_NAME):$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ clean:
 	-rm -rf $(IMPORTER_BUILD)/tmp
 
 # push cdi-importer and cdi-controller images to kubevirt repo for general use. Intended to release stable image built from master branch.
-release:
+release: controller importer
 	@echo '********'
 	@echo 'Releasing CDI images'
 	docker tag $(IMPT_IMG_NAME) $(RELEASE_REGISTRY)/$(IMPT_IMG_NAME):$(RELEASE_TAG)

--- a/hack/version-and-deploy.sh
+++ b/hack/version-and-deploy.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# version-and-deploy.sh
+# This script will be executed by Travis CI upon the push of a new git tag to mark a new version of CDI.
+# When a new git tag is pushed to master, Travis will execute this script and pass in the tag value.
+# This script will replace the existing version values in known files, then commit the changes and push to master.
+# Next it will delete the human created tag in the remote repo, generate a new, identical tag for the
+# current commit, and push this tag to master.
+# This secondary push is required because the human created tag will reference 1 commit behind the new
+# version values.  It is necessary to shift this tag to the commit reflecting the new version.
+# This will cause CI to execute again.  version-and-deploy.sh will not execute if the passed in tag matches the
+# existing version and will exit with code 0.
+#
+# Parameters:
+#   $1: TRAVIS_TAG (git tag string)
+
+set -eou pipefail
+
+# doIncrement replaces the oldVersion value with the newVersion in the given file
+function doIncrement(){
+    local file=$1
+    local oldVersion=$2
+    local newVersion=$3
+
+    sed -i "s#$oldVersion#$newVersion#" $file
+}
+
+# commitAndPush indexes only the files where versions are known to be specified,
+# commits the changes, and pushes to master
+function commitAndPush(){
+    git add "${TARGET_FILES[*]}"
+    git commit -m "CI: versioning commit performed via automation"
+    git push origin master
+}
+
+# shiftTag deletes the human defined tag in the remote repo
+# and sets it again for the current commit. After the CI has updated
+# the version values in the project, a new commit will be pushed to origin.
+# This will cause the human defined tag to fall 1 behind the commit where the
+# values are changed.  Thus, it is necessary to "shift" the tag by one.
+function shiftTag(){
+    local versionTag=$1
+
+    git push origin ":refs/tags/$versionTag"
+    git tag -f -a "$versionTag" -m "CI: tag set via automation"
+    git push origin master "$versionTag"
+}
+
+# containerized-data-importer/
+REPO_ROOT=$(realpath $(dirname $0)/../)
+
+# All files where the version is specified
+VERSION_FILE="$REPO_ROOT/version"
+COMMON_VARS="$REPO_ROOT/pkg/common/common.go"
+CONTROLLER_MANIFEST="$REPO_ROOT/manifests/controller/cdi-controller-deployment.yaml"
+IMPORTER_MANIFEST="$REPO_ROOT/manifests/importer/importer-pod.yaml"
+
+# Array of target files for iterative ops
+TARGET_FILES=($COMMON_VARS $VERSION_FILE $CONTROLLER_MANIFEST $IMPORTER_MANIFEST)
+
+NEW_RELEASE_TAG=$1
+OLD_RELEASE_TAG=$(cat "$VERSION_FILE")
+
+# If the tags are the same, do nothing. We are likely in the 2nd iteration of the CI run and do not need to continue.
+if [[ "$OLD_RELEASE_TAG" == "$NEW_RELEASE_TAG" ]]; then
+    printf "Version %s matches tag %s: skipping.\n" "$OLD_RELEASE_TAG" "$NEW_RELEASE_TAG"
+    exit 0
+fi
+
+for f in  ${TARGET_FILES[*]}; do
+    doIncrement $f $OLD_RELEASE_TAG $NEW_RELEASE_TAG
+done
+commitAndPush
+shiftTag


### PR DESCRIPTION
To implement a common workflow using git tags to trigger versioning operations via Travis CI.

On pushing a git tag, Travis will execute a script that takes the tag value (`v*.*.*...`) and propagates it to specified locations where version is hard coded.  It commits this change and pushes it to master.  Next it deletes the human defined git tag and sets it again for the current commit (containing the updated versions).

Images are then built and published with the new version tag.