### PR TITLE
Backports of Cloning PRs #280 and #297 to 1.1 branch

### DIFF
--- a/cmd/cdi-cloner/script.sh
+++ b/cmd/cdi-cloner/script.sh
@@ -22,7 +22,9 @@ if [ "$1" == "source" ] ; then
   echo "creating fifo pipe"
   mkfifo /tmp/clone/socket/$2/pipe
   echo "creating tarball of the image and redirecting it to /tmp/clone/socket/$2/pipe"
-  tar cv /tmp/clone/image/ > /tmp/clone/socket/$2/pipe
+  pushd /tmp/clone/image
+  tar cv . > /tmp/clone/socket/$2/pipe
+  popd
   echo "finished writing image to /tmp/clone/socket/$2/pipe"
 elif [ "$1" == "target" ] ; then
   echo "Starting clone target"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -461,8 +461,7 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 				AnnCloningCreatedBy: "yes",
 			},
 			Labels: map[string]string{
-				CDI_LABEL_KEY:     CDI_LABEL_VALUE,                               //filtered by the podInformer
-				CLONING_LABEL_KEY: CLONING_LABEL_VALUE + "-" + generatedLabelStr, //used by PodAffinity
+				CDI_LABEL_KEY:     CDI_LABEL_VALUE,    //filtered by the podInformer
 			},
 		},
 		Spec: v1.PodSpec{
@@ -491,6 +490,10 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 					Name:            CLONER_TARGET_PODNAME,
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &[]bool{true}[0],
+						RunAsUser:  &[]int64{0}[0],
+					},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      ImagePathName,


### PR DESCRIPTION
This backports two fixes from master to fix the following issues:

Fixes #298 
> When cloning a source pvc to a target pvc the target pvc has a different file hierarchy. This is because tar is invoked at the container root in the source case but expanded inside the pvc volume mount in the target case. Fix by using pushd in the source case as well.

Fixes #302 
> Having the cloning label in the target pod, make the pod affinity fails.
The target pod looks for a pod with a specific label (specified in the pod affinity) that matches the source pod label.
> In my case the target pod included this label as well, so we can see that the target pod found matching pod, but it is the WRONG pod. It's itself!!
> The target was running without finding the source pod first.
> If we remove this label from the target pod, it will find the source pod and then will be scheduled on the same node.
> If it does not find the source pod (because the scheduler tried to schedule it before the source pod), it will be in 'Pending' state until the source pod is scheduled, and then will be running on the same node.
