### PR TITLE
Add kubevirt cluster environment with sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ bin/*
 manifests/generated/*
 .coverprofile
 release-announcement
+.project
+.vscode
+vendor/**

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 .PHONY: build build-controller build-importer \
 		docker docker-controller docker-cloner docker-importer \
+		cluster-sync cluster-sync-controller cluster-sync-cloner cluster-sync-importer \
 		test test-functional test-unit \
 		publish \
 		vet \
@@ -89,3 +90,19 @@ goveralls:
 
 release-description:
 	./hack/build/release-description.sh ${RELREF} ${PREREF}
+
+cluster-up:
+	./cluster/up.sh
+
+cluster-down:
+	./cluster/down.sh
+
+cluster-sync: build ${WHAT}
+	./cluster/sync.sh ${WHAT}
+
+cluster-sync-controller: WHAT = cmd/cdi-controller
+cluster-sync-controller: cluster-sync
+cluster-sync-importer: WHAT = cmd/cdi-importer
+cluster-sync-importer: cluster-sync
+cluster-sync-cloner: WHAT = cmd/cdi-cloner
+cluster-sync-cloner: cluster-sync

--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+source ./cluster/gocli.sh
+
+$gocli_interactive "$@"
+

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+source ./cluster/gocli.sh
+
+$gocli rm

--- a/cluster/gocli.sh
+++ b/cluster/gocli.sh
@@ -1,0 +1,2 @@
+gocli="docker run --net=host --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/gocli:latest"
+gocli_interactive="docker run --net=host --privileged --rm -it -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/gocli:latest"

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+function _kubectl() {
+    export KUBECONFIG=./cluster/.kubeconfig
+    ./cluster/.kubectl "$@"
+}
+
+_kubectl "$@"

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+cdi=$1
+cdi="${cdi##*/}"
+
+echo $cdi
+
+source ./hack/build/config.sh
+source ./cluster/gocli.sh
+
+registry_port=$($gocli ports registry | tr -d '\r')
+registry=localhost:$registry_port
+
+DOCKER_REPO=${registry} make docker push
+DOCKER_REPO="registry:5000" make manifests
+
+# Make sure that all nodes use the newest images
+container=""
+container_alias=""
+images="${@:-${DOCKER_IMAGES}}"
+for arg in $images; do
+    name=$(basename $arg)
+    container="${container} registry:5000/${name}:latest"
+done
+for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
+    echo "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs \-\-max-args=1 sudo docker pull"
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs \-\-max-args=1 sudo docker pull"
+done
+
+./cluster/kubectl.sh apply -f ./manifests/generated/cdi-controller.yaml

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+source ./cluster/gocli.sh
+source ./hack/build/config.sh
+
+num_nodes=${KUBEVIRT_NUM_NODES:-1}
+re='^-?[0-9]+$'
+if ! [[ $num_nodes =~ $re ]] || [[ $num_nodes -lt 1 ]] ; then
+    num_nodes=1
+fi
+
+case "${KUBEVIRT_PROVIDER}" in
+"k8s-1.10.4")
+    image=$KUBERNETES_IMAGE
+    ;;
+"os-3.10.0")
+    image=$OPENSHIFT_IMAGE
+    ;;
+esac
+echo "Image:${image}"
+if [[ $image == $KUBERNETES_IMAGE ]]; then
+    $gocli run --random-ports --nodes ${num_nodes} --background kubevirtci/${image}
+    cluster_port=$($gocli ports k8s | tr -d '\r')
+    $gocli scp /usr/bin/kubectl - > ./cluster/.kubectl
+    chmod u+x ./cluster/.kubectl
+    $gocli scp /etc/kubernetes/admin.conf - > ./cluster/.kubeconfig
+    export KUBECONFIG=./cluster/.kubeconfig
+    ./cluster/.kubectl config set-cluster kubernetes --server=https://127.0.0.1:$cluster_port
+    ./cluster/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+
+elif [[ $image == $OPENSHIFT_IMAGE ]]; then
+    $gocli run --random-ports --reverse --nodes ${num_nodes} --background kubevirtci/${image}
+    cluster_port=$($gocli ports ocp | tr -d '\r')
+    $gocli scp /etc/origin/master/admin.kubeconfig - > ./cluster/.kubeconfig
+    $gocli ssh node01 -- sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
+    $gocli ssh node01 -- sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
+
+    # Copy oc tool and configuration file
+    $gocli scp /usr/bin/oc - >./cluster/.kubectl
+    chmod u+x ./cluster/.kubectl
+    $gocli scp /etc/origin/master/admin.kubeconfig - > ./cluster/.kubeconfig
+    # Update Kube config to support unsecured connection
+    export KUBECONFIG=./cluster/.kubeconfig
+    ./cluster/.kubectl config set-cluster node01:8443 --server=https://127.0.0.1:$cluster_port
+    ./cluster/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
+fi
+
+echo 'Wait until all nodes are ready'
+until [[ $(./cluster/kubectl.sh get nodes --no-headers | wc -l) -eq $(./cluster/kubectl.sh get nodes --no-headers | grep " Ready" | wc -l) ]]; do
+    sleep 1
+done
+
+echo 'Wait until all pods are running'
+until [[ $(./cluster/kubectl.sh get pods --all-namespaces --no-headers | wc -l) -eq $(./cluster/kubectl.sh get pods --all-namespaces --no-headers | grep "Running" | wc -l) ]]; do
+    sleep 1
+done
+

--- a/hack/README.md
+++ b/hack/README.md
@@ -53,7 +53,10 @@ The standard workflow is performed inside a helper container to normalize the bu
 - `vet`: lint all CDI packages
 - `format`: Execute `shfmt`, `goimports`, and `go vet` on all CDI packages.  Writes back to the source files.
 - `publish`: CI ONLY - this recipe is not intended for use by developers
-
+- 'cluster-up': Start a default Kubernetes or Open Shift cluster. set KUBEVIRT_PROVIDER environment variable to either 'k8s-1.10.4' or 'os-3.10.0' to select the type of cluster. set KUBEVIRT_NUM_NODES to something higher than 1 to have more than one node.
+- 'cluster-down': Stop the cluster, doing a make cluster-down && make cluster-up will basically restart the cluster into an empty fresh state.
+- 'cluster-sync': Builds the controller/importer/cloner, and pushes it into a running cluster. The cluster must be up before running a cluster sync. Also generates a manifest and applies it to the running cluster after pushing the images to it.
+ 
 #### Make Variables
 
 Several variables are provided to alter the targets of the above `Makefile` recipes.

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -34,3 +34,9 @@ function allPkgs {
     ret=$(sed "s,kubevirt.io/containerized-data-importer,${CDI_DIR},g" <(go list ./... | grep -v "pkg/client" | sort -u ))
     echo "$ret"
 }
+
+KUBERNETES_IMAGE="k8s-1.10.4"
+OPENSHIFT_IMAGE="os-3.10.0"
+
+image=$KUBERNETES_IMAGE
+


### PR DESCRIPTION
- Added ability to call make cluster-up to start a kubevirt cluster.
- Added ability to call make cluster-down to stop a kubevirt cluster.
- Added ability to call make cluster-sync to build CDI and sync it with
  the running cluster. This allows for testing during development.
- Added cli.sh and kubectl.sh just like kubevirt, in the CDI project to
  manipulate a running cluster.

Signed-off-by: Alexander Wels <awels@redhat.com>