### PR TITLE
Invoke tar from same location in source and target mode

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -22,7 +22,9 @@ if [ "$1" == "source" ] ; then
   echo "creating fifo pipe"
   mkfifo /tmp/clone/socket/$2/pipe
   echo "creating tarball of the image and redirecting it to /tmp/clone/socket/$2/pipe"
-  tar cv /tmp/clone/image/ > /tmp/clone/socket/$2/pipe
+  pushd /tmp/clone/image
+  tar cv . > /tmp/clone/socket/$2/pipe
+  popd
   echo "finished writing image to /tmp/clone/socket/$2/pipe"
 elif [ "$1" == "target" ] ; then
   echo "Starting clone target"


### PR DESCRIPTION
When cloning we were invoking tar at the container root in the source
mode and within the volume mount in target mode.  The result was the
disk.img file appearing in a tmp/clone/image subdirectory in the target
pvc instead of being copied exactly.  Fixes #296 

Signed-off-by: Adam Litke <alitke@redhat.com>