### PR TITLE
Display QEMU conversion progress in importer pod log.

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -54,7 +54,7 @@ func NewQEMUOperations() QEMUOperations {
 }
 
 func (o *qemuOperations) ConvertQcow2ToRaw(src, dest string) error {
-	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-f", "qcow2", "-O", "raw", src, dest)
+	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-p", "-f", "qcow2", "-O", "raw", src, dest)
 	if err != nil {
 		return errors.Wrap(err, "could not convert local qcow2 image to raw")
 	}
@@ -65,7 +65,7 @@ func (o *qemuOperations) ConvertQcow2ToRaw(src, dest string) error {
 func (o *qemuOperations) ConvertQcow2ToRawStream(url *url.URL, dest string) error {
 	jsonArg := fmt.Sprintf("json: {\"file.driver\": \"%s\", \"file.url\": \"%s\", \"file.timeout\": %d}", url.Scheme, url, networkTimeoutSecs)
 
-	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-f", "qcow2", "-O", "raw", jsonArg, dest)
+	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-p", "-f", "qcow2", "-O", "raw", jsonArg, dest)
 	if err != nil {
 		return errors.Wrap(err, "could not stream/convert qcow2 image to raw")
 	}

--- a/pkg/system/prlimit.go
+++ b/pkg/system/prlimit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package system
 
 import (
+	"bufio"
 	"bytes"
 	"os/exec"
 	"syscall"
@@ -68,18 +69,57 @@ func SetCPUTimeLimit(pid int, value uint64) error {
 	return limiter.SetCPUTimeLimit(pid, value)
 }
 
+// scanLinesWithCR is an alternate split function that works with carriage returns as well
+// as new lines.
+func scanLinesWithCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\r'); i >= 0 {
+		// We have a full carriage return-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+func processScanner(scanner *bufio.Scanner, buf *bytes.Buffer) {
+	for scanner.Scan() {
+		line := scanner.Text()
+		buf.WriteString(line)
+		glog.V(1).Info(line)
+	}
+}
+
 // ExecWithLimits executes a command with process limits
 func ExecWithLimits(limits *ProcessLimitValues, command string, args ...string) ([]byte, error) {
 	var buf bytes.Buffer
+
 	cmd := execCommand(command, args...)
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
+	stdoutIn, _ := cmd.StdoutPipe()
+	stderrIn, _ := cmd.StderrPipe()
+
+	scanner := bufio.NewScanner(stdoutIn)
+	scanner.Split(scanLinesWithCR)
+	errScanner := bufio.NewScanner(stderrIn)
+	errScanner.Split(scanLinesWithCR)
 
 	err := cmd.Start()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Couldn't start %s", command)
 	}
 	defer cmd.Process.Kill()
+
+	go processScanner(scanner, &buf)
+	go processScanner(errScanner, &buf)
 
 	if limits != nil {
 		if limits.CPUTimeLimit > 0 {
@@ -104,7 +144,6 @@ func ExecWithLimits(limits *ProcessLimitValues, command string, args ...string) 
 		glog.Errorf("%s\n", string(output))
 		return output, errors.Wrapf(err, "%s execution failed", command)
 	}
-
 	return output, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR shows the QEMU progress in the importer pod log, this is useful for seeing status progress on converting large images. It can also help debug issues stemming from slow network or disks as you can see some progress happening.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Importer POD now shows progress in the log.
```

