### PR TITLE
Add simple http & s3 file server as func test source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,5 +107,9 @@ cluster-sync-importer: cluster-sync
 cluster-sync-cloner: WHAT = cmd/cdi-cloner
 cluster-sync-cloner: cluster-sync
 
-functest:
+functest: .functest-image-host
 	./hack/build/functests.sh
+
+.functest-image-host: WHAT=tools/cdi-func-test-file-host-init
+.functest-image-host:  manifests build
+	./hack/build/build-cdi-func-test-file-host.sh

--- a/hack/build/build-docker.sh
+++ b/hack/build/build-docker.sh
@@ -28,10 +28,11 @@ printf "Building targets: %s\n" "${targets}"
 
 for tgt in ${targets}; do
     BIN_NAME="$(basename ${tgt})"
+    BIN_PATH="${tgt%/}"
     IMAGE="${DOCKER_REPO}/${BIN_NAME}:${DOCKER_TAG}"
     if [ "${docker_opt}" == "build" ]; then
     (
-        cd "${CMD_OUT_DIR}/${BIN_NAME}"
+        cd "${OUT_DIR}/${BIN_PATH}"
         docker "${docker_opt}" -t ${IMAGE} .
     )
     elif [ "${docker_opt}" == "push" ]; then

--- a/hack/build/build-go.sh
+++ b/hack/build/build-go.sh
@@ -47,11 +47,12 @@ elif [ "${go_opt}" == "build" ]; then
         targets="${BINARIES}"
     fi
 	for tgt in ${targets}; do
-		BIN_NAME=$(basename $tgt)
+		BIN_NAME=$(basename ${tgt})
+		BIN_PATH=${tgt%/}
 		if [[ "${BIN_NAME}" == "${CLONER}" ]]; then
 		    continue
 		fi
-		outFile=${CMD_OUT_DIR}/${BIN_NAME}/${BIN_NAME}
+		outFile=${OUT_DIR}/${BIN_PATH}/${BIN_NAME}
 		outLink=${BIN_DIR}/${BIN_NAME}
 		rm -f ${outFile}
 		rm -f ${outLink}

--- a/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
@@ -1,0 +1,19 @@
+FROM fedora:28
+
+MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+
+ENV container docker
+
+RUN dnf -y install nginx && dnf clean all -y
+
+ARG IMAGE_DIR=/usr/share/nginx/html/images
+
+RUN mkdir -p $IMAGE_DIR
+
+RUN rm -f /etc/nginx/nginx.conf
+
+COPY nginx.conf /etc/nginx/
+
+EXPOSE 80
+
+ENTRYPOINT nginx

--- a/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
+++ b/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
@@ -1,0 +1,25 @@
+worker_processes 1;
+daemon off;
+
+events { worker_connections 1024; }
+
+http {
+    types_hash_max_size 4096;
+
+    include    /etc/nginx/mime.types;
+
+    sendfile on;
+
+    server {
+        root /tmp/shared/images;
+
+        location / {
+            autoindex on;
+            autoindex_format json;
+        }
+
+        server_name localhost;
+
+        listen 80;
+    }
+}

--- a/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora:28
+
+RUN mkdir -p /tmp/shared /tmp/source
+
+RUN yum install -y qemu
+
+COPY cdi-func-test-file-host-init /usr/bin/
+
+RUN chmod u+x /usr/bin/cdi-func-test-file-host-init
+
+COPY tinyCore.iso /tmp/source/tinyCore.iso
+
+ENTRYPOINT ["cdi-func-test-file-host-init", "-alsologtostderr"]

--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: cdi-file-host
+  namespace: {{ .Namespace }}
+  labels:
+    cdi.kubevirt.io: ""
+    cdi.kubevirt.io/testing: ""
+spec:
+  selector:
+    matchLabels:
+      cdi.kubevirt.io/testing: ""
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        cdi.kubevirt.io/testing: ""
+    spec:
+      initContainers:
+      - name: init
+        image: {{ .DockerRepo }}/cdi-func-test-file-host-init:{{ .DockerTag }}
+        imagePullPolicy: {{ .PullPolicy }}
+        args: ["-inFile", "/tmp/source/tinyCore.iso", "-outDir", "/tmp/shared/images"]
+        volumeMounts:
+        - name: "images"
+          mountPath: "/tmp/shared"
+      containers:
+      - name: http
+        image: {{ .DockerRepo }}/cdi-func-test-file-host-http:{{ .DockerTag }}
+        imagePullPolicy: {{ .PullPolicy }}
+        command: ["/usr/sbin/nginx"]
+        ports:
+        - name: http
+          containerPort: 80
+        volumeMounts:
+        - name: "images"
+          mountPath: "/tmp/shared/"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 20
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 20
+          periodSeconds: 20
+      - name: s3
+        image: minio/minio:RELEASE.2018-08-02T23-11-36Z
+        imagePullPolicy: {{ .PullPolicy }}
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "admin"
+        - name: MINIO_SECRET_KEY
+          value: "password"
+        args: ["server", "--address", ":9000", "/tmp/shared"]
+        volumeMounts:
+        - name: "images"
+          mountPath: "/tmp/shared"
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 20
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 20
+          periodSeconds: 20
+      volumes:
+      - name: "images"
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cdi-file-host
+  namespace: {{ .Namespace }}
+  labels:
+    cdi.kubevirt.io: ""
+    cdi.kubevirt.io/testing: ""
+spec:
+  selector:
+      cdi.kubevirt.io/testing: ""
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  - name: s3
+    port: 9000
+    targetPort: 9000

--- a/test/framework/fileConversion.go
+++ b/test/framework/fileConversion.go
@@ -52,28 +52,28 @@ func toTar(src, tgtDir string) (string, error) {
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return "", errors.Wrap(err, "Error opening file")
+		return "", errors.Wrapf(err, "Error opening file %s", src)
 	}
 	defer srcFile.Close()
 
 	srcFileInfo, err := srcFile.Stat()
 	if err != nil {
-		return "", errors.Wrap(err, "Error stating file")
+		return "", errors.Wrapf(err, "Error stating file %s", src)
 	}
 
 	hdr, err := tar.FileInfoHeader(srcFileInfo, "")
 	if err != nil {
-		return "", errors.Wrap(err, "Error generating tar file header")
+		return "", errors.Wrapf(err, "Error generating tar file header for %s", src)
 	}
 
 	err = w.WriteHeader(hdr)
 	if err != nil {
-		return "", errors.Wrap(err, "Error writing header")
+		return "", errors.Wrapf(err, "Error writing tar header to %s", tgtPath)
 	}
 
 	_, err = io.Copy(w, srcFile)
 	if err != nil {
-		return "", errors.Wrap(err, "Error writing to file")
+		return "", errors.Wrapf(err, "Error writing to file %s", tgtPath)
 	}
 	return tgtPath, nil
 }
@@ -87,13 +87,13 @@ func toGz(src, tgtDir string) (string, error) {
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return "", errors.Wrap(err, "Error opening file")
+		return "", errors.Wrapf(err, "Error opening file %s", src)
 	}
 	defer srcFile.Close()
 
 	_, err = io.Copy(w, srcFile)
 	if err != nil {
-		return "", errors.Wrap(err, "Error writing to file")
+		return "", errors.Wrapf(err, "Error writing to file %s", tgtPath)
 	}
 	return tgtPath, nil
 }
@@ -104,19 +104,19 @@ func toXz(src, tgtDir string) (string, error) {
 
 	w, err := xz.NewWriter(tgtFile)
 	if err != nil {
-		return "", errors.Wrap(err, "Error getting writer")
+		return "", errors.Wrapf(err, "Error getting xz writer for file %s", tgtPath)
 	}
 	defer w.Close()
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return "", errors.Wrap(err, "Error opening file")
+		return "", errors.Wrapf(err, "Error opening file %s", src)
 	}
 	defer srcFile.Close()
 
 	_, err = io.Copy(w, srcFile)
 	if err != nil {
-		return "", errors.Wrap(err, "Error writing to file")
+		return "", errors.Wrapf(err, "Error writing to file %s", tgtPath)
 	}
 	return tgtPath, nil
 }

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -1,0 +1,113 @@
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"kubevirt.io/containerized-data-importer/test/framework"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+func main() {
+	inFile := flag.String("inFile", "", "")
+	outDir := flag.String("outDir", "", "")
+	flag.Parse()
+
+	glog.Info("Generating test files")
+	ft := &formatTable{
+		[]string{""},
+		[]string{".tar"},
+		[]string{".gz"},
+		[]string{".xz"},
+		[]string{".tar", ".gz"},
+		[]string{".tar", ".xz"},
+		[]string{".qcow2"},
+		[]string{".qcow2", ".gz"},
+		[]string{".qcow2", ".xz"},
+	}
+
+	if err := os.MkdirAll(*outDir, 0777); err != nil {
+		glog.Fatal(errors.Wrapf(err, "'mkdir %s' errored: ", *outDir))
+	}
+	if err := ft.initializeTestFiles(*inFile, *outDir); err != nil {
+		glog.Fatal(err)
+	}
+	glog.Info("File initialization completed without error.")
+}
+
+type formatTable [][]string
+
+func (ft formatTable) initializeTestFiles(inFile, outDir string) error {
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(ft))
+
+	reportError := func(err error, msg string, format ...interface{}) {
+		e := errors.Wrapf(err, msg, format...)
+		glog.Error(e)
+		errChan <- e
+		return
+	}
+
+	for _, fList := range ft {
+		wg.Add(1)
+
+		go func(i, o string, f []string) {
+			defer wg.Done()
+			glog.Infof("Generating file %s\n", f)
+
+			ext := strings.Join(f, "")
+			tmpDir := filepath.Join(o, "tmp"+ext)
+			if err := os.Mkdir(tmpDir, 0777); err != nil {
+				reportError(err, "Error creating temp dir %s", tmpDir)
+				return
+			}
+
+			defer func() {
+				if err := os.RemoveAll(tmpDir); err != nil {
+					reportError(err, "Error deleting tmp dir %s", tmpDir)
+				}
+			}()
+
+			glog.Infof("Mkdir %s\n", tmpDir)
+
+			p, err := framework.FormatTestData(i, tmpDir, f...)
+			if err != nil {
+				reportError(err, "Error formatting files")
+				return
+			}
+
+			if err = os.Rename(p, filepath.Join(o, filepath.Base(p))); err != nil {
+				reportError(err, "Error moving file %s to %s", p, o)
+				return
+			}
+
+			glog.Infof("Generated file %q\n", p)
+		}(inFile, outDir, fList)
+	}
+	wg.Wait()
+	close(errChan)
+
+	if len(errChan) > 0 {
+		for err := range errChan {
+			glog.Error(err)
+		}
+		return errors.New("Error(s) occurred during file conversion")
+	}
+	return nil
+}


### PR DESCRIPTION
In support of future functional testing, adds a container that will host all permutations of an image that the datastream can handle.  This will enable us to test the actual s3 and http pipelines of the importer.

Dependent on #313 