### PR TITLE
cloner image uses ENTRYPOINT instead of hard coded path

### DIFF
--- a/hack/build/docker/cdi-cloner/Dockerfile
+++ b/hack/build/docker/cdi-cloner/Dockerfile
@@ -1,3 +1,5 @@
 FROM fedora:28
-ADD cloner_startup.sh /tmp/cloner_startup.sh
-RUN chmod +x /tmp/cloner_startup.sh
+ADD cloner_startup.sh /usr/bin/cloner_startup.sh
+RUN chmod +x /usr/bin/cloner_startup.sh
+
+ENTRYPOINT [ "/usr/bin/cloner_startup.sh" ]

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -35,7 +35,6 @@ const (
 	CLONER_TARGET_PODNAME = "clone-target-pod"
 	CLONER_IMAGE_PATH     = "/tmp/clone/image"
 	CLONER_SOCKET_PATH    = "/tmp/clone/socket"
-	CLONER_SCRIPT_ARGS    = "/tmp/cloner_startup.sh"
 
 	// key names expected in credential secret
 	KeyAccess = "accessKeyId"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -371,7 +371,6 @@ func MakeCloneSourcePodSpec(image, verbose, pullPolicy, pvcName string, generate
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Command:         []string{"/bin/sh"},
 					Name:            CLONER_SOURCE_PODNAME,
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
@@ -389,7 +388,7 @@ func MakeCloneSourcePodSpec(image, verbose, pullPolicy, pvcName string, generate
 							MountPath: CLONER_SOCKET_PATH + "/" + generatedLabelStr,
 						},
 					},
-					Args: []string{"-c", CLONER_SCRIPT_ARGS + " source " + generatedLabelStr},
+					Args: []string{"source", generatedLabelStr},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
@@ -471,7 +470,6 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 			},
 			Containers: []v1.Container{
 				{
-					Command:         []string{"/bin/sh"},
 					Name:            CLONER_TARGET_PODNAME,
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
@@ -489,7 +487,7 @@ func MakeCloneTargetPodSpec(image, verbose, pullPolicy string, pvc *v1.Persisten
 							MountPath: CLONER_SOCKET_PATH + "/" + generatedLabelStr,
 						},
 					},
-					Args: []string{"-c", CLONER_SCRIPT_ARGS + " target " + generatedLabelStr},
+					Args: []string{"target", generatedLabelStr},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
- Updated controller to use ENTRYPOINT (no cmd) instead of /bin/sh
- Updated Dockerfile to set path to /usr/bin/cloner_startup.sh instead of /tmp
- Updated Dockerfile to use ENTRYPOINT.

Fixes issue #374

Signed-off-by: Alexander Wels <awels@redhat.com>