### PR TITLE
Update Datavolume status to include progress

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2613,6 +2613,9 @@
      "phase": {
       "description": "Phase is the current phase of the data volume",
       "type": "string"
+     },
+     "progress": {
+      "type": "string"
      }
     }
    },

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -728,6 +728,12 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeStatus(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"progress": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -111,7 +111,8 @@ type DataVolumeSourceHTTP struct {
 // DataVolumeStatus provides the parameters to store the phase of the Data Volume
 type DataVolumeStatus struct {
 	//Phase is the current phase of the data volume
-	Phase DataVolumePhase `json:"phase,omitempty"`
+	Phase    DataVolumePhase    `json:"phase,omitempty"`
+	Progress DataVolumeProgress `json:"progress,omitempty"`
 }
 
 //DataVolumeList provides the needed parameters to do request a list of Data Volumes from the system
@@ -126,6 +127,9 @@ type DataVolumeList struct {
 
 // DataVolumePhase is the current phase of the DataVolume
 type DataVolumePhase string
+
+// DataVolumeProgress is the current progress of the DataVolume transfer operation. Value between 0 and 100 inclusive
+type DataVolumeProgress string
 
 const (
 	// PhaseUnset represents a data volume with no current phase

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -429,6 +429,7 @@ func TestImportSucceeded(t *testing.T) {
 
 	result := dataVolume.DeepCopy()
 	result.Status.Phase = cdiv1.Succeeded
+	result.Status.Progress = "100.0%"
 	f.expectUpdateDataVolumeStatusAction(result)
 	f.run(getKey(dataVolume, t))
 }
@@ -532,6 +533,7 @@ func TestCloneSucceeded(t *testing.T) {
 
 	result := dataVolume.DeepCopy()
 	result.Status.Phase = cdiv1.Succeeded
+	result.Status.Progress = "100.0%"
 	f.expectUpdateDataVolumeStatusAction(result)
 	f.run(getKey(dataVolume, t))
 }
@@ -641,7 +643,7 @@ func TestUploadSucceeded(t *testing.T) {
 
 func TestUploadPodFailed(t *testing.T) {
 	f := newFixture(t)
-	dataVolume := newCloneDataVolume("upload-datavolume")
+	dataVolume := newUploadDataVolume("upload-datavolume")
 	pvc, _ := newPersistentVolumeClaim(dataVolume)
 
 	dataVolume.Status.Phase = cdiv1.Pending
@@ -737,6 +739,7 @@ func TestBlankImageSucceeded(t *testing.T) {
 
 	result := dataVolume.DeepCopy()
 	result.Status.Phase = cdiv1.Succeeded
+	result.Status.Progress = "100.0%"
 	f.expectUpdateDataVolumeStatusAction(result)
 	f.run(getKey(dataVolume, t))
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -325,8 +325,8 @@ func (f *Framework) CreatePrometheusServiceInNs(namespace string) (*v1.Service, 
 			Name:      "kubevirt-prometheus-metrics",
 			Namespace: namespace,
 			Labels: map[string]string{
-				"prometheus.kubevirt.io": "",
-				"kubevirt.io":            "",
+				common.PrometheusLabel: "",
+				"kubevirt.io":          "",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -341,7 +341,7 @@ func (f *Framework) CreatePrometheusServiceInNs(namespace string) (*v1.Service, 
 				},
 			},
 			Selector: map[string]string{
-				"prometheus.kubevirt.io": "",
+				common.PrometheusLabel: "",
 			},
 		},
 	}

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -28,6 +28,8 @@ const (
 	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.cdi/tinycoreqcow2"
 	// HTTPSTinyCoreIsoURL provides a test (https) url for the tineyCore iso image
 	HTTPSTinyCoreIsoURL = "https://cdi-file-host.cdi/tinyCore.iso"
+	// TinyCoreQcow2URLRateLimit provides a test url for the tineyCore iso image
+	TinyCoreQcow2URLRateLimit = "http://cdi-file-host.cdi:82/tinyCore.qcow2"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds DataVolume status field for import/clone progress.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DataVolume status now has a progress field that is updated during import/clone.
```

