### PR TITLE
`NewFrameworkOrDie`

### DIFF
--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -15,12 +15,9 @@ const (
 )
 
 var _ = Describe(TestSuiteName, func() {
-	f, err := framework.NewFramework("sanity", framework.Config{
+	f := framework.NewFrameworkOrDie("sanity", framework.Config{
 		SkipNamespaceCreation: true,
 	})
-	if err != nil {
-		Fail("Unable to create framework struct")
-	}
 
 	Context("CDI service account should exist", func() {
 		It("Should succeed", func() {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 var _ = Describe(testSuiteName, func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix, framework.Config{})
+	f := framework.NewFrameworkOrDie(namespacePrefix)
 
 	var sourcePvc *v1.PersistentVolumeClaim
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -29,10 +29,7 @@ const (
 )
 
 var _ = Describe(testSuiteName, func() {
-	f, err := framework.NewFramework(namespacePrefix, framework.Config{})
-	if err != nil {
-		Fail("Unable to create framework struct")
-	}
+	f := framework.NewFrameworkOrDie(namespacePrefix, framework.Config{})
 
 	var sourcePvc *v1.PersistentVolumeClaim
 
@@ -43,7 +40,7 @@ var _ = Describe(testSuiteName, func() {
 	AfterEach(func() {
 		if sourcePvc != nil {
 			By("[AfterEach] Clean up target PVC")
-			err = f.DeletePVC(sourcePvc)
+			err := f.DeletePVC(sourcePvc)
 			Expect(err).ToNot(HaveOccurred())
 		}
 	})

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -30,7 +30,7 @@ var _ = Describe("DataVolume tests", func() {
 	AfterEach(func() {
 		if sourcePvc != nil {
 			By("[AfterEach] Clean up target PVC")
-			err = f.DeletePVC(sourcePvc)
+			err := f.DeletePVC(sourcePvc)
 			Expect(err).ToNot(HaveOccurred())
 			sourcePvc = nil
 		}

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -25,10 +25,7 @@ var _ = Describe("DataVolume tests", func() {
 	testFile := utils.DefaultPvcMountPath + "/source.txt"
 	fillCommand := "echo \"" + fillData + "\" >> " + testFile
 
-	f, err := framework.NewFramework("dv-func-test", framework.Config{})
-	if err != nil {
-		Fail("Unable to create framework struct")
-	}
+	f := framework.NewFrameworkOrDie("dv-func-test")
 
 	AfterEach(func() {
 		if sourcePvc != nil {

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -96,6 +96,15 @@ func init() {
 	master = flag.String("master", "", "master url:port")
 }
 
+// NewFrameworkOrDie calls NewFramework and handles errors by calling Fail.
+func NewFrameworkOrDie(prefix string, config Config) *Framework {
+	f, err := NewFramework(prefix, config)
+	if err != nil {
+		Fail(fmt.Sprintf("failed to create test framework: %v", err))
+	}
+	return f
+}
+
 // NewFramework makes a new framework and sets up the global BeforeEach/AfterEach's.
 // Test run-time flags are parsed and added to the Framework struct.
 func NewFramework(prefix string, config Config) (*Framework, error) {

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -99,11 +99,8 @@ func init() {
 // NewFrameworkOrDie calls NewFramework and handles errors by calling Fail. Config is optional, but
 // if passed there can only be one.
 func NewFrameworkOrDie(prefix string, config ...Config) *Framework {
-	if len(config) > 1 {
-		Fail("only 1 config can be passed to NewFrameworkOrDie")
-	}
 	cfg := Config{}
-	if len(config) == 1 {
+	if len(config) > 0 {
 		cfg = config[0]
 	}
 	f, err := NewFramework(prefix, cfg)

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -96,11 +96,19 @@ func init() {
 	master = flag.String("master", "", "master url:port")
 }
 
-// NewFrameworkOrDie calls NewFramework and handles errors by calling Fail.
-func NewFrameworkOrDie(prefix string, config Config) *Framework {
-	f, err := NewFramework(prefix, config)
+// NewFrameworkOrDie calls NewFramework and handles errors by calling Fail. Config is optional, but
+// if passed there can only be one.
+func NewFrameworkOrDie(prefix string, config ...Config) *Framework {
+	if len(config) > 1 {
+		Fail("only 1 config can be passed to NewFrameworkOrDie")
+	}
+	cfg := Config{}
+	if len(config) == 1 {
+		cfg = config[0]
+	}
+	f, err := NewFramework(prefix, cfg)
 	if err != nil {
-		Fail(fmt.Sprintf("failed to create test framework: %v", err))
+		Fail(fmt.Sprintf("failed to create test framework with config %+v: %v", cfg, err))
 	}
 	return f
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -88,7 +88,7 @@ func init() {
 	// By accessing something in the ginkgo_reporters package, we are ensuring that the init() is called
 	// That init calls flag.StringVar, and makes sure the --junit-output flag is added before we call
 	// flag.Parse in NewFramework. Without this, the flag is NOT added.
-	fmt.Fprintf(GinkgoWriter, "Making sure junit flag is available"+ginkgo_reporters.JunitOutput)
+	fmt.Fprintf(GinkgoWriter, "Making sure junit flag is available %v\n", ginkgo_reporters.JunitOutput)
 	kubectlPath = flag.String("kubectl-path", "kubectl", "The path to the kubectl binary")
 	ocPath = flag.String("oc-path", "oc", "The path to the oc binary")
 	cdiInstallNs = flag.String("cdi-namespace", "kube-system", "The namespace of the CDI controller")

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 var _ = Describe(testSuiteName, func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix, framework.Config{})
+	f := framework.NewFrameworkOrDie(namespacePrefix)
 
 	It("Should not perform CDI operations on PVC without annotations", func() {
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition("no-import", "1G", nil, nil))

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -17,10 +17,7 @@ const (
 )
 
 var _ = Describe(testSuiteName, func() {
-	f, err := framework.NewFramework(namespacePrefix, framework.Config{})
-	if err != nil {
-		Fail("Unable to create framework struct")
-	}
+	f := framework.NewFrameworkOrDie(namespacePrefix, framework.Config{})
 
 	It("Should not perform CDI operations on PVC without annotations", func() {
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition("no-import", "1G", nil, nil))


### PR DESCRIPTION
Replace the common functional test pattern of:
```
f, err := framework.NewFramework("foo", framework.Config{})
if err != nil {
     Fail("...")
}
```
with
```
f := framework.NewFrameworkOrDie("foo")
```
Note that the Config parameter is optional now.