### PR TITLE
Fix local transport path to file

### DIFF
--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -183,7 +183,7 @@ func (d dataStream) http() (io.ReadCloser, error) {
 }
 
 func (d dataStream) local() (io.ReadCloser, error) {
-	fn := d.Url.Path
+	fn := filepath.Join(d.Url.Host, d.Url.Path)
 	f, err := os.Open(fn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not open file %q", fn)


### PR DESCRIPTION
The file path for local transport is divided between the url.Host and url.Path fields, resulting in a truncated path to a file.

e.g. `file:///root/go/src/github.com/` becomes
```
Host: /root/
Path: go/src/github.com
```

This PR fixes the bug to return a full path to the file.