### PR TITLE
Resize disk.img to actual DataVolume size

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/glog"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
 )
 
@@ -33,6 +34,8 @@ func main() {
 	ep, _ := importer.ParseEnvVar(common.ImporterEndpoint, false)
 	acc, _ := importer.ParseEnvVar(common.ImporterAccessKeyID, false)
 	sec, _ := importer.ParseEnvVar(common.ImporterSecretKey, false)
+	resize, _ := importer.ParseEnvVar(common.ImporterResize, false)
+	resizeTo, _ := importer.ParseEnvVar(common.ImporterResizeTo, false)
 
 	glog.V(1).Infoln("begin import process")
 	err := importer.CopyImage(common.ImporterWritePath, ep, acc, sec)
@@ -41,4 +44,14 @@ func main() {
 		os.Exit(1)
 	}
 	glog.V(1).Infoln("import complete")
+
+	if resize == "true" {
+		glog.V(1).Infoln("begin resize process")
+		err := image.Resize(common.ImporterWritePath, resizeTo)
+		if err != nil {
+			glog.Errorf("%+v", err)
+			os.Exit(1)
+		}
+		glog.V(1).Infoln("resize complete")
+	}
 }

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -11,6 +11,8 @@ package main
 //    ImporterAccessKeyID  Optional. Access key is the user ID that uniquely identifies your
 //			      account.
 //    ImporterSecretKey     Optional. Secret key is the password to your account.
+//    ImporterResizeTo      Optional. If set image downloaded image will be resize to that size.
+//    				Value should by in bytes.
 
 import (
 	"flag"
@@ -34,7 +36,6 @@ func main() {
 	ep, _ := importer.ParseEnvVar(common.ImporterEndpoint, false)
 	acc, _ := importer.ParseEnvVar(common.ImporterAccessKeyID, false)
 	sec, _ := importer.ParseEnvVar(common.ImporterSecretKey, false)
-	resize, _ := importer.ParseEnvVar(common.ImporterResize, false)
 	resizeTo, _ := importer.ParseEnvVar(common.ImporterResizeTo, false)
 
 	glog.V(1).Infoln("begin import process")
@@ -45,7 +46,7 @@ func main() {
 	}
 	glog.V(1).Infoln("import complete")
 
-	if resize == "true" {
+	if resizeTo != "" {
 		glog.V(1).Infoln("begin resize process")
 		err := image.Resize(common.ImporterWritePath, resizeTo)
 		if err != nil {

--- a/hack/build/run-lint-checks.sh
+++ b/hack/build/run-lint-checks.sh
@@ -29,13 +29,13 @@ if [[ ${out} ]]; then
     ec=1
 fi
 for p in "${LINTABLE[@]}"; do
-  echo "running golint on directory: ${p}"
-  out="$(golint ${p}/...)"
-  if [[ ${out} ]]; then
-    echo "FAIL: following golint errors found:"
-    echo "${out}"
-    ec=1
-  fi
+    echo "running golint on directory: ${p}"
+    out="$(golint ${p}/...)"
+    if [[ ${out} ]]; then
+        echo "FAIL: following golint errors found:"
+        echo "${out}"
+        ec=1
+    fi
 done
 
 exit ${ec}

--- a/pkg/apis/datavolumecontroller/v1alpha1/types.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types.go
@@ -38,6 +38,8 @@ type DataVolumeSpec struct {
 	Source DataVolumeSource `json:"source"`
 	//PVC is a pointer to the PVC Spec we want to use
 	PVC *corev1.PersistentVolumeClaimSpec `json:"pvc"`
+	//Resize define if image on DataVolume should be resized
+	Resize bool `json:"resize,omitempty"`
 }
 
 // DataVolumeSource represents the source for our Data Volume, this can be HTTP, S3 or an existing PVC

--- a/pkg/apis/datavolumecontroller/v1alpha1/types.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types.go
@@ -38,8 +38,8 @@ type DataVolumeSpec struct {
 	Source DataVolumeSource `json:"source"`
 	//PVC is a pointer to the PVC Spec we want to use
 	PVC *corev1.PersistentVolumeClaimSpec `json:"pvc"`
-	//Resize define if image on DataVolume should be resized
-	Resize bool `json:"resize,omitempty"`
+	//ResizeTo define if image on DataVolume should be resized
+	ResizeTo string `json:"resizeTo,omitempty"`
 }
 
 // DataVolumeSource represents the source for our Data Volume, this can be HTTP, S3 or an existing PVC

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -44,9 +44,7 @@ const (
 	ImporterAccessKeyID = "IMPORTER_ACCESS_KEY_ID"
 	// ImporterSecretKey provides a constant to capture our env variable "IMPORTER_SECRET_KEY"
 	ImporterSecretKey = "IMPORTER_SECRET_KEY"
-	// ImporterResize  provides a constant to capture our env variable "IMPORTER_RESIZE"
-	ImporterResize = "IMPORTER_RESIZE"
-	// ImporterResizeTo  provides a constant to capture our env variable "IMPORTER_RESIZE"
+	// ImporterResizeTo  provides a constant to capture our env variable "IMPORTER_RESIZE_TO"
 	ImporterResizeTo = "IMPORTER_RESIZE_TO"
 
 	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -44,6 +44,10 @@ const (
 	ImporterAccessKeyID = "IMPORTER_ACCESS_KEY_ID"
 	// ImporterSecretKey provides a constant to capture our env variable "IMPORTER_SECRET_KEY"
 	ImporterSecretKey = "IMPORTER_SECRET_KEY"
+	// ImporterResize  provides a constant to capture our env variable "IMPORTER_RESIZE"
+	ImporterResize = "IMPORTER_RESIZE"
+	// ImporterResizeTo  provides a constant to capture our env variable "IMPORTER_RESIZE"
+	ImporterResizeTo = "IMPORTER_RESIZE_TO"
 
 	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)
 	CloningLabelKey = "cloning"

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -614,6 +614,17 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 
 	annotations := make(map[string]string)
 
+	if dataVolume.Spec.Resize {
+		annotations[AnnResize] = "true"
+	} else {
+		annotations[AnnResize] = "false"
+	}
+
+	quant := dataVolume.Spec.PVC.Resources.Requests[corev1.ResourceStorage]
+	// keep 5% free space on the volume
+	sizeTo := quant.Value() - int64(float64(quant.Value())*0.05)
+	annotations[AnnResizeTo] = fmt.Sprint(sizeTo, "B")
+
 	if dataVolume.Spec.Source.HTTP != nil {
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.HTTP.URL
 		if dataVolume.Spec.Source.HTTP.SecretRef != "" {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -17,9 +17,7 @@ import (
 const (
 	// AnnEndpoint provides a const for our PVC endpoint annotation
 	AnnEndpoint = "cdi.kubevirt.io/storage.import.endpoint"
-	// AnnResize ddada
-	AnnResize = "cdi.kubevirt.io/storage.import.resize"
-	// AnnResizeTo dadad
+	// AnnResizeTo provides a const for our PVC resizeTo annotation
 	AnnResizeTo = "cdi.kubevirt.io/storage.import.resizeTo"
 	// AnnSecret provides a const for our PVC secretName annotation
 	AnnSecret = "cdi.kubevirt.io/storage.import.secretName"
@@ -111,7 +109,7 @@ func (ic *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error 
 		if err != nil {
 			return err
 		}
-		podEnvVar.resizeTo, err := getResizeTo(pvc)
+		podEnvVar.resizeTo, err = getResizeTo(pvc)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -17,6 +17,10 @@ import (
 const (
 	// AnnEndpoint provides a const for our PVC endpoint annotation
 	AnnEndpoint = "cdi.kubevirt.io/storage.import.endpoint"
+	// AnnResize ddada
+	AnnResize = "cdi.kubevirt.io/storage.import.resize"
+	// AnnResizeTo dadad
+	AnnResizeTo = "cdi.kubevirt.io/storage.import.resizeTo"
 	// AnnSecret provides a const for our PVC secretName annotation
 	AnnSecret = "cdi.kubevirt.io/storage.import.secretName"
 	// AnnImportPod provides a const for our PVC importPodName annotation
@@ -31,7 +35,7 @@ type ImportController struct {
 }
 
 type importPodEnvVar struct {
-	ep, secretName string
+	ep, secretName, resizeTo string
 }
 
 // NewImportController sets up an Import Controller, and returns a pointer to
@@ -104,6 +108,13 @@ func (ic *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error 
 			return err
 		}
 		podEnvVar.secretName, err = getSecretName(ic.clientset, pvc)
+		if err != nil {
+			return err
+		}
+		podEnvVar.resizeTo, err := getResizeTo(pvc)
+		if err != nil {
+			return err
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -84,7 +84,7 @@ func (f *ImportFixture) runController(pvcName string,
 // Verifies basic pod creation when new PVC is discovered
 func TestCreatesImportPod(t *testing.T) {
 	f := newImportFixture(t)
-	pvc := createPvc("testPvc1", "default", map[string]string{AnnEndpoint: "http://test"}, nil)
+	pvc := createPvc("testPvc1", "default", map[string]string{AnnEndpoint: "http://test", AnnResizeTo: "123B"}, nil)
 
 	f.pvcLister = append(f.pvcLister, pvc)
 	f.kubeobjects = append(f.kubeobjects, pvc)

--- a/pkg/controller/import_controller_ginkgo_test.go
+++ b/pkg/controller/import_controller_ginkgo_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Controller", func() {
 				ns:          "", // blank used originally in these unit tests
 				name:        "test-pvc",
 				qops:        opAdd,
-				annotations: map[string]string{AnnEndpoint: "http://www.google.com"},
+				annotations: map[string]string{AnnEndpoint: "http://www.google.com", AnnResizeTo: "1231B"},
 				expectError: false,
 			},
 			{
@@ -104,7 +104,7 @@ var _ = Describe("Controller", func() {
 				ns:          "ns-a",
 				name:        "test-pvc",
 				qops:        opAdd,
-				annotations: map[string]string{AnnEndpoint: "http://www.google.com"},
+				annotations: map[string]string{AnnEndpoint: "http://www.google.com", AnnResizeTo: "1231B"},
 				expectError: false,
 			},
 			{
@@ -120,7 +120,7 @@ var _ = Describe("Controller", func() {
 				ns:          "ns-a",
 				name:        "test-pvc",
 				qops:        opUpdate,
-				annotations: map[string]string{AnnEndpoint: "http://www.google.com"},
+				annotations: map[string]string{AnnEndpoint: "http://www.google.com", AnnResizeTo: "1231B"},
 				expectError: false,
 			},
 
@@ -129,7 +129,7 @@ var _ = Describe("Controller", func() {
 				ns:          "ns-a",
 				name:        "test-pvc",
 				qops:        opUpdate,
-				annotations: map[string]string{AnnEndpoint: "http://www.google.com", AnnPodPhase: "Succeeded"},
+				annotations: map[string]string{AnnEndpoint: "http://www.google.com", AnnPodPhase: "Succeeded", AnnResizeTo: "1231B"},
 				expectError: true,
 			},
 		}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -62,24 +62,11 @@ func getEndpoint(pvc *v1.PersistentVolumeClaim) (string, error) {
 	return ep, nil
 }
 
-// retruns "ture" if VM image on DataVolume should be resized
-func getResize(pvc *v1.PersistentVolumeClaim) (string, error) {
-	resize, found := pvc.Annotations[AnnResize]
-	if !found || resize == "" || resize == "false" {
-		return "false", nil
-	}
-	return "true", nil
-}
-
 // returns the size to which the image is to be resized
 func getResizeTo(pvc *v1.PersistentVolumeClaim) (string, error) {
 	resizeTo, found := pvc.Annotations[AnnResizeTo]
 	if !found || resizeTo == "" {
-		verb := "empty"
-		if !found {
-			verb = "missing"
-		}
-		return resizeTo, errors.Errorf("annotation %q in pvc \"%s/%s\" is %s\n", AnnResizeTo, pvc.Namespace, pvc.Name, verb)
+		return "", nil
 	}
 	return resizeTo, nil
 }

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/keys"
 )
@@ -59,6 +60,28 @@ func getEndpoint(pvc *v1.PersistentVolumeClaim) (string, error) {
 		return ep, errors.Errorf("annotation %q in pvc \"%s/%s\" is %s\n", AnnEndpoint, pvc.Namespace, pvc.Name, verb)
 	}
 	return ep, nil
+}
+
+// retruns "ture" if VM image on DataVolume should be resized
+func getResize(pvc *v1.PersistentVolumeClaim) (string, error) {
+	resize, found := pvc.Annotations[AnnResize]
+	if !found || resize == "" || resize == "false" {
+		return "false", nil
+	}
+	return "true", nil
+}
+
+// returns the size to which the image is to be resized
+func getResizeTo(pvc *v1.PersistentVolumeClaim) (string, error) {
+	resizeTo, found := pvc.Annotations[AnnResizeTo]
+	if !found || resizeTo == "" {
+		verb := "empty"
+		if !found {
+			verb = "missing"
+		}
+		return resizeTo, errors.Errorf("annotation %q in pvc \"%s/%s\" is %s\n", AnnResizeTo, pvc.Namespace, pvc.Name, verb)
+	}
+	return resizeTo, nil
 }
 
 // returns the name of the secret containing endpoint credentials consumed by the importer pod.
@@ -248,6 +271,9 @@ func makeEnv(podEnvVar importPodEnvVar) []v1.EnvVar {
 		{
 			Name:  common.ImporterEndpoint,
 			Value: podEnvVar.ep,
+		}, {
+			Name:  common.ImporterResizeTo,
+			Value: podEnvVar.resizeTo,
 		},
 	}
 	if podEnvVar.secretName != "" {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -612,6 +612,8 @@ func TestCreateImporterPod(t *testing.T) {
 		pullPolicy string
 		podEnvVar  importPodEnvVar
 		pvc        *v1.PersistentVolumeClaim
+		resize     string
+		resizeTo   string
 	}
 
 	// create PVC
@@ -651,6 +653,8 @@ func TestMakeImporterPodSpec(t *testing.T) {
 		pullPolicy string
 		podEnvVar  importPodEnvVar
 		pvc        *v1.PersistentVolumeClaim
+		resize     string
+		resizeTo   string
 	}
 	// create PVC
 	pvc := createPvc("testPVC2", "default", nil, nil)
@@ -809,10 +813,18 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string) *v1.Pod {
 	}
 
 	ep, _ := getEndpoint(pvc)
+	resize, _ := getResize(pvc)
+	resizeTo, _ := getResizeTo(pvc)
 	pod.Spec.Containers[0].Env = []v1.EnvVar{
 		{
 			Name:  ImporterEndpoint,
 			Value: ep,
+		}, {
+			Name:  ImporterResize,
+			Value: resize,
+		}, {
+			Name:  ImporterResizeTo,
+			Value: resizeTo,
 		},
 	}
 	return pod
@@ -878,6 +890,9 @@ func createEnv(podEnvVar importPodEnvVar) []v1.EnvVar {
 		{
 			Name:  ImporterEndpoint,
 			Value: podEnvVar.ep,
+		}, {
+			Name:  ImporterResizeTo,
+			Value: resizeTo,
 		},
 	}
 	if podEnvVar.secretName != "" {

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -39,6 +39,7 @@ type QEMUOperations interface {
 	ConvertQcow2ToRaw(string, string) error
 	ConvertQcow2ToRawStream(*url.URL, string) error
 	Validate(string, string) error
+	Resize(string, string) error
 }
 
 type qemuOperations struct{}
@@ -105,6 +106,16 @@ func (o *qemuOperations) Validate(image, format string) error {
 	return nil
 }
 
+func (o *qemuOperations) Resize(image, size string) error {
+	glog.V(2).Infoln("resizing raw image" + image + " to size: " + size)
+	_, err := qemuExecFunction(qemuLimits, "qemu-img", "resize", "-f", "raw", image, size)
+	if err != nil {
+		return errors.Wrap(err, "could not resize disk img to "+size)
+	}
+
+	return nil
+}
+
 // ConvertQcow2ToRaw is a wrapper for qemu-img convert which takes a qcow2 file (specified by src) and converts
 // it to a raw image (written to the provided dest file)
 func ConvertQcow2ToRaw(src, dest string) error {
@@ -119,4 +130,9 @@ func ConvertQcow2ToRawStream(url *url.URL, dest string) error {
 // Validate does basic validation of a qemu image
 func Validate(image, format string) error {
 	return qemuIterface.Validate(image, format)
+}
+
+// Resize change disk.img size to be equal to DataVolume size
+func Resize(image, size string) error {
+	return qemuIterface.Resize(image, size)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR allow resizing downloaded VM image to an actual size of DataVolume-5%. As `disk.img` is living on an filesystem I decided to leave 5% of this filesystem free. By default image will be left as is, until `  dataVolumeTemplates.spec.resize: true` is specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #482 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add resize option for images provisioned on DataVolume
```

