### PR TITLE
Fix default CDI namespace typo

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -24,7 +24,7 @@ source hack/build/common.sh
 KUBECTL=${KUBECTL:-${CDI_DIR}/cluster/.kubectl}
 KUBECONFIG=${KUBECONFIG:-${CDI_DIR}/cluster/.kubeconfig}
 KUBE_MASTER_URL=${KUBE_MASTER_URL:-""}
-CDI_NAMESPACE=${CDI_NAMESPACE:-kubesystem}
+CDI_NAMESPACE=${CDI_NAMESPACE:-kube-system}
 
 # parsetTestOpts sets 'pkgs' and test_args
 parseTestOpts "${@}"


### PR DESCRIPTION
- The default was set to kubesystem, instead of kube-system.

Signed-off-by: Alexander Wels <awels@redhat.com>