### PR TITLE
Rolling timeout on streaming transfer.

### DIFF
--- a/cmd/cdi-cloner/clonertarget_test.go
+++ b/cmd/cdi-cloner/clonertarget_test.go
@@ -49,8 +49,10 @@ var _ = Describe("Update Progress", func() {
 		Expect(*metric.Counter.Value).To(Equal(float64(0)))
 		By("Calling updateProgress with value")
 		promReader := &prometheusProgressReader{
-			current: int64(45),
-			total:   int64(100),
+			CountingReader: util.CountingReader{
+				Current: int64(45),
+			},
+			total: int64(100),
 		}
 		promReader.updateProgress()
 		progress.WithLabelValues(ownerUID).Write(metric)
@@ -65,8 +67,10 @@ var _ = Describe("Update Progress", func() {
 		Expect(*metric.Counter.Value).To(Equal(float64(0)))
 		By("Calling updateProgress with value")
 		promReader := &prometheusProgressReader{
-			current: int64(45),
-			total:   int64(0),
+			CountingReader: util.CountingReader{
+				Current: int64(45),
+			},
+			total: int64(0),
 		}
 		promReader.updateProgress()
 		progress.WithLabelValues(ownerUID).Write(metric)
@@ -121,9 +125,11 @@ var _ = Describe("Read total", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer tarFileReader.Close()
 		promReader := &prometheusProgressReader{
-			reader:  tarFileReader,
-			current: 0,
-			total:   int64(10240), //10240 is the size of the tar containing the file.
+			CountingReader: util.CountingReader{
+				Reader:  tarFileReader,
+				Current: 0,
+			},
+			total: int64(10240), //10240 is the size of the tar containing the file.
 		}
 		err = untar(promReader, targetDirectory)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -13,6 +14,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// CountingReader is a reader that keeps track of how much has been read
+type CountingReader struct {
+	Reader  io.ReadCloser
+	Current int64
+}
 
 // RandAlphaNum provides an implementation to generate a random alpha numeric string of the specified length
 func RandAlphaNum(n int) string {
@@ -50,4 +57,16 @@ func ParseEnvVar(envVarName string, decode bool) (string, error) {
 		value = fmt.Sprintf("%s", v)
 	}
 	return value, nil
+}
+
+// Read reads bytes from the stream and updates the prometheus clone_progress metric according to the progress.
+func (r *CountingReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	r.Current += int64(n)
+	return n, err
+}
+
+// Close closes the stream
+func (r *CountingReader) Close() error {
+	return r.Reader.Close()
 }


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR allows for rolling timeouts on long transfers. As long as there is some activity for 10 minutes the transfer will continue. Right now we have a timeout on imports of one hour, anything that takes longer will abort regardless of progress being made. This allows for long running imports to not abort as long as progress is happening, and for it to abort if the other end is really not sending anything.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rolling timeouts on long imports, as long as there is activity within the last 10 minutes the import will not timeout
```

