### PR TITLE
Set pod restart policy to "OnFailure" and cleanup succesful pods

### DIFF
--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -355,7 +355,7 @@ func TestUploadComplete(t *testing.T) {
 
 	f.expectUpdatePvcAction(updatedPVC)
 	f.expectDeleteServiceAction(service)
-
+	f.expectDeletePodAction(pod)
 	f.run(getPvcKey(pvc, t))
 }
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -796,7 +796,7 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string) *v1.Pod {
 					Args: []string{"-v=5"},
 				},
 			},
-			RestartPolicy: v1.RestartPolicyNever,
+			RestartPolicy: v1.RestartPolicyOnFailure,
 			Volumes: []v1.Volume{
 				{
 					Name: dvname,

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -41,7 +41,6 @@ func VerifyPVCIsEmpty(f *Framework, pvc *k8sv1.PersistentVolumeClaim) bool {
 	err = f.WaitTimeoutForPodReady(executorPod.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	output := f.ExecShellInPod(executorPod.Name, f.Namespace.Name, "ls -1 /pvc | wc -l")
-	f.DeletePod(executorPod)
 	return strings.Compare("0", output) == 0
 }
 
@@ -67,7 +66,6 @@ func (f *Framework) VerifyTargetPVCContent(namespace *k8sv1.Namespace, pvc *k8sv
 	err = utils.WaitTimeoutForPodReady(f.K8sClient, executorPod.Name, namespace.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	output := f.ExecShellInPod(executorPod.Name, namespace.Name, "cat "+fileName)
-	f.DeletePod(executorPod)
 	return strings.Compare(expectedData, output) == 0
 }
 
@@ -78,6 +76,5 @@ func (f *Framework) VerifyTargetPVCContentMD5(namespace *k8sv1.Namespace, pvc *k
 	err = utils.WaitTimeoutForPodReady(f.K8sClient, executorPod.Name, namespace.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	output := f.ExecShellInPod(executorPod.Name, namespace.Name, "md5sum "+fileName)
-	f.DeletePod(executorPod)
 	return strings.Compare(expectedHash, output[:32]) == 0
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -71,7 +71,6 @@ var _ = Describe("Transport Tests", func() {
 		if err != nil {
 			PrintPodLog(f, importer.Name, ns)
 		}
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
 
 		By("Verifying PVC is not empty")
 		Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeFalse(), fmt.Sprintf("Found 0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -6,8 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	k8sv1 "k8s.io/api/core/v1"
-
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
@@ -46,15 +44,11 @@ var _ = Describe("Upload tests", func() {
 		err = utils.UploadImageFromNode(f.K8sClient, f.GoCLIPath, token)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Wait pod succeeded")
-		err = f.WaitTimeoutForPodStatus(utils.UploadPodName(pvc), k8sv1.PodSucceeded, time.Second*20)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Verify content")
 		same := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, testFile, utils.UploadFileMD5)
 		Expect(same).To(BeTrue())
 
-		By("Delete upoad PVC")
+		By("Delete upload PVC")
 		err = f.DeletePVC(pvc)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -56,7 +56,7 @@ func PrintPodLog(f *framework.Framework, podName, namespace string) {
 	if err == nil {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Controller log\n%s\n", log)
 	} else {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Unable to get controller log")
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Unable to get controller log\n")
 	}
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:

This patch does two things:
1. We modify the restart policy from never to "OnFailure" for the
    Importer (we already did this for Upload, and we don't want to do it yet
    for the Clone pods)
2. Upon successful completion delete our worker pods
    We're not doing this on failed pods right now because in general an
    admin will likely want to inspect the pod to see why it failed.

**Special notes for your reviewer**:

The first question someone will likely ask is "well what about a node
failure", well in the case of a node failure for CDI we have a bigger
outstanding issue remaining to figure out how to deal with volume
connections.  We can't just simply reschedule the job.

Partial Fixes #400

**Release note**:

```Image pods now use RestartOnFailure (Cloner pods are the only ones that still RestartNever)
PODS are now deleted upon successful completion

```



