### PR TITLE
Set file host nginx servernames

### DIFF
--- a/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
+++ b/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
@@ -10,10 +10,10 @@ http {
 
     sendfile on;
 
-    server_name localhost;
-
     # no auth
     server {
+
+        server_name localhost;
 
         listen 80;
 
@@ -26,6 +26,9 @@ http {
     }
     # auth
     server {
+
+        server_name localhost;
+
         listen 81;
 
         root /tmp/shared/images;


### PR DESCRIPTION
Moves `servername` directive to appropriate config blocks.