### PR TITLE
backport manifests rbac

### DIFF
--- a/manifests/controller/cdi-controller-deployment.yaml
+++ b/manifests/controller/cdi-controller-deployment.yaml
@@ -22,14 +22,22 @@ rules:
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiGroups: [""]
+  resources: ["persistentvolumeclaims/finalizers"]
+  verbs: ["update"]
+- apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "watch", "create"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: [""]
+  resources: ["pods/finalizers"]
+  verbs: ["update"]
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create"]
 - apiGroups: ["cdi.kubevirt.io"]
-  resources: ["datavolumes"]
-  verbs: ["get", "list", "watch", "update"]
+  resources:
+   - '*'
+  verbs:
+   - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This will sync up release-v1.1 branch that addressed issue #287 - but only addressed the templates and not the manifests - so master is in sync with PR #308 but release-v1.1 still has out-dated manifests yaml based on datavolume resource and rbac perms that do not work