### PR TITLE
Bug Fix - Match all tar magic numbers

### DIFF
--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -35,7 +35,7 @@ var knownHeaders = Headers{
 	},
 	"tar": Header{
 		Format:      "tar",
-		magicNumber: []byte{0x75, 0x73, 0x74, 0x61, 0x72, 0x20},
+		magicNumber: []byte{0x75, 0x73, 0x74, 0x61, 0x72},
 		mgOffset:    0x101,
 		SizeOff:     124,
 		SizeLen:     8,


### PR DESCRIPTION
Fixes #318 

Truncate the magic number slice for tar to match all tarball identifies.