### PR TITLE
Properly count the contributions by ignoring merges.

### DIFF
--- a/hack/build/release-description.sh
+++ b/hack/build/release-description.sh
@@ -45,7 +45,7 @@ EOF
 }
 
 shortlog() {
-    git shortlog -sne $RELSPANREF | sed "s/^/    /"
+    git shortlog -sne --no-merges $RELSPANREF | sed "s/^/    /"
 }
 
 usage() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Our current script that counts contributions counts merges by maintainers as well. This PR makes it so it doesn't count those.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

