### PR TITLE
Fix lint errors on common package

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -54,8 +54,8 @@ func init() {
 		glog.Fatalf("Environment Variable %q undefined\n", CLONER_IMAGE)
 	}
 
-	pullPolicy = DEFAULT_PULL_POLICY
-	if pp := os.Getenv(PULL_POLICY); len(pp) != 0 {
+	pullPolicy = DefaultPullPolicy
+	if pp := os.Getenv(PullPolicy); len(pp) != 0 {
 		pullPolicy = pp
 	}
 
@@ -93,10 +93,10 @@ func main() {
 		glog.Fatalf("Error building example clientset: %s", err.Error())
 	}
 
-	cdiInformerFactory := informers.NewSharedInformerFactory(cdiClient, DEFAULT_RESYNC_PERIOD)
-	pvcInformerFactory := k8sinformers.NewSharedInformerFactory(client, DEFAULT_RESYNC_PERIOD)
-	podInformerFactory := k8sinformers.NewFilteredSharedInformerFactory(client, DEFAULT_RESYNC_PERIOD, "", func(options *v1.ListOptions) {
-		options.LabelSelector = CDI_LABEL_SELECTOR
+	cdiInformerFactory := informers.NewSharedInformerFactory(cdiClient, DefaultResyncPeriod)
+	pvcInformerFactory := k8sinformers.NewSharedInformerFactory(client, DefaultResyncPeriod)
+	podInformerFactory := k8sinformers.NewFilteredSharedInformerFactory(client, DefaultResyncPeriod, "", func(options *v1.ListOptions) {
+		options.LabelSelector = CDILabelSelector
 	})
 
 	pvcInformer := pvcInformerFactory.Core().V1().PersistentVolumeClaims()

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -5,12 +5,12 @@ package main
 // https for public remotes, and "file" for local files. The main use-case for this importer is
 // to copy VM images to a "golden" namespace for consumption by kubevirt.
 // This process expects several environmental variables:
-//    IMPORTER_ENDPOINT       Endpoint url minus scheme, bucket/object and port, eg. s3.amazon.com.
+//    ImporterEndpoint       Endpoint url minus scheme, bucket/object and port, eg. s3.amazon.com.
 //			      Access and secret keys are optional. If omitted no creds are passed
 //			      to the object store client.
-//    IMPORTER_ACCESS_KEY_ID  Optional. Access key is the user ID that uniquely identifies your
+//    ImporterAccessKeyID  Optional. Access key is the user ID that uniquely identifies your
 //			      account.
-//    IMPORTER_SECRET_KEY     Optional. Secret key is the password to your account.
+//    ImporterSecretKey     Optional. Secret key is the password to your account.
 
 import (
 	"flag"
@@ -30,12 +30,12 @@ func main() {
 	defer glog.Flush()
 
 	glog.V(1).Infoln("Starting importer")
-	ep, _ := ParseEnvVar(IMPORTER_ENDPOINT, false)
-	acc, _ := ParseEnvVar(IMPORTER_ACCESS_KEY_ID, false)
-	sec, _ := ParseEnvVar(IMPORTER_SECRET_KEY, false)
+	ep, _ := ParseEnvVar(ImporterEndpoint, false)
+	acc, _ := ParseEnvVar(ImporterAccessKeyID, false)
+	sec, _ := ParseEnvVar(ImporterSecretKey, false)
 
 	glog.V(1).Infoln("begin import process")
-	err := CopyImage(IMPORTER_WRITE_PATH, ep, acc, sec)
+	err := CopyImage(ImporterWritePath, ep, acc, sec)
 	if err != nil {
 		glog.Errorf("%+v", err)
 		os.Exit(1)

--- a/hack/build/run-lint-checks.sh
+++ b/hack/build/run-lint-checks.sh
@@ -20,9 +20,6 @@
 source hack/build/config.sh
 source hack/build/common.sh
 
-# Temporary var for pkgs that are ready to enforce linting
-LINTABLE=(pkg/controller pkg/apis pkg/client pkg/controller pkg/expectations pkg/image pkg/importer pkg/lib pkg/util)
-
 ec=0
 out="$(gofmt -l -s ${SOURCE_DIRS} | grep ".*\.go")"
 if [[ ${out} ]]; then
@@ -31,14 +28,12 @@ if [[ ${out} ]]; then
     ec=1
 fi
 
-for p in "${LINTABLE[@]}"; do
-    echo "Performing lint checks on: ${p}"
-    out="$(golint ${p}/...)"
-    if [[ ${out} ]]; then
-        echo "FAIL: following golint errors found:"
-        echo "${out}"
-        ec=1
-    fi
-done
+echo "running golint on the pkg directory (golint pkg/...)"
+out="$(golint pkg/...)"
+if [[ ${out} ]]; then
+    echo "FAIL: following golint errors found:"
+    echo "${out}"
+    ec=1
+fi
 
 exit ${ec}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -10,37 +10,58 @@ import (
 // TODO: maybe the vm cloner can use these common values
 
 const (
-	CDI_LABEL_KEY      = "app"
-	CDI_LABEL_VALUE    = "containerized-data-importer"
-	CDI_LABEL_SELECTOR = CDI_LABEL_KEY + "=" + CDI_LABEL_VALUE
+	// CDILabelKey provides a constant for CDI PVC labels
+	CDILabelKey = "app"
+	// CDILabelValue provides a constant  for CDI PVC label values
+	CDILabelValue = "containerized-data-importer"
+	// CDILabelSelector provides a constant to use for the selector to identify CDI objects in list
+	CDILabelSelector = CDILabelKey + "=" + CDILabelValue
 
 	// host file constants:
-	IMPORTER_WRITE_DIR  = "/data"
-	IMPORTER_WRITE_FILE = "disk.img"
-	IMPORTER_WRITE_PATH = IMPORTER_WRITE_DIR + "/" + IMPORTER_WRITE_FILE
-	// importer container constants:
-	IMPORTER_PODNAME    = "importer"
-	IMPORTER_DATA_DIR   = "/data"
-	IMPORTER_S3_HOST    = "s3.amazonaws.com"
-	DEFAULT_PULL_POLICY = string(v1.PullIfNotPresent)
-	// env var names
-	PULL_POLICY            = "PULL_POLICY"
-	IMPORTER_ENDPOINT      = "IMPORTER_ENDPOINT"
-	IMPORTER_ACCESS_KEY_ID = "IMPORTER_ACCESS_KEY_ID"
-	IMPORTER_SECRET_KEY    = "IMPORTER_SECRET_KEY"
+	importerWriteDir = "/data"
+	// ImporterWriteFile provides a constant for our importer/datastream_ginkgo_test and to build ImporterWritePath
+	ImporterWriteFile = "disk.img"
+	//ImporterWritePath provides a constant for for the cmd/cdi-importer/importer.go executable
+	ImporterWritePath = importerWriteDir + "/" + ImporterWriteFile
 
-	CLONING_LABEL_KEY     = "cloning"
-	CLONING_LABEL_VALUE   = "host-assisted-cloning"
-	CLONING_TOPOLOGY_KEY  = "kubernetes.io/hostname"
-	CLONER_SOURCE_PODNAME = "clone-source-pod"
-	CLONER_TARGET_PODNAME = "clone-target-pod"
-	CLONER_IMAGE_PATH     = "/tmp/clone/image"
-	CLONER_SOCKET_PATH    = "/tmp/clone/socket"
+	// ImporterPodName provides a constant to use as a prefix for Pods created by CDI (controller only)
+	ImporterPodName = "importer"
+	// ImporterDataDir provides a constant for the controller pkg to use as a hardcoded path to where content is transferred to/from (controller only)
+	ImporterDataDir = "/data"
+	// ImporterS3Host provides an S3 string used by importer/dataStream.go only
+	ImporterS3Host = "s3.amazonaws.com"
+	// DefaultPullPolicy imports k8s "IfNotPresent" string for the import_controller_gingko_test and the cdi-controller executable
+	DefaultPullPolicy = string(v1.PullIfNotPresent)
 
-	// key names expected in credential secret
-	KEY_ACCESS = "accessKeyId"
-	KEY_SECRET = "secretKey"
+	// PullPolicy provides a constant to capture our env variable "PULL_POLICY" (only used by cmd/cdi-controller/controller.go)
+	PullPolicy = "PULL_POLICY"
+	// ImporterEndpoint provides a constant to capture our env variable "IMPOTER_ENDPOINT"
+	ImporterEndpoint = "IMPORTER_ENDPOINT"
+	// ImporterAccessKeyID provides a constant to capture our env variable "IMPORTER_ACCES_KEY_ID"
+	ImporterAccessKeyID = "IMPORTER_ACCESS_KEY_ID"
+	// ImporterSecretKey provides a constant to capture our env variable "IMPORTER_SECRET_KEY"
+	ImporterSecretKey = "IMPORTER_SECRET_KEY"
 
-	// Shared informer resync period.
-	DEFAULT_RESYNC_PERIOD = 10 * time.Minute
+	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)
+	CloningLabelKey = "cloning"
+	// CloningLabelValue provides a constant to use as a label value for pod affinity (controller pkg only)
+	CloningLabelValue = "host-assisted-cloning"
+	// CloningTopologyKey  (controller pkg only)
+	CloningTopologyKey = "kubernetes.io/hostname"
+	// ClonerSourcePodName (controller pkg only)
+	ClonerSourcePodName = "clone-source-pod"
+	// ClonerTargetPodName (controller pkg only)
+	ClonerTargetPodName = "clone-target-pod"
+	// ClonerImagePath (controller pkg only)
+	ClonerImagePath = "/tmp/clone/image"
+	// ClonerSocketPath (controller pkg only)
+	ClonerSocketPath = "/tmp/clone/socket"
+
+	// KeyAccess provides a constant to the accessKeyId label using in controller pkg and transport_test.go
+	KeyAccess = "accessKeyId"
+	// KeySecret provides a constant to the secretKey label using in controller pkg and transport_test.go
+	KeySecret = "secretKey"
+
+	// DefaultResyncPeriod sets a 10 minute resync period, used in the controller pkg and the controller cmd executable
+	DefaultResyncPeriod = 10 * time.Minute
 )

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -360,8 +360,8 @@ func (c *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 		anno[AnnCloneOf] = "true"
 	}
 	var lab map[string]string
-	if !checkIfLabelExists(pvc, common.CDI_LABEL_KEY, common.CDI_LABEL_VALUE) {
-		lab = map[string]string{common.CDI_LABEL_KEY: common.CDI_LABEL_VALUE}
+	if !checkIfLabelExists(pvc, common.CDILabelKey, common.CDILabelValue) {
+		lab = map[string]string{common.CDILabelKey: common.CDILabelValue}
 	}
 	pvc, err = updatePVC(c.clientset, pvc, anno, lab)
 	if err != nil {

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -233,7 +233,7 @@ func TestCloneObservePod(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, targetPod)
 
 	expPvc := pvc.DeepCopy()
-	expPvc.ObjectMeta.Labels = map[string]string{CDI_LABEL_KEY: CDI_LABEL_VALUE}
+	expPvc.ObjectMeta.Labels = map[string]string{CDILabelKey: CDILabelValue}
 	expPvc.ObjectMeta.Annotations = map[string]string{AnnClonePodPhase: string(corev1.PodPending), AnnCloneRequest: "source-ns/golden-pvc"}
 
 	f.expectUpdatePvcAction(expPvc)
@@ -257,7 +257,7 @@ func TestClonePodStatusUpdating(t *testing.T) {
 	targetPod.Namespace = "target-ns"
 
 	pvc.ObjectMeta.Annotations = map[string]string{AnnClonePodPhase: string(corev1.PodPending), AnnCloneRequest: "source-ns/golden-pvc"}
-	pvc.ObjectMeta.Labels = map[string]string{CDI_LABEL_KEY: CDI_LABEL_VALUE}
+	pvc.ObjectMeta.Labels = map[string]string{CDILabelKey: CDILabelValue}
 
 	f.pvcLister = append(f.pvcLister, pvc)
 	f.podLister = append(f.podLister, sourcePod)

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -329,8 +329,8 @@ func (c *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 	}
 
 	var lab map[string]string
-	if !checkIfLabelExists(pvc, common.CDI_LABEL_KEY, common.CDI_LABEL_VALUE) {
-		lab = map[string]string{common.CDI_LABEL_KEY: common.CDI_LABEL_VALUE}
+	if !checkIfLabelExists(pvc, common.CDILabelKey, common.CDILabelValue) {
+		lab = map[string]string{common.CDILabelKey: common.CDILabelValue}
 	}
 
 	pvc, err = updatePVC(c.clientset, pvc, anno, lab)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -217,7 +217,7 @@ func TestImportPodCreationExpectation(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, pvc)
 
 	expPvc := pvc.DeepCopy()
-	expPvc.ObjectMeta.Labels = map[string]string{CDI_LABEL_KEY: CDI_LABEL_VALUE}
+	expPvc.ObjectMeta.Labels = map[string]string{CDILabelKey: CDILabelValue}
 	f.expectUpdatePvcAction(expPvc)
 
 	f.runWithExpectation(getPvcKey(pvc, t))
@@ -238,7 +238,7 @@ func TestImportObservePod(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, pod)
 
 	expPvc := pvc.DeepCopy()
-	expPvc.ObjectMeta.Labels = map[string]string{CDI_LABEL_KEY: CDI_LABEL_VALUE}
+	expPvc.ObjectMeta.Labels = map[string]string{CDILabelKey: CDILabelValue}
 	expPvc.ObjectMeta.Annotations = map[string]string{AnnImportPod: pod.Name, AnnPodPhase: string(corev1.PodPending), AnnEndpoint: "http://test"}
 
 	f.expectUpdatePvcAction(expPvc)
@@ -257,7 +257,7 @@ func TestImportPodStatusUpdating(t *testing.T) {
 	pod.Namespace = pvc.Namespace
 
 	pvc.ObjectMeta.Annotations = map[string]string{AnnImportPod: pod.Name, AnnPodPhase: string(corev1.PodPending), AnnEndpoint: "http://test"}
-	pvc.ObjectMeta.Labels = map[string]string{CDI_LABEL_KEY: CDI_LABEL_VALUE}
+	pvc.ObjectMeta.Labels = map[string]string{CDILabelKey: CDILabelValue}
 
 	f.pvcLister = append(f.pvcLister, pvc)
 	f.podLister = append(f.podLister, pod)

--- a/pkg/controller/import_controller_ginkgo_test.go
+++ b/pkg/controller/import_controller_ginkgo_test.go
@@ -50,13 +50,13 @@ var _ = Describe("Controller", func() {
 			podSource.Add(pod)
 		}
 
-		pvcInformerFactory := k8sinformers.NewSharedInformerFactory(fakeClient, DEFAULT_RESYNC_PERIOD)
-		podInformerFactory := k8sinformers.NewSharedInformerFactory(fakeClient, DEFAULT_RESYNC_PERIOD)
+		pvcInformerFactory := k8sinformers.NewSharedInformerFactory(fakeClient, DefaultResyncPeriod)
+		podInformerFactory := k8sinformers.NewSharedInformerFactory(fakeClient, DefaultResyncPeriod)
 
 		pvcInformer := pvcInformerFactory.Core().V1().PersistentVolumeClaims()
 		podInformer := podInformerFactory.Core().V1().Pods()
 
-		controller = NewImportController(fakeClient, pvcInformer, podInformer, IMPORTER_DEFAULT_IMAGE, DEFAULT_PULL_POLICY, verboseDebug)
+		controller = NewImportController(fakeClient, pvcInformer, podInformer, IMPORTER_DEFAULT_IMAGE, DefaultPullPolicy, verboseDebug)
 
 		go pvcInformerFactory.Start(stop)
 		go podInformerFactory.Start(stop)

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -81,7 +81,7 @@ var rdrTypM = map[string]int{
 // Note: the caller must close the `Readers` in reverse order. See Close().
 func NewDataStream(endpt, accKey, secKey string) (*DataStream, error) {
 	if len(accKey) == 0 || len(secKey) == 0 {
-		glog.V(2).Infof("%s and/or %s are empty\n", common.IMPORTER_ACCESS_KEY_ID, common.IMPORTER_SECRET_KEY)
+		glog.V(2).Infof("%s and/or %s are empty\n", common.ImporterAccessKeyID, common.ImporterSecretKey)
 	}
 	ep, err := ParseEndpoint(endpt)
 	if err != nil {
@@ -147,7 +147,7 @@ func (d DataStream) s3() (io.ReadCloser, error) {
 	glog.V(3).Infoln("Using S3 client to get data")
 	bucket := d.url.Host
 	object := strings.Trim(d.url.Path, "/")
-	mc, err := minio.NewV4(common.IMPORTER_S3_HOST, d.accessKeyID, d.secretKey, false)
+	mc, err := minio.NewV4(common.ImporterS3Host, d.accessKeyID, d.secretKey, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not build minio client for %q", d.url.Host)
 	}

--- a/pkg/importer/datastream_ginkgo_test.go
+++ b/pkg/importer/datastream_ginkgo_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 				fmt.Fprintf(GinkgoWriter, "INFO: converted source file name is %q\n", testSample)
 
 				testEp := "file://" + testSample
-				testTarget := filepath.Join(tmpTestDir, common.IMPORTER_WRITE_FILE)
+				testTarget := filepath.Join(tmpTestDir, common.ImporterWriteFile)
 				By(fmt.Sprintf("Importing %q to %q", testEp, testTarget))
 				err = importer.CopyImage(testTarget, testEp, "", "")
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -30,12 +30,12 @@ func ParseEnvVar(envVarName string, decode bool) (string, error) {
 func ParseEndpoint(endpt string) (*url.URL, error) {
 	var err error
 	if endpt == "" {
-		endpt, err = ParseEnvVar(common.IMPORTER_ENDPOINT, false)
+		endpt, err = ParseEnvVar(common.ImporterEndpoint, false)
 		if err != nil {
 			return nil, err
 		}
 		if endpt == "" {
-			return nil, errors.Errorf("endpoint %q is missing or blank", common.IMPORTER_ENDPOINT)
+			return nil, errors.Errorf("endpoint %q is missing or blank", common.ImporterEndpoint)
 		}
 	}
 	return url.Parse(endpt)

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -99,9 +99,9 @@ func TestParseEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(common.IMPORTER_ENDPOINT, "www.google.com")
+			os.Setenv(common.ImporterEndpoint, "www.google.com")
 			if !tt.setEnv {
-				os.Unsetenv(common.IMPORTER_ENDPOINT)
+				os.Unsetenv(common.ImporterEndpoint)
 			}
 			got, err := ParseEndpoint(tt.args.endpt)
 			if (err != nil) != tt.wantErr {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -73,12 +73,12 @@ func doCloneTest(f *framework.Framework, targetNs *v1.Namespace) {
 	err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, targetNs.Name, v1.ClaimBound, targetPvc.Name)
 
 	By("Find cloner pods")
-	sourcePod, err := f.FindPodByPrefix(common.CLONER_SOURCE_PODNAME)
+	sourcePod, err := f.FindPodByPrefix(common.ClonerSourcePodName)
 	if err != nil {
 		PrintControllerLog(f)
 	}
 	Expect(err).ToNot(HaveOccurred())
-	targetPod, err := utils.FindPodByPrefix(f.K8sClient, targetNs.Name, common.CLONER_TARGET_PODNAME, common.CDI_LABEL_SELECTOR)
+	targetPod, err := utils.FindPodByPrefix(f.K8sClient, targetNs.Name, common.ClonerTargetPodName, common.CDILabelSelector)
 	if err != nil {
 		PrintControllerLog(f)
 	}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -166,7 +166,7 @@ func NewFramework(prefix string, config Config) (*Framework, error) {
 func (f *Framework) BeforeEach() {
 	if !f.SkipControllerPodLookup {
 		if f.ControllerPod == nil {
-			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, CdiPodPrefix, common.CDI_LABEL_SELECTOR)
+			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, CdiPodPrefix, common.CDILabelSelector)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Fprintf(GinkgoWriter, "INFO: Located cdi-controller-pod: %q\n", pod.Name)
 			f.ControllerPod = pod

--- a/tests/framework/pod.go
+++ b/tests/framework/pod.go
@@ -26,5 +26,5 @@ func (f *Framework) WaitTimeoutForPodStatus(podName string, status k8sv1.PodPhas
 }
 
 func (f *Framework) FindPodByPrefix(prefix string) (*k8sv1.Pod, error) {
-	return utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, prefix, common.CDI_LABEL_SELECTOR)
+	return utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, prefix, common.CDILabelSelector)
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -64,8 +64,8 @@ var _ = Describe("Transport Tests", func() {
 		if credentialed {
 			By(fmt.Sprintf("Creating secret for endpoint %s", ep))
 			stringData := map[string]string{
-				common.KEY_ACCESS: utils.AccessKeyValue,
-				common.KEY_SECRET: utils.SecretKeyValue,
+				common.KeyAccess: utils.AccessKeyValue,
+				common.KeySecret: utils.SecretKeyValue,
 			}
 			sec, err = utils.CreateSecretFromDefinition(c, utils.NewSecretDefinition(nil, stringData, nil, ns, secretPrefix))
 			Expect(err).NotTo(HaveOccurred(), "Error creating test secret")


### PR DESCRIPTION
This change just updates the common package to pass golint.  Of course
that has some reaching implications into other packages with renaming of
constants.

I've intentionally kept this patch set to the bare minimum for the lint
test, I do think that we should put some effort into our use of
constants (especially those in common.go) in the future.

Ideally we'd declare constants where they're used, and we wouldn't
export them if they don't need to be.  There are some in here that
are only used in one or two packages, and that can be cleaned up pretty
easily however it's likely that there might be plans to use them
elsewhere in the future.