### PR TITLE
Remove duplicate default timeout

### DIFF
--- a/tests/pvc_utils.go
+++ b/tests/pvc_utils.go
@@ -13,9 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-)
-
 // Creates a PVC in the passed in namespace from the passed in PersistentVolumeClaim definition.
 // An example of creating a PVC without annotations looks like this:
 // CreatePVCFromDefinition(client, namespace, NewPVCDefinition(name, size, nil))

--- a/tests/pvc_utils.go
+++ b/tests/pvc_utils.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	defaultTimeout = 30*time.Second
 )
 
 // Creates a PVC in the passed in namespace from the passed in PersistentVolumeClaim definition.


### PR DESCRIPTION
Removed default timeout declaration that was duplicated in two files.

make functest will not compile without this.

Signed-off-by: Alexander Wels <awels@redhat.com>