### PR TITLE
Integration test between DataVolume and import from registry 

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -30,6 +30,9 @@ done
 for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
     echo "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs \-\-max-args=1 sudo docker pull"
     ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs \-\-max-args=1 sudo docker pull"
+    # Temporary until image is updated with provisioner that sets this field
+    # This field is required by buildah tool
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" "sudo sysctl -w user.max_user_namespaces=1024"
 done
 
 # In order to make the cloner work in open shift, we need to give the cdi-sa Service Account privileged rights.

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -46,10 +46,6 @@ elif [[ $image == $OPENSHIFT_IMAGE ]]; then
     ./cluster/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
 fi
 
-# Temporary until image is updated with provisioner that sets this field
-# This field is required by buildah tool
-$gocli ssh node01 -- sudo sysctl -w user.max_user_namespaces=1024
-
 echo 'Wait until all nodes are ready'
 until [[ $(./cluster/kubectl.sh get nodes --no-headers | wc -l) -eq $(./cluster/kubectl.sh get nodes --no-headers | grep " Ready" | wc -l) ]]; do
     sleep 1

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -24,6 +24,8 @@ const (
 const (
 	// TinyCoreIsoURL provides a test url for the tineyCore iso image
 	TinyCoreIsoURL = "http://cdi-file-host.kube-system/tinyCore.iso"
+	// TinyCoreIsoRegistryURL provides a test url for the tineyCore iso image stored in docker registry
+	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.kube-system/tinycore.qcow2"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume
@@ -158,6 +160,30 @@ func NewDataVolumeForImageCloning(dataVolumeName, size string, namespace, pvcNam
 				PVC: &cdiv1.DataVolumeSourcePVC{
 					Namespace: namespace,
 					Name:      pvcName,
+				},
+			},
+			PVC: &k8sv1.PersistentVolumeClaimSpec{
+				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+				Resources: k8sv1.ResourceRequirements{
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewDataVolumeWithRegistryImport initializes a DataVolume struct with registry annotations
+func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registryURL string) *cdiv1.DataVolume {
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dataVolumeName,
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			Source: cdiv1.DataVolumeSource{
+				Registry: &cdiv1.DataVolumeSourceRegistry{
+					URL: registryURL,
 				},
 			},
 			PVC: &k8sv1.PersistentVolumeClaimSpec{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds functional tests for testing importing from registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Added a line that tests that DataVolume can be created with import from registry source. The registry utilized is cdi-docker-registry-host.kube-system used by functional tests.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

