### PR TITLE
add initial unit tests for importer package

### DIFF
--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -2,9 +2,11 @@ package importer
 
 import (
 	"io"
-	"net/url"
-	"reflect"
+	"os"
+	"strings"
 	"testing"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 func TestParseEnvVar(t *testing.T) {
@@ -12,16 +14,49 @@ func TestParseEnvVar(t *testing.T) {
 		envVarName string
 		decode     bool
 	}
+
+	os.Setenv("TESTKEY", "KEYVALUE")
+	os.Setenv("ENCODEDKEY", "RU5DT0RFRFZBTFVF")
+	os.Setenv("BADKEY", "")
+
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:    "successfully get EnvVar",
+			args:    args{"TESTKEY", false},
+			want:    "KEYVALUE",
+			wantErr: false,
+		},
+		{
+			name:    "successfully get encoded EnvVar",
+			args:    args{"ENCODEDKEY", true},
+			want:    "ENCODEDVALUE",
+			wantErr: false,
+		},
+		{
+			name:    "invalid EnvVar",
+			args:    args{"FAKETESTKEY", false},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "produce error when trying to decode non-encoded EnvVar",
+			args:    args{"BADKEY", true},
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := ParseEnvVar(tt.args.envVarName, tt.args.decode); got != tt.want {
+			got, err := ParseEnvVar(tt.args.envVarName, tt.args.decode)
+			if err != nil && !tt.wantErr {
+				t.Errorf("ParseEnvVar() do not expect error but got %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
 				t.Errorf("ParseEnvVar() = %v, want %v", got, tt.want)
 			}
 		})
@@ -32,23 +67,49 @@ func TestParseEndpoint(t *testing.T) {
 	type args struct {
 		endpt string
 	}
+
 	tests := []struct {
 		name    string
 		args    args
-		want    *url.URL
+		want    bool
+		setEnv  bool
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:    "successfully get url object from endpoint",
+			args:    args{"http://www.bing.com"},
+			want:    true,
+			setEnv:  true,
+			wantErr: false,
+		},
+		{
+			name:    "successfully get url object from default value",
+			args:    args{""},
+			want:    true,
+			setEnv:  true,
+			wantErr: false,
+		},
+		{
+			name:    "return error with empty endpoint and no default endpoint set",
+			args:    args{""},
+			want:    false,
+			setEnv:  false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(common.IMPORTER_ENDPOINT, "www.google.com")
+			if !tt.setEnv {
+				os.Unsetenv(common.IMPORTER_ENDPOINT)
+			}
 			got, err := ParseEndpoint(tt.args.endpt)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseEndpoint() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseEndpoint() = %v, want %v", got, tt.want)
+			if got == nil && tt.want {
+				t.Errorf("ParseEndpoint() did not get url object and expected it = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -64,10 +125,20 @@ func TestStreamDataToFile(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:    "successfully streamDataToFile",
+			args:    args{strings.NewReader("test data for reader 1"), "/tmp/testoutfile"},
+			wantErr: false,
+		},
+		{
+			name:    "expect error when trying to open an invalid out file",
+			args:    args{strings.NewReader("test data for reader 1"), ""},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer os.Remove(tt.args.filePath)
 			if err := StreamDataToFile(tt.args.dataReader, tt.args.filePath); (err != nil) != tt.wantErr {
 				t.Errorf("StreamDataToFile() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
```
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:78:	NewDataStream		93.8%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:113:	Read			100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:118:	Close			100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:124:	dataStreamSelector	90.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:143:	s3			0.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:159:	http			50.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:185:	local			100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:196:	CopyImage		100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:227:	constructReaders	95.2%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:266:	appendReader		81.8%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:285:	topReader		100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:291:	fileFormatSelector	91.7%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:318:	gzReader		83.3%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:331:	qcow2NopReader		80.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:346:	xzReader		80.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:358:	tarReader		83.3%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:370:	isoSize			76.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:438:	matchHeader		100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:455:	closeReaders		100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:467:	copy			100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:472:	copy			94.1%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:501:	randTmpName		100.0%
kubevirt.io/containerized-data-importer/pkg/importer/dataStream.go:511:	parseDataPath		0.0%
kubevirt.io/containerized-data-importer/pkg/importer/util.go:15:	ParseEnvVar		85.7%
kubevirt.io/containerized-data-importer/pkg/importer/util.go:28:	ParseEndpoint		87.5%
kubevirt.io/containerized-data-importer/pkg/importer/util.go:42:	StreamDataToFile	77.8%
total:									(statements)		80.7%
```