### PR TITLE
Refresh goreport after each PR push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ script:
 - make goveralls
 - make test-lint
 
+after_script:
+  - curl -d "repo=github.com/kubevirt/containerized-data-importer" https://goreportcard.com/checks
+
 before_deploy:
 - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR calls a refresh on goreport on each PR submitted, so we are never out of sync much.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

