### PR TITLE
Fix WaitForPersistentVolumeClaimPhase returning error unconditionally

### DIFF
--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -76,12 +76,15 @@ func NewPVCDefinition(pvcName string, size string, annotations, labels map[strin
 
 // Wait for the PVC to be in a particular phase (Pending, Bound, or Lost)
 func WaitForPersistentVolumeClaimPhase(clientSet *kubernetes.Clientset, namespace string, phase k8sv1.PersistentVolumeClaimPhase, pvcName string) error {
-	wait.PollImmediate(pvcPollInterval, PVCPhaseTime, func() (bool, error) {
+	err := wait.PollImmediate(pvcPollInterval, PVCPhaseTime, func() (bool, error) {
 		pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(pvcName, metav1.GetOptions{})
 		if err != nil || pvc.Status.Phase != phase {
 			return false, err
 		}
 		return true, nil
 	})
-	return fmt.Errorf("PersistentVolumeClaim %s not in phase %s within %v", pvcName, phase, PVCPhaseTime)
+	if err != nil{
+		return fmt.Errorf("PersistentVolumeClaim %s not in phase %s within %v", pvcName, phase, PVCPhaseTime)
+	}
+	return nil
 }


### PR DESCRIPTION
Fix function returning an error regardless of the output from the `wait` call.