### PR TITLE
Add golint enforcement to all pkgs but common

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -23,7 +23,8 @@ RUN \
     go install ./... ) && \
     ( go get -d github.com/mattn/goveralls && \
     cd $GOPATH/src/github.com/mattn/goveralls && \
-    go install ./... )
+    go install ./... ) && \
+    ( go get -u golang.org/x/lint/golint )
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/hack/build/run-lint-checks.sh
+++ b/hack/build/run-lint-checks.sh
@@ -20,6 +20,9 @@
 source hack/build/config.sh
 source hack/build/common.sh
 
+# Temporary var for pkgs that are ready to enforce linting
+LINTABLE=(pkg/controller pkg/apis pkg/client pkg/controller pkg/expectations pkg/image pkg/importer pkg/lib pkg/util)
+
 ec=0
 out="$(gofmt -l -s ${SOURCE_DIRS} | grep ".*\.go")"
 if [[ ${out} ]]; then
@@ -27,4 +30,15 @@ if [[ ${out} ]]; then
     echo "${out}"
     ec=1
 fi
+
+for p in "${LINTABLE[@]}"; do
+    echo "Performing lint checks on: ${p}"
+    out="$(golint ${p}/...)"
+    if [[ ${out} ]]; then
+        echo "FAIL: following golint errors found:"
+        echo "${out}"
+        ec=1
+    fi
+done
+
 exit ${ec}


### PR DESCRIPTION
Now that the updates have merged to fix golint errors in all of the
CDI pkgs (except common) turn on lint checks to keep things up to date.

This patch does that by:
1.  Adding a check in hack/build/run-lint-checks.sh
    NOTE:  We temporarily set a list variable in the script to indicate
    the directories that we've fixed and want to enforce.  This will be
    removed when common is "lintified"
2.  Adding golint to our build containers Dockerfile