### PR TITLE
Fixes incorrect call of resize.

### DIFF
--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	dto "github.com/prometheus/client_model/go"
 
 	"kubevirt.io/containerized-data-importer/pkg/system"
@@ -178,6 +180,15 @@ var _ = Describe("Report Progress", func() {
 		reportProgress("45.34")
 		progress.WithLabelValues(ownerUID).Write(metric)
 		Expect(*metric.Counter.Value).To(Equal(float64(0)))
+	})
+})
+
+var _ = Describe("quantity to qemu", func() {
+	It("Should properly parse quantity to qemu", func() {
+		result := convertQuantityToQemuSize(resource.MustParse("1Gi"))
+		Expect(result).To(Equal("1G"))
+		result = convertQuantityToQemuSize(resource.MustParse("10Ki"))
+		Expect(result).To(Equal("10k"))
 	})
 })
 

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -18,13 +18,14 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
-
 	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
@@ -81,7 +82,7 @@ var _ = Describe("Data Stream", func() {
 			secretKey,
 			controller.SourceHTTP,
 			controller.ContentTypeKubevirt,
-			"1G"})
+			""})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
 		}
@@ -132,7 +133,7 @@ var _ = Describe("Data Stream", func() {
 			"",
 			controller.SourceHTTP,
 			controller.ContentTypeKubevirt,
-			"1G"})
+			"20M"})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
 		}
@@ -160,7 +161,7 @@ var _ = Describe("Data Stream", func() {
 			"",
 			controller.SourceHTTP,
 			controller.ContentTypeKubevirt,
-			"1G"})
+			"20M"})
 		defer func() {
 			tempTestServer.Close()
 		}()
@@ -228,7 +229,7 @@ var _ = Describe("Copy", func() {
 				"",
 				controller.SourceHTTP,
 				controller.ContentTypeKubevirt,
-				"1G"})
+				""})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
 			} else {
@@ -371,7 +372,7 @@ var _ = Describe("Streaming Data Conversion", func() {
 			"",
 			controller.SourceHTTP,
 			controller.ContentTypeKubevirt,
-			"1G"})
+			""})
 		Expect(err).NotTo(HaveOccurred())
 
 		By(fmt.Sprintf("Checking size of the output file %q", testTarget))
@@ -379,13 +380,13 @@ var _ = Describe("Streaming Data Conversion", func() {
 		if useVirtSize {
 			By("... using output image's virtual size")
 			targetSize = getImageVirtualSize(testTarget)
-			Expect(targetSize).To(Equal(sourceSize))
+			Expect(targetSize).To(Equal(int64(sourceSize)))
 		} else {
 			By("... using stat()")
 			finfo, err = os.Stat(testTarget)
 			Expect(err).NotTo(HaveOccurred())
 			targetSize = finfo.Size()
-			Expect(targetSize).To(Equal(sourceSize))
+			Expect(targetSize).To(Equal(int64(sourceSize)))
 		}
 		fmt.Fprintf(GinkgoWriter, "INFO: byte size = %d\n", targetSize)
 
@@ -502,7 +503,7 @@ func (o *fakeQEMUOperations) Validate(string, string) error {
 	return o.e5
 }
 
-func (o *fakeQEMUOperations) Resize(string, string) error {
+func (o *fakeQEMUOperations) Resize(string, resource.Quantity) error {
 	return o.e3
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,11 +1,8 @@
 package util
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
-	"syscall"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -45,35 +42,4 @@ var _ = Describe("Compare quantities", func() {
 		result = MinQuantity(big, small)
 		Expect(result).To(Equal(*small))
 	})
-})
-
-var _ = Describe("File system", func() {
-	By("Checking current available space")
-	var stat syscall.Statfs_t
-	syscall.Statfs(".", &stat)
-	blockSize := stat.Bsize
-	fmt.Fprintf(GinkgoWriter, "INFO: Block size: %d\n", blockSize)
-
-	table.DescribeTable("Write file near block size", func(fileSize, usedBlocks int64) {
-		By("Checking current available space")
-		var stat syscall.Statfs_t
-		syscall.Statfs(".", &stat)
-		currentAvailabeBlocks := int64(stat.Bavail)
-		f, err := os.Create("smallerthanblock.txt")
-		defer os.Remove("smallerthanblock.txt")
-		Expect(err).NotTo(HaveOccurred())
-		for i := int64(0); i < fileSize; i++ {
-			f.WriteString("t")
-		}
-		fileInfo, err := f.Stat()
-		fmt.Fprintf(GinkgoWriter, "INFO: Written file size: %d\n", fileInfo.Size())
-		err = f.Close()
-		Expect(err).NotTo(HaveOccurred())
-		newAvailableSpace := GetAvailableSpace(".")
-		Expect(newAvailableSpace).To(Equal((currentAvailabeBlocks - usedBlocks) * blockSize))
-	},
-		table.Entry("< block size", blockSize-int64(1), int64(1)),
-		table.Entry("= block size", blockSize, int64(1)),
-		table.Entry("> block size", blockSize+int64(1), int64(2)),
-	)
 })

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -75,10 +75,8 @@ var _ = Describe("Transport Tests", func() {
 
 		importer, err := utils.FindPodByPrefix(c, ns, common.ImporterPodName, common.CDILabelSelector)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
+
 		err = utils.WaitTimeoutForPodStatus(c, importer.Name, importer.Namespace, v1.PodSucceeded, utils.PodWaitForTime)
-		if err != nil {
-			PrintPodLog(f, importer.Name, ns)
-		}
 
 		if shouldSucceed {
 			By("Verifying PVC is not empty")
@@ -88,8 +86,7 @@ var _ = Describe("Transport Tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(utils.WaitTimeoutForPodReady(c, sizeCheckPod, ns, 20*time.Second)).To(Succeed())
 
-			// Get the remote file size, the imported file size and compare them
-			command := `expSize=$(curl -s http://cdi-file-host.kube-system | grep -E '"name":"tinyCore.iso"' | grep -Eo '"size":[0-9]+' | tr -d '":[:alpha:]'); haveSize=$(wc -c < /pvc/disk.img); (( $expSize == $haveSize )); echo $?`
+			command := `expSize=20971520; haveSize=$(wc -c < /pvc/disk.img); (( $expSize == $haveSize )); echo $?`
 			exitCode := f.ExecShellInPod(pod.Name, ns, command)
 			// A 0 exitCode should indicate that $expSize == $haveSize
 			Expect(strconv.Atoi(exitCode)).To(BeZero())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -54,9 +54,9 @@ func PrintControllerLog(f *framework.Framework) {
 func PrintPodLog(f *framework.Framework, podName, namespace string) {
 	log, err := RunKubectlCommand(f, "logs", podName, "-n", namespace)
 	if err == nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Controller log\n%s\n", log)
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Pod log\n%s\n", log)
 	} else {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Unable to get controller log\n")
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Unable to get pod log, %s\n", err.Error())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Resize was not being called in all paths, specifically the streaming path was not working.
Updated unit and functional tests to take resize into account.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

