### PR TITLE
Add source and contentType annotations

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -42,9 +42,19 @@ func main() {
 	ep, _ := util.ParseEnvVar(common.ImporterEndpoint, false)
 	acc, _ := util.ParseEnvVar(common.ImporterAccessKeyID, false)
 	sec, _ := util.ParseEnvVar(common.ImporterSecretKey, false)
+	source, _ := util.ParseEnvVar(common.ImporterSource, false)
+	contentType, _ := util.ParseEnvVar(common.ImporterContentType, false)
 
 	glog.V(1).Infoln("begin import process")
-	err = importer.CopyImage(common.ImporterWritePath, ep, acc, sec)
+	dso := &importer.DataStreamOptions{
+		common.ImporterWritePath,
+		ep,
+		acc,
+		sec,
+		source,
+		contentType,
+	}
+	err = importer.CopyImage(dso)
 	if err != nil {
 		glog.Errorf("%+v", err)
 		os.Exit(1)

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -1,0 +1,94 @@
+# Sources and contentType
+All annotations associated with Containerized Data Importer (CDI) have a prefix of: cdi.kubevirt.io. This denotes that the annotations are meant to be consumed by the CDI controller.
+
+## Source
+Source describes the type of data source CDI will be collecting the data from. Based on the value of source, additional annotations may be required to successfully import the data. The full annotation for source is: cdi.kubevirt.io/storage.import.source. The following values are currently available:
+* http
+* S3
+* none (don't import, but create data based on the contentType annotation)
+
+### http and s3
+The http and s3 sources require an additional annotation to describe the end point CDI needs to connect to. The annotation is cdi.kubevirt.io/storage.import.endpoint. If the end point requires authentication one can add an optional annotation to point to a Kubernetes Secret to get authentication information from. This annotation is: cdi.kubevirt.io/storage.import.secretName. If the source annotation is missing it will default to "http". 
+
+#### contentType
+There is an additional annotation that determines the content type of the http/s3 source, the content type can be one of the following:
+* kubevirt (Virtual Machine image)
+* archive (tar archive)
+If the contentType is missing, it is defaulted to kubevirt.
+
+#### examples
+Creating a PVC that imports data from an http source with kubevirt contentType:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "example-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.source: "http" #defaults to http if missing or invalid
+    cdi.kubevirt.io/storage.import.contentType: "kubevirt" #defaults to kubevirt if missing or invalid.
+    cdi.kubevirt.io/storage.import.endpoint: "https://www.source.example/path/of/data" # http or https is supported
+    cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the end point
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi # Request a size that is large enough to accept the data from the source, including conversion
+  # Optional: Set the storage class or omit to accept the default
+  # storageClassName: local
+``` 
+
+Creating a PVC that imports data from an http source with archive contentType:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "example-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.source: "http" #defaults to http if missing or invalid
+    cdi.kubevirt.io/storage.import.contentType: "archive" #defaults to kubevirt if missing or invalid.
+    cdi.kubevirt.io/storage.import.endpoint: "http://www.source.example/path/of/data.tar" # http or https is supported
+    cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the end point
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi # Request a size that is large enough to accept the data from the source, including conversion
+  # Optional: Set the storage class or omit to accept the default
+  # storageClassName: local
+``` 
+
+### None
+The none source indicates there is no source to get data from and instead a default action should be taken based on the contentType.
+
+#### contentType
+There is currently only one contentType that any meaning with a source of None. If the contentType is kubevirt, it will create an empty Virtual Machine image of the size specified in the PersistentVolumeClaim(PVC) request. Specifying a source of none and a contentType of archive will not do anything.
+
+#### example
+Creating a PVC that creates an empty virtual machine disk:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "example-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.source: "none"
+    cdi.kubevirt.io/storage.import.contentType: "kubevirt" #defaults to kubevirt if missing or invalid.
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi # Request a size that is large enough to accept the data from the source, including conversion
+  # Optional: Set the storage class or omit to accept the default
+  # storageClassName: local
+``` 
+
+

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -41,6 +41,10 @@ const (
 
 	// PullPolicy provides a constant to capture our env variable "PULL_POLICY" (only used by cmd/cdi-controller/controller.go)
 	PullPolicy = "PULL_POLICY"
+	// ImporterSource provides a constant to capture our env variable "IMPORTER_SOURCE"
+	ImporterSource = "IMPORTER_SOURCE"
+	// ImporterContentType provides a constant to capture our env variable "IMPORTER_CONTENTTYPE"
+	ImporterContentType = "IMPORTER_CONTENTTYPE"
 	// ImporterEndpoint provides a constant to capture our env variable "IMPORTER_ENDPOINT"
 	ImporterEndpoint = "IMPORTER_ENDPOINT"
 	// ImporterAccessKeyID provides a constant to capture our env variable "IMPORTER_ACCES_KEY_ID"

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -38,8 +38,6 @@ func main() {
 		[]string{".tar", ".gz"},
 		[]string{".tar", ".xz"},
 		[]string{".qcow2"},
-		[]string{".qcow2", ".gz"},
-		[]string{".qcow2", ".xz"},
 	}
 
 	if err := os.MkdirAll(*outDir, 0777); err != nil {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds new annotations to help determine the source and content type used for an import.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New annotation for source: cdi.kubevirt.io/storage.import.source
New annotation for content-type: cdi.kubevirt.io/storage.contentType
```

