### PR TITLE
disable more data stream tests

### DIFF
--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -525,11 +525,13 @@ var _ = Describe("Streaming Data Conversion", func() {
 		// Disabled until issue 335 is resolved
 		// https://github.com/kubevirt/containerized-data-importer/issues/335
 		//table.Entry("should unpack .tar.xz", tinyCoreFilePath, false, image.ExtTar, image.ExtXz),
-		table.Entry("should convert .qcow2", tinyCoreFilePath, true, image.ExtQcow2),
-		table.Entry("should convert and unpack .qcow2.gz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtGz),
-		table.Entry("should convert and unpack .qcow2.xz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtXz),
 		// Disabled until issue 580 is resolved
 		// https://github.com/kubevirt/containerized-data-importer/issues/580
+		//table.Entry("should convert .qcow2", tinyCoreFilePath, true, image.ExtQcow2),
+		table.Entry("should convert and unpack .qcow2.gz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtGz),
+		// Disabled until issue 580 is resolved
+		// https://github.com/kubevirt/containerized-data-importer/issues/580
+		//table.Entry("should convert and unpack .qcow2.xz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtXz),
 		//table.Entry("should convert and untar .qcow2.tar", tinyCoreFilePath, false, image.ExtQcow2, image.ExtTar),
 		table.Entry("should convert and untar and unpack .qcow2.tar.gz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtTar, image.ExtGz),
 		table.Entry("should convert and untar and unpack .qcow2.tar.xz", tinyCoreFilePath, false, image.ExtQcow2, image.ExtTar, image.ExtXz),


### PR DESCRIPTION
**What this PR does / why we need it**:
disable temporarily qcow2 and qcow2.xz data stream tests since they are sporadically failing, as described in #580.

**Release note**:

```release-note
NONE
```

