### PR TITLE
Revert "change controller labels from 'kubevirt.io' to 'cdi.io'"

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -17,12 +17,12 @@ import (
 
 const (
 	// pvc annotations
-	AnnEndpoint  = "cdi.io/storage.import.endpoint"
-	AnnSecret    = "cdi.io/storage.import.secretName"
-	AnnImportPod = "cdi.io/storage.import.importPodName"
+	AnnEndpoint  = "kubevirt.io/storage.import.endpoint"
+	AnnSecret    = "kubevirt.io/storage.import.secretName"
+	AnnImportPod = "kubevirt.io/storage.import.importPodName"
 	// importer pod annotations
-	AnnCreatedBy = "cdi.io/storage.createdByController"
-	AnnPodPhase  = "cdi.io/storage.import.pod.phase"
+	AnnCreatedBy = "kubevirt.io/storage.createdByController"
+	AnnPodPhase  = "kubevirt.io/storage.import.pod.phase"
 )
 
 type ImportController struct {


### PR DESCRIPTION
Roll back annotation changes to release a stable pre-change image