### PR TITLE
Functest file host - reduce qemu install to qemu-img

### DIFF
--- a/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:28
 
 RUN mkdir -p /tmp/shared /tmp/source
 
-RUN yum install -y qemu
+RUN yum install -y qemu-img
 
 COPY cdi-func-test-file-host-init /usr/bin/
 


### PR DESCRIPTION
Partially fixes #347 

One line fix to reduce install time and storage footprint of the file host. 