### PR TITLE
image: fix size (Quantity) string format

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -201,7 +201,7 @@ func (o *qemuOperations) CreateBlankImage(dest string, size resource.Quantity) e
 	_, err := qemuExecFunction(qemuLimits, nil, "qemu-img", "create", "-f", "raw", dest, convertQuantityToQemuSize(size))
 	if err != nil {
 		os.Remove(dest)
-		return errors.Wrap(err, fmt.Sprintf("could not create raw image with size %s in %s", size, dest))
+		return errors.Wrap(err, fmt.Sprintf("could not create raw image with size %s in %s", size.String(), dest))
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Daniel Erez <derez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix string formatting of size arg, to resolve: "Sprintf format %s has arg size of wrong type .../resource.Quantity"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

