### PR TITLE
Adding DataVolume support for unpacking imported archive

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1719,6 +1719,10 @@
      "pvc"
     ],
     "properties": {
+     "contentType": {
+      "description": "DataVolumeContentType options: \"kubevirt\", \"archive\"",
+      "type": "string"
+     },
      "pvc": {
       "description": "PVC is a pointer to the PVC Spec we want to use",
       "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/image"
@@ -50,7 +51,7 @@ func main() {
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 
 	dest := common.ImporterWritePath
-	if contentType == controller.ContentTypeArchive || source == controller.SourceRegistry {
+	if contentType == string(cdiv1.DataVolumeArchive) || source == controller.SourceRegistry {
 		dest = common.ImporterVolumePath
 	}
 
@@ -65,7 +66,7 @@ func main() {
 		imageSize,
 	}
 
-	if source == controller.SourceNone && contentType == controller.ContentTypeKubevirt {
+	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {
 		requestImageSizeQuantity := resource.MustParse(imageSize)
 		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(util.GetAvailableSpace(common.ImporterVolumePath), 0), &requestImageSizeQuantity)
 		if minSizeQuantity.Cmp(requestImageSizeQuantity) != 0 {

--- a/manifests/example/import-archive-datavolume.yaml
+++ b/manifests/example/import-archive-datavolume.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: import-archive-datavolume
+spec:
+  source:
+      http:
+         url: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz" #This url is just an example. You should change this to your destination url
+  contentType: archive
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Mi

--- a/manifests/example/import-archive-pvc.yaml
+++ b/manifests/example/import-archive-pvc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "golden-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.endpoint: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz" #This url is just an example. You should change this to your destination url
+    cdi.kubevirt.io/storage.import.secretName: "" # Optional. The name of the secret containing credentials for the data source
+    cdi.kubevirt.io/storage.import.source: "http"
+    cdi.kubevirt.io/storage.contentType: "archive"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # Optional: Set the storage class or omit to accept the default
+  # storageClassName: local

--- a/pkg/apis/datavolumecontroller/v1alpha1/openapi_generated.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/openapi_generated.go
@@ -326,6 +326,13 @@ func schema_pkg_apis_datavolumecontroller_v1alpha1_DataVolumeSpec(ref common.Ref
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
 						},
 					},
+					"contentType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DataVolumeContentType options: \"kubevirt\", \"archive\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"source", "pvc"},
 			},

--- a/pkg/apis/datavolumecontroller/v1alpha1/types.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types.go
@@ -42,7 +42,19 @@ type DataVolumeSpec struct {
 	Source DataVolumeSource `json:"source"`
 	//PVC is a pointer to the PVC Spec we want to use
 	PVC *corev1.PersistentVolumeClaimSpec `json:"pvc"`
+	//DataVolumeContentType options: "kubevirt", "archive"
+	ContentType DataVolumeContentType `json:"contentType,omitempty"`
 }
+
+// DataVolumeContentType represents the types of the imported data
+type DataVolumeContentType string
+
+const (
+	// DataVolumeKubeVirt is the content-type of the imported file, defaults to kubevirt
+	DataVolumeKubeVirt DataVolumeContentType = "kubevirt"
+	// DataVolumeArchive is the content-type to specify if there is a need to extract the imported archive
+	DataVolumeArchive DataVolumeContentType = "archive"
+)
 
 // DataVolumeSource represents the source for our Data Volume, this can be HTTP, S3, Registry or an existing PVC
 type DataVolumeSource struct {

--- a/pkg/apis/datavolumecontroller/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/datavolumecontroller/v1alpha1/types_swagger_generated.go
@@ -10,9 +10,10 @@ func (DataVolume) SwaggerDoc() map[string]string {
 
 func (DataVolumeSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":       "DataVolumeSpec defines our specification for a DataVolume type",
-		"source": "Source is the src of the data for the requested DataVolume",
-		"pvc":    "PVC is a pointer to the PVC Spec we want to use",
+		"":            "DataVolumeSpec defines our specification for a DataVolume type",
+		"source":      "Source is the src of the data for the requested DataVolume",
+		"pvc":         "PVC is a pointer to the PVC Spec we want to use",
+		"contentType": "DataVolumeContentType options: \"kubevirt\", \"archive\"",
 	}
 }
 

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -634,6 +634,12 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 
 	if dataVolume.Spec.Source.HTTP != nil {
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.HTTP.URL
+		annotations[AnnSource] = SourceHTTP
+		if dataVolume.Spec.ContentType == cdiv1.DataVolumeArchive {
+			annotations[AnnContentType] = string(cdiv1.DataVolumeArchive)
+		} else {
+			annotations[AnnContentType] = string(cdiv1.DataVolumeKubeVirt)
+		}
 		if dataVolume.Spec.Source.HTTP.SecretRef != "" {
 			annotations[AnnSecret] = dataVolume.Spec.Source.HTTP.SecretRef
 		}
@@ -658,7 +664,7 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 		annotations[AnnUploadRequest] = ""
 	} else if dataVolume.Spec.Source.Blank != nil {
 		annotations[AnnSource] = SourceNone
-		annotations[AnnContentType] = ContentTypeKubevirt
+		annotations[AnnContentType] = string(cdiv1.DataVolumeKubeVirt)
 	} else {
 		return nil, errors.Errorf("no source set for datavolume")
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/cert/triple"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/keys"
 	"strings"
@@ -38,11 +39,6 @@ const (
 	SourceNone = "none"
 	// SourceRegistry is the source type of Registry
 	SourceRegistry = "registry"
-
-	// ContentTypeKubevirt is the content-type of the import, defaults to kubevirt
-	ContentTypeKubevirt = "kubevirt"
-	// ContentTypeArchive is the content-type to specify if wanting to extract an archive
-	ContentTypeArchive = "archive"
 )
 
 type podDeleteRequest struct {
@@ -115,12 +111,12 @@ func getContentType(pvc *v1.PersistentVolumeClaim) string {
 	}
 	switch contentType {
 	case
-		ContentTypeKubevirt,
-		ContentTypeArchive:
+		string(cdiv1.DataVolumeKubeVirt),
+		string(cdiv1.DataVolumeArchive):
 		glog.V(2).Infof("pvc content type annotation found for pvc \"%s/%s\", value %s\n", pvc.Namespace, pvc.Name, contentType)
 	default:
 		glog.V(2).Infof("No content type annotation found for pvc \"%s/%s\", default to kubevirt\n", pvc.Namespace, pvc.Name)
-		contentType = ContentTypeKubevirt
+		contentType = string(cdiv1.DataVolumeKubeVirt)
 	}
 	return contentType
 }

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	. "kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/keys"
 )
@@ -410,8 +411,8 @@ func Test_getContentType(t *testing.T) {
 	}
 
 	pvcNoAnno := createPvc("testPVCNoAnno", "default", nil, nil)
-	pvcArchiveAnno := createPvc("testPVCArchiveAnno", "default", map[string]string{AnnContentType: ContentTypeArchive}, nil)
-	pvcKubevirtAnno := createPvc("testPVCKubevirtAnno", "default", map[string]string{AnnContentType: ContentTypeKubevirt}, nil)
+	pvcArchiveAnno := createPvc("testPVCArchiveAnno", "default", map[string]string{AnnContentType: string(cdiv1.DataVolumeArchive)}, nil)
+	pvcKubevirtAnno := createPvc("testPVCKubevirtAnno", "default", map[string]string{AnnContentType: string(cdiv1.DataVolumeKubeVirt)}, nil)
 	pvcInvalidValue := createPvc("testPVCInvalidValue", "default", map[string]string{AnnContentType: "iaminvalid"}, nil)
 
 	tests := []struct {
@@ -422,22 +423,22 @@ func Test_getContentType(t *testing.T) {
 		{
 			name: "expected to kubevirt content type",
 			args: args{pvcNoAnno},
-			want: ContentTypeKubevirt,
+			want: string(cdiv1.DataVolumeKubeVirt),
 		},
 		{
 			name: "expected to find archive content type",
 			args: args{pvcArchiveAnno},
-			want: ContentTypeArchive,
+			want: string(cdiv1.DataVolumeArchive),
 		},
 		{
 			name: "expected to kubevirt content type",
 			args: args{pvcKubevirtAnno},
-			want: ContentTypeKubevirt,
+			want: string(cdiv1.DataVolumeKubeVirt),
 		},
 		{
 			name: "expected to find kubevirt with invalid anno",
 			args: args{pvcInvalidValue},
-			want: ContentTypeKubevirt,
+			want: string(cdiv1.DataVolumeKubeVirt),
 		},
 	}
 	for _, tt := range tests {
@@ -795,7 +796,7 @@ func TestMakeImporterPodSpec(t *testing.T) {
 	}{
 		{
 			name:    "expect pod to be created",
-			args:    args{"test/myimage", "5", "Always", &importPodEnvVar{"", "", SourceHTTP, ContentTypeKubevirt, "1G"}, pvc},
+			args:    args{"test/myimage", "5", "Always", &importPodEnvVar{"", "", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G"}, pvc},
 			wantPod: pod,
 		},
 	}
@@ -825,8 +826,8 @@ func Test_makeEnv(t *testing.T) {
 	}{
 		{
 			name: "env should match",
-			args: args{&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, ContentTypeKubevirt, "1G"}},
-			want: createEnv(&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, ContentTypeKubevirt, "1G"}, mockUID),
+			args: args{&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G"}},
+			want: createEnv(&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G"}, mockUID),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/ulikunitz/xz"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/image"
@@ -131,7 +132,7 @@ func newDataStreamFromStream(stream io.ReadCloser) (*DataStream, error) {
 		"",
 		"",
 		controller.SourceHTTP,
-		controller.ContentTypeKubevirt,
+		string(cdiv1.DataVolumeKubeVirt),
 		"", // Blank means don't resize
 	}, stream)
 }
@@ -300,7 +301,7 @@ func CopyData(dso *DataStreamOptions) error {
 			return errors.Wrap(err, "unable to create data stream")
 		}
 		defer ds.Close()
-		if dso.ContentType == controller.ContentTypeArchive {
+		if dso.ContentType == string(cdiv1.DataVolumeArchive) {
 			if err := util.UnArchiveTar(ds.topReader(), dso.Dest); err != nil {
 				return errors.Wrap(err, "unable to untar files from endpoint")
 			}
@@ -425,7 +426,7 @@ func (d *DataStream) constructReaders(stream io.ReadCloser) error {
 		}
 	}
 
-	if d.ContentType == controller.ContentTypeArchive && !isTarFile {
+	if d.ContentType == string(cdiv1.DataVolumeArchive) && !isTarFile {
 		return errors.Errorf("cannot process a non tar file as an archive")
 	}
 
@@ -533,7 +534,7 @@ func (d *DataStream) xzReader() (io.Reader, int64, error) {
 // Assumes a single file was archived.
 // Note: the size stored in the header is used rather than raw metadata.
 func (d *DataStream) tarReader() (io.Reader, int64, error) {
-	if d.ContentType == controller.ContentTypeArchive {
+	if d.ContentType == string(cdiv1.DataVolumeArchive) {
 		return d.mulFileTarReader()
 	}
 	tr := tar.NewReader(d.topReader())

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/image"
@@ -108,7 +109,7 @@ var _ = Describe("Data Stream", func() {
 			image = ts.URL + "/" + image
 		}
 		dest := common.ImporterWritePath
-		if contentType == controller.ContentTypeArchive {
+		if contentType == string(cdiv1.DataVolumeArchive) {
 			dest = common.ImporterVolumePath
 		}
 		By(fmt.Sprintf("Creating new datastream for %s", image))
@@ -138,11 +139,11 @@ var _ = Describe("Data Stream", func() {
 			Expect(err).To(HaveOccurred())
 		}
 	},
-		table.Entry("expect NewDataStream to succeed with valid image", cirrosFileName, "", "", controller.ContentTypeKubevirt, true, cirrosData, false),
-		table.Entry("expect NewDataStream to fail with non existing image", "badimage.iso", "", "", controller.ContentTypeKubevirt, false, nil, true),
-		table.Entry("expect NewDataStream to fail with invalid or missing image", "", "", "", controller.ContentTypeKubevirt, false, nil, true),
-		table.Entry("expect NewDataStream to succeed with valid iso image", tinyCoreFileName, "accessKey", "secretKey", controller.ContentTypeKubevirt, false, tinyCoreData, false),
-		table.Entry("expect NewDataStream to fail with a valid image and an incorrect content", cirrosFileName, "", "", controller.ContentTypeArchive, true, cirrosData, true),
+		table.Entry("expect NewDataStream to succeed with valid image", cirrosFileName, "", "", string(cdiv1.DataVolumeKubeVirt), true, cirrosData, false),
+		table.Entry("expect NewDataStream to fail with non existing image", "badimage.iso", "", "", string(cdiv1.DataVolumeKubeVirt), false, nil, true),
+		table.Entry("expect NewDataStream to fail with invalid or missing image", "", "", "", string(cdiv1.DataVolumeKubeVirt), false, nil, true),
+		table.Entry("expect NewDataStream to succeed with valid iso image", tinyCoreFileName, "accessKey", "secretKey", string(cdiv1.DataVolumeKubeVirt), false, tinyCoreData, false),
+		table.Entry("expect NewDataStream to fail with a valid image and an incorrect content", cirrosFileName, "", "", string(cdiv1.DataVolumeArchive), true, cirrosData, true),
 	)
 
 	It("can close all readers", func() {
@@ -153,7 +154,7 @@ var _ = Describe("Data Stream", func() {
 			"",
 			"",
 			controller.SourceHTTP,
-			controller.ContentTypeKubevirt,
+			string(cdiv1.DataVolumeKubeVirt),
 			"1G"})
 		Expect(err).NotTo(HaveOccurred())
 		By("Closing data stream")
@@ -172,7 +173,7 @@ var _ = Describe("Data Stream", func() {
 			"",
 			"",
 			controller.SourceHTTP,
-			controller.ContentTypeKubevirt,
+			string(cdiv1.DataVolumeKubeVirt),
 			"20M"})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
@@ -194,7 +195,7 @@ var _ = Describe("Data Stream", func() {
 		By(fmt.Sprintf("Creating new fileserver for %s and file %s", filepath.Dir(filename), filepath.Base(filename)))
 		tempTestServer := createTestServer(filepath.Dir(filename))
 		dest := common.ImporterWritePath
-		if contentType == controller.ContentTypeArchive {
+		if contentType == string(cdiv1.DataVolumeArchive) {
 			dest = common.ImporterVolumePath
 		}
 		By(fmt.Sprintf("Creating new datastream to %s", tempTestServer.URL+"/"+filepath.Base(filename)))
@@ -223,14 +224,14 @@ var _ = Describe("Data Stream", func() {
 			Expect(err).To(HaveOccurred())
 		}
 	},
-		table.Entry("successfully construct a xz reader", tinyCoreXzFilePath, controller.ContentTypeKubevirt, 5, false),     // [http, multi-r, xz, multi-r]
-		table.Entry("successfully construct a gz reader", tinyCoreGzFilePath, controller.ContentTypeKubevirt, 5, false),     // [http, multi-r, gz, multi-r]
-		table.Entry("successfully construct a tar reader", tinyCoreTarFilePath, controller.ContentTypeKubevirt, 4, false),   // [http, multi-r, tar, multi-r]
-		table.Entry("successfully constructed an archive reader", archiveFilePath, controller.ContentTypeArchive, 4, false), // [http, multi-r, mul-tar, multi-r]
-		table.Entry("successfully construct qcow2 reader", cirrosFilePath, controller.ContentTypeKubevirt, 2, false),        // [http, multi-r]
-		table.Entry("successfully construct .iso reader", tinyCoreFilePath, controller.ContentTypeKubevirt, 3, false),       // [http, multi-r]
-		table.Entry("fail constructing reader for invalid file path", filepath.Join(imageDir, "tinyCorebad.iso"), controller.ContentTypeKubevirt, 0, true),
-		table.Entry("fail constructing reader for a valid archive file and a wrong content", archiveFileName, controller.ContentTypeKubevirt, 0, true),
+		table.Entry("successfully construct a xz reader", tinyCoreXzFilePath, string(cdiv1.DataVolumeKubeVirt), 5, false),     // [http, multi-r, xz, multi-r]
+		table.Entry("successfully construct a gz reader", tinyCoreGzFilePath, string(cdiv1.DataVolumeKubeVirt), 5, false),     // [http, multi-r, gz, multi-r]
+		table.Entry("successfully construct a tar reader", tinyCoreTarFilePath, string(cdiv1.DataVolumeKubeVirt), 4, false),   // [http, multi-r, tar, multi-r]
+		table.Entry("successfully constructed an archive reader", archiveFilePath, string(cdiv1.DataVolumeArchive), 4, false), // [http, multi-r, mul-tar, multi-r]
+		table.Entry("successfully construct qcow2 reader", cirrosFilePath, string(cdiv1.DataVolumeKubeVirt), 2, false),        // [http, multi-r]
+		table.Entry("successfully construct .iso reader", tinyCoreFilePath, string(cdiv1.DataVolumeKubeVirt), 3, false),       // [http, multi-r]
+		table.Entry("fail constructing reader for invalid file path", filepath.Join(imageDir, "tinyCorebad.iso"), string(cdiv1.DataVolumeKubeVirt), 0, true),
+		table.Entry("fail constructing reader for a valid archive file and a wrong content", archiveFileName, string(cdiv1.DataVolumeKubeVirt), 0, true),
 	)
 })
 
@@ -276,7 +277,7 @@ var _ = Describe("Copy", func() {
 				"",
 				"",
 				controller.SourceHTTP,
-				controller.ContentTypeKubevirt,
+				string(cdiv1.DataVolumeKubeVirt),
 				""})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
@@ -321,7 +322,7 @@ var _ = Describe("Copy", func() {
 				"",
 				"",
 				controller.SourceHTTP,
-				controller.ContentTypeKubevirt,
+				string(cdiv1.DataVolumeKubeVirt),
 				"1G"})
 			if wantErr {
 				Expect(err).To(HaveOccurred())

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -35,7 +36,7 @@ var _ = Describe("Copy from Registry", func() {
 				"",
 				"",
 				controller.SourceRegistry,
-				controller.ContentTypeKubevirt,
+				string(cdiv1.DataVolumeKubeVirt),
 				"1G"})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/tests"
@@ -79,7 +80,7 @@ var _ = Describe(testSuiteName, func() {
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition(
 			"create-image",
 			"1G",
-			map[string]string{controller.AnnSource: controller.SourceNone, controller.AnnContentType: controller.ContentTypeKubevirt},
+			map[string]string{controller.AnnSource: controller.SourceNone, controller.AnnContentType: string(cdiv1.DataVolumeKubeVirt)},
 			nil))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/local_volume_test.go
+++ b/tests/local_volume_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"fmt"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/tests/framework"
@@ -37,7 +38,7 @@ var _ = Describe("Local Volume tests", func() {
 			"1G",
 			map[string]string{"node": node},
 			map[string]string{controller.AnnSource: controller.SourceHTTP,
-				controller.AnnContentType: controller.ContentTypeKubevirt, controller.AnnEndpoint: httpEp + "/tinyCore.iso"},
+				controller.AnnContentType: string(cdiv1.DataVolumeKubeVirt), controller.AnnEndpoint: httpEp + "/tinyCore.iso"},
 			nil, storageClassName))
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adding DataVolume support for unpacking imported archive

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding DataVolume support for unpacking imported archive
```

