### PR TITLE
Make data volume status optional.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2382,8 +2382,7 @@
    "v1alpha1.DataVolume": {
     "description": "DataVolume provides a representation of our data volume\n+genclient\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object",
     "required": [
-     "spec",
-     "status"
+     "spec"
     ],
     "properties": {
      "apiVersion": {

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -198,7 +198,7 @@ func schema_pkg_apis_core_v1alpha1_DataVolume(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"spec", "status"},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -33,7 +33,7 @@ type DataVolume struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   DataVolumeSpec   `json:"spec"`
-	Status DataVolumeStatus `json:"status"`
+	Status DataVolumeStatus `json:"status,omitempty"`
 }
 
 // DataVolumeSpec defines our specification for a DataVolume type


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR makes the data volume status object optional.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

