### PR TITLE
Add skip namespace creation flag.

### DIFF
--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -15,7 +15,9 @@ const (
 )
 
 var _ = Describe(TestSuiteName, func() {
-	f, err := framework.NewFramework("sanity")
+	f, err := framework.NewFramework("sanity", &framework.Config{
+		SkipNamespaceCreation: true,
+	})
 	if err != nil {
 		Fail("Unable to create framework struct")
 	}

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 var _ = Describe(testSuiteName, func() {
-	f, err := framework.NewFramework(namespacePrefix)
+	f, err := framework.NewFramework(namespacePrefix, &framework.Config{})
 	if err != nil {
 		Fail("Unable to create framework struct")
 	}


### PR DESCRIPTION
- Not all tests require a namespace to run, add the ability
  to skip creating the generated namespace.

Signed-off-by: Alexander Wels <awels@redhat.com>