### PR TITLE
add cluster considerations for cloning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,26 @@ Make copies of the [example manifests](./manifests/example) for editing. The nec
 
 ### Cloning VM Images
 
-Cloning is achieved by creating a new PVC with the 'k8s.io/CloneRequest' annotation indicating the name of the PVC the image is copied from. Once the controller detects the PVC, it starts two pods which are responsible for the cloning of the image from one PVC to another using a unix socket that is created on the host itself. When the cloning is completed, the PVC which the image was copied to, is assigned with the 'k8s.io/CloneOf' annotation to indicate cloning completion. The copied VM image can be used by a new pod only after the cloning process is completed.
+Cloning is achieved by creating a new PVC with the 'k8s.io/CloneRequest' annotation indicating the name of the PVC the image is copied from.
+Once the controller detects the PVC, it starts two pods which are responsible for the cloning of the image from one PVC to another using a unix socket that is created on the host itself.
+When the cloning is completed, the PVC which the image was copied to, is assigned with the 'k8s.io/CloneOf' annotation to indicate cloning completion.
+The copied VM image can be used by a new pod only after the cloning process is completed.
+
+Cloning requires two pods, the source pod and target pod, which must execute on the same node.
+Pod adffinity is used to enforce this requirement; however, the cluster also needs to be configured to delay volume binding until pod scheduling has completed.
+
+In Kubernetes 1.10 and older export KUBE_FEATURE_GATES before bringing up the cluster:
+`$ export KUBE_FEATURE_GATES="PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"`
+Also create a storage class with _volumeBindingMode_ set to "WaitForFirstConsumer", eg:
+```
+   kind: StorageClass
+   apiVersion: storage.k8s.io/v1
+   metadata:
+     name: <local-storage-name>
+   provisioner: kubernetes.io/no-provisioner
+   volumeBindingMode: WaitForFirstConsumer
+```
+
 
 ### Start Cloning Images
 
@@ -161,6 +180,7 @@ From the [example manifests](./manifests/example) you copied earlier, the necess
 
 ###### Edit target-pvc.yaml:
 1.  `k8s.io/CloneRequest:` The name of the PVC we copy the image from (including its namespace). For example: "source-ns/golden-pvc".
+2. add the name of the storage class which defines `volumeBindingMode` per above. Note, this is not required in Kubernetes 1.10 and later.
 
 ### Deploy the API Object
 1. (Optional) Create the namespace where the target PVC will be deployed:

--- a/README.md
+++ b/README.md
@@ -153,16 +153,18 @@ Make copies of the [example manifests](./manifests/example) for editing. The nec
 ### Cloning VM Images
 
 Cloning is achieved by creating a new PVC with the 'k8s.io/CloneRequest' annotation indicating the name of the PVC the image is copied from.
-Once the controller detects the PVC, it starts two pods which are responsible for the cloning of the image from one PVC to another using a unix socket that is created on the host itself.
+Once the controller detects the PVC, it starts two pods (source and target pods) which are responsible for the cloning of the image from one PVC to another using a unix socket that is created on the host itself. 
 When the cloning is completed, the PVC which the image was copied to, is assigned with the 'k8s.io/CloneOf' annotation to indicate cloning completion.
 The copied VM image can be used by a new pod only after the cloning process is completed.
 
-Cloning requires two pods, the source pod and target pod, which must execute on the same node.
-Pod adffinity is used to enforce this requirement; however, the cluster also needs to be configured to delay volume binding until pod scheduling has completed.
+The two cloning pods must execute on the same node. Pod adffinity is used to enforce this requirement; however, the cluster also needs to be configured to delay volume binding until pod scheduling has completed.
 
-In Kubernetes 1.10 and older export KUBE_FEATURE_GATES before bringing up the cluster:
+In Kubernetes 1.9 and older export KUBE_FEATURE_GATES before bringing up the cluster:
 `$ export KUBE_FEATURE_GATES="PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"`
-Also create a storage class with _volumeBindingMode_ set to "WaitForFirstConsumer", eg:
+
+These features default to true in Kubernetes 1.10 and later and thus do not need to be set.
+
+Regardless of the Kubernetes version, a storage class with _volumeBindingMode_ set to "WaitForFirstConsumer" needs to be created. Eg:
 ```
    kind: StorageClass
    apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
and increase num of retries in _cloner-startup.sh_ script to account for slower nodes.
Note: all feature gates mentioned in this pr default to true in k8s 1.10 and later. I expect the addition to the readme to be short-lived but still worthwhile as long as cdi is used on k8s 1.9 and earlier clusters.
Fixes #306 
Feature gate statuses:  https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/