### PR TITLE
Fix clone tests

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -110,7 +110,7 @@ func doCloneTest(f *framework.Framework, targetNs *v1.Namespace) {
 	Expect(cloneAnnotationFound).To(BeTrue())
 
 	By("Verify the clone status is success on the target PVC")
-	status, phaseAnnotation, err := utils.WaitForPVCAnnotation(f.K8sClient, targetNs.Name, targetPvc, controller.AnnPodPhase)
+	status, phaseAnnotation, err := utils.WaitForPVCAnnotation(f.K8sClient, targetNs.Name, targetPvc, controller.AnnClonePodPhase)
 	Expect(phaseAnnotation).To(BeTrue())
 	Expect(status).Should(BeEquivalentTo(v1.PodSucceeded))
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -17,15 +17,16 @@ import (
 )
 
 const (
-	testSuiteName        = "Cloner Test Suite"
-	namespacePrefix      = "cloner"
-	sourcePodFillerName  = "fill-source"
-	sourcePVCName        = "source-pvc"
-	fillData             = "123456789012345678901234567890123456789012345678901234567890"
-	testFile             = utils.DefaultPvcMountPath + "/source.txt"
-	fillCommand          = "echo \"" + fillData + "\" >> " + testFile
-	cloneCompleteTimeout = 10 * time.Second
-	testCompleteTimeout  = 300 * time.Second
+	testSuiteName         = "Cloner Test Suite"
+	namespacePrefix       = "cloner"
+	sourcePodFillerName   = "fill-source"
+	sourcePVCName         = "source-pvc"
+	fillData              = "123456789012345678901234567890123456789012345678901234567890"
+	testFile              = utils.DefaultPvcMountPath + "/source.txt"
+	fillCommand           = "echo \"" + fillData + "\" >> " + testFile
+	assertionPollInterval = 2 * time.Second
+	cloneCompleteTimeout  = 10 * time.Second
+	testCompleteTimeout   = 300 * time.Second
 )
 
 var _ = Describe(testSuiteName, func() {
@@ -94,10 +95,16 @@ func doCloneTest(f *framework.Framework, targetNs *v1.Namespace) {
 	targetPod, err := utils.FindPodByPrefix(f.K8sClient, targetNs.Name, common.CLONER_TARGET_PODNAME, common.CDI_LABEL_SELECTOR)
 	Expect(err).ToNot(HaveOccurred())
 
-	By("Source and Target pods have to be on same node")
-	fmt.Fprintf(GinkgoWriter, "INFO: Source POD host %s\n", sourcePod.Spec.NodeName)
-	fmt.Fprintf(GinkgoWriter, "INFO: Target POD host %s\n", targetPod.Spec.NodeName)
-	Expect(sourcePod.Spec.NodeName).To(Equal(targetPod.Spec.NodeName))
+	By("Verifying that the source and target pods are scheduled on the same node")
+	Eventually(func() bool {
+		srcNode, err := utils.PodNode(f.K8sClient, sourcePod.Name, sourcePod.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+		tgtNode, err := utils.PodNode(f.K8sClient, targetPod.Name, targetPod.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+		fmt.Fprintf(GinkgoWriter, "INFO: Source POD host %s\n", srcNode)
+		fmt.Fprintf(GinkgoWriter, "INFO: Target POD host %s\n", tgtNode)
+		return srcNode == tgtNode
+	}, cloneCompleteTimeout, assertionPollInterval).Should(BeTrue())
 
 	err = f.WaitTimeoutForPodStatus(sourcePod.Name, v1.PodSucceeded, cloneCompleteTimeout)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -136,3 +136,11 @@ func podStatus(clientSet *kubernetes.Clientset, podName, namespace string, statu
 		return false, nil
 	}
 }
+
+func PodGetNode(clientSet *kubernetes.Clientset, podName, namespace string) (string, error) {
+	pod, err := clientSet.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return pod.Spec.NodeName, nil
+}


### PR DESCRIPTION
Apply two fixes to the clone tests:
- check for the correct PVC annotation
- Poll pods to check onto which node they were scheduled.