### PR TITLE
Add gofmt check to makefile and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
 - k_wait_all_running pods
 - kubectl get pods --all-namespaces
 - make goveralls
+- make test-lint
 
 before_deploy:
 - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build build-controller build-importer build-functest-image-init build-functest-image-http build-functest \
 		docker docker-controller docker-cloner docker-importer docker-functest-image-init docker-functest-image-http\
 		cluster-sync cluster-sync-controller cluster-sync-cloner cluster-sync-importer \
-		test test-functional test-unit \
+		test test-functional test-unit test-lint \
 		publish \
 		vet \
 		format \
@@ -51,7 +51,7 @@ build-functest:
 	${DO} ./hack/build/build-functest.sh
 
 # WHAT must match go tool style package paths for test targets (e.g. ./path/to/my/package/...)
-test: test-unit test-functional
+test: test-unit test-functional test-lint
 
 test-unit: WHAT = ./pkg/...
 test-unit:
@@ -60,6 +60,10 @@ test-unit:
 test-functional:  WHAT = ./tests/...
 test-functional:
 	./hack/build/run-functional-tests.sh ${WHAT} "${TEST_ARGS}"
+
+# test-lint runs gofmt and golint tests against src files
+test-lint:
+	${DO} "./hack/build/run-lint-checks.sh"
 
 docker: build
 	./hack/build/build-docker.sh build ${WHAT}

--- a/hack/build/run-lint-checks.sh
+++ b/hack/build/run-lint-checks.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #Copyright 2018 The CDI Authors.
 #
 #Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,17 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-CDI_DIR="$(readlink -f $(dirname $0)/../../)"
-BIN_DIR=${CDI_DIR}/bin
-OUT_DIR=${CDI_DIR}/_out
-CMD_OUT_DIR=${OUT_DIR}/cmd
-TESTS_OUT_DIR=${OUT_DIR}/tests
-BUILD_DIR=${CDI_DIR}/hack/build
-MANIFEST_TEMPLATE_DIR=${CDI_DIR}/manifests/templates
-MANIFEST_GENERATED_DIR=${CDI_DIR}/manifests/generated
-SOURCE_DIRS="pkg tests tools"
+# NOTE: Not using pipefail because gofmt returns 0 when it finds
+# suggestions and 1 when files are clean
+
+source hack/build/config.sh
+source hack/build/common.sh
+
+ec=0
+out="$(gofmt -l -s ${SOURCE_DIRS} | grep ".*\.go")"
+if [[ ${out} ]]; then
+  echo "FAIL: Format errors found in the following files:"
+  echo "${out}"
+  ec=1
+fi
+exit ${ec}

--- a/tests/reporters/reporters.go
+++ b/tests/reporters/reporters.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package reporters
 
-
 import (
 	. "github.com/onsi/ginkgo"
 


### PR DESCRIPTION
Add checkformat to Makefile and add Travis check                                                                                                              
                                                                                                                                                              
This adds a super simple gofmt check for Travis to run.  If there are                                                                                         
files that gofmt recommends updating, the check fails, if there aren't                                                                                        
it passes.                                           