### PR TITLE
Remove old commented out lintcheck code

### DIFF
--- a/hack/build/run-lint-checks.sh
+++ b/hack/build/run-lint-checks.sh
@@ -38,12 +38,4 @@ for p in "${LINTABLE[@]}"; do
   fi
 done
 
-#echo "running golint on the pkg directory (golint pkg/...)"
-#out="$(golint pkg/...)"
-#if [[ ${out} ]]; then
-#    echo "FAIL: following golint errors found:"
-#    echo "${out}"
-#    ec=1
-#fi
-
 exit ${ec}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the commented out code in run-lint-checks.sh, this was leftover
from when we were only linting the pkg directory, we've now extended
that out to the other .go folders in the project and this was commented
out but should've been removed.

**Release note**:

```release-note
NONE
```

