### PR TITLE
[WIP] expand imported disk

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -33,6 +33,7 @@ func main() {
 	ep, _ := importer.ParseEnvVar(common.ImporterEndpoint, false)
 	acc, _ := importer.ParseEnvVar(common.ImporterAccessKeyID, false)
 	sec, _ := importer.ParseEnvVar(common.ImporterSecretKey, false)
+	pvcSize, _ := importer.ParseEnvVar(common.ImporterPvcSize, false)
 
 	glog.V(1).Infoln("begin import process")
 	err := importer.CopyImage(common.ImporterWritePath, ep, acc, sec)
@@ -41,4 +42,10 @@ func main() {
 		os.Exit(1)
 	}
 	glog.V(1).Infoln("import complete")
+
+	glog.V(1).Infoln("Expanding image (if required)")
+	err = importer.ExapndImage(common.ImporterWritePath, pvcSize)
+	if err != nil {
+		glog.Warningf("Could not expand image, error: %+v", err)
+	}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -44,6 +44,8 @@ const (
 	ImporterAccessKeyID = "IMPORTER_ACCESS_KEY_ID"
 	// ImporterSecretKey provides a constant to capture our env variable "IMPORTER_SECRET_KEY"
 	ImporterSecretKey = "IMPORTER_SECRET_KEY"
+	// ImporterPvcSize provides a constant to capture our env variable "IMPORTER_PVC_SIZE"
+	ImporterPvcSize = "IMPORTER_PVC_SIZE"
 
 	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)
 	CloningLabelKey = "cloning"

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -103,9 +103,13 @@ func (ic *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error 
 		if secretName == "" {
 			glog.V(2).Infof("no secret will be supplied to endpoint %q\n", ep)
 		}
+		pvcSize, err := getPvcSize(pvc)
+		if err != nil {
+			return err
+		}
 		// all checks passed, let's create the importer pod!
 		ic.expectPodCreate(pvcKey)
-		pod, err = CreateImporterPod(ic.clientset, ic.image, ic.verbose, ic.pullPolicy, ep, secretName, pvc)
+		pod, err = CreateImporterPod(ic.clientset, ic.image, ic.verbose, ic.pullPolicy, ep, secretName, pvcSize, pvc)
 		if err != nil {
 			ic.observePodCreate(pvcKey)
 			return err


### PR DESCRIPTION
Expand imported disk to fill maximum space available on the PV:
* Parsed PVC storage size from 'resources.requests.storage'
* Passed the size value as an env variable to the improter pod
  (taking into account the filesystem overhead).
* Added 'Resize' and 'Info' to QEMUOperations interface.
* Invoked expand image on the importer pod (verifying necessity
  according to the 'virtual-size' extracted from image info).

Change-Id: Ie574cda297f658be2013ec885e4c5a43f88d985b
Signed-off-by: Daniel Erez <derez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

