### PR TITLE
add namespace template parameter for cdi manifests

### DIFF
--- a/hack/build/build-manifests.sh
+++ b/hack/build/build-manifests.sh
@@ -33,6 +33,7 @@ for tmpl in ${templates}; do
         -docker-repo="${DOCKER_REPO}" \
         -docker-tag="${DOCKER_TAG}" \
         -verbosity="${VERBOSITY}" \
-        -pull-policy="${PULL_POLICY}"
+        -pull-policy="${PULL_POLICY}" \
+        -namespace="${NAMESPACE}"
     ) 1>"${MANIFEST_GENERATED_DIR}/${outFile}"
 done

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -28,6 +28,7 @@ DOCKER_REPO=${DOCKER_REPO:-kubevirt}
 DOCKER_TAG=${DOCKER_TAG:-latest}
 VERBOSITY=${VERBOSITY:-1}
 PULL_POLICY=${PULL_POLICY:-IfNotPresent}
+NAMESPACE=${NAMESPACE:-kube-system}
 
 function allPkgs {
     ret=$(sed "s,kubevirt.io/containerized-data-importer,${CDI_DIR},g" <(go list ./... | grep -v "pkg/client" | sort -u ))

--- a/manifests/templates/cdi-controller.yaml.in
+++ b/manifests/templates/cdi-controller.yaml.in
@@ -2,7 +2,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: cdi-sa
-  namespace: default  # update accordingly based on the namespace you are deploying in
+  namespace: {{ .Namespace }}
   labels:
     cdi.kubevirt.io: ""
 ---
@@ -10,6 +10,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cdi
+  namespace: {{ .Namespace }}
   labels:
     cdi.kubevirt.io: ""
 rules:
@@ -35,6 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cdi-sa
+  namespace: {{ .Namespace }}
   labels:
     cdi.kubevirt.io: ""
 roleRef:
@@ -44,13 +46,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cdi-sa
-    namespace: default  # update accordingly based on the namespace you are deploying in
+    namespace: {{ .Namespace }}
 ---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-deployment
-  namespace: default  # update accordingly based on the namespace you are deploying in
+  namespace: {{ .Namespace }}
   labels:
     cdi.kubevirt.io: ""
     app: containerized-data-importer

--- a/tools/manifest-generator/manifest-generator.go
+++ b/tools/manifest-generator/manifest-generator.go
@@ -13,10 +13,10 @@
 package main
 
 import (
-	"text/template"
-	"os"
 	"flag"
 	"github.com/golang/glog"
+	"os"
+	"text/template"
 )
 
 type data struct {
@@ -24,14 +24,16 @@ type data struct {
 	DockerTag  string
 	Verbosity  int
 	PullPolicy string
+	Namespace  string
 }
 
-func main () {
+func main() {
 	dockerRepo := flag.String("docker-repo", "", "")
 	dockertag := flag.String("docker-tag", "", "")
 	templFile := flag.String("template", "", "")
 	verbosity := flag.Int("verbosity", 1, "")
 	pullPolicy := flag.String("pull-policy", "", "")
+	namespace := flag.String("namespace", "", "")
 	flag.Parse()
 
 	data := &data{
@@ -39,6 +41,7 @@ func main () {
 		DockerRepo: *dockerRepo,
 		DockerTag:  *dockertag,
 		PullPolicy: *pullPolicy,
+		Namespace:  *namespace,
 	}
 
 	file, err := os.OpenFile(*templFile, os.O_RDONLY, 0)


### PR DESCRIPTION
Right now we assume everything is installed into the default namespace. This should be configurable and ideally we should be installing into a more secure namespace like kube-system instead.

This patch adds namespace to the manifest templates and changes the default install namespace to kube-system, which is what kubevirt does as well. 