### PR TITLE
Update no annotation PVC import test.

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -10,6 +10,9 @@ source ./cluster/gocli.sh
 
 CDI_NAMESPACE=${CDI_NAMESPACE:-kube-system}
 
+# Set controller verbosity to 3 for functional tests.
+export VERBOSITY=3
+
 registry_port=$($gocli ports registry | tr -d '\r')
 registry=localhost:$registry_port
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -55,7 +55,7 @@ func checkPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	// check if we have proper AnnEndPoint annotation
 	if !metav1.HasAnnotation(pvc.ObjectMeta, AnnEndpoint) {
-		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc\n", AnnEndpoint)
+		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc \"%s/%s\"\n", AnnEndpoint, pvc.Namespace, pvc.Name)
 		return false
 	}
 
@@ -552,13 +552,13 @@ func checkClonePVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	// check if we have proper AnnCloneRequest annotation on the target pvc
 	if !metav1.HasAnnotation(pvc.ObjectMeta, AnnCloneRequest) {
-		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc\n", AnnCloneRequest)
+		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc \"%s/%s\"\n", AnnCloneRequest, pvc.Namespace, pvc.Name)
 		return false
 	}
 
 	//checking for CloneOf annotation indicating that the clone was already taken care of by the provisioner (smart clone).
 	if metav1.HasAnnotation(pvc.ObjectMeta, AnnCloneOf) {
-		glog.V(Vadmin).Infof("pvc annotation %q exists indicating cloning completed, skipping pvc\n", AnnCloneOf)
+		glog.V(Vadmin).Infof("pvc annotation %q exists indicating cloning completed, skipping pvc \"%s/%s\"\n", AnnCloneOf, pvc.Namespace, pvc.Name)
 		return false
 	}
 	return true

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1,19 +1,23 @@
 package tests_test
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+	"kubevirt.io/containerized-data-importer/tests"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
 
 const (
-	testSuiteName           = "Importer Test Suite"
-	namespacePrefix         = "importer"
-	waitForCDIImportTimeout = 30 * time.Second
+	testSuiteName                    = "Importer Test Suite"
+	namespacePrefix                  = "importer"
+	assertionPollInterval            = 2 * time.Second
+	controllerSkipPVCCompleteTimeout = 60 * time.Second
 )
 
 var _ = Describe(testSuiteName, func() {
@@ -24,9 +28,14 @@ var _ = Describe(testSuiteName, func() {
 
 	It("Should not perform CDI operations on PVC without annotations", func() {
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition("no-import", "1G", nil, nil))
+		By("Verifying PVC with no annotation remains empty")
+		Eventually(func() bool {
+			log, err := tests.RunKubectlCommand(f, "logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
+			Expect(err).NotTo(HaveOccurred())
+			return strings.Contains(log, "pvc annotation \""+controller.AnnEndpoint+"\" not found, skipping pvc \""+f.Namespace.Name+"/no-import\"")
+		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 		// Wait a while to see if CDI puts anything in the PVC.
-		time.Sleep(waitForCDIImportTimeout)
 		Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeTrue())
 		// Not deleting PVC as it will be removed with the NS removal.
 	})


### PR DESCRIPTION
- Set verbosity on controller to 3 to enable simpler tests.
- Updated test to check controller log for skipping PVC
- Updated message in log to include PVC and NS.

Signed-off-by: Alexander Wels <awels@redhat.com>