### PR TITLE
Remove log-level constants

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -59,8 +59,9 @@ func init() {
 		pullPolicy = pp
 	}
 
-	// get the verbose level so it can be passed to the importer pod
-	defVerbose := fmt.Sprintf("%d", DEFAULT_VERBOSE) // note flag values are strings
+	// NOTE we used to have a constant here and we're now just passing in the level directly
+	// that should be fine since it was a constant and not a mutable variable
+	defVerbose := fmt.Sprintf("%d", 1) // note flag values are strings
 	verbose = defVerbose
 	// visit actual flags passed in and if passed check -v and set verbose
 	flag.Visit(func(f *flag.Flag) {
@@ -69,10 +70,10 @@ func init() {
 		}
 	})
 	if verbose == defVerbose {
-		glog.V(Vuser).Infof("Note: increase the -v level in the controller deployment for more detailed logging, eg. -v=%d or -v=%d\n", Vadmin, Vdebug)
+		glog.V(1).Infof("Note: increase the -v level in the controller deployment for more detailed logging, eg. -v=%d or -v=%d\n", 2, 3)
 	}
 
-	glog.V(Vdebug).Infof("init: complete: cdi controller will create importer using image %q\n", importerImage)
+	glog.V(3).Infof("init: complete: cdi controller will create importer using image %q\n", importerImage)
 }
 
 func main() {
@@ -122,7 +123,7 @@ func main() {
 		pullPolicy,
 		verbose)
 
-	glog.V(Vuser).Infoln("created cdi controllers")
+	glog.V(1).Infoln("created cdi controllers")
 
 	stopCh := handleSignals()
 
@@ -130,7 +131,7 @@ func main() {
 	go pvcInformerFactory.Start(stopCh)
 	go podInformerFactory.Start(stopCh)
 
-	glog.V(Vuser).Infoln("started informers")
+	glog.V(1).Infoln("started informers")
 
 	go func() {
 		err = dataVolumeController.Run(3, stopCh)
@@ -154,7 +155,7 @@ func main() {
 	}()
 
 	<-stopCh
-	glog.V(Vadmin).Infoln("cdi controller exited")
+	glog.V(2).Infoln("cdi controller exited")
 }
 
 // Shutdown gracefully on system signals

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -29,18 +29,18 @@ func init() {
 func main() {
 	defer glog.Flush()
 
-	glog.V(Vuser).Infoln("Starting importer")
+	glog.V(1).Infoln("Starting importer")
 	ep, _ := ParseEnvVar(IMPORTER_ENDPOINT, false)
 	acc, _ := ParseEnvVar(IMPORTER_ACCESS_KEY_ID, false)
 	sec, _ := ParseEnvVar(IMPORTER_SECRET_KEY, false)
 
-	glog.V(Vuser).Infoln("begin import process")
+	glog.V(1).Infoln("begin import process")
 	err := CopyImage(IMPORTER_WRITE_PATH, ep, acc, sec)
 	if err != nil {
 		glog.Errorf("%+v", err)
 		os.Exit(1)
 	}
-	glog.V(Vuser).Infoln("import complete")
+	glog.V(1).Infoln("import complete")
 
 	// temporary local import deprecation notice
 	glog.Warningf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -43,12 +43,4 @@ const (
 
 	// Shared informer resync period.
 	DEFAULT_RESYNC_PERIOD = 10 * time.Minute
-
-	// logging verbosity
-	Vuser           = 1
-	Vadmin          = 2
-	Vdebug          = 3
-	DEFAULT_VERBOSE = Vuser
-	// the length of the random generated cloning label
-	GENERATED_CLONING_LABEL_LEN = 10
 )

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -124,9 +124,9 @@ func (c *CloneController) handlePodObject(obj interface{}, verb string) {
 			runtime.HandleError(errors.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
-		glog.V(Vdebug).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+		glog.V(3).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
-	glog.V(Vdebug).Infof("Processing object: %s", object.GetName())
+	glog.V(3).Infof("Processing object: %s", object.GetName())
 	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
 		_, createdByUs := object.GetAnnotations()[AnnCloningCreatedBy]
 
@@ -138,7 +138,7 @@ func (c *CloneController) handlePodObject(obj interface{}, verb string) {
 
 		pvc, err := c.pvcLister.PersistentVolumeClaims(object.GetAnnotations()[AnnTargetPodNamespace]).Get(ownerRef.Name)
 		if err != nil {
-			glog.V(Vdebug).Infof("ignoring orphaned object '%s' of pvc '%s'", object.GetSelfLink(), ownerRef.Name)
+			glog.V(3).Infof("ignoring orphaned object '%s' of pvc '%s'", object.GetSelfLink(), ownerRef.Name)
 			return
 		}
 
@@ -170,7 +170,7 @@ func (c *CloneController) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer func() {
 		c.queue.ShutDown()
 	}()
-	glog.V(Vadmin).Infoln("Starting clone controller Run loop")
+	glog.V(2).Infoln("Starting clone controller Run loop")
 	if threadiness < 1 {
 		return errors.Errorf("expected >0 threads, got %d", threadiness)
 	}
@@ -181,7 +181,7 @@ func (c *CloneController) Run(threadiness int, stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.podInformer.HasSynced) {
 		return errors.New("Timeout waiting for pod cache sync")
 	}
-	glog.V(Vdebug).Infoln("CloneController cache has synced")
+	glog.V(3).Infoln("CloneController cache has synced")
 
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runPVCWorkers, time.Second, stopCh)
@@ -207,7 +207,7 @@ func (c *CloneController) syncPvc(key string) error {
 	if !checkClonePVC(pvc) {
 		return nil
 	}
-	glog.V(Vdebug).Infof("ProcessNextPvcItem: next pvc to process: %s\n", key)
+	glog.V(3).Infof("ProcessNextPvcItem: next pvc to process: %s\n", key)
 	return c.processPvcItem(pvc)
 }
 
@@ -354,7 +354,7 @@ func (c *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 // forget the passed-in key for this event and optionally log a message.
 func (c *CloneController) forgetKey(key interface{}, msg string) bool {
 	if len(msg) > 0 {
-		glog.V(Vdebug).Info(msg)
+		glog.V(3).Info(msg)
 	}
 	c.queue.Forget(key)
 	return true

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -43,7 +43,6 @@ import (
 	cdischeme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 	informers "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/datavolumecontroller/v1alpha1"
 	listers "kubevirt.io/containerized-data-importer/pkg/client/listers/datavolumecontroller/v1alpha1"
-	. "kubevirt.io/containerized-data-importer/pkg/common"
 	expectations "kubevirt.io/containerized-data-importer/pkg/expectations"
 )
 
@@ -84,9 +83,9 @@ func NewDataVolumeController(
 	// Add datavolume-controller types to the default Kubernetes Scheme so Events can be
 	// logged for datavolume-controller types.
 	cdischeme.AddToScheme(scheme.Scheme)
-	glog.V(Vdebug).Info("Creating event broadcaster")
+	glog.V(3).Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.V(Vadmin).Infof)
+	eventBroadcaster.StartLogging(glog.V(2).Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
@@ -102,7 +101,7 @@ func NewDataVolumeController(
 		pvcExpectations:   expectations.NewUIDTrackingControllerExpectations(expectations.NewControllerExpectations()),
 	}
 
-	glog.V(Vadmin).Info("Setting up event handlers")
+	glog.V(2).Info("Setting up event handlers")
 
 	// Set up an event handler for when DataVolume resources change
 	dataVolumeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -140,23 +139,23 @@ func (c *DataVolumeController) Run(threadiness int, stopCh <-chan struct{}) erro
 	defer c.workqueue.ShutDown()
 
 	// Start the informer factories to begin populating the informer caches
-	glog.V(Vadmin).Info("Starting DataVolume controller")
+	glog.V(2).Info("Starting DataVolume controller")
 
 	// Wait for the caches to be synced before starting workers
-	glog.V(Vadmin).Info("Waiting for informer caches to sync")
+	glog.V(2).Info("Waiting for informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.pvcsSynced, c.dataVolumesSynced); !ok {
 		return errors.Errorf("failed to wait for caches to sync")
 	}
 
-	glog.V(Vadmin).Info("Starting workers")
+	glog.V(2).Info("Starting workers")
 	// Launch two workers to process DataVolume resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
 
-	glog.V(Vadmin).Info("Started workers")
+	glog.V(2).Info("Started workers")
 	<-stopCh
-	glog.V(Vadmin).Info("Shutting down workers")
+	glog.V(2).Info("Shutting down workers")
 
 	return nil
 }
@@ -210,7 +209,7 @@ func (c *DataVolumeController) processNextWorkItem() bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.workqueue.Forget(obj)
-		glog.V(Vadmin).Infof("Successfully synced '%s'", key)
+		glog.V(2).Infof("Successfully synced '%s'", key)
 		return nil
 	}(obj)
 
@@ -393,9 +392,9 @@ func (c *DataVolumeController) handleObject(obj interface{}, verb string) {
 			runtime.HandleError(errors.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
-		glog.V(Vdebug).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+		glog.V(3).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
-	glog.V(Vdebug).Infof("Processing object: %s", object.GetName())
+	glog.V(3).Infof("Processing object: %s", object.GetName())
 	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
 		// If this object is not owned by a DataVolume, we should not do anything more
 		// with it.
@@ -405,7 +404,7 @@ func (c *DataVolumeController) handleObject(obj interface{}, verb string) {
 
 		dataVolume, err := c.dataVolumesLister.DataVolumes(object.GetNamespace()).Get(ownerRef.Name)
 		if err != nil {
-			glog.V(Vdebug).Infof("ignoring orphaned object '%s' of dataVolume '%s'", object.GetSelfLink(), ownerRef.Name)
+			glog.V(3).Infof("ignoring orphaned object '%s' of dataVolume '%s'", object.GetSelfLink(), ownerRef.Name)
 			return
 		}
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -124,9 +124,9 @@ func (c *ImportController) handlePodObject(obj interface{}, verb string) {
 			runtime.HandleError(errors.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
-		glog.V(Vdebug).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+		glog.V(3).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
-	glog.V(Vdebug).Infof("Processing object: %s", object.GetName())
+	glog.V(3).Infof("Processing object: %s", object.GetName())
 	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
 		_, createdByUs := object.GetAnnotations()[AnnCreatedBy]
 
@@ -138,7 +138,7 @@ func (c *ImportController) handlePodObject(obj interface{}, verb string) {
 
 		pvc, err := c.pvcLister.PersistentVolumeClaims(object.GetNamespace()).Get(ownerRef.Name)
 		if err != nil {
-			glog.V(Vdebug).Infof("ignoring orphaned object '%s' of pvc '%s'", object.GetSelfLink(), ownerRef.Name)
+			glog.V(3).Infof("ignoring orphaned object '%s' of pvc '%s'", object.GetSelfLink(), ownerRef.Name)
 			return
 		}
 
@@ -170,7 +170,7 @@ func (c *ImportController) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer func() {
 		c.queue.ShutDown()
 	}()
-	glog.V(Vadmin).Infoln("Starting cdi controller Run loop")
+	glog.V(2).Infoln("Starting cdi controller Run loop")
 	if threadiness < 1 {
 		return errors.Errorf("expected >0 threads, got %d", threadiness)
 	}
@@ -181,7 +181,7 @@ func (c *ImportController) Run(threadiness int, stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.podInformer.HasSynced) {
 		return errors.New("Timeout waiting for pod cache sync")
 	}
-	glog.V(Vdebug).Infoln("ImportController cache has synced")
+	glog.V(3).Infoln("ImportController cache has synced")
 
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runPVCWorkers, time.Second, stopCh)
@@ -207,7 +207,7 @@ func (c *ImportController) syncPvc(key string) error {
 	if !checkPVC(pvc) {
 		return nil
 	}
-	glog.V(Vdebug).Infof("ProcessNextPvcItem: next pvc to process: %s\n", key)
+	glog.V(3).Infof("ProcessNextPvcItem: next pvc to process: %s\n", key)
 	return c.processPvcItem(pvc)
 }
 
@@ -291,7 +291,7 @@ func (c *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 			return err
 		}
 		if secretName == "" {
-			glog.V(Vadmin).Infof("no secret will be supplied to endpoint %q\n", ep)
+			glog.V(2).Infof("no secret will be supplied to endpoint %q\n", ep)
 		}
 
 		// all checks passed, let's create the importer pod!
@@ -326,7 +326,7 @@ func (c *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 // forget the passed-in key for this event and optionally log a message.
 func (c *ImportController) forgetKey(key interface{}, msg string) bool {
 	if len(msg) > 0 {
-		glog.V(Vdebug).Info(msg)
+		glog.V(3).Info(msg)
 	}
 	c.queue.Forget(key)
 	return true

--- a/pkg/controller/import_controller_ginkgo_test.go
+++ b/pkg/controller/import_controller_ginkgo_test.go
@@ -26,7 +26,7 @@ const (
 	IMPORTER_DEFAULT_IMAGE = "kubevirt/cdi-importer:latest"
 )
 
-var verboseDebug = fmt.Sprintf("%d", Vdebug)
+var verboseDebug = fmt.Sprintf("%d", 3)
 
 var _ = Describe("Controller", func() {
 	var (

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -11,8 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	. "kubevirt.io/containerized-data-importer/pkg/common"
-	"strings"
-	"time"
 )
 
 const DataVolName = "cdi-data-vol"
@@ -55,7 +56,7 @@ func checkPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	// check if we have proper AnnEndPoint annotation
 	if !metav1.HasAnnotation(pvc.ObjectMeta, AnnEndpoint) {
-		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc \"%s/%s\"\n", AnnEndpoint, pvc.Namespace, pvc.Name)
+		glog.V(2).Infof("pvc annotation %q not found, skipping pvc\n", AnnEndpoint)
 		return false
 	}
 
@@ -88,19 +89,19 @@ func getSecretName(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (
 		} else {
 			msg += "secret name is missing from annotation %q in pvc \"%s/%s\""
 		}
-		glog.V(Vadmin).Infof(msg+"\n", AnnSecret, ns, pvc.Name)
+		glog.V(2).Infof(msg+"\n", AnnSecret, ns, pvc.Name)
 		return "", nil // importer pod will not contain secret credentials
 	}
-	glog.V(Vdebug).Infof("getEndpointSecret: retrieving Secret \"%s/%s\"\n", ns, name)
+	glog.V(3).Infof("getEndpointSecret: retrieving Secret \"%s/%s\"\n", ns, name)
 	_, err := client.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
-		glog.V(Vuser).Infof("secret %q defined in pvc \"%s/%s\" is missing. Importer pod will run once this secret is created\n", name, ns, pvc.Name)
+		glog.V(1).Infof("secret %q defined in pvc \"%s/%s\" is missing. Importer pod will run once this secret is created\n", name, ns, pvc.Name)
 		return name, nil
 	}
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting secret %q defined in pvc \"%s/%s\"", name, ns, pvc.Name)
 	}
-	glog.V(Vuser).Infof("retrieved secret %q defined in pvc \"%s/%s\"\n", name, ns, pvc.Name)
+	glog.V(1).Infof("retrieved secret %q defined in pvc \"%s/%s\"\n", name, ns, pvc.Name)
 	return name, nil
 }
 
@@ -108,7 +109,7 @@ func getSecretName(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (
 // both can be passed.
 // Note: the only pvc changes supported are annotations and labels.
 func updatePVC(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, anno, label map[string]string) (*v1.PersistentVolumeClaim, error) {
-	glog.V(Vdebug).Infof("updatePVC: updating pvc \"%s/%s\" with anno: %+v and label: %+v", pvc.Namespace, pvc.Name, anno, label)
+	glog.V(3).Infof("updatePVC: updating pvc \"%s/%s\" with anno: %+v and label: %+v", pvc.Namespace, pvc.Name, anno, label)
 
 	applyUpdt := func(claim *v1.PersistentVolumeClaim, a, l map[string]string) {
 		if a != nil {
@@ -133,7 +134,7 @@ func updatePVC(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, anno,
 			return true, nil // successful update
 		}
 		if apierrs.IsConflict(e) { // pvc is likely stale
-			glog.V(Vdebug).Infof("pvc %q is stale, re-trying\n", nsName)
+			glog.V(3).Infof("pvc %q is stale, re-trying\n", nsName)
 			pvcCopy, e = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 			if e == nil {
 				return false, nil // retry update
@@ -146,7 +147,7 @@ func updatePVC(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, anno,
 	})
 
 	if err == nil {
-		glog.V(Vdebug).Infof("updatePVC: pvc %q updated", nsName)
+		glog.V(3).Infof("updatePVC: pvc %q updated", nsName)
 		return updtPvc, nil
 	}
 	return pvc, errors.Wrapf(err, "error updating pvc %q\n", nsName)
@@ -154,7 +155,7 @@ func updatePVC(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, anno,
 
 // Sets an annotation `key: val` in the given pvc. Returns the updated pvc.
 func setPVCAnnotation(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, key, val string) (*v1.PersistentVolumeClaim, error) {
-	glog.V(Vdebug).Infof("setPVCAnnotation: adding annotation \"%s: %s\" to pvc \"%s/%s\"\n", key, val, pvc.Namespace, pvc.Name)
+	glog.V(3).Infof("setPVCAnnotation: adding annotation \"%s: %s\" to pvc \"%s/%s\"\n", key, val, pvc.Namespace, pvc.Name)
 	return updatePVC(client, pvc, map[string]string{key: val}, nil)
 }
 
@@ -187,7 +188,7 @@ func CreateImporterPod(client kubernetes.Interface, image, verbose, pullPolicy, 
 	if err != nil {
 		return nil, errors.Wrap(err, "importer pod API create errored")
 	}
-	glog.V(Vuser).Infof("importer pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
+	glog.V(1).Infof("importer pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
 	return pod, nil
 }
 
@@ -319,7 +320,7 @@ func getCloneRequestPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
 func ParseSourcePvcAnnotation(sourcePvcAnno, del string) (namespace, name string) {
 	strArr := strings.Split(sourcePvcAnno, del)
 	if strArr == nil || len(strArr) < 2 {
-		glog.V(Vdebug).Infof("Bad CloneRequest Annotation")
+		glog.V(3).Infof("Bad CloneRequest Annotation")
 		return "", ""
 	}
 	return strArr[0], strArr[1]
@@ -336,7 +337,7 @@ func CreateCloneSourcePod(client kubernetes.Interface, image string, verbose str
 	if err != nil {
 		return nil, errors.Wrap(err, "source pod API create errored")
 	}
-	glog.V(Vuser).Infof("cloning source pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
+	glog.V(1).Infof("cloning source pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
 	return pod, nil
 }
 
@@ -432,7 +433,7 @@ func CreateCloneTargetPod(client kubernetes.Interface, image string, verbose str
 	if err != nil {
 		return nil, errors.Wrap(err, "clone target pod API create errored")
 	}
-	glog.V(Vuser).Infof("cloning target pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
+	glog.V(1).Infof("cloning target pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
 	return pod, nil
 }
 
@@ -552,13 +553,13 @@ func checkClonePVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	// check if we have proper AnnCloneRequest annotation on the target pvc
 	if !metav1.HasAnnotation(pvc.ObjectMeta, AnnCloneRequest) {
-		glog.V(Vadmin).Infof("pvc annotation %q not found, skipping pvc \"%s/%s\"\n", AnnCloneRequest, pvc.Namespace, pvc.Name)
+		glog.V(2).Infof("pvc annotation %q not found, skipping pvc\n", AnnCloneRequest)
 		return false
 	}
 
 	//checking for CloneOf annotation indicating that the clone was already taken care of by the provisioner (smart clone).
 	if metav1.HasAnnotation(pvc.ObjectMeta, AnnCloneOf) {
-		glog.V(Vadmin).Infof("pvc annotation %q exists indicating cloning completed, skipping pvc \"%s/%s\"\n", AnnCloneOf, pvc.Namespace, pvc.Name)
+		glog.V(2).Infof("pvc annotation %q exists indicating cloning completed, skipping pvc\n", AnnCloneOf)
 		return false
 	}
 	return true

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-
-	. "kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 // Size of buffer used to read file headers.
@@ -80,6 +78,6 @@ func (h Header) Size(b []byte) (int64, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to determine original file size from %+v", s)
 	}
-	glog.V(Vdebug).Infof("Size: %q size in bytes (at off %d:%d): %d", h.Format, h.SizeOff, h.SizeOff+h.SizeLen, size)
+	glog.V(3).Infof("Size: %q size in bytes (at off %d:%d): %d", h.Format, h.SizeOff, h.SizeOff+h.SizeLen, size)
 	return size, nil
 }

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -80,7 +80,7 @@ var rdrTypM = map[string]int{
 // Note: the caller must close the `Readers` in reverse order. See Close().
 func NewDataStream(endpt, accKey, secKey string) (*dataStream, error) {
 	if len(accKey) == 0 || len(secKey) == 0 {
-		glog.V(Vadmin).Infof("%s and/or %s are empty\n", IMPORTER_ACCESS_KEY_ID, IMPORTER_SECRET_KEY)
+		glog.V(2).Infof("%s and/or %s are empty\n", IMPORTER_ACCESS_KEY_ID, IMPORTER_SECRET_KEY)
 	}
 	ep, err := ParseEndpoint(endpt)
 	if err != nil {
@@ -106,7 +106,7 @@ func NewDataStream(endpt, accKey, secKey string) (*dataStream, error) {
 			return nil, errors.Wrapf(err, "unable to calculate iso file size")
 		}
 	}
-	glog.V(Vdebug).Infof("NewDataStream: endpoint %q's computed byte size: %d", ep, ds.Size)
+	glog.V(3).Infof("NewDataStream: endpoint %q's computed byte size: %d", ep, ds.Size)
 	return ds, nil
 }
 
@@ -143,14 +143,14 @@ func (d *dataStream) dataStreamSelector() (err error) {
 }
 
 func (d dataStream) s3() (io.ReadCloser, error) {
-	glog.V(Vdebug).Infoln("Using S3 client to get data")
+	glog.V(3).Infoln("Using S3 client to get data")
 	bucket := d.Url.Host
 	object := strings.Trim(d.Url.Path, "/")
 	mc, err := minio.NewV4(IMPORTER_S3_HOST, d.accessKeyId, d.secretKey, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not build minio client for %q", d.Url.Host)
 	}
-	glog.V(Vadmin).Infof("Attempting to get object %q via S3 client\n", d.Url.String())
+	glog.V(2).Infof("Attempting to get object %q via S3 client\n", d.Url.String())
 	objectReader, err := mc.GetObject(bucket, object, minio.GetObjectOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get s3 object: \"%s/%s\"", bucket, object)
@@ -172,7 +172,7 @@ func (d dataStream) http() (io.ReadCloser, error) {
 	if len(d.accessKeyId) > 0 && len(d.secretKey) > 0 {
 		req.SetBasicAuth(d.accessKeyId, d.secretKey)
 	}
-	glog.V(Vadmin).Infof("Attempting to get object %q via http client\n", d.Url.String())
+	glog.V(2).Infof("Attempting to get object %q via http client\n", d.Url.String())
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request errored")
@@ -199,7 +199,7 @@ func (d dataStream) local() (io.ReadCloser, error) {
 
 // Copy the source endpoint (vm image) to the provided destination path.
 func CopyImage(dest, endpoint, accessKey, secKey string) error {
-	glog.V(Vuser).Infof("copying %q to %q...\n", endpoint, dest)
+	glog.V(1).Infof("copying %q to %q...\n", endpoint, dest)
 	ds, err := NewDataStream(endpoint, accessKey, secKey)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create data stream")
@@ -247,7 +247,7 @@ func CopyImage(dest, endpoint, accessKey, secKey string) error {
 // Note: file extensions are ignored.
 // Note: readers are not closed here, see dataStream.Close().
 func (d *dataStream) constructReaders() error {
-	glog.V(Vadmin).Infof("create the initial Reader based on the endpoint's %q scheme", d.Url.Scheme)
+	glog.V(2).Infof("create the initial Reader based on the endpoint's %q scheme", d.Url.Scheme)
 	// create the scheme-specific source reader and append it to dataStream readers stack
 	err := d.dataStreamSelector()
 	if err != nil {
@@ -258,7 +258,7 @@ func (d *dataStream) constructReaders() error {
 	// note: iso file headers are not processed here due to their much larger size and if
 	//   the iso file is tar'd we can get its size via the tar hdr -- see intro comments.
 	knownHdrs := image.CopyKnownHdrs() // need local copy since keys are removed
-	glog.V(Vdebug).Infof("constructReaders: checking compression and archive formats: %s\n", d.Url.Path)
+	glog.V(3).Infof("constructReaders: checking compression and archive formats: %s\n", d.Url.Path)
 	for {
 		hdr, err := d.matchHeader(&knownHdrs)
 		if err != nil {
@@ -267,7 +267,7 @@ func (d *dataStream) constructReaders() error {
 		if hdr == nil {
 			break // done processing headers, we have the orig source file
 		}
-		glog.V(Vadmin).Infof("found header of type %q\n", hdr.Format)
+		glog.V(2).Infof("found header of type %q\n", hdr.Format)
 		// create format-specific reader and append it to dataStream readers stack
 		err = d.fileFormatSelector(hdr)
 		if err != nil {
@@ -282,9 +282,9 @@ func (d *dataStream) constructReaders() error {
 
 	if len(d.Readers) <= 2 {
 		// 1st rdr is source, 2nd rdr is multi-rdr, >2 means we have additional formats
-		glog.V(Vdebug).Infof("constructReaders: no headers found for file %q\n", d.Url.Path)
+		glog.V(3).Infof("constructReaders: no headers found for file %q\n", d.Url.Path)
 	}
-	glog.V(Vadmin).Infof("done processing %q headers\n", d.Url.Path)
+	glog.V(2).Infof("done processing %q headers\n", d.Url.Path)
 	return nil
 }
 
@@ -348,7 +348,7 @@ func (d dataStream) gzReader() (io.ReadCloser, int64, error) {
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "could not create gzip reader")
 	}
-	glog.V(Vadmin).Infof("gzip: extracting %q\n", gz.Name)
+	glog.V(2).Infof("gzip: extracting %q\n", gz.Name)
 	size := int64(0) //TODO: implement size
 	return gz, size, nil
 }
@@ -389,7 +389,7 @@ func (d dataStream) tarReader() (io.Reader, int64, error) {
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "could not read tar header")
 	}
-	glog.V(Vadmin).Infof("tar: extracting %q\n", hdr.Name)
+	glog.V(2).Infof("tar: extracting %q\n", hdr.Name)
 	return tr, hdr.Size, nil
 }
 
@@ -443,7 +443,7 @@ func (d *dataStream) isoSize() (int64, error) {
 		return 0, nil
 	}
 	if vdtyp != primaryVD && string(buf[idOff:idOff+idLen]) != id {
-		glog.V(Vdebug).Infof("isoSize: endpoint %q is not an ISO file", d.Url.Path)
+		glog.V(3).Infof("isoSize: endpoint %q is not an ISO file", d.Url.Path)
 		return 0, nil
 	}
 
@@ -507,12 +507,12 @@ func (d dataStream) copy(dest string) error {
 // Copy the file using its Reader (r) to the passed-in destination (`out`).
 func copy(r io.Reader, out string, qemu bool) error {
 	out = filepath.Clean(out)
-	glog.V(Vadmin).Infof("copying image file to %q", out)
+	glog.V(2).Infof("copying image file to %q", out)
 	dest := out
 	if qemu {
 		// copy to tmp; qemu conversion will write to passed-in destination
 		dest = randTmpName(out)
-		glog.V(Vdebug).Infof("Copy: temp file for qcow2 conversion: %q", dest)
+		glog.V(3).Infof("Copy: temp file for qcow2 conversion: %q", dest)
 		defer func(f string) {
 			os.Remove(f)
 		}(dest)
@@ -523,7 +523,7 @@ func copy(r io.Reader, out string, qemu bool) error {
 		return errors.WithMessage(err, fmt.Sprintf("unable to stream data to file %q", dest))
 	}
 	if qemu {
-		glog.V(Vadmin).Infoln("converting qcow2 image")
+		glog.V(2).Infoln("converting qcow2 image")
 		err = image.ConvertQcow2ToRaw(dest, out)
 		if err != nil {
 			return errors.WithMessage(err, "unable to copy image")
@@ -546,6 +546,6 @@ func randTmpName(src string) string {
 // parseDataPath only used for debugging
 func (d dataStream) parseDataPath() (string, string) {
 	pathSlice := strings.Split(strings.Trim(d.Url.EscapedPath(), "/"), "/")
-	glog.V(Vdebug).Infof("parseDataPath: url path: %v", pathSlice)
+	glog.V(3).Infof("parseDataPath: url path: %v", pathSlice)
 	return pathSlice[0], strings.Join(pathSlice[1:], "/")
 }

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -47,7 +47,7 @@ func StreamDataToFile(dataReader io.Reader, filePath string) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not open file %q", filePath)
 	}
-	glog.V(Vuser).Infof("begin import...\n")
+	glog.V(1).Infof("begin import...\n")
 	if _, err = io.Copy(outFile, dataReader); err != nil {
 		os.Remove(outFile.Name())
 		return errors.Wrapf(err, "unable to write to file")


### PR DESCRIPTION
This change just removes the log level constants that were set in
pkg/common/common.go and falls back to just using the int arguments (1,
2 or 3) to glog.  While the constants are handy to limit the choices for example it also introduces a pkg dependency on common.go.  It seems just as easy to type 1, 2 or 3 and if we want to enforce the use of levels inclusive of a certain range we can do that through lint checks or review criteria.  I'm not advocating we do that, just mentioning that if that's a restriction we want we can certainly make it work.

Now instead of issuing a log call with the constant:
  `glog.V(common.Vuser)`

We just provide the argument as an int:
  `glog.V(1)`

I started doing this as part of the effort to fix linting, but that's
going package by package and it was rightly pointed out that the result
is a period of inconsistency and confusion.  So this patch just jumps
ahead and takes care of the low hanging fruit in one shot.

Related PR #404 #410