### PR TITLE
DataVolume functional test suite

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1,0 +1,51 @@
+package tests_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/extensions/table"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
+)
+
+var _ = Describe("DataVolume tests", func() {
+
+	f, err := framework.NewFramework("dv-func-test", framework.Config{})
+	if err != nil {
+		Fail("Unable to create framework struct")
+	}
+
+	Describe("Verify DataVolume", func() {
+		table.DescribeTable("with http import source should", func(url string, phase cdiv1.DataVolumePhase, dataVolumeName string) {
+			dataVolume := utils.NewDataVolumeWithHttpImport(dataVolumeName, "1Gi", url)
+
+			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))
+			utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+
+			// verify PVC was created
+			By("verifying pvc was created")
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(dataVolume.Name, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).To(BeNil())
+
+		},
+			table.Entry("succeed when given valid url", utils.TinyCoreIsoURL, cdiv1.Succeeded, "dv-phase-test-1"),
+			table.Entry("fail due to invalid DNS entry", "http://i-made-this-up.kube-system/tinyCore.iso", cdiv1.Failed, "dv-phase-test-2"),
+			table.Entry("fail due to file not found", utils.TinyCoreIsoURL+"not.real.file", cdiv1.Failed, "dv-phase-test-3"),
+		)
+	})
+})

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
+	cdiclientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
+)
+
+const (
+	dataVolumePollInterval = 2 * time.Second
+	DataVolumeCreateTime   = 30 * time.Second
+	DataVolumeDeleteTime   = 30 * time.Second
+	DataVolumePhaseTime    = 30 * time.Second
+)
+
+const (
+	TinyCoreIsoURL = "http://cdi-file-host.kube-system/tinyCore.iso"
+)
+
+func CreateDataVolumeFromDefinition(clientSet *cdiclientset.Clientset, namespace string, def *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	var dataVolume *cdiv1.DataVolume
+	err := wait.PollImmediate(dataVolumePollInterval, DataVolumeCreateTime, func() (bool, error) {
+		var err error
+		dataVolume, err = clientSet.CdiV1alpha1().DataVolumes(namespace).Create(def)
+		if err == nil || apierrs.IsAlreadyExists(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dataVolume, nil
+}
+
+// Delete the passed in DataVolume
+func DeleteDataVolume(clientSet *cdiclientset.Clientset, namespace string, dataVolume *cdiv1.DataVolume) error {
+	return wait.PollImmediate(dataVolumePollInterval, DataVolumeDeleteTime, func() (bool, error) {
+		err := clientSet.CdiV1alpha1().DataVolumes(namespace).Delete(dataVolume.GetName(), nil)
+		if err == nil || apierrs.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}
+
+func NewDataVolumeWithHttpImport(dataVolumeName string, size string, httpUrl string) *cdiv1.DataVolume {
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dataVolumeName,
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			Source: cdiv1.DataVolumeSource{
+				HTTP: &cdiv1.DataVolumeSourceHTTP{
+					URL: httpUrl,
+				},
+			},
+			PVC: &k8sv1.PersistentVolumeClaimSpec{
+				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+				Resources: k8sv1.ResourceRequirements{
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+					},
+				},
+			},
+		},
+	}
+}
+
+// Wait for the DataVolume to be in a particular phase (Pending, Bound, or Lost)
+func WaitForDataVolumePhase(clientSet *cdiclientset.Clientset, namespace string, phase cdiv1.DataVolumePhase, dataVolumeName string) error {
+	err := wait.PollImmediate(dataVolumePollInterval, DataVolumePhaseTime, func() (bool, error) {
+		dataVolume, err := clientSet.CdiV1alpha1().DataVolumes(namespace).Get(dataVolumeName, metav1.GetOptions{})
+		if err != nil || dataVolume.Status.Phase != phase {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		fmt.Errorf("DataVolume %s not in phase %s within %v", dataVolumeName, phase, DataVolumePhaseTime)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is adding initial functional tests for DataVolumes into cdi

I've added hostpath PVs and an http import server to help with testing. This will help the importer and clone tests as well. 