### PR TITLE
change cdi anno from `kubevirt.io/` to `cdi.kubevirt.io/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ Make copies of the [example manifests](./manifests/example) for editing. The nec
 ###### Edit golden-pvc.yaml:
 1.  `storageClassName:` The default StorageClass will be used if not set.  Otherwise, set to a desired StorageClass.
 
-1.  `kubevirt.io/storage.import.endpoint:` The full URL to the VM image in the format of: `http://www.myUrl.com/path/of/data` or `s3://bucketName/fileName`.
+1.  `cdi.kubevirt.io/storage.import.endpoint:` The full URL to the VM image in the format of: `http://www.myUrl.com/path/of/data` or `s3://bucketName/fileName`.
 
-1.  `kubevirt.io/storage.import.secretName:` (Optional) The name of the secret containing the authentication credentials required by the file server.
+1.  `cdi.kubevirt.io/storage.import.secretName:` (Optional) The name of the secret containing the authentication credentials required by the file server.
 
 ###### Edit endpoint-secret.yaml (Optional):
 
 > Note: Only set these values if the file server requires authentication credentials.
 
-1. `metadata.name:` Arbitrary name of the secret. Must match the PVC's `kubevirt.io/storage.import.secretName:`
+1. `metadata.name:` Arbitrary name of the secret. Must match the PVC's `cdi.kubevirt.io/storage.import.secretName:`
 
 1.  `accessKeyId:` Contains the endpoint's key and/or user name. This value **must be base64 encoded** with no extraneous linefeeds. Use `echo -n "xyzzy" | base64` or `printf "xyzzy" | base64` to avoid a trailing linefeed
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -50,9 +50,9 @@ The controller scans PVCs within its namespace by looking for specific annotatio
 
 **Golden PVC:** Long-lived Persistent Volume Claim manually created by an admin in the "golden" namespace. Linked to the Dynamic Provisioner via a reference to the storage class and automatically bound to a dynamically created Golden PV. The "default" provisioner and storage class is used in the example; however, the importer pod supports any dynamic provisioner which supports mountable volumes.
 
-- kubevirt.io/storage.import.endpoint:  Defined by the admin: the full endpoint URI for the source file/image
-- kubevirt.io/storage.import.secretName: Defined by the admin: the name of the existing Secret containing the credential to access the endpoint.
-- kubevirt.io/storage.import.status: Added by the controller: the current status of the PVC with respect to the import/copy process. Values include:  ”In process”, “Success”, “ Failed”
+- cdi.kubevirt.io/storage.import.endpoint:  Defined by the admin: the full endpoint URI for the source file/image
+- cdi.kubevirt.io/storage.import.secretName: Defined by the admin: the name of the existing Secret containing the credential to access the endpoint.
+- cdi.kubevirt.io/storage.import.status: Added by the controller: the current status of the PVC with respect to the import/copy process. Values include:  ”In process”, “Success”, “ Failed”
 
 **Object Store:** Arbitrary url-based storage location.  Currently we support http and S3 protocols.
 

--- a/manifests/example/golden-pvc.yaml
+++ b/manifests/example/golden-pvc.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    kubevirt.io/storage.import.endpoint: ""   # Required.  Format: (http||s3)://www.myUrl.com/path/of/data
-    kubevirt.io/storage.import.secretName: "" # Optional.  The name of the secret containing credentials for the data source
+    cdi.kubevirt.io/storage.import.endpoint: ""   # Required. Format: (http||s3)://www.myUrl.com/path/of/data
+    cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the data source
 spec:
   accessModes:
   - ReadWriteOnce

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -17,12 +17,12 @@ import (
 
 const (
 	// pvc annotations
-	AnnEndpoint  = "kubevirt.io/storage.import.endpoint"
-	AnnSecret    = "kubevirt.io/storage.import.secretName"
-	AnnImportPod = "kubevirt.io/storage.import.importPodName"
+	AnnEndpoint  = "cdi.kubevirt.io/storage.import.endpoint"
+	AnnSecret    = "cdi.kubevirt.io/storage.import.secretName"
+	AnnImportPod = "cdi.kubevirt.io/storage.import.importPodName"
 	// importer pod annotations
-	AnnCreatedBy = "kubevirt.io/storage.createdByController"
-	AnnPodPhase  = "kubevirt.io/storage.import.pod.phase"
+	AnnCreatedBy = "cdi.kubevirt.io/storage.createdByController"
+	AnnPodPhase  = "cdi.kubevirt.io/storage.import.pod.phase"
 )
 
 type ImportController struct {


### PR DESCRIPTION
This pr will require cdi consumers that use explict annotation in the triggering pvc to change to the new annotations.