### PR TITLE
fix transient failure in datavolume unit tests

### DIFF
--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -222,8 +222,8 @@ func filterInformerActions(actions []core.Action) []core.Action {
 		if len(action.GetNamespace()) == 0 &&
 			(action.Matches("list", "dataVolumes") ||
 				action.Matches("watch", "dataVolumes") ||
-				action.Matches("list", "pvcs") ||
-				action.Matches("watch", "pvcs")) {
+				action.Matches("list", "persistentvolumeclaims") ||
+				action.Matches("watch", "persistentvolumeclaims")) {
 			continue
 		}
 		ret = append(ret, action)


### PR DESCRIPTION
sometimes the datavolume tests fail because I wasn't properly filtering out list/watch actions. 