### PR TITLE
Add disclaimer and a log warning about local (:file//) endpoints (#312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Supported file formats are:
 - A running Kubernetes cluster with roles and role bindings implementing security necesary for the CDI controller to watch PVCs and pods across all namespaces.
 - A storage class and provisioner.
 - An HTTP or S3 file server hosting VM images
+> Note: CDI is able to import a local file endpoint but this is not supported except for testing and debugging.
+`file:///` endpoints can only access the container's filesystem and require that files on the host be mounted via hostPath to the impoter pod. This bind-mount is **not** done by CDI.
+
 - An optional "golden" namespace acting as the image registry. The `default` namespace is fine for tire kicking.
 
 ### Download CDI

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -184,6 +184,7 @@ func (d dataStream) http() (io.ReadCloser, error) {
 
 func (d dataStream) local() (io.ReadCloser, error) {
 	fn := d.Url.Path
+	glog.Warning("the file:/// protocol is intended *only* for debugging and testing. Files outside of the container cannot be accessed.")
 	f, err := os.Open(fn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not open file %q", fn)


### PR DESCRIPTION
Cherry Pick of PR #312 (9f6455)

Adds documentation explaining that `file:///` endpoint  is strictly for debugging in non-containerized run times.