### PR TITLE
fix upload-datavolume manifest

### DIFF
--- a/manifests/example/upload-datavolume.yaml
+++ b/manifests/example/upload-datavolume.yaml
@@ -4,7 +4,7 @@ metadata:
   name: upload-datavolume
 spec:
   source:
-      upload:
+      upload: {}
   pvc:
     #the storageClassName is optional, if missing we use the default storage class.
     #storageClassName: "hostpath"


### PR DESCRIPTION

**What this PR does / why we need it**:
fix upload-datavolume example manifest. upload source can't be empty and should be an empty struct.

**Release note**:

```release-note
None
```

