### PR TITLE
Move file/registry hosts back to kube-system

### DIFF
--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -3,7 +3,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-file-host
-  namespace: {{ .Namespace }}
+  namespace: kube-system
   labels:
     cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing: ""
@@ -82,7 +82,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cdi-file-host
-  namespace: {{ .Namespace }}
+  namespace: kube-system
   labels:
     cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing: ""

--- a/manifests/templates/registry-host.yaml.in
+++ b/manifests/templates/registry-host.yaml.in
@@ -5,7 +5,7 @@ metadata:
   labels:
     cdi.kubevirt.io/registry.vol.pvc: registry-vol-pvc
   name: registry-vol-pvc
-  namespace: {{ .Namespace }}
+  namespace: kube-system
 spec:
   accessModes:
     - ReadWriteOnce
@@ -18,7 +18,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-docker-registry-host
-  namespace: {{ .Namespace }}
+  namespace: kube-system
   labels:
     cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing.registry: ""
@@ -98,7 +98,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cdi-docker-registry-host
-  namespace: {{ .Namespace }}
+  namespace: kube-system
   labels:
     cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing.registry: ""

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -5,7 +5,7 @@ const (
 	// FileHostName provides a deployment and service name for tests
 	FileHostName = "cdi-file-host"
 	// FileHostNs provides a deployment ans service namespace for tests
-	FileHostNs = "cdi"
+	FileHostNs = "kube-system"
 	// FileHostS3Bucket provides an S3 bucket name for tests (e.g. http://<serviceIP:port>/FileHostS3Bucket/image)
 	FileHostS3Bucket = "images"
 	// AccessKeyValue provides a username to use for http and S3 (see hack/build/docker/cdi-func-test-file-host-http/htpasswd)

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -23,9 +23,9 @@ const (
 
 const (
 	// TinyCoreIsoURL provides a test url for the tineyCore iso image
-	TinyCoreIsoURL = "http://cdi-file-host.cdi/tinyCore.iso"
+	TinyCoreIsoURL = "http://cdi-file-host.kube-system/tinyCore.iso"
 	// TinyCoreIsoRegistryURL provides a test url for the tineyCore iso image stored in docker registry
-	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.cdi/tinycore.qcow2"
+	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.kube-system/tinycore.qcow2"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix the OS CI by putting the file/registry servers back in kube-system so they start.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

