### PR TITLE
transport_test: remove invalid creds for registry test

### DIFF
--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Transport Tests", func() {
 		importer, err := utils.FindPodByPrefix(c, ns, common.ImporterPodName, common.CDILabelSelector)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
 
-		err = utils.WaitTimeoutForPodStatus(c, importer.Name, importer.Namespace, v1.PodSucceeded, utils.PodWaitForTime)
+		utils.WaitTimeoutForPodStatus(c, importer.Name, importer.Namespace, v1.PodRunning, utils.PodWaitForTime)
 
 		if shouldSucceed {
 			By("Verifying PVC is not empty")

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Transport Tests", func() {
 	httpNoAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPNoAuthPort)
 	httpAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPAuthPort)
 	registryNoAuthEp := fmt.Sprintf("docker://%s", "docker.io")
+	registryAuthEp := fmt.Sprintf("docker://%s", "registry:5000")
 	DescribeTable("Transport Test Table", it,
 		Entry("should connect to http endpoint without credentials", httpNoAuthEp, targetFile, "", "", controller.SourceHTTP, true),
 		Entry("should connect to http endpoint with credentials", httpAuthEp, targetFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, true),
@@ -116,5 +117,5 @@ var _ = Describe("Transport Tests", func() {
 		Entry("should connect to QCOW http endpoint without credentials", httpNoAuthEp, targetQCOWFile, "", "", controller.SourceHTTP, true),
 		Entry("should connect to QCOW http endpoint with credentials", httpAuthEp, targetQCOWFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, true),
 		Entry("should connect to registry endpoint without credentials", registryNoAuthEp, "registry", "", "", controller.SourceRegistry, true),
-		Entry("should not connect to registry endpoint with invalid credentials", registryNoAuthEp, "registry", "gopats", "bradyisthegoat", controller.SourceRegistry, false))
+		Entry("should not connect to registry endpoint with invalid credentials", registryAuthEp, "cdi-importer", "gopats", "bradyisthegoat", controller.SourceRegistry, false))
 })


### PR DESCRIPTION
Signed-off-by: Daniel Erez <derez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Until testing against a private (local or exteral) registry that requires credentials, we can remove the invalid creds test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

