### PR TITLE
Support CDI in any namespace

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -9,7 +9,7 @@ echo "Cleaning up ..."
 ./cluster/kubectl.sh delete ds -l "cdi.kubevirt.io" -n ${NAMESPACE} --cascade=false --grace-period 0 2>/dev/null || :
 
 # Delete all traces of kubevirt
-namespaces=(default ${NAMESPACE})
+namespaces=(default kube-system ${NAMESPACE})
 for i in ${namespaces[@]}; do
     ./cluster/kubectl.sh -n ${i} delete deployment -l 'cdi.kubevirt.io'
     ./cluster/kubectl.sh -n ${i} delete services -l 'cdi.kubevirt.io'

--- a/manifests/templates/cdi-controller.yaml.in
+++ b/manifests/templates/cdi-controller.yaml.in
@@ -218,6 +218,39 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cdi-extension-apiserver-authentication
+  namespace: kube-system
+  labels:
+    cdi.kubevirt.io: ""
+roleRef:
+  kind: Role
+  name: cdi-extension-apiserver-authentication
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: cdi-apiserver
+    namespace: {{ .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cdi-extension-apiserver-authentication
+  namespace: kube-system
+  labels:
+    cdi.kubevirt.io: ""
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - extension-apiserver-authentication
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cdi-apiserver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

cdi-apiserver always needs permission to read the `extension-apiserver-authentication` configmap in kube-system.  Currently, this is not an issue as CDI is installed in kube-system.  But in order to support CDI in a different namespace, let's explicitly give the appropriate permissions to cdi-apiserver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #531 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

