### PR TITLE
clean up if qemu-img fails

### DIFF
--- a/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 ENV container docker
 
-RUN dnf -y install nginx && dnf clean all -y
+RUN dnf -y update && dnf -y install nginx && dnf clean all -y
 
 ARG IMAGE_DIR=/usr/share/nginx/html/images
 

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -56,6 +57,7 @@ func NewQEMUOperations() QEMUOperations {
 func (o *qemuOperations) ConvertQcow2ToRaw(src, dest string) error {
 	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-p", "-f", "qcow2", "-O", "raw", src, dest)
 	if err != nil {
+		os.Remove(dest)
 		return errors.Wrap(err, "could not convert local qcow2 image to raw")
 	}
 
@@ -67,6 +69,7 @@ func (o *qemuOperations) ConvertQcow2ToRawStream(url *url.URL, dest string) erro
 
 	_, err := qemuExecFunction(qemuLimits, "qemu-img", "convert", "-p", "-f", "qcow2", "-O", "raw", jsonArg, dest)
 	if err != nil {
+		os.Remove(dest)
 		return errors.Wrap(err, "could not stream/convert qcow2 image to raw")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, if "qemu-img convert" does not complete successfully (usually because of a segfault) it is possible that the output file exists.  This pr will delete the file when that happens.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

