### PR TITLE
local (file://) endpoint deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ In Addition, the Containerized Data Importer gives the option to clone the impor
 1. [Hacking (WIP)](hack/README.md#getting-started-for-developers)
 1. [Security Configurations](#security-configurations)
 
+> DEPRECATION NOTICE:
+Support for local (file://) endpoints will be removed from CDI in the next release. There is no replacement and no work-around. All import endpoints must reference http(s) or s3 endpoints.
+
 
 ## Overview
 
@@ -57,8 +60,6 @@ Supported file formats are:
 - A running Kubernetes cluster with roles and role bindings implementing security necesary for the CDI controller to watch PVCs and pods across all namespaces.
 - A storage class and provisioner.
 - An HTTP or S3 file server hosting VM images
-> Note: CDI is able to import a local file endpoint but this is not supported except for testing and debugging.
-`file:///` endpoints can only access the container's filesystem and require that files on the host be mounted via hostPath to the impoter pod. This bind-mount is **not** done by CDI.
 
 - An optional "golden" namespace acting as the image registry. The `default` namespace is fine for tire kicking.
 

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -40,4 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 	glog.V(Vuser).Infoln("import complete")
+
+	// temporary local import deprecation notice
+	glog.Warningf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
 }

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -1,5 +1,9 @@
 package importer
 
+// DEPRECATION NOTICE: Support for local (file://) endpoints will be removed from CDI in the next
+// release. There is no replacement and no work-around. All import endpoints must reference http(s)
+// or s3 endpoints\n")
+
 import (
 	"archive/tar"
 	"bytes"
@@ -180,8 +184,10 @@ func (d dataStream) http() (io.ReadCloser, error) {
 }
 
 func (d dataStream) local() (io.ReadCloser, error) {
+	// temporary local import deprecation notice
+	glog.Warningf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
 	fn := d.Url.Path
-	glog.Warning("the file:/// protocol is intended *only* for debugging and testing. Files outside of the container cannot be accessed.")
+
 	f, err := os.Open(fn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not open file %q", fn)
@@ -201,6 +207,10 @@ func CopyImage(dest, endpoint, accessKey, secKey string) error {
 	return ds.copy(dest)
 }
 
+// DEPRECATION NOTICE: Support for local (file://) endpoints will be removed from CDI in the next
+// release. There is no replacement and no work-around. All import endpoints must reference http(s)
+// or s3 endpoints\n")
+//
 // Read the endpoint and determine the file composition (eg. .iso.tar.gz) based on the magic number in
 // each known file format header. Set the Reader slice in the receiver and set the Size field to each
 // reader's original size. Note: if, when this method returns, the Size is still 0 then another method

--- a/pkg/lib/size/size_test.go
+++ b/pkg/lib/size/size_test.go
@@ -14,6 +14,9 @@ const (
 )
 
 func TestSize(t *testing.T) {
+	// temporary local import deprecation notice
+	fmt.Printf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
+
 	testImg1, err := filepath.Abs(filepath.Join(baseImageRelPath, tinyCore))
 	if err != nil {
 		t.Fatalf("failed to get %q source image Abs path: %v\n", tinyCore, err)

--- a/test/functional/importer/datastream/datastream_test.go
+++ b/test/functional/importer/datastream/datastream_test.go
@@ -191,6 +191,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 				fmt.Fprintf(GinkgoWriter, "End test on test file %q\n", testSample)
 			})
 		}
+		fmt.Fprintf(GinkgoWriter, "\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
 	})
 })
 


### PR DESCRIPTION
partially fixes #338 
A separate issue and pr will be created to remove the code supporting and testing local file import. This pr just announces the deprecation of this feature via doc, code statements, and importer logs.