### PR TITLE
[WIP] Functional Test to use relative base image path

### DIFF
--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"kubevirt.io/containerized-data-importer/pkg/image"
+	"fmt"
 )
 
 var formatTable = map[string]func(string) (string, error){
@@ -19,8 +20,10 @@ var formatTable = map[string]func(string) (string, error){
 
 // create file based on targetFormat extensions and return created file's name.
 // note: intermediate files are removed.
-func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
-	outFile := srcFile
+// TODO write the formatted file somewhere useful
+func FormatTestData(srcFile, outDir string, targetFormats ...string) (string, error) {
+
+	fmt.Printf("[fileConversion.go:L26] %s<%T>: %+v\n", "outDir", outDir, outDir)
 	var err error
 	var prevFile string
 
@@ -33,16 +36,16 @@ func FormatTestData(srcFile string, targetFormats ...string) (string, error) {
 			continue
 		}
 		// invoke conversion func
-		outFile, err = f(outFile)
+		outDir, err = f(outDir)
 		if prevFile != srcFile {
 			os.Remove(prevFile)
 		}
 		if err != nil {
 			return "", errors.Wrap(err, "could not format test data")
 		}
-		prevFile = outFile
+		prevFile = outDir
 	}
-	return outFile, nil
+	return outDir, nil
 }
 
 func transformFile(srcFile, outfileName, osCmd string, osArgs ...string) (string, error) {

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -77,10 +77,12 @@ func xzCmd(src, tgtDir string) (string, error) {
 
 func qcow2Cmd(srcfile, tgtDir string) (string, error) {
 	tgt := strings.Replace(filepath.Base(srcfile), ".iso", image.ExtQcow2, 1)
+	fmt.Printf("[fileConversion.go:L80] %s<%T>: %+v\n", "tgt", tgt, tgt)
 	tgt = filepath.Join(tgtDir, tgt)
+	fmt.Printf("[fileConversion.go:L82] %s<%T>: %+v\n", "tgt", tgt, tgt)
 	args := []string{"convert", "-f", "raw", "-O", "qcow2", srcfile, tgt}
 
-	if err := doCmdAndVerifyFile(tgt, "gzip", args...); err != nil {
+	if err := doCmdAndVerifyFile(tgt, "qemu-img", args...); err != nil {
 		return "", err
 	}
 	return tgt, nil

--- a/test/functional/importer/datastream_test.go
+++ b/test/functional/importer/datastream_test.go
@@ -4,7 +4,6 @@ package importer
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,13 +12,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
 	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
 	f "kubevirt.io/containerized-data-importer/test/framework"
-	"time"
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 var _ = Describe("Streaming Data Conversion", func() {
@@ -39,23 +37,23 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 		var tmpTestDir string
 		BeforeEach(func() {
-			tmpDir := os.TempDir()
+			//tmpDir := os.TempDir()
+			tmpDir, _ := filepath.Abs(baseImageRelPath)
 			tmpTestDir = testDir(tmpDir)
 			if err != nil {
 				Fail(fmt.Sprintf("Failed created test dir: %v\n", err))
 			}
 
-			err = os.Mkdir(tmpTestDir, 0666)
+			err = os.Mkdir(tmpTestDir, os.ModePerm)
 			if err != nil {
 				Fail(fmt.Sprintf("Could not create tmp file: %v\n ", err))
 			}
-			By(fmt.Sprintf("Creating temporary dir %s", tmpTestDir))
+			By(fmt.Sprintf("Created temporary dir %s", tmpTestDir))
 		})
 
-
 		AfterEach(func() {
-			By(fmt.Sprintf("Cleaning up temporary dir %s", tmpTestDir) )
-			os.Remove(tmpTestDir)
+			By(fmt.Sprintf("Cleaning up temporary dir %s", tmpTestDir))
+			//os.Remove(tmpTestDir)
 		})
 
 		// Test Table
@@ -206,13 +204,6 @@ func getImageVirtualSize(outFile string) int64 {
 }
 
 func testDir(parent string) string {
-	const suffixSize = 8
-	sufSource := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-
-	rand.Seed(time.Now().UnixNano())
-	suf := make([]rune, suffixSize)
-	for i := range suf {
-		suf[i] = sufSource[rand.Intn(len(sufSource))]
-	}
+	suf := util.RandAlphaNum(12)
 	return filepath.Join(parent, fmt.Sprintf(".tmp-%s", string(suf)))
 }

--- a/test/functional/importer/datastream_test.go
+++ b/test/functional/importer/datastream_test.go
@@ -18,6 +18,7 @@ import (
 	f "kubevirt.io/containerized-data-importer/test/framework"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	"syscall"
 )
 
 var _ = Describe("Streaming Data Conversion", func() {
@@ -43,8 +44,8 @@ var _ = Describe("Streaming Data Conversion", func() {
 			if err != nil {
 				Fail(fmt.Sprintf("Failed created test dir: %v\n", err))
 			}
-
-			err = os.Mkdir(tmpTestDir, os.ModePerm)
+			syscall.Umask(0000)
+			err = os.Mkdir(tmpTestDir, 0777)
 			if err != nil {
 				Fail(fmt.Sprintf("Could not create tmp file: %v\n ", err))
 			}
@@ -53,7 +54,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 		AfterEach(func() {
 			By(fmt.Sprintf("Cleaning up temporary dir %s", tmpTestDir))
-			//os.Remove(tmpTestDir)
+			os.Remove(tmpTestDir)
 		})
 
 		// Test Table
@@ -151,11 +152,17 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 				By(fmt.Sprintf("Converting sample file to format: %v", ff))
 				// Generate the expected data format from the random bytes
+				fmt.Printf("[datastream_test.go:L155] %s<%T>: %+v\n", "origFile", origFile, origFile)
+				fmt.Printf("[datastream_test.go:L156] %s<%T>: %+v\n", "tmpTestDir", tmpTestDir, tmpTestDir)
 				testSample, err := f.FormatTestData(origFile, tmpTestDir, ff...)
 				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
 
+				fmt.Printf("[datastream_test.go:L158] %s<%T>: %+v\n", "testSample", testSample, testSample)
+
 				testSample = "file:/" + testSample
+				fmt.Printf("[datastream_test.go:L163] %s<%T>: %+v\n", "testSample", testSample, testSample)
 				testTarget := filepath.Join(tmpTestDir, common.IMPORTER_WRITE_FILE)
+				fmt.Printf("[datastream_test.go:L165] %s<%T>: %+v\n", "testTarget", testTarget, testTarget)
 				By(fmt.Sprintf("Processing sample file %q to %q", testSample, testTarget))
 				err = importer.CopyImage(testTarget, testSample, "", "")
 				Expect(err).NotTo(HaveOccurred())

--- a/test/functional/importer/datastream_test.go
+++ b/test/functional/importer/datastream_test.go
@@ -38,8 +38,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 		var tmpTestDir string
 		BeforeEach(func() {
-			//tmpDir := os.TempDir()
-			tmpDir, _ := filepath.Abs(baseImageRelPath)
+			tmpDir := os.TempDir()
 			tmpTestDir = testDir(tmpDir)
 			if err != nil {
 				Fail(fmt.Sprintf("Failed created test dir: %v\n", err))
@@ -54,7 +53,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 		AfterEach(func() {
 			By(fmt.Sprintf("Cleaning up temporary dir %s", tmpTestDir))
-			os.Remove(tmpTestDir)
+			os.RemoveAll(tmpTestDir)
 		})
 
 		// Test Table
@@ -152,17 +151,11 @@ var _ = Describe("Streaming Data Conversion", func() {
 
 				By(fmt.Sprintf("Converting sample file to format: %v", ff))
 				// Generate the expected data format from the random bytes
-				fmt.Printf("[datastream_test.go:L155] %s<%T>: %+v\n", "origFile", origFile, origFile)
-				fmt.Printf("[datastream_test.go:L156] %s<%T>: %+v\n", "tmpTestDir", tmpTestDir, tmpTestDir)
 				testSample, err := f.FormatTestData(origFile, tmpTestDir, ff...)
 				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
 
-				fmt.Printf("[datastream_test.go:L158] %s<%T>: %+v\n", "testSample", testSample, testSample)
-
-				testSample = "file:/" + testSample
-				fmt.Printf("[datastream_test.go:L163] %s<%T>: %+v\n", "testSample", testSample, testSample)
+				testSample = "file://" + testSample
 				testTarget := filepath.Join(tmpTestDir, common.IMPORTER_WRITE_FILE)
-				fmt.Printf("[datastream_test.go:L165] %s<%T>: %+v\n", "testTarget", testTarget, testTarget)
 				By(fmt.Sprintf("Processing sample file %q to %q", testSample, testTarget))
 				err = importer.CopyImage(testTarget, testSample, "", "")
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Currently, functional tests require a specialized container environment where the test is compiled into a binary and copied to `/` along with an expected base iso.  This puts too much responsibility on `make` and disallows devs from running the tests in a host env.  Additionally, it requires a make recipe for every single functional test individually, which is not extensible.

This PR refactors the datastream functional test to access the included ISO directly and to write test images to a known tmp directory.  This makes the test solely responsible for setting up it's own dependencies and decouples it from the build workflow entirely.