### PR TITLE
Fix flaky transport test

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 5e0806ce615b5f75c7fdb18fb908c86d2736e3099252adaff74e31e74314fba2
-updated: 2018-08-30T20:09:10.641503414-04:00
+updated: 2018-09-28T13:34:58.423343014-04:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
@@ -16,7 +16,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 5cf292cae48347c2490ac1a58fe36735fb78df7e
+  version: fa25069db393aecc09b71267d0489b357781c860
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -103,7 +103,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pkg/errors
-  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
+  version: c059e472caf75dbe73903f6521a20abac245b17f
 - name: github.com/spf13/pflag
   version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/ulikunitz/xz
@@ -166,7 +166,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/square/go-jose.v2
-  version: 8254d6c783765f38c8675fae4427a1fe73fbd09d
+  version: ef984e69dd356202fd4e4910d4d9c24468bdf0b8
   subpackages:
   - cipher
   - json
@@ -422,9 +422,12 @@ imports:
   - pkg/apis/apiregistration/v1
   - pkg/apis/apiregistration/v1beta1
   - pkg/client/clientset_generated/clientset
+  - pkg/client/clientset_generated/clientset/fake
   - pkg/client/clientset_generated/clientset/scheme
   - pkg/client/clientset_generated/clientset/typed/apiregistration/v1
+  - pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake
   - pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake
 - name: k8s.io/kube-openapi
   version: 39cb288412c48cb533ba4be5d6c28620b9a0c1b4
   subpackages:

--- a/pkg/system/prlimit.go
+++ b/pkg/system/prlimit.go
@@ -138,6 +138,10 @@ func ExecWithLimits(limits *ProcessLimitValues, command string, args ...string) 
 	}
 
 	err = cmd.Wait()
+
+	// Make sure nothing is left in the buffer.
+	processScanner(scanner, &buf)
+	processScanner(errScanner, &buf)
 	output := buf.Bytes()
 	if err != nil {
 		glog.Errorf("%s %s failed output is:\n", command, args)

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -67,7 +67,11 @@ var _ = Describe("Transport Tests", func() {
 
 		importer, err := utils.FindPodByPrefix(c, ns, common.ImporterPodName, common.CDILabelSelector)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
-		Expect(utils.WaitTimeoutForPodStatus(c, importer.Name, importer.Namespace, v1.PodSucceeded, utils.PodWaitForTime)).To(Succeed())
+		err = utils.WaitTimeoutForPodStatus(c, importer.Name, importer.Namespace, v1.PodSucceeded, utils.PodWaitForTime)
+		if err != nil {
+			PrintPodLog(f, importer.Name, ns)
+		}
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
 
 		By("Verifying PVC is not empty")
 		Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeFalse(), fmt.Sprintf("Found 0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -48,7 +48,12 @@ func RunKubectlCommand(f *framework.Framework, args ...string) (string, error) {
 
 //PrintControllerLog ...
 func PrintControllerLog(f *framework.Framework) {
-	log, err := RunKubectlCommand(f, "logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
+	PrintPodLog(f, f.ControllerPod.Name, f.CdiInstallNs)
+}
+
+//PrintPodLog ...
+func PrintPodLog(f *framework.Framework, podName, namespace string) {
+	log, err := RunKubectlCommand(f, "logs", podName, "-n", namespace)
 	if err == nil {
 		fmt.Fprintf(GinkgoWriter, "INFO: Controller log\n%s\n", log)
 	} else {

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -147,6 +147,7 @@ func podStatus(clientSet *kubernetes.Clientset, podName, namespace string, statu
 			}
 			return false, err
 		}
+		By("Checking POD phase: " + string(pod.Status.Phase))
 		switch pod.Status.Phase {
 		case status:
 			return true, nil

--- a/vendor/github.com/go-ini/ini/README.md
+++ b/vendor/github.com/go-ini/ini/README.md
@@ -20,6 +20,8 @@ Package ini provides INI file read and write functionality in Go.
 
 ## Installation
 
+The minimum requirement of Go is **1.6**.
+
 To use a tagged revision:
 
 ```sh

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -192,7 +192,7 @@ func Wrap(err error, message string) error {
 }
 
 // Wrapf returns an error annotating err with a stack trace
-// at the point Wrapf is call, and the format specifier.
+// at the point Wrapf is called, and the format specifier.
 // If err is nil, Wrapf returns nil.
 func Wrapf(err error, format string, args ...interface{}) error {
 	if err == nil {

--- a/vendor/gopkg.in/square/go-jose.v2/jwk.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwk.go
@@ -489,6 +489,16 @@ func fromRsaPrivateKey(rsa *rsa.PrivateKey) (*rawJSONWebKey, error) {
 	raw.P = newBuffer(rsa.Primes[0].Bytes())
 	raw.Q = newBuffer(rsa.Primes[1].Bytes())
 
+	if rsa.Precomputed.Dp != nil {
+		raw.Dp = newBuffer(rsa.Precomputed.Dp.Bytes())
+	}
+	if rsa.Precomputed.Dq != nil {
+		raw.Dq = newBuffer(rsa.Precomputed.Dq.Bytes())
+	}
+	if rsa.Precomputed.Qinv != nil {
+		raw.Qi = newBuffer(rsa.Precomputed.Qinv.Bytes())
+	}
+
 	return raw, nil
 }
 

--- a/vendor/gopkg.in/square/go-jose.v2/jwk_test.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwk_test.go
@@ -121,6 +121,42 @@ func TestRoundtripRsaPrivate(t *testing.T) {
 	}
 }
 
+func TestRoundtripRsaPrivatePrecomputed(t *testing.T) {
+	// Isolate a shallow copy of the rsaTestKey to avoid polluting it with Precompute
+	localKey := &(*rsaTestKey)
+	localKey.Precompute()
+
+	jwk, err := fromRsaPrivateKey(localKey)
+	if err != nil {
+		t.Error("problem constructing JWK from rsa key", err)
+	}
+
+	rsa2, err := jwk.rsaPrivateKey()
+	if err != nil {
+		t.Error("problem converting RSA private -> JWK", err)
+	}
+
+	if rsa2.Precomputed.Dp == nil {
+		t.Error("RSA private Dp nil")
+	}
+	if rsa2.Precomputed.Dq == nil {
+		t.Error("RSA private Dq nil")
+	}
+	if rsa2.Precomputed.Qinv == nil {
+		t.Error("RSA private Qinv nil")
+	}
+
+	if rsa2.Precomputed.Dp.Cmp(localKey.Precomputed.Dp) != 0 {
+		t.Error("RSA private Dp mismatch")
+	}
+	if rsa2.Precomputed.Dq.Cmp(localKey.Precomputed.Dq) != 0 {
+		t.Error("RSA private Dq mismatch")
+	}
+	if rsa2.Precomputed.Qinv.Cmp(localKey.Precomputed.Qinv) != 0 {
+		t.Error("RSA private Qinv mismatch")
+	}
+}
+
 func TestRsaPrivateInsufficientPrimes(t *testing.T) {
 	brokenRsaPrivateKey := rsa.PrivateKey{
 		PublicKey: rsa.PublicKey{

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
@@ -47,6 +47,14 @@ func (e Expected) WithTime(t time.Time) Expected {
 
 // Validate checks claims in a token against expected values.
 // A default leeway value of one minute is used to compare time values.
+//
+// The default leeway will cause the token to be deemed valid until one
+// minute after the expiration time. If you're a server application that
+// wants to give an extra minute to client tokens, use this
+// function. If you're a client application wondering if the server
+// will accept your token, use ValidateWithLeeway with a leeway <=0,
+// otherwise this function might make you think a token is valid when
+// it is not.
 func (c Claims) Validate(e Expected) error {
 	return c.ValidateWithLeeway(e, DefaultLeeway)
 }
@@ -56,6 +64,15 @@ func (c Claims) Validate(e Expected) error {
 // zero value to check time values with no leeway, but you should not that
 // numeric date values are rounded to the nearest second and sub-second
 // precision is not supported.
+//
+// The leeway gives some extra time to the token from the server's
+// point of view. That is, if the token is expired, ValidateWithLeeway
+// will still accept the token for 'leeway' amount of time. This fails
+// if you're using this function to check if a server will accept your
+// token, because it will think the token is valid even after it
+// expires. So if you're a client validating if the token is valid to
+// be submitted to a server, use leeway <=0, if you're a server
+// validation a token, use leeway >=0.
 func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 	if e.Issuer != "" && e.Issuer != c.Issuer {
 		return ErrInvalidIssuer


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The http transport test is failing intermittently because the qemu process stdout/err are not always fully read. This PR adds some debugging information and fixes the issue.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

