### PR TITLE
manifests example: import registry image

### DIFF
--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -44,3 +44,16 @@ $ docker build . -t my-vm-img
 $ docker tag my-vm-img <registry>:5000/my-vm-img
 $ docker push <registry>:5000/my-vm-img
 ```
+
+# Import the registry image into a PVC
+
+Use the following annotations in the PVC yaml:
+```
+...
+annotations:
+    cdi.kubevirt.io/storage.import.source: "registry"
+    cdi.kubevirt.io/storage.import.endpoint: "docker://<registry>:5000/my-vm-img"
+...
+```
+
+Full example is available here: [registry-image-pvc](https://github.com/kubevirt/containerized-data-importer/blob/master/manifests/example/registry-image-pvc.yaml)

--- a/manifests/example/registry-image-pvc.yaml
+++ b/manifests/example/registry-image-pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "registry-image-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.source: "registry"
+    cdi.kubevirt.io/storage.import.endpoint: "docker://docker.io/cirros"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # Optional: Set the storage class or omit to accept the default
+  storageClassName: local


### PR DESCRIPTION
Change-Id: I3cd19b512ff46e295ae4a093400c5cac9b189652
Signed-off-by: Daniel Erez <derez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Added an example yaml of import registry image (to manifest/example/).
- Updated import-from-registry.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

