### PR TITLE
Tweak functest-image-host build flow to fix perm issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ cluster-sync-importer: cluster-sync
 cluster-sync-cloner: WHAT = cmd/cdi-cloner
 cluster-sync-cloner: cluster-sync
 
-functest: .functest-image-host
+functest:
 	./hack/build/functests.sh
 
-.functest-image-host: WHAT=tools/cdi-func-test-file-host-init
-.functest-image-host:  manifests build
-	./hack/build/build-cdi-func-test-file-host.sh
+functest-image-host: WHAT=tools/cdi-func-test-file-host-init
+functest-image-host:  manifests build
+	${DO} ./hack/build/build-cdi-func-test-file-host.sh && ./hack/build/build-docker.sh "tools/cdi-func-test-file-host-init tools/cdi-func-test-file-host-http"

--- a/hack/build/build-cdi-func-test-file-host.sh
+++ b/hack/build/build-cdi-func-test-file-host.sh
@@ -34,7 +34,3 @@ ${BUILD_DIR}/build-copy-artifacts.sh "${FILE_INIT_PATH}"
 OUT_PATH="${OUT_DIR}/tools"
 cp ${BUILD_DIR}/docker/${FILE_HOST}/* ${OUT_PATH}/${FILE_HOST}/
 cp "${CDI_DIR}/test/images/tinyCore.iso" "${OUT_PATH}/${FILE_INIT}/"
-
-for target in "${FILE_HOST}" "${FILE_INIT}"; do
-	${BUILD_DIR}/build-docker.sh build "tools/${target}"
-done


### PR DESCRIPTION
Fixes #350 

This PR alters the build flow for the functional test image host to perform some copy ops in a container.

The problem is that the container writes files as root, which then breaks copy ops in the host env when running as a regular user.  This is a long lived complaint with docker is not a configurable behavior, requiring a workaround.