### PR TITLE
don't show test flags every time NewFramework invoked

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -121,13 +121,13 @@ func NewFramework(prefix string, config Config) (*Framework, error) {
 	// handle run-time flags
 	if !flag.Parsed() {
 		flag.Parse()
+		fmt.Fprintf(GinkgoWriter, "** Test flags:\n")
+		flag.Visit(func(f *flag.Flag) {
+			fmt.Fprintf(GinkgoWriter, "   %s = %q\n", f.Name, f.Value.String())
+		})
+		fmt.Fprintf(GinkgoWriter, "**\n")
 	}
-	// report flags values passed to test binary
-	fmt.Fprintf(GinkgoWriter, "** Test flags:\n")
-	flag.Visit(func(f *flag.Flag) {
-		fmt.Fprintf(GinkgoWriter, "   %s = %q\n", f.Name, f.Value.String())
-	})
-	fmt.Fprintf(GinkgoWriter, "**\n")
+
 	f.KubectlPath = *kubectlPath
 	f.OcPath = *ocPath
 	f.CdiInstallNs = *cdiInstallNs


### PR DESCRIPTION
This pr gets `NewFramework` back to how it originally handled printing of the passed-in flags.
Currently, the flags are displayed every time a test calls `NewFramework`. With this pr the flags will be displayed once per test binary run. This is sufficient for debugging and seeing what flags are set.