### PR TITLE
fix: Handle sparse files when cloning

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -40,7 +40,7 @@ if [ "$obj" == "source" ]; then
     echo $size
     #Write the size to the pipe so the other end can read it.
     echo "$size" >$pipe_dir
-    tar cv . >$pipe_dir
+    tar cv --sparse . >$pipe_dir
     popd
     echo "cloner: finished writing image to $pipe_dir"
     exit 0


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add `--sparse` to tar on `cloner-startup.sh` so sparse files are not unsparsified when cloned.

**Which issue(s) this PR fixes**:

Fixes #574
Fixes [BZ#1658615](https://bugzilla.redhat.com/show_bug.cgi?id=1658615)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle sparse files when cloning PVCs.
```

Signed-off-by: Sergi Jimenez <sjr@redhat.com>