### PR TITLE
fix typo in cdi-uploadproxy-ingress manifest

### DIFF
--- a/manifests/templates/cdi-uploadproxy-ingress.yaml.in
+++ b/manifests/templates/cdi-uploadproxy-ingress.yaml.in
@@ -7,7 +7,7 @@ metadata:
     nginx.org/ssl-services: "cdi-uploadproxy"
     ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/secure-backends: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
 spec:
   rules:
     # change to a valid FQDN in your organization


### PR DESCRIPTION
**What this PR does / why we need it**:
missing ```"``` in ```proxy-body-size``` field, causing an error when trying to apply the manifest.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

