### PR TITLE
Add gofmt checks to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
   - make manifests
 
 before_script:
+- make goveralls
+- make checkformat
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v$K8S_VER/bin/linux/amd64/kubectl
   && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v$MK_VER/minikube-linux-amd64
@@ -47,7 +49,6 @@ script:
 - "sed \"s#cdi.kubevirt.io/storage.import.endpoint:.*#cdi.kubevirt.io/storage.import.endpoint: \"$SRC#\"\" manifests/example/golden-pvc.yaml | kubectl apply -f -"
 - k_wait_all_running pods
 - kubectl get pods --all-namespaces
-- make goveralls
 
 before_deploy:
 - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@
 		format \
 		manifests \
 		goveralls \
-		release-description
+		release-description \
+		checkformat \
+		lint
 
 DOCKER=1
 ifeq (${DOCKER}, 1)
@@ -29,6 +31,7 @@ DO=./hack/build/in-docker.sh
 else
 DO=eval
 endif
+SOURCE_DIRS = pkg tests tools
 
 all: docker
 
@@ -97,6 +100,13 @@ manifests:
 
 goveralls:
 	${DO} "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/build/goveralls.sh"
+
+checkformat:
+	## Just run gofmt without attempting to update files
+	@gofmt -l -s $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+lint:
+	## Run golint on source files
+	@$(foreach dir,$(SOURCE_DIRS),echo "loop dir: $(dir)\n" && golint "$(dir)/...";)
 
 release-description:
 	./hack/build/release-description.sh ${RELREF} ${PREREF}

--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -16,11 +16,11 @@
 
 set -euo pipefail
 
-if [ $# != 2 ] ; then
-  echo "cloner: 2 args are supported: source|target and socket name"
-  exit 1
+if [ $# != 2 ]; then
+    echo "cloner: 2 args are supported: source|target and socket name"
+    exit 1
 fi
-obj="$1"  # source|target
+obj="$1"      # source|target
 rand_dir="$2" # part of socket path
 
 pipe_dir="/tmp/clone/socket/$rand_dir/pipe"
@@ -29,38 +29,38 @@ retries=0
 max_retries=20
 sleep_time=3
 
-if [ "$obj" == "source" ] ; then
-  echo "cloner: Starting clone source"
-  echo "cloner: creating fifo pipe"
-  mkfifo $pipe_dir
-  echo "cloner: creating tarball of the image and redirecting it to $pipe_dir"
-  pushd $image_dir
-  tar cv . > $pipe_dir
-  popd
-  echo "cloner: finished writing image to $pipe_dir"
-  exit 0
+if [ "$obj" == "source" ]; then
+    echo "cloner: Starting clone source"
+    echo "cloner: creating fifo pipe"
+    mkfifo $pipe_dir
+    echo "cloner: creating tarball of the image and redirecting it to $pipe_dir"
+    pushd $image_dir
+    tar cv . >$pipe_dir
+    popd
+    echo "cloner: finished writing image to $pipe_dir"
+    exit 0
 fi
 
-if [ "$obj" == "target" ] ; then
-  echo "cloner: Starting clone target"
-  while true ; do
-    echo "cloner: check if the fifo pipe was created by the cloning source pod"
-    if [ -e "$pipe_dir" ] ; then
-      pushd $image_dir
-      echo "cloner: extract the image from $pipe_dir into $image_dir directory"
-      tar xv < $pipe_dir
-      popd
-      echo "cloner: finished cloning image from $pipe_dir to $image_dir"
-      exit 0
-    fi
-    if (( retries == max_retries )) ; then
-      echo "cloner: failed after $retries retries to clone image"
-      exit 1
-    fi
-    echo "cloner: $retries: fifo pipe has not been created by the source pod. Waiting $sleep_time seconds before checking again..."
-    sleep $sleep_time
-    let retries+=1
-  done
+if [ "$obj" == "target" ]; then
+    echo "cloner: Starting clone target"
+    while true; do
+        echo "cloner: check if the fifo pipe was created by the cloning source pod"
+        if [ -e "$pipe_dir" ]; then
+            pushd $image_dir
+            echo "cloner: extract the image from $pipe_dir into $image_dir directory"
+            tar xv <$pipe_dir
+            popd
+            echo "cloner: finished cloning image from $pipe_dir to $image_dir"
+            exit 0
+        fi
+        if ((retries == max_retries)); then
+            echo "cloner: failed after $retries retries to clone image"
+            exit 1
+        fi
+        echo "cloner: $retries: fifo pipe has not been created by the source pod. Waiting $sleep_time seconds before checking again..."
+        sleep $sleep_time
+        let retries+=1
+    done
 fi
 
 echo "cloner: argument \"$obj\" is wrong; expect 'source' or 'target'"

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/golang/glog"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -17,6 +17,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/importer"
 )

--- a/hack/build/build-docker.sh
+++ b/hack/build/build-docker.sh
@@ -31,10 +31,10 @@ for tgt in ${targets}; do
     BIN_PATH="${tgt%/}"
     IMAGE="${DOCKER_REPO}/${BIN_NAME}:${DOCKER_TAG}"
     if [ "${docker_opt}" == "build" ]; then
-    (
-        cd "${OUT_DIR}/${BIN_PATH}"
-        docker "${docker_opt}" -t ${IMAGE} .
-    )
+        (
+            cd "${OUT_DIR}/${BIN_PATH}"
+            docker "${docker_opt}" -t ${IMAGE} .
+        )
     elif [ "${docker_opt}" == "push" ]; then
         if [ "${DOCKER_REPO}" == "kubevirt" ]; then
             echo "Pushes to docker.io/kubevirt should only be performed by CI."

--- a/hack/build/build-go.sh
+++ b/hack/build/build-go.sh
@@ -24,47 +24,47 @@ mkdir -p ${BIN_DIR}
 mkdir -p ${CMD_OUT_DIR}
 
 if [ -z "$1" ]; then
-	go_opt="build"
+    go_opt="build"
 else
-	go_opt=$1
-	shift
+    go_opt=$1
+    shift
 fi
 
 targets="$@"
 
 if [ "${go_opt}" == "test" ]; then
-	if [ -z "${targets}" ]; then
-            targets="${CDI_PKGS}"
-	fi
-	for tgt in ${targets}; do
+    if [ -z "${targets}" ]; then
+        targets="${CDI_PKGS}"
+    fi
+    for tgt in ${targets}; do
         (
             cd $tgt
             go test -v ./...
         )
-	done
+    done
 elif [ "${go_opt}" == "build" ]; then
     if [ -z "${targets}" ]; then
         targets="${BINARIES}"
     fi
-	for tgt in ${targets}; do
-		BIN_NAME=$(basename ${tgt})
-		BIN_PATH=${tgt%/}
-		if [[ "${BIN_NAME}" == "${CLONER}" ]]; then
-		    continue
-		fi
-		outFile=${OUT_DIR}/${BIN_PATH}/${BIN_NAME}
-		outLink=${BIN_DIR}/${BIN_NAME}
-		rm -f ${outFile}
-		rm -f ${outLink}
-		(
-			cd $tgt
+    for tgt in ${targets}; do
+        BIN_NAME=$(basename ${tgt})
+        BIN_PATH=${tgt%/}
+        if [[ "${BIN_NAME}" == "${CLONER}" ]]; then
+            continue
+        fi
+        outFile=${OUT_DIR}/${BIN_PATH}/${BIN_NAME}
+        outLink=${BIN_DIR}/${BIN_NAME}
+        rm -f ${outFile}
+        rm -f ${outLink}
+        (
+            cd $tgt
 
             # Only build executables for linux amd64
-			GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"'
+            GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"'
 
-			ln -sf ${outFile} ${outLink}
-		)
-	done
+            ln -sf ${outFile} ${outLink}
+        )
+    done
 else # Pass go commands directly on to packages except vendor
     if [ -z ${targets} ]; then
         targets=$(allPkgs) # pkg/client is generated code, ignore it

--- a/hack/build/build-manifests.sh
+++ b/hack/build/build-manifests.sh
@@ -38,12 +38,12 @@ for tmpl in ${templates}; do
     ) 1>"${MANIFEST_GENERATED_DIR}/${outFile}"
 
     (${generator} -template="${tmpl}" \
-            -docker-repo="{{ docker_prefix }}" \
-            -docker-tag="{{ docker_tag }}" \
-            -verbosity="{{ verbosity }}" \
-            -pull-policy="{{ pull_policy }}" \
-            -namespace="{{ namespace }}"
-        ) 1>"${MANIFEST_GENERATED_DIR}/${outFile}.j2"
+        -docker-repo="{{ docker_prefix }}" \
+        -docker-tag="{{ docker_tag }}" \
+        -verbosity="{{ verbosity }}" \
+        -pull-policy="{{ pull_policy }}" \
+        -namespace="{{ namespace }}"
+    ) 1>"${MANIFEST_GENERATED_DIR}/${outFile}.j2"
 done
 
 # Remove empty lines at the end of files which are added by go templating

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -37,28 +37,28 @@ OPENSHIFT_IMAGE="os-3.10.0@sha256:cdc9f998e19915b28b5c5be1ccc4c6fa2c8336435f38a3
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 
-function allPkgs {
-    ret=$(sed "s,kubevirt.io/containerized-data-importer,${CDI_DIR},g" <(go list ./... | grep -v "pkg/client" | sort -u ))
+function allPkgs() {
+    ret=$(sed "s,kubevirt.io/containerized-data-importer,${CDI_DIR},g" <(go list ./... | grep -v "pkg/client" | sort -u))
     echo "$ret"
 }
 
-function parseTestOpts {
+function parseTestOpts() {
     pkgs=""
     test_args=""
     while [[ $# -gt 0 ]] && [[ $1 != "" ]]; do
         case "${1}" in
-            --test-args=*)
-                test_args="${1#*=}"
-                shift 1
-                ;;
-            ./*...)
-                pkgs="${pkgs} ${1}"
-                shift 1
-                ;;
-            *)
-                echo "ABORT: Unrecognized option \"$1\""
-                exit 1
-                ;;
+        --test-args=*)
+            test_args="${1#*=}"
+            shift 1
+            ;;
+        ./*...)
+            pkgs="${pkgs} ${1}"
+            shift 1
+            ;;
+        *)
+            echo "ABORT: Unrecognized option \"$1\""
+            exit 1
+            ;;
         esac
     done
 }

--- a/hack/build/format.sh
+++ b/hack/build/format.sh
@@ -23,3 +23,4 @@ source "${script_dir}"/config.sh
 shfmt -i 4 -w ${CDI_DIR}/hack ${CLONER_MAIN}
 goimports -w -local kubevirt.io ${CDI_DIR}/cmd/ ${CDI_DIR}/pkg/ ${CDI_DIR}/test/
 (cd ${CDI_DIR} && go vet $(go list ./... | grep -v -E "vendor|pkg/client" | sort -u))
+gofmt -l -s -w $(SOURCE_DIRS)

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,13 +19,16 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${CODEGEN_PKG:-$(
+    cd ${SCRIPT_ROOT}
+    ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator
+)}
 
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
 ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
-  kubevirt.io/containerized-data-importer/pkg/client kubevirt.io/containerized-data-importer/pkg/apis \
-  datavolumecontroller:v1alpha1 \
-  --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt
+    kubevirt.io/containerized-data-importer/pkg/client kubevirt.io/containerized-data-importer/pkg/apis \
+    datavolumecontroller:v1alpha1 \
+    --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -25,7 +25,7 @@ TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
 _tmp="${SCRIPT_ROOT}/_tmp"
 
 cleanup() {
-  rm -rf "${_tmp}"
+    rm -rf "${_tmp}"
 }
 trap "cleanup" EXIT SIGINT
 
@@ -39,10 +39,9 @@ echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
 cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
-if [[ $ret -eq 0 ]]
-then
-  echo "${DIFFROOT} up to date."
+if [[ $ret -eq 0 ]]; then
+    echo "${DIFFROOT} up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
-  exit 1
+    echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+    exit 1
 fi

--- a/hack/version/ci-skip-check.sh
+++ b/hack/version/ci-skip-check.sh
@@ -3,8 +3,7 @@
 # ci-skip-check.sh
 # Travis does not have a way to skip tag builds
 
-if [[ $(git name-rev --name-only --tags HEAD) != *"undefined"* ]] && \
-    [[ $(git tag -ln --format '%(subject)' $(git describe --exact-match --tags HEAD)) = *'[ci skip]'* ]]
-    then
+if [[ $(git name-rev --name-only --tags HEAD) != *"undefined"* ]] &&
+    [[ $(git tag -ln --format '%(subject)' $(git describe --exact-match --tags HEAD)) == *'[ci skip]'* ]]; then
     exit 1
 fi

--- a/hack/version/lib.sh
+++ b/hack/version/lib.sh
@@ -3,7 +3,7 @@
 # lib.sh
 
 # doIncrement replaces the oldVersion value with the newVersion in the given file
-function setNewVersion(){
+function setNewVersion() {
     local file=$1
     local oldVersion=$2
     local newVersion=$3
@@ -16,8 +16,9 @@ function setNewVersion(){
 # Parameters:
 #   $1: the new version tag
 #   $@: Known files containing an updated version value
-function commitAndTag(){
-    local new_tag_name="$1"; shift
+function commitAndTag() {
+    local new_tag_name="$1"
+    shift
     local files="$@"
     printf "Adding changed files\n"
     for f in "$files"; do
@@ -30,10 +31,10 @@ function commitAndTag(){
     git tag -f -a -m "Update Version" $new_tag_name
 }
 
-function verifyOnMaster(){
+function verifyOnMaster() {
     local branch="master"
     printf "Verifying current branch is %s\n" "$branch"
-    if [  "$(git rev-parse --abbrev-ref HEAD)" != "$branch" ]; then
+    if [ "$(git rev-parse --abbrev-ref HEAD)" != "$branch" ]; then
         printf "Please checkout %s branch before continuing.\n" $branch
         exit 1
     fi
@@ -64,7 +65,7 @@ function verifyNoDiff() {
     printf "Verified local master matches %s\n" "$upstream"
 }
 
-function verifyVersionFormat(){
+function verifyVersionFormat() {
     printf "Validating version format\n"
     local newVersion="$1"
     # TODO improve regex to handle *-alpha.# suffixes
@@ -74,7 +75,7 @@ function verifyVersionFormat(){
     fi
 }
 
-function getCurrentVersion(){
+function getCurrentVersion() {
     local cv="$(git describe --tags --abbrev=0 HEAD)"
     if [ -z $cv ]; then
         exit 1
@@ -82,10 +83,10 @@ function getCurrentVersion(){
     printf $cv
 }
 
-function getVersionedFiles(){
+function getVersionedFiles() {
     local curVersion=$1
     local repoRoot=$2
-    local verFiles="$(grep -rl --exclude-dir={vender,bin,.git} --exclude={glide.*,.git*} "$curVersion" $repoRoot/ 2>/dev/null )"
+    local verFiles="$(grep -rl --exclude-dir={vender,bin,.git} --exclude={glide.*,.git*} "$curVersion" $repoRoot/ 2>/dev/null)"
     if [ -z "$verFiles" ]; then
         printf "" # this func exec'd inside subshell, so return null string
         exit 1
@@ -93,7 +94,7 @@ function getVersionedFiles(){
     printf "$(echo $verFiles | tr '\n' ' ')"
 }
 
-function acceptChanges(){
+function acceptChanges() {
     local curVersion=$1
     local newVersion=$2
     local targetFiles=$3
@@ -103,13 +104,13 @@ function acceptChanges(){
     read -n 1 -p "Do you accept these changes [N|y]: " key
     printf "\n"
     case "$key" in
-        y|Y)
-            printf "Continuing with version update\n"
-            ;;
+    y | Y)
+        printf "Continuing with version update\n"
+        ;;
 
-        ?)
-            printf "Aborting\n"
-            exit 1
-            ;;
+    ?)
+        printf "Aborting\n"
+        exit 1
+        ;;
     esac
 }

--- a/pkg/apis/datavolumecontroller/v1alpha1/types.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types.go
@@ -37,14 +37,14 @@ type DataVolumeSpec struct {
 }
 
 type DataVolumeSource struct {
-	HTTP *DataVolumeSourceHTTP `json:"http,omitempty"`
-	S3   *DataVolumeSourceS3   `json:"s3,omitempty"`
-	PVC *PersistentVolumeClaim `json:"pvc,omitempty"`
+	HTTP *DataVolumeSourceHTTP  `json:"http,omitempty"`
+	S3   *DataVolumeSourceS3    `json:"s3,omitempty"`
+	PVC  *PersistentVolumeClaim `json:"pvc,omitempty"`
 }
 
 type PersistentVolumeClaim struct {
 	Namespace string `json:"namespace,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name      string `json:"name,omitempty"`
 }
 
 type DataVolumeSourceS3 struct {

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -23,6 +23,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+
 	clientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1"
 	fakecdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/fake"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -23,6 +23,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -23,6 +23,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/datavolume.go
+++ b/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/datavolume.go
@@ -23,6 +23,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/datavolumecontroller_client.go
+++ b/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/datavolumecontroller_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/fake/fake_datavolume.go
+++ b/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/fake/fake_datavolume.go
@@ -25,6 +25,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/fake/fake_datavolumecontroller_client.go
+++ b/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1/fake/fake_datavolumecontroller_client.go
@@ -21,6 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/informers/externalversions/datavolumecontroller/v1alpha1/datavolume.go
+++ b/pkg/client/informers/externalversions/datavolumecontroller/v1alpha1/datavolume.go
@@ -25,6 +25,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	datavolumecontrollerv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -27,6 +27,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	datavolumecontroller "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/datavolumecontroller"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -23,6 +23,7 @@ import (
 
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
+
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 )
 

--- a/pkg/client/listers/datavolumecontroller/v1alpha1/datavolume.go
+++ b/pkg/client/listers/datavolumecontroller/v1alpha1/datavolume.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,17 +1,18 @@
 package common
 
 import (
-	"k8s.io/api/core/v1"
 	"time"
+
+	"k8s.io/api/core/v1"
 )
 
 // Common types and constants used by the importer and controller.
 // TODO: maybe the vm cloner can use these common values
 
 const (
-	CDI_LABEL_KEY          = "app"
-	CDI_LABEL_VALUE        = "containerized-data-importer"
-	CDI_LABEL_SELECTOR     = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
+	CDI_LABEL_KEY      = "app"
+	CDI_LABEL_VALUE    = "containerized-data-importer"
+	CDI_LABEL_SELECTOR = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
 
 	// host file constants:
 	IMPORTER_WRITE_DIR  = "/data"

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -10,8 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
-	"time"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -11,6 +11,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	k8stesting "k8s.io/client-go/tools/cache/testing"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 

--- a/pkg/controller/import_controller_ginkgo_test.go
+++ b/pkg/controller/import_controller_ginkgo_test.go
@@ -13,14 +13,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 	k8stesting "k8s.io/client-go/tools/cache/testing"
 
-	. "kubevirt.io/containerized-data-importer/pkg/controller"
 	. "kubevirt.io/containerized-data-importer/pkg/common"
+	. "kubevirt.io/containerized-data-importer/pkg/controller"
 )
 
 type operation int
 
 const (
-	opAdd                  operation = iota
+	opAdd operation = iota
 	opUpdate
 	opDelete
 	IMPORTER_DEFAULT_IMAGE = "kubevirt/cdi-importer:latest"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -446,7 +446,7 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 				AnnCloningCreatedBy: "yes",
 			},
 			Labels: map[string]string{
-				CDI_LABEL_KEY:     CDI_LABEL_VALUE,    //filtered by the podInformer
+				CDI_LABEL_KEY: CDI_LABEL_VALUE, //filtered by the podInformer
 			},
 		},
 		Spec: v1.PodSpec{

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -229,7 +229,7 @@ func MakeImporterPodSpec(image, verbose, pullPolicy, ep, secret string, pvc *v1.
 				LabelImportPvc: pvc.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         "v1",
 					Kind:               "PersistentVolumeClaim",
 					Name:               pvc.Name,

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -661,7 +661,7 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string) *v1.Pod {
 				LabelImportPvc: pvc.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         "v1",
 					Kind:               "PersistentVolumeClaim",
 					Name:               pvc.Name,

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minio/minio-go"
 	"github.com/pkg/errors"
 	"github.com/ulikunitz/xz"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 )

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -352,7 +352,7 @@ func Test_dataStream_constructReaders(t *testing.T) {
 			defer tt.ds.Close()
 			actualNumRdrs := len(tt.ds.Readers)
 			if tt.numRdrs != actualNumRdrs {
-				t.Errorf("dataStream.constructReaders(): expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs) 
+				t.Errorf("dataStream.constructReaders(): expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs)
 			}
 			if len(tt.outfile) > 0 {
 				os.Remove(filepath.Join(os.TempDir(), tt.outfile))

--- a/pkg/importer/datastream_ginkgo_test.go
+++ b/pkg/importer/datastream_ginkgo_test.go
@@ -8,15 +8,17 @@ import (
 	"strconv"
 	"strings"
 
+	"syscall"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"kubevirt.io/containerized-data-importer/pkg/image"
-	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
-	"kubevirt.io/containerized-data-importer/tests/utils"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	"kubevirt.io/containerized-data-importer/pkg/util"
-	"syscall"
+	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
+	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/tests/utils"
 )
 
 var _ = Describe("Streaming Data Conversion", func() {

--- a/pkg/importer/datastream_suite_test.go
+++ b/pkg/importer/datastream_suite_test.go
@@ -14,11 +14,10 @@ import (
 //   2) in tinyCore.iso where the returned size is smaller than the original. Note: this is not
 //      the case for larger iso files such as windows.
 var sizeExceptions = map[string]struct{}{
-	".iso":	   struct{}{},
+	".iso":    struct{}{},
 	".iso.gz": struct{}{},
 	".iso.xz": struct{}{},
 }
-
 
 func TestDatastream(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/importer/datastream_suite_test.go
+++ b/pkg/importer/datastream_suite_test.go
@@ -14,9 +14,9 @@ import (
 //   2) in tinyCore.iso where the returned size is smaller than the original. Note: this is not
 //      the case for larger iso files such as windows.
 var sizeExceptions = map[string]struct{}{
-	".iso":    struct{}{},
-	".iso.gz": struct{}{},
-	".iso.xz": struct{}{},
+	".iso":    {},
+	".iso.gz": {},
+	".iso.xz": {},
 }
 
 func TestDatastream(t *testing.T) {

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 

--- a/pkg/lib/size/size.go
+++ b/pkg/lib/size/size.go
@@ -2,6 +2,7 @@ package size
 
 import (
 	"github.com/pkg/errors"
+
 	. "kubevirt.io/containerized-data-importer/pkg/importer"
 )
 

--- a/pkg/lib/size/size_test.go
+++ b/pkg/lib/size/size_test.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	baseImageRelPath = "../../../tests/images"
-	tinyCore	 = "tinyCore.iso"
-	cirros		 = "cirros-qcow2.img"
+	tinyCore         = "tinyCore.iso"
+	cirros           = "cirros-qcow2.img"
 )
 
 func TestSize(t *testing.T) {
@@ -29,7 +29,7 @@ func TestSize(t *testing.T) {
 	type args struct {
 		endpoint  string
 		accessKey string
-		secKey	  string
+		secKey    string
 	}
 	tests := []struct {
 		name  string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"time"
 	"math/rand"
+	"time"
 )
 
 func RandAlphaNum(n int) string {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"testing"
 	"regexp"
+	"testing"
 )
 
 func TestRandAlphaNum(t *testing.T) {
@@ -16,7 +16,7 @@ func TestRandAlphaNum(t *testing.T) {
 		name        string
 		args        args
 		wantMatches string
-		expectErr bool
+		expectErr   bool
 	}{
 		{
 			name: "Test expected input",
@@ -32,7 +32,7 @@ func TestRandAlphaNum(t *testing.T) {
 			if len(got) != tt.args.n {
 				t.Errorf("len(RandAlphaNum()) = %v, want %v", len(got), tt.args.n)
 			}
-			if ! regexp.MustCompile(tt.wantMatches).Match([]byte(got)){
+			if !regexp.MustCompile(tt.wantMatches).Match([]byte(got)) {
 				t.Errorf("RandAlphaNum() = %v, want match %v", got, tt.wantMatches)
 			}
 		})


### PR DESCRIPTION
Add formatting check to travis                                                                                                                                                                            
                                                                                                                                                                                                                             
This just adds the `make checkformat` test to .travis.yml file to                                                                                                                                                        
include these as part of the build.  

We'll get all the lint errors cleaned 
up and pushed then add the `make lint`
as well.