### PR TITLE
Ensure expectation keys are deleted when object is deleted from cluster

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -205,10 +205,13 @@ func (c *CloneController) runPVCWorkers() {
 }
 
 func (c *CloneController) syncPvc(key string) error {
-	pvc, err := c.pvcFromKey(key)
+	pvc, exists, err := c.pvcFromKey(key)
 	if err != nil {
 		return err
+	} else if !exists {
+		c.podExpectations.DeleteExpectations(key)
 	}
+
 	if pvc == nil {
 		return nil
 	}

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -249,6 +249,7 @@ func (c *DataVolumeController) syncHandler(key string) error {
 		// processing.
 		if k8serrors.IsNotFound(err) {
 			runtime.HandleError(errors.Errorf("dataVolume '%s' in work queue no longer exists", key))
+			c.pvcExpectations.DeleteExpectations(key)
 			return nil
 		}
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -206,10 +206,14 @@ func (c *ImportController) runPVCWorkers() {
 }
 
 func (c *ImportController) syncPvc(key string) error {
-	pvc, err := c.pvcFromKey(key)
+	pvc, exists, err := c.pvcFromKey(key)
 	if err != nil {
 		return err
+	} else if !exists {
+		c.podExpectations.DeleteExpectations(key)
+		return nil
 	}
+
 	if pvc == nil {
 		return nil
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -24,32 +24,34 @@ const ImagePathName = "image-path"
 const socketPathName = "socket-path"
 
 // return a pvc pointer based on the passed-in work queue key.
-func (c *ImportController) pvcFromKey(key interface{}) (*v1.PersistentVolumeClaim, error) {
-	obj, err := c.objFromKey(c.pvcInformer, key)
+func (c *ImportController) pvcFromKey(key interface{}) (*v1.PersistentVolumeClaim, bool, error) {
+	obj, exists, err := c.objFromKey(c.pvcInformer, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get pvc object from key")
+		return nil, false, errors.Wrap(err, "could not get pvc object from key")
+	} else if !exists {
+		return nil, false, nil
 	}
 
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
-		return nil, errors.New("Object not of type *v1.PersistentVolumeClaim")
+		return nil, false, errors.New("Object not of type *v1.PersistentVolumeClaim")
 	}
-	return pvc, nil
+	return pvc, true, nil
 }
 
-func (c *ImportController) objFromKey(informer cache.SharedIndexInformer, key interface{}) (interface{}, error) {
+func (c *ImportController) objFromKey(informer cache.SharedIndexInformer, key interface{}) (interface{}, bool, error) {
 	keyString, ok := key.(string)
 	if !ok {
-		return nil, errors.New("keys is not of type string")
+		return nil, false, errors.New("keys is not of type string")
 	}
 	obj, ok, err := informer.GetIndexer().GetByKey(keyString)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting interface obj from store")
+		return nil, false, errors.Wrap(err, "error getting interface obj from store")
 	}
 	if !ok {
-		return nil, errors.New("interface object not found in store")
+		return nil, false, nil
 	}
-	return obj, nil
+	return obj, true, nil
 }
 
 func checkPVC(pvc *v1.PersistentVolumeClaim) bool {
@@ -571,9 +573,11 @@ func checkClonePVC(pvc *v1.PersistentVolumeClaim) bool {
 }
 
 func (c *CloneController) podFromKey(key interface{}) (*v1.Pod, error) {
-	obj, err := c.objFromKey(c.podInformer, key)
+	obj, exists, err := c.objFromKey(c.podInformer, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get pod object from key")
+	} else if !exists {
+		return nil, errors.New("interface object not found in store")
 	}
 
 	pod, ok := obj.(*v1.Pod)
@@ -583,30 +587,32 @@ func (c *CloneController) podFromKey(key interface{}) (*v1.Pod, error) {
 	return pod, nil
 }
 
-func (c *CloneController) pvcFromKey(key interface{}) (*v1.PersistentVolumeClaim, error) {
-	obj, err := c.objFromKey(c.pvcInformer, key)
+func (c *CloneController) pvcFromKey(key interface{}) (*v1.PersistentVolumeClaim, bool, error) {
+	obj, exists, err := c.objFromKey(c.pvcInformer, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get pvc object from key")
+		return nil, false, errors.Wrap(err, "could not get pvc object from key")
+	} else if !exists {
+		return nil, false, nil
 	}
 
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
-		return nil, errors.New("Object not of type *v1.PersistentVolumeClaim")
+		return nil, false, errors.New("Object not of type *v1.PersistentVolumeClaim")
 	}
-	return pvc, nil
+	return pvc, true, nil
 }
 
-func (c *CloneController) objFromKey(informer cache.SharedIndexInformer, key interface{}) (interface{}, error) {
+func (c *CloneController) objFromKey(informer cache.SharedIndexInformer, key interface{}) (interface{}, bool, error) {
 	keyString, ok := key.(string)
 	if !ok {
-		return nil, errors.New("keys is not of type string")
+		return nil, false, errors.New("keys is not of type string")
 	}
 	obj, ok, err := informer.GetIndexer().GetByKey(keyString)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting interface obj from store")
+		return nil, false, errors.Wrap(err, "error getting interface obj from store")
 	}
 	if !ok {
-		return nil, errors.New("interface object not found in store")
+		return nil, false, nil
 	}
-	return obj, nil
+	return obj, true, nil
 }

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -50,18 +50,21 @@ func TestController_pvcFromKey(t *testing.T) {
 			name:    "expect to not get pvc object from key",
 			args:    args{fmt.Sprintf("%s/%s", "myns", pvc.Name)},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.pvcFromKey(tt.args.key)
+			got, exists, err := c.pvcFromKey(tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.pvcFromKey() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Controller.pvcFromKey() = %v, want %v", got, tt.want)
+			}
+			if tt.want == nil && exists {
+				t.Errorf("Controller.pvcFromKey() expected key not to exist")
 			}
 		})
 	}
@@ -101,7 +104,7 @@ func TestCloneController_pvcFromKey(t *testing.T) {
 			name:    "expect to not get pvc object from key",
 			args:    args{fmt.Sprintf("%s/%s", "myns", pvc.Name)},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "expect to get pvc object from key",
@@ -112,13 +115,16 @@ func TestCloneController_pvcFromKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.pvcFromKey(tt.args.key)
+			got, exists, err := c.pvcFromKey(tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.pvcFromKey() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Controller.pvcFromKey() = %v, want %v", got, tt.want)
+			}
+			if tt.want == nil && exists {
+				t.Errorf("Controller.pvcFromKey() expected key not to exist")
 			}
 		})
 	}
@@ -156,18 +162,21 @@ func TestController_objFromKey(t *testing.T) {
 			name:    "expect to not get object key",
 			args:    args{c.pvcInformer, fmt.Sprintf("%s/%s", "myns", pvc.Name)},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.objFromKey(tt.args.informer, tt.args.key)
+			got, exists, err := c.objFromKey(tt.args.informer, tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.objFromKey() error = %v, wantErr %v  myKey = %v", err, tt.wantErr, tt.args.key)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Controller.objFromKey() = %v, want %v", got, tt.want)
+			}
+			if tt.want == nil && exists {
+				t.Errorf("Controller.pvcFromKey() expected key not to exist")
 			}
 		})
 	}
@@ -207,7 +216,7 @@ func TestCloneController_objFromKey(t *testing.T) {
 			name:    "expect to not get object key",
 			args:    args{c.pvcInformer, fmt.Sprintf("%s/%s", "myns", pvc.Name)},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "expect to get object key",
@@ -218,13 +227,16 @@ func TestCloneController_objFromKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.objFromKey(tt.args.informer, tt.args.key)
+			got, exists, err := c.objFromKey(tt.args.informer, tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.objFromKey() error = %v, wantErr %v  myKey = %v", err, tt.wantErr, tt.args.key)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Controller.objFromKey() = %v, want %v", got, tt.want)
+			}
+			if tt.want == nil && exists {
+				t.Errorf("Controller.pvcFromKey() expected key not to exist")
 			}
 		})
 	}


### PR DESCRIPTION
We're supposed to be cleaning up the expectation keys as objects are deleted from the cluster. 