### PR TITLE
Remove minikube deployment from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 env:
   global:
-  - DOCKER_TAG=$TRAVIS_TAG CHANGE_MINIKUBE_NONE_USER=true K8S_VER=1.9.0 MK_VER=0.25.2 K6T_VER=0.4.0 SRC="http://www.tinycorelinux.net/9.x/x86/release/Core-current.iso"
+  - DOCKER_TAG=$TRAVIS_TAG
   - secure: RWxtzwVEpMvaJlPUuRo+m6Kv9kJJFID7E0tdbE57d1XJN5nEq9ryxsTu8GIVHDPKIoUs0zqt4MtWi+4Wwb+21B2IoXJiHtc1YUex3L/6h64ztgH0iBjd/2Kv2piN4XVY9eYOUcu0PsSU0+Fv785rNfy2/LOi+3Bgs5d20AU9SZs2QDwKBlgWBXeJx7/aqLeytTUUX4tshBfQsxZkhYfVJgNcA1oUGtGS+zjeYVbmveLYQriOdQsfoWcfSZGumRSVH+jH7YCC2MXvIOfL131aOYm6CS0DlJTR3LDuBtI+9tP5C7eF+4nPO/kkIZzpz9RwkOZK2Ejn6D//unHgbyHqzoU4n4YZxw2DUonwXxCYieQ2nEZI5CQeoKXwV26ufdTvFGUYfYMUUnyk8phlP13eZEIoHNFJR2yeCSVSC6p82kpO0Drl+HJpnpo86IePwlcAp6tOekcGiDuM8i8bRmgPtWQzNxsE34OZ7v1j3S2nCrOgO8S9AE262nM3FsIGXCl2KTtKUDOSx0/1xx27tZhsqGDMOksdfdE6msFTJ1cEU53KoJfyyr1UUAtHfIpGLYu67C3tveBB4pcgvZ8SyiP50O8SQkQWX1ovJPj4kZYEx3PKAvTiwvDcCXU21uJH60Qa3lugiNfabmoX4mxjkRgiUswkW4P/Tc9avVa6g6EKnqA=
 
 notifications:
@@ -28,27 +28,8 @@ install:
   - make manifests
 
 before_script:
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v$K8S_VER/bin/linux/amd64/kubectl
-  && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v$MK_VER/minikube-linux-amd64
-  && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v$K8S_VER
-- minikube update-context
-- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}';
-  until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
-  sleep 1; done
-- k_wait_all_running() { while [[ "$(kubectl get $1 --all-namespaces --field-selector=status.phase!=Running | wc -l)" -gt 1 ]];
-  do kubectl get $1 --all-namespaces ; sleep 6; done ; }
-- kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v$K6T_VER/kubevirt.yaml
-- k_wait_all_running pods
 
 script:
-- kubectl apply -f manifests/generated/cdi-operator.yaml
-- kubectl apply -f manifests/generated/cdi-operator-cr.yaml
-- kubectl apply -f manifests/example/endpoint-secret.yaml
-- "sed \"s#cdi.kubevirt.io/storage.import.endpoint:.*#cdi.kubevirt.io/storage.import.endpoint: \"$SRC#\"\" manifests/example/golden-pvc.yaml | kubectl apply -f -"
-- k_wait_all_running pods
-- kubectl get pods --all-namespaces
 - make goveralls
 - make test-lint
 

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -339,7 +339,7 @@ func TestNewCdiAPIServer(t *testing.T) {
 
 	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer)
 	if err != nil {
-		t.Errorf("Createion upload api server creation failed: %+v", err)
+		t.Errorf("Upload api server creation failed: %+v", err)
 	}
 
 	app := server.(*cdiAPIApp)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const pattern = "^[a-zA-Z0-9]+$"
@@ -31,13 +30,13 @@ var _ = Describe("Util", func() {
 		Expect(result).To(Equal(expectedResult))
 	},
 		table.Entry("Valid namespace", filepath.Join(fileDir, "namespace.txt"), "test-namespace"),
-		table.Entry("Invalid file", "doesnotexist", v1.NamespaceSystem),
+		table.Entry("Invalid file", "doesnotexist", "cdi"),
 	)
 })
 
 var _ = Describe("GetNameSpace", func() {
 	It("Report default namespace outside container", func() {
-		Expect(v1.NamespaceSystem).To(Equal(GetNamespace()))
+		Expect("cdi").To(Equal(GetNamespace()))
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport

This PR removes the useless creation of minikube (v1.9) and the deployment of CDI (latest) and kubevirt(0.4) from the travis build. We now have much better tests of if CDI can be deployed and it wasn't testing the correct version of CDI anyway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

