### PR TITLE
Run gofmt on our directories

### DIFF
--- a/pkg/apis/datavolumecontroller/v1alpha1/types.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types.go
@@ -37,14 +37,14 @@ type DataVolumeSpec struct {
 }
 
 type DataVolumeSource struct {
-	HTTP *DataVolumeSourceHTTP `json:"http,omitempty"`
-	S3   *DataVolumeSourceS3   `json:"s3,omitempty"`
-	PVC *PersistentVolumeClaim `json:"pvc,omitempty"`
+	HTTP *DataVolumeSourceHTTP  `json:"http,omitempty"`
+	S3   *DataVolumeSourceS3    `json:"s3,omitempty"`
+	PVC  *PersistentVolumeClaim `json:"pvc,omitempty"`
 }
 
 type PersistentVolumeClaim struct {
 	Namespace string `json:"namespace,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name      string `json:"name,omitempty"`
 }
 
 type DataVolumeSourceS3 struct {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -9,9 +9,9 @@ import (
 // TODO: maybe the vm cloner can use these common values
 
 const (
-	CDI_LABEL_KEY          = "app"
-	CDI_LABEL_VALUE        = "containerized-data-importer"
-	CDI_LABEL_SELECTOR     = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
+	CDI_LABEL_KEY      = "app"
+	CDI_LABEL_VALUE    = "containerized-data-importer"
+	CDI_LABEL_SELECTOR = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
 
 	// host file constants:
 	IMPORTER_WRITE_DIR  = "/data"

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	. "kubevirt.io/containerized-data-importer/pkg/common"
-	"time"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	"time"
 )
 
 const (

--- a/pkg/controller/import_controller_ginkgo_test.go
+++ b/pkg/controller/import_controller_ginkgo_test.go
@@ -13,14 +13,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 	k8stesting "k8s.io/client-go/tools/cache/testing"
 
-	. "kubevirt.io/containerized-data-importer/pkg/controller"
 	. "kubevirt.io/containerized-data-importer/pkg/common"
+	. "kubevirt.io/containerized-data-importer/pkg/controller"
 )
 
 type operation int
 
 const (
-	opAdd                  operation = iota
+	opAdd operation = iota
 	opUpdate
 	opDelete
 	IMPORTER_DEFAULT_IMAGE = "kubevirt/cdi-importer:latest"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -229,7 +229,7 @@ func MakeImporterPodSpec(image, verbose, pullPolicy, ep, secret string, pvc *v1.
 				LabelImportPvc: pvc.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         "v1",
 					Kind:               "PersistentVolumeClaim",
 					Name:               pvc.Name,
@@ -446,7 +446,7 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 				AnnCloningCreatedBy: "yes",
 			},
 			Labels: map[string]string{
-				CDI_LABEL_KEY:     CDI_LABEL_VALUE,    //filtered by the podInformer
+				CDI_LABEL_KEY: CDI_LABEL_VALUE, //filtered by the podInformer
 			},
 		},
 		Spec: v1.PodSpec{

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -661,7 +661,7 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string) *v1.Pod {
 				LabelImportPvc: pvc.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         "v1",
 					Kind:               "PersistentVolumeClaim",
 					Name:               pvc.Name,

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -352,7 +352,7 @@ func Test_dataStream_constructReaders(t *testing.T) {
 			defer tt.ds.Close()
 			actualNumRdrs := len(tt.ds.Readers)
 			if tt.numRdrs != actualNumRdrs {
-				t.Errorf("dataStream.constructReaders(): expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs) 
+				t.Errorf("dataStream.constructReaders(): expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs)
 			}
 			if len(tt.outfile) > 0 {
 				os.Remove(filepath.Join(os.TempDir(), tt.outfile))

--- a/pkg/importer/datastream_ginkgo_test.go
+++ b/pkg/importer/datastream_ginkgo_test.go
@@ -10,13 +10,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"kubevirt.io/containerized-data-importer/pkg/image"
-	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
-	"kubevirt.io/containerized-data-importer/tests/utils"
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	"kubevirt.io/containerized-data-importer/pkg/util"
-	"syscall"
+	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
+	imagesize "kubevirt.io/containerized-data-importer/pkg/lib/size"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+	"syscall"
 )
 
 var _ = Describe("Streaming Data Conversion", func() {

--- a/pkg/importer/datastream_suite_test.go
+++ b/pkg/importer/datastream_suite_test.go
@@ -14,11 +14,10 @@ import (
 //   2) in tinyCore.iso where the returned size is smaller than the original. Note: this is not
 //      the case for larger iso files such as windows.
 var sizeExceptions = map[string]struct{}{
-	".iso":	   struct{}{},
-	".iso.gz": struct{}{},
-	".iso.xz": struct{}{},
+	".iso":    {},
+	".iso.gz": {},
+	".iso.xz": {},
 }
-
 
 func TestDatastream(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/lib/size/size_test.go
+++ b/pkg/lib/size/size_test.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	baseImageRelPath = "../../../tests/images"
-	tinyCore	 = "tinyCore.iso"
-	cirros		 = "cirros-qcow2.img"
+	tinyCore         = "tinyCore.iso"
+	cirros           = "cirros-qcow2.img"
 )
 
 func TestSize(t *testing.T) {
@@ -29,7 +29,7 @@ func TestSize(t *testing.T) {
 	type args struct {
 		endpoint  string
 		accessKey string
-		secKey	  string
+		secKey    string
 	}
 	tests := []struct {
 		name  string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"time"
 	"math/rand"
+	"time"
 )
 
 func RandAlphaNum(n int) string {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"testing"
 	"regexp"
+	"testing"
 )
 
 func TestRandAlphaNum(t *testing.T) {
@@ -16,7 +16,7 @@ func TestRandAlphaNum(t *testing.T) {
 		name        string
 		args        args
 		wantMatches string
-		expectErr bool
+		expectErr   bool
 	}{
 		{
 			name: "Test expected input",
@@ -32,7 +32,7 @@ func TestRandAlphaNum(t *testing.T) {
 			if len(got) != tt.args.n {
 				t.Errorf("len(RandAlphaNum()) = %v, want %v", len(got), tt.args.n)
 			}
-			if ! regexp.MustCompile(tt.wantMatches).Match([]byte(got)){
+			if !regexp.MustCompile(tt.wantMatches).Match([]byte(got)) {
 				t.Errorf("RandAlphaNum() = %v, want match %v", got, tt.wantMatches)
 			}
 		})


### PR DESCRIPTION
Just do a simple `gofmt -s -w` on pkg, tests and controller directories
to fix the misc space/tab mixes and some other ez formatting issues.