### PR TITLE
Add linter formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DO=eval
 endif
 SOURCE_DIRS = pkg tests tools
 
-all: docker
+all: docker fmt
 
 clean:
 	${DO} "./hack/build/build-go.sh clean; rm -rf bin/* _out/* manifests/generated/* .coverprofile release-announcement"
@@ -102,13 +102,12 @@ manifests:
 goveralls:
 	${DO} "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/build/goveralls.sh"
 
-fmt:
-	## Run gofmt with simplification
-	@gofmt -l -s -w $(SOURCE_DIRS)
-
-fmtcheck:
+checkformat:
 	## Just run gofmt without attempting to update files
 	@gofmt -l -s $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+lint:
+	## Run golint on source files
+	@$(foreach dir,$(SOURCE_DIRS),echo "loop dir: $(dir)\n" && golint "$(dir)/...";)
 
 release-description:
 	./hack/build/release-description.sh ${RELREF} ${PREREF}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@
 		format \
 		manifests \
 		goveralls \
-		release-description
+		release-description \
+		fmt \
+		fmtcheck \
+		lint
 
 DOCKER=1
 ifeq (${DOCKER}, 1)
@@ -29,6 +32,7 @@ DO=./hack/build/in-docker.sh
 else
 DO=eval
 endif
+SOURCE_DIRS = pkg tests tools
 
 all: docker
 
@@ -97,6 +101,14 @@ manifests:
 
 goveralls:
 	${DO} "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/build/goveralls.sh"
+
+fmt:
+	## Run gofmt with simplification
+	@gofmt -l -s -w $(SOURCE_DIRS)
+
+fmtcheck:
+	## Just run gofmt without attempting to update files
+	@gofmt -l -s $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 
 release-description:
 	./hack/build/release-description.sh ${RELREF} ${PREREF}

--- a/hack/build/format.sh
+++ b/hack/build/format.sh
@@ -23,3 +23,4 @@ source "${script_dir}"/config.sh
 shfmt -i 4 -w ${CDI_DIR}/hack ${CLONER_MAIN}
 goimports -w -local kubevirt.io ${CDI_DIR}/cmd/ ${CDI_DIR}/pkg/ ${CDI_DIR}/test/
 (cd ${CDI_DIR} && go vet $(go list ./... | grep -v -E "vendor|pkg/client" | sort -u))
+gofmt -l -s -w $(SOURCE_DIRS)


### PR DESCRIPTION
    Add formatting and linter checks to Makefile
    
    This commit adds 2 new options to the Makefile, and extends the existing
    `format` option:
    1. checkfmt
        This runs `gofmt -l -s` against all gofiles in the provided
        SOURCE_DIRS list (pkg, tests and tools), writing suggestions to
        stdout.
    2. lint
        Runs `golint` against all gofiles in the provided SOURCE_DIRS list
    3. Extends the existing format option
        In addition to running `go vet` and `go imports` via the hack/format.sh script, we
        add `gofmt -w -s` against the go files in SOURCE_DIRS trying to
        automatically update and write out simplifications to the files as
        necessary.
