### PR TITLE
manifest/example/local-pv-allocation-claim.yaml fails on validation #565

### DIFF
--- a/manifests/example/local-pv-allocation-claim.yaml
+++ b/manifests/example/local-pv-allocation-claim.yaml
@@ -2,10 +2,13 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: local-pv-allocation-claim
-  cdi.kubevirt.io/storage.import.source: "http" #defaults to http if missing or invalid
-  cdi.kubevirt.io/storage.contentType: "kubevirt" #defaults to kubevirt if missing or invalid.
-  cdi.kubevirt.io/storage.import.endpoint: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso" # http or https is supported
-  cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the end point
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.source: "http" #defaults to http if missing or invalid
+    cdi.kubevirt.io/storage.contentType: "kubevirt" #defaults to kubevirt if missing or invalid.
+    cdi.kubevirt.io/storage.import.endpoint: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso" # http or https is supported
+    cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the end point
 spec:
   storageClassName: manual
   accessModes:


### PR DESCRIPTION
Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
manifest/example/local-pv-allocation-claim.yaml fails on validation as 'annotations' tag is missing

**Which issue(s) this PR fixes** :
Fixes #565 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

