### PR TITLE
Correct singularName for UploadTokenRequests

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -440,7 +440,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 			list.GroupVersion = uploadTokenGroup + "/" + uploadTokenVersion
 			list.APIResources = append(list.APIResources, metav1.APIResource{
 				Name:         "uploadtokenrequests",
-				SingularName: "UploadtokenRequest",
+				SingularName: "uploadtokenrequest",
 				Namespaced:   true,
 				Group:        uploadTokenGroup,
 				Version:      uploadTokenVersion,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -488,7 +488,7 @@ func TestGetAPIResouceList(t *testing.T) {
 		APIResources: []metav1.APIResource{
 			{
 				Name:         "uploadtokenrequests",
-				SingularName: "UploadtokenRequest",
+				SingularName: "uploadtokenrequest",
 				Namespaced:   true,
 				Group:        "upload.cdi.kubevirt.io",
 				Version:      "v1alpha1",


### PR DESCRIPTION
(At least) by convention names and singularNames are all lower case. If
they're not, it might confuse client libraries that don't lowercase
everything proactively. Example:
https://github.com/openshift/openshift-restclient-python/pull/250

Release note:

```release-note
Correct API discovery for UploadTokenRequests
```