### PR TITLE
E2E Testing - transport protocols

### DIFF
--- a/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
@@ -8,12 +8,18 @@ RUN dnf -y install nginx && dnf clean all -y
 
 ARG IMAGE_DIR=/usr/share/nginx/html/images
 
+RUN mkdir -p $IMAGE_DIR/priv
+
 RUN mkdir -p $IMAGE_DIR
 
 RUN rm -f /etc/nginx/nginx.conf
 
 COPY nginx.conf /etc/nginx/
 
+COPY htpasswd /etc/nginx/
+
 EXPOSE 80
+
+EXPOSE 81
 
 ENTRYPOINT nginx

--- a/hack/build/docker/cdi-func-test-file-host-http/htpasswd
+++ b/hack/build/docker/cdi-func-test-file-host-http/htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$1clZzd4o$w7dsAjb5.p7r9Fka94lWU.

--- a/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
+++ b/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
@@ -10,16 +10,32 @@ http {
 
     sendfile on;
 
+    server_name localhost;
+
+    # no auth
     server {
+
+        listen 80;
+
         root /tmp/shared/images;
 
         location / {
             autoindex on;
             autoindex_format json;
         }
+    }
+    # auth
+    server {
+        listen 81;
 
-        server_name localhost;
+        root /tmp/shared/images;
 
-        listen 80;
+        auth_basic "auth test";
+        auth_basic_user_file /etc/nginx/htpasswd;
+
+        location / {
+            autoindex on;
+            autoindex_format json;
+        }
     }
 }

--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -31,8 +31,10 @@ spec:
         imagePullPolicy: {{ .PullPolicy }}
         command: ["/usr/sbin/nginx"]
         ports:
-        - name: http
+        - name: http-no-auth
           containerPort: 80
+        - name: http-auth
+          containerPort: 81
         volumeMounts:
         - name: "images"
           mountPath: "/tmp/shared/"
@@ -89,7 +91,10 @@ spec:
       cdi.kubevirt.io/testing: ""
   type: ClusterIP
   ports:
-  - name: http
+  - name: http-auth
+    port: 81
+    targetPort: 81
+  - name: http-no-auth
     port: 80
     targetPort: 80
   - name: s3

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTests(t *testing.T) {
+	defer GinkgoRecover()
 	RegisterFailHandler(tests.CDIFailHandler)
 	RunSpecsWithDefaultAndCustomReporters(t, "Tests Suite", reporters.NewReporters())
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+
+	"k8s.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+)
+
+var _ = Describe("Transport Tests", func() {
+
+	const (
+		secretPrefix = "transport-e2e-sec"
+		targetFile   = "tinyCore.iso"
+	)
+
+	f, err := framework.NewFramework("", framework.Config{SkipNamespaceCreation: false})
+	handelError(errors.Wrap(err, "error creating test framework"))
+
+	c, err := f.GetKubeClient()
+	handelError(errors.Wrap(err, "error creating k8s client"))
+
+	fileHostService := utils.GetServiceInNamespaceOrDie(c, utils.FileHostNs, utils.FileHostName)
+
+	httoAuthPort, err := utils.GetServicePortByName(fileHostService, utils.HttpAuthPortName)
+	handelError(err)
+	noAuthPort, err := utils.GetServicePortByName(fileHostService, utils.HttpNoAuthPortName)
+	handelError(err)
+
+	httpAuthEp := fmt.Sprintf("http://%s:%d/%s", fileHostService.Spec.ClusterIP, httoAuthPort, targetFile)
+	httpNoAuthEp := fmt.Sprintf("http://%s:%d/%s", fileHostService.Spec.ClusterIP, noAuthPort, targetFile)
+
+	var ns string
+	BeforeEach(func() {
+		ns = f.Namespace.Name
+		By(fmt.Sprintf("Waiting for all \"%s/%s\" deployment replicas to be Ready", utils.FileHostNs, utils.FileHostName))
+		utils.WaitForDeploymentReplicasReadyOrDie(c, utils.FileHostNs, utils.FileHostName)
+	})
+
+	// it() is the body of the test and is executed once per Entry() by DescribeTable()
+	// closes over c and ns
+	it := func(ep string, credentialed bool) {
+
+		pvcAnn := map[string]string{
+			controller.AnnEndpoint: ep,
+			controller.AnnSecret:   "",
+		}
+
+		var (
+			err error // prevent shadowing
+			sec *v1.Secret
+		)
+
+		if credentialed {
+			By(fmt.Sprintf("Creating secret for endpoint %s", ep))
+			stringData := map[string]string{
+				common.KeyAccess: utils.AccessKeyValue,
+				common.KeySecret: utils.SecretKeyValue,
+			}
+			sec, err = utils.CreateSecretFromDefinition(c, utils.NewSecretDefinition(nil, stringData, nil, ns, secretPrefix))
+			Expect(err).NotTo(HaveOccurred(), "Error creating test secret")
+			pvcAnn[controller.AnnSecret] = sec.Name
+		}
+
+		By(fmt.Sprintf("Creating PVC with endpoint annotation %q", ep))
+		pvc, err := utils.CreatePVCFromDefinition(c, ns, utils.NewPVCDefinition("transport-e2e", "20M", pvcAnn, nil))
+		Expect(err).NotTo(HaveOccurred(), "Error creating PVC")
+
+		err = utils.WaitForPersistentVolumeClaimPhase(c, ns, v1.ClaimBound, pvc.Name)
+		Expect(err).NotTo(HaveOccurred(), "Error waiting for claim phase Bound")
+
+		By("Verifying PVC is not empty")
+		Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeFalse())
+	}
+
+	DescribeTable("Transport Test Table", it,
+		Entry("should connect to http endpoint without credentials", httpNoAuthEp, false),
+		Entry("should connect to http endpoint with credentials", httpAuthEp, true))
+})
+
+// handelError is intended for use outside It(), BeforeEach() and AfterEach() blocks where Expect() cannot be called.
+func handelError(e error) {
+	if e != nil {
+		Fail(fmt.Sprintf("Encountered error: %v", e))
+	}
+}

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,0 +1,12 @@
+package utils
+
+const (
+	// cdi-file-host pod/service relative values
+	FileHostName       = "cdi-file-host" // deployment and service name
+	FileHostNs         = "kube-system"   // deployment and service namespace
+	FileHostS3Bucket   = "images"        // s3 bucket name (e.g. http://<serviceIP:port>/FileHostS3Bucket/image)
+	AccessKeyValue     = "admin"         // http && s3 username, see hack/build/docker/cdi-func-test-file-host-http/htpasswd
+	SecretKeyValue     = "password"      // http && s3 password,  ditto
+	HttpAuthPortName   = "http-auth"     // cdi-file-host service auth port
+	HttpNoAuthPortName = "http-no-auth"  // cdi-file-host service no-auth port, requires AccessKeyValue and SecretKeyValue
+)

--- a/tests/utils/deployments.go
+++ b/tests/utils/deployments.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+func WaitForDeploymentReplicasReadyOrDie(c *kubernetes.Clientset, namespace, name string) {
+	if err := WaitForDeploymentReplicasReady(c, namespace, name); err != nil {
+		glog.Fatal(errors.Wrapf(err, "Failed waiting for deployment \"%s/%s\" replicas to become Ready", namespace, name))
+	}
+}
+
+func WaitForDeploymentReplicasReady(c *kubernetes.Clientset, namespace, name string) error {
+	return wait.PollImmediate(defaultPollInterval, defaultPollPeriod, func() (done bool, err error) {
+		dep, err := c.ExtensionsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
+		// Fail if deployment not found, ignore other (possibly intermittent) API errors
+		if apierrs.IsNotFound(err) {
+			return true, err
+		}
+		// Log non-fatal errors
+		if err != nil {
+			glog.Error(errors.Wrapf(err, "Error getting deployment \"%s/%s\"", namespace, name))
+		}
+		// All replicas not ready, continue wait
+		if dep.Status.ReadyReplicas != *dep.Spec.Replicas {
+			return false, nil
+		}
+		// Replicas ready, done
+		return true, nil
+	})
+}

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	PodCreateTime  = 30 * time.Second
-	PodDeleteTime  = 30 * time.Second
-	PodWaitForTime = 30 * time.Second
+	PodCreateTime  = defaultPollPeriod
+	PodDeleteTime  = defaultPollPeriod
+	PodWaitForTime = defaultPollPeriod
 )
 
 // Create a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to

--- a/tests/utils/secrets.go
+++ b/tests/utils/secrets.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	SecretPollPeriod   = defaultPollPeriod
+	SecretPollInterval = defaultPollInterval
+)
+
+func NewSecretDefinition(labels, stringData map[string]string, data map[string][]byte, ns, prefix string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: prefix,
+			Namespace:    ns,
+			Labels:       labels,
+		},
+		StringData: stringData,
+		Data:       data,
+	}
+}
+
+func CreateSecretFromDefinition(c *kubernetes.Clientset, secret *v1.Secret) (*v1.Secret, error) {
+	err := wait.PollImmediate(SecretPollInterval, SecretPollPeriod, func() (done bool, err error) {
+		secret, err = c.CoreV1().Secrets(secret.Namespace).Create(secret)
+		// success
+		if err == nil {
+			return true, nil
+		}
+		// fail if secret exists.
+		if apierrs.IsAlreadyExists(err) {
+			return true, err
+		}
+		// Log non-fatal errors
+		glog.Error(errors.Wrapf(err, "Encountered create error for secret \"%s/%s\"", secret.Namespace, secret.Name))
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}

--- a/tests/utils/services.go
+++ b/tests/utils/services.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ServicePollInterval = defaultPollInterval
+	ServicePollPeriod   = defaultPollPeriod
+)
+
+// GetServiceInNamespaceOrDie attempts to get the service in namespace `ns` by `name`.  Returns pointer to service on
+// success.  Panics on error.
+func GetServiceInNamespaceOrDie(c *kubernetes.Clientset, ns, name string) *v1.Service {
+	svc, err := GetServiceInNamespace(c, ns, name)
+	if err != nil || svc == nil {
+		glog.Fatal(err)
+	}
+	return svc
+}
+
+// GetServiceInNamespace retries get on service `name` in namespace `ns` until timeout or IsNotFound error.  Ignores
+// api errors that may be intermittent.  Returns pointer to service (nil on error) or an error (nil on success)
+func GetServiceInNamespace(c *kubernetes.Clientset, ns, name string) (*v1.Service, error) {
+	var svc *v1.Service
+	err := wait.PollImmediate(ServicePollInterval, ServicePollPeriod, func() (done bool, err error) {
+		svc, err = c.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+		// success
+		if err == nil {
+			return true, nil
+		}
+		// fail if the service does not exist
+		if apierrs.IsNotFound(err) {
+			return false, errors.Wrap(err, "Service not found")
+		}
+		// log non-fatal errors
+		glog.Error(errors.Wrapf(err, "Encountered non-fatal error getting service \"%s/%s\". retrying", ns, name))
+		return false, nil
+	})
+	return svc, err
+}
+
+// GetServicesInNamespaceByLabel retries get of services in namespace `ns` by `labelSelector` until timeout.  Ignores
+// api errors that may be intermittent.  Returns pointer to ServiceList (nil on error) and an error (nil on success)
+func GetServicesInNamespaceByLabel(c *kubernetes.Clientset, ns, labelSelector string) (*v1.ServiceList, error) {
+	var svcList *v1.ServiceList
+	err := wait.PollImmediate(ServicePollInterval, ServicePollPeriod, func() (done bool, err error) {
+		svcList, err = c.CoreV1().Services(ns).List(metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		// success
+		if err == nil {
+			return true, nil
+		}
+		// log non-fatal errors
+		glog.Error(errors.Wrapf(err, "Encountered non-fatal error getting service list in namespace %s", ns))
+		return false, nil
+	})
+	return svcList, err
+}
+
+// GetServicePortByName scan's a services ports for names matching `name`.  Returns integer port value (0 on error) and
+// error (nil on success).
+func GetServicePortByName(svc *v1.Service, name string) (int, error) {
+	if svc == nil {
+		return 0, errors.New("nil service")
+	}
+
+	var port int
+	for _, p := range svc.Spec.Ports {
+		if p.Name == name {
+			port = int(p.Port)
+			break
+		}
+	}
+	if port == 0 {
+		return 0, errors.Errorf("port %q not found", name)
+	}
+	return port, nil
+}


### PR DESCRIPTION
- Adds tests that create PVCs in a cluster with the endpoint of the file host pod.   This test exercises the import pod's ability to connect to real host over supported protocols.
- Adds utility funcs for services and deployments.

cc @jeffvance @awels 