### PR TITLE
Fixed junit report not getting generated.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -27,7 +27,7 @@ set -ex
 export WORKSPACE="${WORKSPACE:-$PWD}"
 readonly ARTIFACTS_PATH="exported-artifacts"
 
-mkdir -p "$ARTIFACTS_PATH"
+mkdir -p "${WORKSPACE}/${ARTIFACTS_PATH}"
 
 if [[ $TARGET =~ openshift-.* ]]; then
   export KUBEVIRT_PROVIDER="os-3.11.0"
@@ -48,7 +48,7 @@ make cluster-up
 set +e
 kubectl_rc=0
 retry_counter=0
-while [ $retry_counter -lt 30 ] && [ $kubectl_rc -ne 0 || -n "$(kubectl get nodes --no-headers | grep NotReady)" ]; do
+while [[ $retry_counter -lt 30 ]] && [[ $kubectl_rc -ne 0 || -n "$(kubectl get nodes --no-headers | grep NotReady)" ]]; do
     echo "Waiting for all nodes to become ready ..."
     kubectl get nodes --no-headers
     kubectl_rc=$?
@@ -57,7 +57,7 @@ while [ $retry_counter -lt 30 ] && [ $kubectl_rc -ne 0 || -n "$(kubectl get node
 done
 set -e
 
-if [ $retry_counter eq 30 ]; then
+if [ $retry_counter -eq 30 ]; then
 	echo "Not all nodes are up"
 	exit 1
 fi
@@ -69,7 +69,7 @@ make cluster-sync
 
 kubectl version
 
-ginko_params="--test-args=--ginkgo.noColor --junit-output=exported-artifacts/tests.junit.xml"
+ginko_params="--test-args=--ginkgo.noColor --junit-output=${WORKSPACE}/exported-artifacts/tests.junit.xml"
 
 # Run functional tests
 TEST_ARGS=$ginko_params make test-functional-ci


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The CI is no longer generating junit reports because we switched directory that we are running in. This patch fixes the path in which the junit report output directory is being created.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

