### PR TITLE
deprecation of local endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ In Addition, the Containerized Data Importer gives the option to clone the impor
 1. [Hacking (WIP)](hack/README.md#getting-started-for-developers)
 1. [Security Configurations](#security-configurations)
 
-> DEPRECATION NOTICE:
-Support for local (file://) endpoints will be removed from CDI in the next release. There is no replacement and no work-around. All import endpoints must reference http(s) or s3 endpoints.
-
-
 ## Overview
 
 ### Purpose

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -41,7 +41,4 @@ func main() {
 		os.Exit(1)
 	}
 	glog.V(1).Infoln("import complete")
-
-	// temporary local import deprecation notice
-	glog.Warningf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
 }

--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -43,12 +43,12 @@ test_args="${test_args} -ginkgo.v ${arg_master} ${arg_namespace} ${arg_kubeconfi
 echo 'Wait until all CDI Pods are ready'
 retry_counter=0
 while [ $retry_counter -lt $MAX_CDI_WAIT_RETRY ] && [ -n "$(./cluster/kubectl.sh get pods -n $CDI_NAMESPACE -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false)" ]; do
-	retry_counter=$((retry_counter+1))
+    retry_counter=$((retry_counter + 1))
     sleep $CDI_WAIT_TIME
-	echo "Checking CDI pods again, count $retry_counter"
-	if [ $retry_counter -gt 1 ] && [ "$((retry_counter % 6))" -eq 0 ]; then
-		./cluster/kubectl.sh get pods -n $CDI_NAMESPACE
-	fi
+    echo "Checking CDI pods again, count $retry_counter"
+    if [ $retry_counter -gt 1 ] && [ "$((retry_counter % 6))" -eq 0 ]; then
+        ./cluster/kubectl.sh get pods -n $CDI_NAMESPACE
+    fi
 done
 
 if [ $retry_counter -eq $MAX_CDI_WAIT_RETRY ]; then

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
 	"kubevirt.io/containerized-data-importer/pkg/system"
 )
 

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -126,7 +126,7 @@ func getURLPath(testfile string) string {
 	// CWD is set within go test to the directory of the test
 	// being executed, so using relative path
 	imageDir, _ := filepath.Abs(TestImagesDir)
-	return "file://" + imageDir + "/" + testfile
+	return "file://" + imageDir + "/" + testfile //TODO: use file server
 }
 
 func startHTTPServer(port int, dir string) (*http.Server, error) {
@@ -170,7 +170,7 @@ func TestNewDataStream(t *testing.T) {
 	}
 
 	imageDir, _ := filepath.Abs(TestImagesDir)
-	localImageBase := filepath.Join("file://", imageDir)
+	localImageBase := filepath.Join("file://", imageDir) //TODO: use file server
 
 	tests := []struct {
 		name    string
@@ -280,7 +280,7 @@ func Test_dataStream_Close(t *testing.T) {
 
 func Test_dataStream_dataStreamSelector(t *testing.T) {
 	imageDir, _ := filepath.Abs(TestImagesDir)
-	localImageBase := filepath.Join("file://", imageDir)
+	localImageBase := filepath.Join("file://", imageDir) //TODO: use file server
 
 	tests := []struct {
 		name     string
@@ -331,7 +331,7 @@ func TestCopyImage(t *testing.T) {
 		qemuOperations image.QEMUOperations
 	}
 	imageDir, _ := filepath.Abs(TestImagesDir)
-	localImageBase := filepath.Join("file://", imageDir)
+	localImageBase := filepath.Join("file://", imageDir) //TODO: use file server
 
 	t.Logf("Image dir '%s' '%s'", imageDir, TestImagesDir)
 	port := 9999
@@ -430,7 +430,7 @@ func createTestData() map[string]string {
 
 func Test_dataStream_constructReaders(t *testing.T) {
 	imageDir, _ := filepath.Abs(TestImagesDir)
-	localImageBase := filepath.Join("file://", imageDir)
+	localImageBase := filepath.Join("file://", imageDir) //TODO: use file server
 
 	testfiles := createTestData()
 
@@ -444,29 +444,29 @@ func Test_dataStream_constructReaders(t *testing.T) {
 		{
 			name:    "successfully construct a xz reader",
 			outfile: "tinyCore.iso.xz",
-			ds:      createDataStream(filepath.Join("file://", testfiles[".xz"]), "", ""),
-			numRdrs: 4, // [file, multi-r, xz, multi-r]
+			ds:      createDataStream(filepath.Join("file://", testfiles[".xz"]), "", ""), //TODO: use file server
+			numRdrs: 4, // [http, multi-r, xz, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct a gz reader",
 			outfile: "tinyCore.iso.gz",
-			ds:      createDataStream(filepath.Join("file://", testfiles[".gz"]), "", ""),
-			numRdrs: 4, // [file, multi-r, gz, multi-r]
+			ds:      createDataStream(filepath.Join("file://", testfiles[".gz"]), "", ""), //TODO: use file server
+			numRdrs: 4, // [http, multi-r, gz, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct qcow2 reader",
 			outfile: "",
 			ds:      createDataStream(filepath.Join(localImageBase, "cirros-qcow2.img"), "", ""),
-			numRdrs: 2, // [file, multi-r]
+			numRdrs: 2, // [http, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct .iso reader",
 			outfile: "",
 			ds:      createDataStream(filepath.Join(localImageBase, "tinyCore.iso"), "", ""),
-			numRdrs: 2, // [file, multi-r]
+			numRdrs: 2, // [http, multi-r]
 			wantErr: false,
 		},
 		{

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -27,7 +27,8 @@ const (
 	TestImagesDir = "../../tests/images"
 	defaultPort   = 9999
 )
-var imageDir, _    = filepath.Abs(TestImagesDir)
+
+var imageDir, _ = filepath.Abs(TestImagesDir)
 var localImageBase = fmt.Sprintf("http://%s", imageDir)
 
 type fakeQEMUOperations struct {
@@ -77,8 +78,7 @@ func createDataStreamOrDie(ep, accKey, secKey string) *DataStream {
 	}
 
 	err := ds.constructReaders()
-	if err != nil {
-		
+	if err != nil {//what??
 	}
 
 	return ds
@@ -180,22 +180,22 @@ func TestNewDataStream(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		qemu	bool
-		rdrCnt	int
+		qemu    bool
+		rdrCnt  int
 		wantErr bool
 	}{
 		{
 			name:    "new DataStream for qcow2",
 			args:    args{"cirros-qcow2.img", "", ""},
-			qemu:	 true,
-			rdrCnt:	 2,
+			qemu:    true,
+			rdrCnt:  2,
 			wantErr: false,
 		},
 		{
 			name:    "new DataStream for iso",
 			args:    args{"tinyCore.iso", "", ""},
-			qemu:	 false,
-			rdrCnt:	 3,
+			qemu:    false,
+			rdrCnt:  3,
 			wantErr: false,
 		},
 		{

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 var imageDir, _ = filepath.Abs(TestImagesDir)
-var localImageBase = fmt.Sprintf("http://%s", imageDir)
+var httpImageBase = fmt.Sprintf("http://localhost:%d/", defaultPort)
 
 type fakeQEMUOperations struct {
 	e1 error
@@ -67,41 +67,52 @@ func replaceQEMUOperations(replacement image.QEMUOperations, f func()) {
 	f()
 }
 
-func createDataStreamOrDie(ep, accKey, secKey string) *DataStream {
-	dsurl, _ := ParseEndpoint(ep)
-
+// Parses the endpoint but does not call the constructReaders() method, and thus Close() is
+// not necessary.
+func FakeNewDataStream(ep, accKey, secKey string) (*DataStream, error) {
+	dsurl, err := ParseEndpoint(ep)
+	if err != nil {
+		return nil, fmt.Errorf("FakeNewDataStream parse error: %v", err)
+	}
 	ds := &DataStream{
 		url:         dsurl,
 		buf:         make([]byte, image.MaxExpectedHdrSize),
 		accessKeyID: accKey,
 		secretKey:   secKey,
 	}
-
-	err := ds.constructReaders()
-	if err != nil {//what??
-	}
-
-	return ds
+	return ds, nil
 }
 
+// Creates a fake dataStream and returns the byte content of testfile, if it's passed.
+// Note: if ep is passed then ":port" is expected.
 func createDataStreamBytes(testfile, ep string, defaultBuf bool) (*DataStream, []byte, error) {
-	urlPath := filepath.Join(ep, testfile)
+	var urlPath string
 	if len(ep) == 0 {
 		urlPath = getURLPath(testfile)
+	} else {
+		urlPath = ep + "/" + testfile
 	}
 	testFilePath := getTestFilePath(testfile)
-	ds := createDataStreamOrDie(urlPath, "", "")
+
+	ds, err := FakeNewDataStream(urlPath, "", "")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// if no file supplied just return empty byte stream
-	if len(testfile) == 0 && !defaultBuf {
+	if len(testfile) == 0 {
+		if defaultBuf {
+			return ds, []byte{'T', 'E', 'S', 'T'}, nil
+		}
 		return ds, nil, nil
 	}
-	if len(testfile) == 0 && defaultBuf {
-		return ds, []byte{'T', 'E', 'S', 'T'}, nil
-	}
 
-	f, _ := os.Open(testFilePath)
+	f, err := os.Open(testFilePath)
+	if err != nil {
+		return nil, nil, err
+	}
 	defer f.Close()
+
 	testBytes, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Unable to read datastream buffer")
@@ -130,10 +141,17 @@ func getTestFilePath(testfile string) string {
 	return filepath.Join(imageDir, testfile)
 }
 
-func getURLPath(testfile string) string {
+// Return the web root path to `f`.
+func getURLPath(f string) string {
 	// CWD is set within go test to the directory of the test
 	// being executed, so using relative path
-	return fmt.Sprintf("http://%s/%s", imageDir, testfile)
+	if len(f) == 0 {
+		return httpImageBase
+	}
+	if f[len(f)-1:] != "/" {
+		f += "/"
+	}
+	return httpImageBase + f
 }
 
 func startHTTPServer(port int, dir string) (*http.Server, error) {
@@ -175,7 +193,6 @@ func TestNewDataStream(t *testing.T) {
 		accKey string
 		secKey string
 	}
-	imageBase := fmt.Sprintf("http://%s", imageDir)
 
 	tests := []struct {
 		name    string
@@ -204,11 +221,6 @@ func TestNewDataStream(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "new DataStream should fail with invalid endpoint",
-			args:    args{"/a/b/c", "", ""},
-			wantErr: true,
-		},
-		{
 			name:    "new DataStream should fail with empty endpoint",
 			args:    args{"", "", ""},
 			wantErr: true,
@@ -216,9 +228,9 @@ func TestNewDataStream(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := filepath.Join(imageBase, tt.args.endpt)
-			t.Logf("testing image %q...", f)
-			got, err := NewDataStream(f, tt.args.accKey, tt.args.secKey)
+			ep := getURLPath(tt.args.endpt)
+			t.Logf("NewDataStream testing endpoint: %q...", ep)
+			got, err := NewDataStream(ep, tt.args.accKey, tt.args.secKey)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("NewDataStream error: %v", err)
@@ -262,60 +274,62 @@ func Test_dataStream_Read(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "successful read of datastream buffer",
+			name:     "successful read of dataStream buffer",
 			testFile: "tinyCore.iso",
 			wantErr:  false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ds, testBytes, errDs := createDataStreamBytes(tt.testFile, "", true)
-			if errDs != nil {
-				t.Errorf("error setting up test infrastructure %v", errDs)
+			ep := getURLPath(tt.testFile)
+			t.Logf("by creating a dataStream on endpoint %q...", ep)
+			ds, err := NewDataStream(ep, "", "")
+			if err != nil {
+				t.Errorf("NewDataStreamerror: %v", err)
+				return
 			}
-			defer ds.Close()
+			if ds == nil {
+				t.Error("NewateDataStream returned nil ptr and no error")
+				return
+			}
 
-			got, err := ds.Read(testBytes)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("dataStream.Read() error = %v, wantErr %v", err, tt.wantErr)
+			// read test file
+			var readbuf []byte
+t.Logf("len Readers=%d", len(ds.Readers))
+			n, err := ds.Read(readbuf)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("dataStream.Read error = %v, wantErr %v", err, tt.wantErr)
+				}
 				return
 			}
-			expectedSize, errFs := getFileSize(tt.testFile)
-			if errFs != nil {
-				t.Errorf("error getting test file size %v", errFs)
+
+			// size check
+			expectedSize, err := getFileSize(tt.testFile)
+			if err != nil {
+				t.Errorf("error getting test file size: %v", err)
 				return
 			}
-			if got != expectedSize {
-				t.Errorf("dataStream.Read() sizes do not match = %v, want %v", got, expectedSize)
+			if n != expectedSize {
+				t.Errorf("dataStream.Read return cnt (%d) does not match %q's Stat size (%d)", n, tt.testFile, expectedSize)
+				return
 			}
 		})
 	}
 }
 
 func Test_dataStream_Close(t *testing.T) {
-	ds, _, errDs := createDataStreamBytes("tinyCore.iso", "", false)
-	defer ds.Close()
-
-	tests := []struct {
-		name    string
-		wantErr bool
-	}{
-		{
-			name:    "successfully close all readers",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if errDs != nil {
-				t.Errorf("error setting up test infrastructure %v", errDs)
-				return
-			}
-			if err := ds.Close(); (err != nil) != tt.wantErr {
-				t.Errorf("dataStream.Close() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
+	t.Run("successfully close all readers", func(t *testing.T) {
+		ep := getURLPath("tinyCore.iso")
+		ds, err := NewDataStream(ep, "", "")
+		if err != nil {
+			t.Errorf("NewDataStream error on %q: %v", ep, err)
+			return
+		}
+		if err := ds.Close(); err != nil {
+			t.Errorf("dataStream.Close error on %q: %v", ep, err)
+		}
+	})
 }
 
 func Test_dataStream_dataStreamSelector(t *testing.T) {
@@ -326,9 +340,9 @@ func Test_dataStream_dataStreamSelector(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "success building selector for file",
+			name:     "success building selector for http file",
 			testFile: "tinyCore.iso",
-			ep:       localImageBase,
+			ep:       httpImageBase,
 			wantErr:  false,
 		},
 		{
@@ -338,7 +352,7 @@ func Test_dataStream_dataStreamSelector(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:     "fail trying to build invalid selector",
+			name:     "fail trying to build invalid selector scheme",
 			testFile: "tinyCore.iso",
 			ep:       "fake://somefakefile",
 			wantErr:  true,
@@ -346,28 +360,40 @@ func Test_dataStream_dataStreamSelector(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ds, _, errDs := createDataStreamBytes(tt.testFile, tt.ep, false)
-			defer ds.Close()
-			if errDs != nil {
-				t.Errorf("error setting up test infrastructure %v", errDs)
+			ep := tt.ep + tt.testFile
+			ds, err := FakeNewDataStream(ep, "", "")
+			if err != nil {
+				t.Errorf("FakeNewDataStreamBytes error on %q: %v", ep, err)
 				return
 			}
-			if err := ds.dataStreamSelector(); (err != nil) != tt.wantErr {
-				t.Errorf("dataStream.dataStreamSelector() error = %v, wantErr %v", err, tt.wantErr)
+			if ds == nil {
+				t.Error("FakeNewDataStreamBytes returned nil ptr and no error")
+				return
 			}
+
+			err = ds.dataStreamSelector()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("dataStream.dataStreamSelector error: %v", err)
+				}
+				return
+			}
+			defer ds.Close()
 		})
 	}
 }
 
 func TestCopyImage(t *testing.T) {
+	const copyDir = "cdi-copy"
+	tmpDir := filepath.Join(os.TempDir(), copyDir)
+
 	type args struct {
-		dest           string
-		endpoint       string
+		dest           string // full pathname, index counter appended for uniqueness
+		endpoint       string // just image filename, not full endpt
 		accessKey      string
 		secKey         string
 		qemuOperations image.QEMUOperations
 	}
-	t.Logf("Image dir: %q", imageDir)
 
 	tests := []struct {
 		name    string
@@ -375,10 +401,32 @@ func TestCopyImage(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "successfully copy streaming image",
+			name: "successfully copy iso image",
 			args: args{
-				filepath.Join(localImageBase, "cirros-qcow2.raw"),
-				fmt.Sprintf("http://localhost:%d/cirros-qcow2.img", defaultPort),
+				"disk-img",
+				"tinyCore.iso",
+				"",
+				"",
+				NewQEMUAllErrors(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail copy non-existent iso image",
+			args: args{
+				"disk-img",
+				"fooBar.iso",
+				"",
+				"",
+				NewQEMUAllErrors(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "successfully copy qcow2 image",
+			args: args{
+				"disk-img",
+				"cirros-qcow2.img",
 				"",
 				"",
 				NewFakeQEMUOperations(errors.New("should not be called"), nil, nil),
@@ -388,8 +436,8 @@ func TestCopyImage(t *testing.T) {
 		{
 			name: "streaming image qemu validation fails",
 			args: args{
-				filepath.Join(localImageBase, "cirros-qcow2.raw"),
-				fmt.Sprintf("http://localhost:%d/cirros-qcow2.img", defaultPort),
+				"disk-img",
+				"cirros-qcow2.img",
 				"",
 				"",
 				NewFakeQEMUOperations(nil, nil, errors.New("invalid image")),
@@ -399,8 +447,8 @@ func TestCopyImage(t *testing.T) {
 		{
 			name: "streaming image qemu convert fails",
 			args: args{
-				filepath.Join(localImageBase, "cirros-qcow2.raw"),
-				fmt.Sprintf("http://localhost:%d/cirros-qcow2.img", defaultPort),
+				"disk-img",
+				"cirros-qcow2.img",
 				"",
 				"",
 				NewFakeQEMUOperations(nil, errors.New("exit 1"), nil),
@@ -408,11 +456,21 @@ func TestCopyImage(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	for _, tt := range tests {
-		defer os.RemoveAll(tt.args.dest)
+	for i, tt := range tests {
+		// create sequenced temp dir for destination image
+		dest := filepath.Join(fmt.Sprintf("%s%d", tmpDir, i), tt.args.dest)
+		err := os.MkdirAll(dest, os.ModePerm)
+		if err != nil {
+			t.Errorf("cannot create dir %q: %v", dest, err)
+			continue
+		}
+		defer os.RemoveAll(dest)
+		ep := httpImageBase + tt.args.endpoint
+
+		t.Logf("CopyImage from %q to %q...", ep, dest)
 		t.Run(tt.name, func(t *testing.T) {
 			replaceQEMUOperations(tt.args.qemuOperations, func() {
-				if err := CopyImage(tt.args.dest, tt.args.endpoint, tt.args.accessKey, tt.args.secKey); (err != nil) != tt.wantErr {
+				if err := CopyImage(dest, ep, tt.args.accessKey, tt.args.secKey); (err != nil) != tt.wantErr {
 					t.Errorf("CopyImage() error = %v, wantErr %v", err, tt.wantErr)
 				}
 			})
@@ -421,9 +479,9 @@ func TestCopyImage(t *testing.T) {
 }
 
 func createTestData() map[string]string {
-	xzfile, _ := utils.FormatTestData(filepath.Join(imageDir, "tinyCore.iso"), os.TempDir(), image.ExtXz)
-	gzfile, _ := utils.FormatTestData(filepath.Join(imageDir, "tinyCore.iso"), os.TempDir(), image.ExtGz)
-	xztarfile, _ := utils.FormatTestData(filepath.Join(imageDir, "tinyCore.iso"), os.TempDir(), []string{image.ExtTar, image.ExtGz}...)
+	xzfile, _ := utils.FormatTestData(getTestFilePath("tinyCore.iso"), os.TempDir(), image.ExtXz)
+	gzfile, _ := utils.FormatTestData(getTestFilePath("tinyCore.iso"), os.TempDir(), image.ExtGz)
+	xztarfile, _ := utils.FormatTestData(getTestFilePath("tinyCore.iso"), os.TempDir(), []string{image.ExtTar, image.ExtGz}...)
 
 	return map[string]string{
 		".xz":     xzfile,
@@ -438,52 +496,65 @@ func Test_dataStream_constructReaders(t *testing.T) {
 	tests := []struct {
 		name    string
 		outfile string
-		ds      *DataStream
+		src     string
 		numRdrs int
 		wantErr bool
 	}{
 		{
 			name:    "successfully construct a xz reader",
 			outfile: "tinyCore.iso.xz",
-			ds:      createDataStreamOrDie(fmt.Sprintf("http://%s", testfiles[".xz"]), "", ""),
+			src:     testfiles[".xz"],
 			numRdrs: 4, // [http, multi-r, xz, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct a gz reader",
 			outfile: "tinyCore.iso.gz",
-			ds:      createDataStreamOrDie(fmt.Sprintf("http://%s", testfiles[".gz"]), "", ""),
+			src:     testfiles[".gz"],
 			numRdrs: 4, // [http, multi-r, gz, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct qcow2 reader",
 			outfile: "",
-			ds:      createDataStreamOrDie(filepath.Join(localImageBase, "cirros-qcow2.img"), "", ""),
+			src:     "cirros-qcow2.img",
 			numRdrs: 2, // [http, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "successfully construct .iso reader",
 			outfile: "",
-			ds:      createDataStreamOrDie(filepath.Join(localImageBase, "tinyCore.iso"), "", ""),
+			src:     "tinyCore.iso",
 			numRdrs: 2, // [http, multi-r]
 			wantErr: false,
 		},
 		{
 			name:    "fail constructing reader for invalid file path",
 			outfile: "",
-			ds:      createDataStreamOrDie(filepath.Join(localImageBase, "tinyCorebad.iso"), "", ""),
+			src:     "tinyMissing.iso",
 			numRdrs: 0,
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer tt.ds.Close()
-			actualNumRdrs := len(tt.ds.Readers)
+			ep := getURLPath(tt.src)
+			ds, err := FakeNewDataStream(ep, "", "")
+			if err != nil {
+				t.Errorf("FakeNewDataStream error on endpoint %q: %v", ep, err)
+				return
+			}
+
+			err = ds.constructReaders()
+			if err != nil {
+				t.Errorf("FakeNewDataStream.constructReaders error on endpoint %q: %v", ep, err)
+				return
+			}
+			defer ds.Close()
+
+			actualNumRdrs := len(ds.Readers)
 			if tt.numRdrs != actualNumRdrs {
-				t.Errorf("dataStream.constructReaders(): expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs)
+				t.Errorf("FakeNewDataStream.constructReaders: expect num-readers to be %d, got %d", tt.numRdrs, actualNumRdrs)
 			}
 			if len(tt.outfile) > 0 {
 				os.Remove(filepath.Join(os.TempDir(), tt.outfile))
@@ -533,7 +604,7 @@ func Test_copy(t *testing.T) {
 	}
 	rdrs1 := strings.NewReader("test data for reader 1")
 
-	file := filepath.Join(imageDir, "cirros-qcow2.img")
+	file := getTestFilePath("cirros-qcow2.img")
 	rdrfile, _ := os.Open(file)
 	rdrs2 := bufio.NewReader(rdrfile)
 

--- a/pkg/importer/datastream_ginkgo_test.go
+++ b/pkg/importer/datastream_ginkgo_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 				Expect(err).NotTo(HaveOccurred(), "Error formatting test data.")
 				fmt.Fprintf(GinkgoWriter, "INFO: converted source file name is %q\n", testSample)
 
-				testEp := "file://" + testSample
+				testEp := "file://" + testSample //TODO: use file server
 				testTarget := filepath.Join(tmpTestDir, common.ImporterWriteFile)
 				By(fmt.Sprintf("Importing %q to %q", testEp, testTarget))
 				err = importer.CopyImage(testTarget, testEp, "", "")
@@ -190,7 +190,6 @@ var _ = Describe("Streaming Data Conversion", func() {
 				fmt.Fprintf(GinkgoWriter, "End test on test file %q\n", testSample)
 			})
 		}
-		fmt.Fprintf(GinkgoWriter, "\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
 	})
 })
 

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Importer", func() {
 				filename:    "test-local",
 				createFile:  false,
 				expected:    "file dataStream",
-				endpoint:    "file:///tmp/fake-file",
+				endpoint:    "file:///tmp/fake-file", //TODO: use file server
 				expectError: false,
 			},
 			{

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -26,9 +26,9 @@ func ParseEnvVar(envVarName string, decode bool) (string, error) {
 	return value, nil
 }
 
-// ParseEndpoint parses the required endpoint and return the url struct.
-func ParseEndpoint(endpt string) (*url.URL, error) {
-	var err error
+// ParseEndpoint parses the required endpoint and returns the url struct. Additional
+// checks are done beyond url.Parse, eg. make sure the Path is not empty.
+func ParseEndpoint(endpt string) (url *url.URL, err error) {
 	if endpt == "" {
 		endpt, err = ParseEnvVar(common.ImporterEndpoint, false)
 		if err != nil {
@@ -38,7 +38,16 @@ func ParseEndpoint(endpt string) (*url.URL, error) {
 			return nil, errors.Errorf("endpoint %q is missing or blank", common.ImporterEndpoint)
 		}
 	}
-	return url.Parse(endpt)
+
+	url, err = url.Parse(endpt)
+	if err != nil || url == nil {
+		return nil, errors.Errorf("endpoint %q parsing error: %v", endpt, err)
+	}
+	if len(url.Path) == 0 {
+		return nil, errors.Errorf("endpoint %q Path is missing", endpt)
+	}
+
+	return url, nil
 }
 
 // StreamDataToFile provides a function to stream the specified io.Reader to the specified local file

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -79,7 +79,7 @@ func TestParseEndpoint(t *testing.T) {
 			name:    "successfully get url object from endpoint",
 			args:    args{"http://www.bing.com"},
 			want:    true,
-			setEnv:  true,
+			setEnv:  false,
 			wantErr: false,
 		},
 		{
@@ -99,8 +99,9 @@ func TestParseEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(common.ImporterEndpoint, "www.google.com")
-			if !tt.setEnv {
+			if tt.setEnv {
+				os.Setenv(common.ImporterEndpoint, "www.google.com")
+			} else {
 				os.Unsetenv(common.ImporterEndpoint)
 			}
 			got, err := ParseEndpoint(tt.args.endpt)

--- a/pkg/lib/size/size_test.go
+++ b/pkg/lib/size/size_test.go
@@ -14,9 +14,6 @@ const (
 )
 
 func TestSize(t *testing.T) {
-	// temporary local import deprecation notice
-	fmt.Printf("\nDEPRECATION NOTICE:\n   Support for local (file://) endpoints will be removed from CDI in the next release.\n   There is no replacement and no work-around.\n   All import endpoints must reference http(s) or s3 endpoints\n")
-
 	testImg1, err := filepath.Abs(filepath.Join(baseImageRelPath, tinyCore))
 	if err != nil {
 		t.Fatalf("failed to get %q source image Abs path: %v\n", tinyCore, err)
@@ -54,7 +51,7 @@ func TestSize(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep := fmt.Sprintf("file://%s", tt.args.endpoint)
+		ep := fmt.Sprintf("file://%s", tt.args.endpoint) //TODO: use file server
 		descr := fmt.Sprintf("testing %q file size", ep)
 		t.Log(descr)
 		t.Run(descr, func(t *testing.T) {


### PR DESCRIPTION
Completes [338](https://github.com/kubevirt/containerized-data-importer/issues/338).

Removal of all code and tests related to local (file://) endpoints.

TODO: unit tests still are coded for local endpoints and need to be changed to use the new file server.

@aglitke @copejon @nellyc 