### PR TITLE
[WIP] introspect file formats

### DIFF
--- a/cmd/importer/importer.go
+++ b/cmd/importer/importer.go
@@ -33,11 +33,11 @@ func main() {
 	acc, _ := ParseEnvVar(IMPORTER_ACCESS_KEY_ID, false)
 	sec, _ := ParseEnvVar(IMPORTER_SECRET_KEY, false)
 
-	glog.V(Vuser).Infof("beginning import from %q\n", ep)
+	glog.V(Vuser).Infoln("begin import process")
 	err := CopyImage(IMPORTER_WRITE_PATH, ep, acc, sec)
 	if err != nil {
 		glog.Errorf("%+v", err)
 		os.Exit(1)
 	}
-	glog.V(Vuser).Infoln("Import complete, exiting")
+	glog.V(Vuser).Infoln("import complete")
 }

--- a/hack/README.md
+++ b/hack/README.md
@@ -16,7 +16,7 @@ git push origin master -f
 
  ```
  cd $GOPATH/src/
- mkdir -p github.com/kubevirt && cd github.com/kubevirt
+ mkdir -p kubevirt.io/kubevirt && cd kubevirt.io/kubevirt
  git clone <your-forked-containerized-data-importer-url>
  cd containerized-data-importer
  git remote add upstream https://kubevirt.io/containerized-data-importer.git

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -53,8 +53,16 @@ type Header struct {
 	SizeLen	    int // in bytes
 }
 
+// simple map copy since := assignment copies the reference to the map, not contents.
+func CopyKnownHdrs() Headers {
+	m := make(Headers)
+	for k, v := range KnownHeaders {
+		m[k] = v
+	}
+	return m
+}
+
 func (h Header) Match(b []byte) bool {
-glog.Infof("\n***** match: len(b)=%d, h=%+v, slice=%+v\n",len(b),h,b[h.mgOffset:h.mgOffset+len(h.magicNumber)])
 	return bytes.Equal(b[h.mgOffset:h.mgOffset+len(h.magicNumber)], h.magicNumber)
 }
 
@@ -67,6 +75,6 @@ func (h *Header) Size(b []byte) (int64, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to determine original file size from %+v", s)
 	}
-	glog.V(Vdebug).Infof("Size: %q size in bytes: %d", h.Format, size)
+	glog.V(Vdebug).Infof("Size: %q size in bytes (at off %d:%d): %d", h.Format, h.SizeOff, h.SizeOff+h.SizeLen, size)
 	return size, nil
 }

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -18,7 +18,7 @@ const MaxExpectedHdrSize = 512
 // key is file format, eg. "gz" or "tar", value is metadata describing the layout for this hdr
 type Headers map[string]Header
 
-var KnownHeaders = Headers{
+var knownHeaders = Headers{
 	"gz": Header{
 		Format:      "gz",
 		magicNumber: []byte{0x1F, 0x8B},
@@ -60,7 +60,7 @@ type Header struct {
 // simple map copy since := assignment copies the reference to the map, not contents.
 func CopyKnownHdrs() Headers {
 	m := make(Headers)
-	for k, v := range KnownHeaders {
+	for k, v := range knownHeaders {
 		m[k] = v
 	}
 	return m
@@ -70,7 +70,7 @@ func (h Header) Match(b []byte) bool {
 	return bytes.Equal(b[h.mgOffset:h.mgOffset+len(h.magicNumber)], h.magicNumber)
 }
 
-func (h *Header) Size(b []byte) (int64, error) {
+func (h Header) Size(b []byte) (int64, error) {
 	if h.SizeLen == 0 { // no size is supported in this format's header
 		return 0, nil
 	}

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -24,29 +24,29 @@ var KnownHdrs = []*Header{
 		Format:      "gz",
 		magicNumber: []byte{0x1F, 0x8B},
 		// TODO: size not in hdr
-		sizeOff:     0,
-		sizeLen:     0,
+		SizeOff:     0,
+		SizeLen:     0,
 	},
 	{
 		Format:      "qcow2",
 		magicNumber: []byte{'Q', 'F', 'I', 0xfb},
 		mgOffset:    0,
-		sizeOff:     24,
-		sizeLen:     8,
+		SizeOff:     24,
+		SizeLen:     8,
 	},
 	{
 		Format:      "tar",
 		magicNumber: []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x20},
 		mgOffset:    0x101,
-		sizeOff:     124,
-		sizeLen:     12,
+		SizeOff:     124,
+		SizeLen:     8,
 	},
 	{
 		Format:      "xz",
 		magicNumber: []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
 		// TODO: size not in hdr
-		sizeOff:     0,
-		sizeLen:     0,
+		SizeOff:     0,
+		SizeLen:     0,
 	},
 }
 
@@ -54,8 +54,8 @@ type Header struct {
 	Format	    string
 	magicNumber []byte
 	mgOffset    int
-	sizeOff	    int // in bytes
-	sizeLen	    int // in bytes
+	SizeOff	    int // in bytes
+	SizeLen	    int // in bytes
 }
 
 func (h Header) match(b []byte) bool {
@@ -64,11 +64,10 @@ glog.Infof("\n***** match: len(b)=%d, h=%+v, slice=%+v\n",len(b),h,b[h.mgOffset:
 }
 
 func (h *Header) Size(b []byte) (int64, error) {
-	if h.sizeLen == 0 { // no size is supported in this format's header
+	if h.SizeLen == 0 { // no size is supported in this format's header
 		return 0, nil
 	}
-	s := hex.EncodeToString(b[h.sizeOff:h.sizeOff+h.sizeLen])
-glog.Infof("\n***** Size: bytes=%+v, hexstr=%q\n", b[h.sizeOff:h.sizeOff+h.sizeLen], s)
+	s := hex.EncodeToString(b[h.SizeOff:h.SizeOff+h.SizeLen])
 	size, err := strconv.ParseInt(s, 16, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to determine original file size from %+v", s)

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -1,0 +1,73 @@
+package image
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+const MaxExpectedHdrSize = 1024 // 1kb
+
+func MatchHeader(hdr *Header, r io.Reader, b []byte) (*Header, error) {
+	if b == nil {
+		b = make([]byte, MaxExpectedHdrSize)
+	}
+	n, err := r.Read(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read file header")
+	}
+	if n != MaxExpectedHdrSize {
+		return nil, errors.Errorf("could not read all %d bytes of file header", MaxExpectedHdrSize)
+	}
+	if hdr.match(b) {
+		return hdr, nil
+	}
+	return nil, nil
+}
+
+var KnownHdrs = []*Header{
+	{
+		Format:      "qcow2",
+		magicNumber: []byte{'Q', 'F', 'I', 0xfb},
+		mgOffset:    0,
+		sizeOff:     24,
+		sizeLen:     8,
+	},
+	{
+		Format:      "tar",
+		magicNumber: []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x00},
+		mgOffset:    0x101,
+		sizeOff:     124,
+		sizeLen:     8,
+	},
+	{
+		Format:      "xz",
+		magicNumber: []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
+		// TODO size
+		sizeOff:     0,
+		sizeLen:     8,
+	},
+}
+
+type Header struct {
+	Format	    string
+	magicNumber []byte
+	mgOffset    int
+	sizeOff	    int // in bytes
+	sizeLen	    int // in bytes
+}
+
+func (h *Header) match(b []byte) bool {
+	return bytes.Equal(b[h.mgOffset-1:h.mgOffset-1+len(h.magicNumber)], h.magicNumber)
+}
+
+// BIG OR LITTLE-ENDIAN?
+func (h *Header) Size(b []byte) (int64, error) {
+	size, n := binary.Varint(b[h.sizeOff-1:h.sizeOff-1+h.sizeLen])
+	if n != len(b) {
+		return 0, errors.Errorf("internal Size error: number of bytes read (%d) != expected (%d)", n, len(b))
+	}
+	return size, nil
+}

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -5,22 +5,26 @@ import (
 	"encoding/hex"
 	"strconv"
 
+	"github.com/golang/glog"
 	. "github.com/kubevirt/containerized-data-importer/pkg/common"
 	"github.com/pkg/errors"
-	"github.com/golang/glog"
 )
 
-const MaxExpectedHdrSize = 1024 // 1kb
+// Size of buffer used to read file headers.
+// Note: this is the size of tar's header. If a larger number is used the tar unarchive operation
+//   creates the destination file too large, by the difference between this const and 512.
+const MaxExpectedHdrSize = 512
 
-type Headers map[string]Header // key is file format, eg. .gz or .tar
+// key is file format, eg. "gz" or "tar", value is metadata describing the layout for this hdr
+type Headers map[string]Header
 
 var KnownHeaders = Headers{
 	"gz": Header{
 		Format:      "gz",
 		magicNumber: []byte{0x1F, 0x8B},
 		// TODO: size not in hdr
-		SizeOff:     0,
-		SizeLen:     0,
+		SizeOff: 0,
+		SizeLen: 0,
 	},
 	"qcow2": Header{
 		Format:      "qcow2",
@@ -40,17 +44,17 @@ var KnownHeaders = Headers{
 		Format:      "xz",
 		magicNumber: []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
 		// TODO: size not in hdr
-		SizeOff:     0,
-		SizeLen:     0,
+		SizeOff: 0,
+		SizeLen: 0,
 	},
 }
 
 type Header struct {
-	Format	    string
+	Format      string
 	magicNumber []byte
 	mgOffset    int
-	SizeOff	    int // in bytes
-	SizeLen	    int // in bytes
+	SizeOff     int // in bytes
+	SizeLen     int // in bytes
 }
 
 // simple map copy since := assignment copies the reference to the map, not contents.
@@ -70,7 +74,7 @@ func (h *Header) Size(b []byte) (int64, error) {
 	if h.SizeLen == 0 { // no size is supported in this format's header
 		return 0, nil
 	}
-	s := hex.EncodeToString(b[h.SizeOff:h.SizeOff+h.SizeLen])
+	s := hex.EncodeToString(b[h.SizeOff : h.SizeOff+h.SizeLen])
 	size, err := strconv.ParseInt(s, 16, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to determine original file size from %+v", s)

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -12,36 +12,31 @@ import (
 
 const MaxExpectedHdrSize = 1024 // 1kb
 
-func MatchHeader(hdr *Header, b []byte) *Header {
-	if hdr.match(b) {
-		return hdr
-	}
-	return nil
-}
+type Headers map[string]Header // key is file format, eg. .gz or .tar
 
-var KnownHdrs = []*Header{
-	{
+var KnownHeaders = Headers{
+	"gz": Header{
 		Format:      "gz",
 		magicNumber: []byte{0x1F, 0x8B},
 		// TODO: size not in hdr
 		SizeOff:     0,
 		SizeLen:     0,
 	},
-	{
+	"qcow2": Header{
 		Format:      "qcow2",
 		magicNumber: []byte{'Q', 'F', 'I', 0xfb},
 		mgOffset:    0,
 		SizeOff:     24,
 		SizeLen:     8,
 	},
-	{
+	"tar": Header{
 		Format:      "tar",
 		magicNumber: []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x20},
 		mgOffset:    0x101,
 		SizeOff:     124,
 		SizeLen:     8,
 	},
-	{
+	"xz": Header{
 		Format:      "xz",
 		magicNumber: []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
 		// TODO: size not in hdr
@@ -58,7 +53,7 @@ type Header struct {
 	SizeLen	    int // in bytes
 }
 
-func (h Header) match(b []byte) bool {
+func (h Header) Match(b []byte) bool {
 glog.Infof("\n***** match: len(b)=%d, h=%+v, slice=%+v\n",len(b),h,b[h.mgOffset:h.mgOffset+len(h.magicNumber)])
 	return bytes.Equal(b[h.mgOffset:h.mgOffset+len(h.magicNumber)], h.magicNumber)
 }

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"strconv"
 
-	"github.com/golang/glog"
-	. "github.com/kubevirt/containerized-data-importer/pkg/common"
 	"github.com/pkg/errors"
+	"github.com/golang/glog"
+	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 // Size of buffer used to read file headers.

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -1,7 +1,13 @@
 package image
 
 import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -74,4 +80,56 @@ func IsSupportedCompressArchiveType(fn string) bool {
 // Return string as lowercase with all spaces removed.
 func TrimString(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// supported file format magic strings;
+var (
+	GzMagicStr    = []byte{0x1F, 0x8B}
+	Qcow2MagicStr = []byte{'Q', 'F', 'I', 0xFB}
+	TarMagicStr   = []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x00, 0x30, 0x30} // ustar.00  OR just 6 bytes
+	XzMagicStr    = []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00, 0x00}
+)
+
+type offSizeT struct{
+	off int
+	size int
+}
+type magicMapT map[string]offSizeT
+var magicMap = magicMapT {
+	ExtImg:   offSizeT{off: 0, size: 0},
+	ExtGz:    offSizeT{off: 0, size: len(GzMagicStr)},
+	ExtQcow2: offSizeT{off: 0, size: len(Qcow2MagicStr)},
+	ExtTar:   offSizeT{off: 257, size: len(TarMagicStr)},
+	ExtXz:    offSizeT{off: 0, size: len(XzMagicStr)},
+}
+
+func FileFormat(ext string, r io.ReadCloser) (string, io.ReadCloser, error) {
+	offSize, ok := magicMap[ext]
+	if !ok || offSize.size == 0 {
+		return "", r, nil
+	}
+	magic, rdr, err := GetMagicString(r, offSize.off, offSize.size)
+	if err != nil {
+		return "", rdr, err
+	}
+	return magic, rdr, nil
+}
+
+
+// Return the magic string defined in `r`, starting at `offset` for `size` bytes. A MultiReader is
+// wrapped around the passed in reader so that the bytes read here are not lost. Zero is returned 
+// for all errors and cases where the magic string cannot be found.
+func GetMagicString(r io.ReadCloser, offset, size int) (string, io.ReadCloser, error) {
+	bufSize := offset + size
+	buf := make([]byte, bufSize)
+	cnt, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF {
+		return "", r, errors.Wrap(err, "unable to read byte buffer")
+	}
+	multiR := ioutil.NopCloser(io.MultiReader(bytes.NewReader(buf), r)) // don't lose bytes just read
+	if cnt < bufSize {
+		return "", multiR, errors.Errorf("only %d bytes read to find magic num at offset %d of size %d", cnt, offset, size)
+	}
+	magicStr := hex.EncodeToString(buf[offset:])
+	return magicStr, multiR, nil
 }

--- a/pkg/image/validate.go
+++ b/pkg/image/validate.go
@@ -1,13 +1,7 @@
 package image
 
 import (
-	"bytes"
-	"encoding/hex"
-	"io"
-	"io/ioutil"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -80,56 +74,4 @@ func IsSupportedCompressArchiveType(fn string) bool {
 // Return string as lowercase with all spaces removed.
 func TrimString(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
-}
-
-// supported file format magic strings;
-var (
-	GzMagicStr    = []byte{0x1F, 0x8B}
-	Qcow2MagicStr = []byte{'Q', 'F', 'I', 0xFB}
-	TarMagicStr   = []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x00, 0x30, 0x30} // ustar.00  OR just 6 bytes
-	XzMagicStr    = []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00, 0x00}
-)
-
-type offSizeT struct{
-	off int
-	size int
-}
-type magicMapT map[string]offSizeT
-var magicMap = magicMapT {
-	ExtImg:   offSizeT{off: 0, size: 0},
-	ExtGz:    offSizeT{off: 0, size: len(GzMagicStr)},
-	ExtQcow2: offSizeT{off: 0, size: len(Qcow2MagicStr)},
-	ExtTar:   offSizeT{off: 257, size: len(TarMagicStr)},
-	ExtXz:    offSizeT{off: 0, size: len(XzMagicStr)},
-}
-
-func FileFormat(ext string, r io.ReadCloser) (string, io.ReadCloser, error) {
-	offSize, ok := magicMap[ext]
-	if !ok || offSize.size == 0 {
-		return "", r, nil
-	}
-	magic, rdr, err := GetMagicString(r, offSize.off, offSize.size)
-	if err != nil {
-		return "", rdr, err
-	}
-	return magic, rdr, nil
-}
-
-
-// Return the magic string defined in `r`, starting at `offset` for `size` bytes. A MultiReader is
-// wrapped around the passed in reader so that the bytes read here are not lost. Zero is returned 
-// for all errors and cases where the magic string cannot be found.
-func GetMagicString(r io.ReadCloser, offset, size int) (string, io.ReadCloser, error) {
-	bufSize := offset + size
-	buf := make([]byte, bufSize)
-	cnt, err := io.ReadFull(r, buf)
-	if err != nil && err != io.EOF {
-		return "", r, errors.Wrap(err, "unable to read byte buffer")
-	}
-	multiR := ioutil.NopCloser(io.MultiReader(bytes.NewReader(buf), r)) // don't lose bytes just read
-	if cnt < bufSize {
-		return "", multiR, errors.Errorf("only %d bytes read to find magic num at offset %d of size %d", cnt, offset, size)
-	}
-	magicStr := hex.EncodeToString(buf[offset:])
-	return magicStr, multiR, nil
 }

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -17,11 +17,11 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	. "kubevirt.io/containerized-data-importer/pkg/common"
-	"kubevirt.io/containerized-data-importer/pkg/image"
 	"github.com/minio/minio-go"
 	"github.com/pkg/errors"
 	"github.com/xi2/xz"
+	. "kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/image"
 )
 
 type DataStreamInterface interface {

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -25,10 +25,11 @@ import (
 )
 
 type DataStreamInterface interface {
-	dataStreamSelector() (Reader, error)
-	s3() (Reader, error)
-	http() (Reader, error)
-	local() (Reader, error)
+	dataStreamSelector() error
+	s3() (*Reader, error)
+	http() (*Reader, error)
+	local() (*Reader, error)
+	fileFormatSelector(h *image.Header) error
 	parseDataPath() (string, string)
 	Read(p []byte) (int, error)
 	Close() error
@@ -101,37 +102,43 @@ func (d dataStream) Close() error {
 	return closeReaders(d.Readers)
 }
 
-// Based on the enpoint scheme, return a scheme-specific dataStream Reader.
-func (d dataStream) dataStreamSelector() (Reader, error) {
+// Based on the endpoint scheme, append the scheme-specific reader to the receiver's
+// reader stack.
+func (d *dataStream) dataStreamSelector() (err error) {
+	var r *Reader
 	switch d.Url.Scheme {
 	case "s3":
-		return d.s3()
+		r, err = d.s3()
 	case "http", "https":
-		return d.http()
+		r, err = d.http()
 	case "file":
-		return d.local()
+		r, err = d.local()
 	default:
-		return Reader{}, errors.Errorf("invalid url scheme: %q", d.Url.Scheme)
+		return errors.Errorf("invalid url scheme: %q", d.Url.Scheme)
 	}
+	if r != nil {
+		d.Readers = append(d.Readers, *r)
+	}
+	return err
 }
 
-func (d dataStream) s3() (Reader, error) {
+func (d dataStream) s3() (*Reader, error) {
 	glog.V(Vdebug).Infoln("Using S3 client to get data")
 	bucket := d.Url.Host
 	object := strings.Trim(d.Url.Path, "/")
 	mc, err := minio.NewV4(IMPORTER_S3_HOST, d.accessKeyId, d.secretKey, false)
 	if err != nil {
-		return Reader{}, errors.Wrapf(err, "could not build minio client for %q", d.Url.Host)
+		return nil, errors.Wrapf(err, "could not build minio client for %q", d.Url.Host)
 	}
 	glog.V(Vadmin).Infof("Attempting to get object %q via S3 client\n", d.Url.String())
 	objectReader, err := mc.GetObject(bucket, object, minio.GetObjectOptions{})
 	if err != nil {
-		return Reader{}, errors.Wrapf(err, "could not get s3 object: \"%s/%s\"", bucket, object)
+		return nil, errors.Wrapf(err, "could not get s3 object: \"%s/%s\"", bucket, object)
 	}
-	return Reader{RdrType: RdrS3, Rdr: objectReader}, nil
+	return &Reader{RdrType: RdrS3, Rdr: objectReader}, nil
 }
 
-func (d dataStream) http() (Reader, error) {
+func (d dataStream) http() (*Reader, error) {
 	client := http.Client{
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			r.SetBasicAuth(d.accessKeyId, d.secretKey) // Redirects will lose basic auth, so reset them manually
@@ -140,7 +147,7 @@ func (d dataStream) http() (Reader, error) {
 	}
 	req, err := http.NewRequest("GET", d.Url.String(), nil)
 	if err != nil {
-		return Reader{}, errors.Wrap(err, "could not create HTTP request")
+		return nil, errors.Wrap(err, "could not create HTTP request")
 	}
 	if len(d.accessKeyId) > 0 && len(d.secretKey) > 0 {
 		req.SetBasicAuth(d.accessKeyId, d.secretKey)
@@ -148,23 +155,23 @@ func (d dataStream) http() (Reader, error) {
 	glog.V(Vadmin).Infof("Attempting to get object %q via http client\n", d.Url.String())
 	resp, err := client.Do(req)
 	if err != nil {
-		return Reader{}, errors.Wrap(err, "HTTP request errored")
+		return nil, errors.Wrap(err, "HTTP request errored")
 	}
 	if resp.StatusCode != 200 {
 		glog.Errorf("http: expected status code 200, got %d", resp.StatusCode)
-		return Reader{}, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
+		return nil, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
 	}
-	return Reader{RdrType: RdrHttp, Rdr: resp.Body}, nil
+	return &Reader{RdrType: RdrHttp, Rdr: resp.Body}, nil
 }
 
-func (d dataStream) local() (Reader, error) {
+func (d dataStream) local() (*Reader, error) {
 	fn := d.Url.Path
 	f, err := os.Open(fn)
 	if err != nil {
-		return Reader{}, errors.Wrapf(err, "could not open file %q", fn)
+		return nil, errors.Wrapf(err, "could not open file %q", fn)
 	}
 	//note: if poor perf here consider wrapping this with a buffered i/o Reader
-	return Reader{RdrType: RdrFile, Rdr: f}, nil
+	return &Reader{RdrType: RdrFile, Rdr: f}, nil
 }
 
 // Copy the source endpoint (vm image) to the provided destination path.
@@ -199,13 +206,12 @@ func CopyImage(dest, endpoint, accessKey, secKey string) error {
 // Note: readers are not closed here, see dataStream.Close().
 // Assumption: a particular header format only appears once in the data stream. Eg. foo.gz.gz is not supported.
 func (d *dataStream) constructReaders() error {
-	glog.V(Vadmin).Infof("create the initial Reader based on the url's %q scheme", d.Url.Scheme)
-	r, err := d.dataStreamSelector()
+	glog.V(Vadmin).Infof("create the initial Reader based on the endpoint's %q scheme", d.Url.Scheme)
+	// create the scheme-specific source reader and append it to dataStream readers stack
+	err := d.dataStreamSelector()
 	if err != nil {
 		return errors.WithMessage(err, "could not get data reader")
 	}
-	// append source reader to datastream reader stack
-	d.Readers = append(d.Readers, r)
 
 	// loop through all supported file formats until we do not find a header we recognize
 	knownHdrs := image.CopyKnownHdrs() // need local copy since keys are removed
@@ -222,13 +228,14 @@ func (d *dataStream) constructReaders() error {
 		}
 		glog.V(Vadmin).Infof("found header of type %q\n", hdr.Format)
 
-		// create format-specific reader and append it to dataStream Readers slice
+		// create format-specific reader and append it to dataStream readers stack
 		err = d.fileFormatSelector(hdr)
 		if err != nil {
 			return errors.WithMessage(err, "could not create compression/unarchive reader")
 		}
 	}
-	if len(d.Readers) <= 2 { // 1st rdr is source, 2nd rdr is multi-rdr, >2 means we have additional formats
+	if len(d.Readers) <= 2 {
+		// 1st rdr is source, 2nd rdr is multi-rdr, >2 means we have additional formats
 		glog.V(Vdebug).Infof("constructReaders: no headers found for file %q\n", d.Url.Path)
 	}
 	glog.V(Vadmin).Infof("done processing %q headers\n", d.Url.Path)
@@ -240,75 +247,82 @@ func (d dataStream) topReader() io.ReadCloser {
 	return d.Readers[len(d.Readers)-1].Rdr
 }
 
-// Based on the passed in header, return the format-specific reader.
-func (d *dataStream) fileFormatSelector(hdr *image.Header) error {
+// Based on the passed in header, append the format-specific reader to the readers stack,
+// and update the receiver Size field. Note: a bool is set in the receiver for qcow2 files.
+func (d *dataStream) fileFormatSelector(hdr *image.Header) (err error) {
+	var r *Reader
 	switch hdr.Format {
 	case "gz":
-		return d.gzReader()
+		r, d.Size, err = d.gzReader()
 	case "qcow2":
-		return d.qcow2NopReader(hdr)
+		r, d.Size, err = d.qcow2NopReader(hdr)
+		d.Qemu = true
 	case "tar":
-		return d.tarReader()
+		r, d.Size, err = d.tarReader()
 	case "xz":
-		return d.xzReader()
+		r, d.Size, err = d.xzReader()
 	default:
 		return errors.Errorf("mismatch between supported file formats and this header type: %q", hdr.Format)
 	}
-}
-
-//NOTE: size in gz is stored in the last 4 bytes of the file. This requires the file to be decompressed in
-//  order to get its original size. For now 0 is returned.
-// Assumes a single file was gzipped.
-//TODO: support gz size.
-func (d *dataStream) gzReader() error {
-	gz, err := gzip.NewReader(d.topReader())
-	if err != nil {
-		return errors.Wrap(err, "could not create gzip reader")
+	if r != nil {
+		d.Readers = append(d.Readers, *r)
 	}
-	glog.V(Vadmin).Infof("gzip: extracting %q\n", gz.Name)
-	d.Readers = append(d.Readers, Reader{RdrType: RdrGz, Rdr: gz})
-	d.Size = 0 //TODO: implement size
 	return nil
 }
 
+// Return the gz reader and the size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was gzipped.
+//NOTE: size in gz is stored in the last 4 bytes of the file. This probably requires the file
+//  to be decompressed in order to get its original size. For now 0 is returned.
+//TODO: support gz size.
+func (d dataStream) gzReader() (*Reader, int64, error) {
+	gz, err := gzip.NewReader(d.topReader())
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "could not create gzip reader")
+	}
+	glog.V(Vadmin).Infof("gzip: extracting %q\n", gz.Name)
+	size := int64(0) //TODO: implement size
+	return &Reader{RdrType: RdrGz, Rdr: gz}, size, nil
+}
+
+// Return the size of the endpoint "through the eye" of the previous reader. Note: there is no
+// qcow2 reader so nil is returned so that nothing is appended to the reader stack.
 // Note: size is stored at offset 24 in the qcow2 header.
-// Note: there is no qcow2 reader.
-func (d *dataStream) qcow2NopReader(h *image.Header) error {
+func (d dataStream) qcow2NopReader(h *image.Header) (*Reader, int64, error) {
 	s := hex.EncodeToString(d.buf[h.SizeOff : h.SizeOff+h.SizeLen])
 	size, err := strconv.ParseInt(s, 16, 64)
 	if err != nil {
-		return errors.Wrapf(err, "unable to determine original qcow2 file size from %+v", s)
+		return nil, 0, errors.Wrapf(err, "unable to determine original qcow2 file size from %+v", s)
 	}
-	d.Qemu = true
-	d.Size = size
-	return nil
+	return nil, size, nil
 }
 
+// Return the xz reader and size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was compressed. Note: the xz reader is not a closer so we wrap a
+// nop Closer around it.
 //NOTE: size is not stored in the xz header. This may require the file to be decompressed in
 //  order to get its original size. For now 0 is returned.
-// Assumes a single file was gzipped.
 //TODO: support gz size.
-func (d *dataStream) xzReader() error {
+func (d dataStream) xzReader() (*Reader, int64, error) {
 	xz, err := xz.NewReader(d.topReader(), 0) //note: default dict size may be too small
 	if err != nil {
-		return errors.Wrap(err, "could not create xz reader")
+		return nil, 0, errors.Wrap(err, "could not create xz reader")
 	}
-	d.Readers = append(d.Readers, Reader{RdrType: RdrXz, Rdr: ioutil.NopCloser(xz)})
-	d.Size = 0 //TODO: implement size
-	return nil
+	size := int64(0) //TODO: implement size
+	return &Reader{RdrType: RdrXz, Rdr: ioutil.NopCloser(xz)}, size, nil
 }
 
-// Assumes a single file was archived.
-func (d *dataStream) tarReader() error {
+// Return the tar reader and size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was archived. 
+// Note: the size stored in the header is used rather than raw metadata.
+func (d dataStream) tarReader() (*Reader, int64, error) {
 	tr := tar.NewReader(d.topReader())
 	hdr, err := tr.Next() // advance cursor to 1st (and only) file in tarball
 	if err != nil {
-		return errors.Wrap(err, "could not read tar header")
+		return nil, 0, errors.Wrap(err, "could not read tar header")
 	}
 	glog.V(Vadmin).Infof("tar: extracting %q\n", hdr.Name)
-	d.Size = hdr.Size
-	d.Readers = append(d.Readers, Reader{RdrType: RdrTar, Rdr: ioutil.NopCloser(tr)})
-	return nil
+	return &Reader{RdrType: RdrTar, Rdr: ioutil.NopCloser(tr)}, hdr.Size, nil
 }
 
 // Return the matching header, if one is found, from the passed-in map of known headers.

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	. "kubevirt.io/containerized-data-importer/pkg/common"
 	"github.com/pkg/errors"
+	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 func ParseEnvVar(envVarName string, decode bool) (string, error) {

--- a/pkg/lib/size/size.go
+++ b/pkg/lib/size/size.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strconv"
 
-	. "kubevirt.io/containerized-data-importer/pkg/importer"
 	"github.com/pkg/errors"
+	. "kubevirt.io/containerized-data-importer/pkg/importer"
 )
 
 // Return the size in bytes of the provided endpoint. If the endpoint was archived, compressed or converted to

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"kubevirt.io/containerized-data-importer/pkg/image"
 	"github.com/pkg/errors"
+	"kubevirt.io/containerized-data-importer/pkg/image"
 )
 
 var formatTable = map[string]func(string) (string, error){

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -17,8 +17,9 @@ var formatTable = map[string]func(string) (string, error){
 	"":             transformNoop,
 }
 
+// create file based on targetFormat extensions and return created file's name.
+// note: intermediate files are removed.
 func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
-
 	outFile := srcFile
 	var err error
 	var prevFile string
@@ -31,6 +32,7 @@ func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
 		if len(tf) == 0 {
 			continue
 		}
+		// invoke conversion func
 		outFile, err = f(outFile)
 		if prevFile != srcFile {
 			os.Remove(prevFile)

--- a/test/functional/controller/controller_test.go
+++ b/test/functional/controller/controller_test.go
@@ -5,11 +5,11 @@ package controller
 import (
 	"fmt"
 
-	. "kubevirt.io/containerized-data-importer/pkg/common"
-	. "kubevirt.io/containerized-data-importer/pkg/controller"
+	"github.com/pkg/errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
+	. "kubevirt.io/containerized-data-importer/pkg/common"
+	. "kubevirt.io/containerized-data-importer/pkg/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/test/functional/image/validation_test.go
+++ b/test/functional/image/validation_test.go
@@ -7,9 +7,9 @@ import (
 	"math/rand"
 	"path/filepath"
 
-	. "kubevirt.io/containerized-data-importer/pkg/image"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "kubevirt.io/containerized-data-importer/pkg/image"
 )
 
 var _ = Describe("Validate file and extensions", func() {

--- a/test/functional/importer/datastream_test.go
+++ b/test/functional/importer/datastream_test.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
 	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
 	f "kubevirt.io/containerized-data-importer/test/framework"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 type testCase struct {

--- a/test/functional/importer/datastream_test.go
+++ b/test/functional/importer/datastream_test.go
@@ -129,15 +129,18 @@ var _ = Describe("Streaming Data Conversion", func() {
 			},
 		}
 
+		var i int
 		for _, t := range tests {
-			desc := t.testDesc
+			i++
+			desc := fmt.Sprintf("[%d] %s", i, t.testDesc)
 			ff := t.expectFormats
 			fn := t.inFileName
 			of := t.outFileName
 			useVSize := t.useVirtSize
 
 			It(desc, func() {
-				By(fmt.Sprintf("Stating the source image file %q", fn))
+				By(fmt.Sprintf("[%d] Begin test on image file %q", i, fn))
+				By(fmt.Sprintf("stat() file %q", fn))
 				finfo, err := os.Stat(fn)
 				Expect(err).NotTo(HaveOccurred())
 				size := finfo.Size()
@@ -153,7 +156,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 				}()
 				Expect(sampleFilename).To(Equal(of), "Test data filename doesn't match expected file name.")
 
-				dest := filepath.Join(os.TempDir(), of)
+				dest := fmt.Sprintf("%s.%d", filepath.Join(os.TempDir(), outfileBase), i)
 				fUrl := "file:/" + sampleFilename
 				By(fmt.Sprintf("Copying sample file to %q using `local` dataStream w/o auth", dest))
 				err = importer.CopyImage(dest, fUrl, "", "")
@@ -174,14 +177,14 @@ var _ = Describe("Streaming Data Conversion", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(newSize).To(Equal(size))
 				} else {
-					By("Stating output file")
-					finfo, err := os.Stat(dest)
+					By("stat() output file")
+					finfo, err = os.Stat(dest)
 					Expect(err).NotTo(HaveOccurred())
 					newSize := finfo.Size()
 					Expect(newSize).To(Equal(size))
 				}
-
 				//Expect(output.Bytes()).To(Equal(size)) // TODO replace with checksum?
+				By(fmt.Sprintf("[%d] End test on image file %q", i, fn))
 			})
 		}
 	})

--- a/test/functional/importer/importer_test.go
+++ b/test/functional/importer/importer_test.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"path/filepath"
 
-	. "kubevirt.io/containerized-data-importer/pkg/importer"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "kubevirt.io/containerized-data-importer/pkg/importer"
 )
 
 type fakeDataStream struct {


### PR DESCRIPTION
Instead of using file extension strings, determine file type based on its magic number. This becomes the foundation for providing the source endpoint file size, as needed by the data-controller CRD, without decompressing and copying the entire file.

Potential Issues:
1. file extensions are completely ignored so no error/warning is reported if the inferred file type differs from its extension
2. Matt Holt's [tar archiver](https://github.com/mholt/archiver) uses file extensions first and introspection second to determine file type.
3. the `dataStream` struct contains a 512 byte buffer -- the exact size of a tar header. A larger buffer  leaves residual bytes in the multi-reader that are added back to the unarchived target file. It's possible that this buffer could be increased if point 4 below works.
4. the reader stack (_pkg/importer/dataStream.go_ `constructReaders`) may be overly complex. Perhaps, after we determine the file formats, we should reconstruct the reader stack and remove the intermediate multi-readers?

Known Issues:
1. _gzip_ and _xy_ do not contain a size field in their headers. The typical answer to the question of how to determine the original size of a gzip file is _you have to decompress the entire file_. Note: gzip contains the size in the last 4 bytes of the file but this is problematic due to a) a 4gb file size limit, b) only works with a single gzipped file (which is ok from a kubevirt perspective).

Note: some of the changed files are due to some kind of rebase error I made trying to rebase in pr #198. A few others are just due to running `gofmt`.