### PR TITLE
The Operator CRD needs the operator.cdi.kubevirt.io label

### DIFF
--- a/manifests/templates/cdi-operator.yaml.in
+++ b/manifests/templates/cdi-operator.yaml.in
@@ -89,6 +89,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cdis.cdi.kubevirt.io
+  labels:
+    operator.cdi.kubevirt.io: ""
 spec:
   group: cdi.kubevirt.io
   names:


### PR DESCRIPTION
**What this PR does / why we need it**:

The CDI operator CRD does not have a label.  This makes it hard to identify what resources are associated with the operator.

KubeVirt's CI needs a label to make tearing down the cluster work properly. I've already fixed this in the KubeVirt CDI related manifests that we test with https://github.com/kubevirt/kubevirt/pull/1953  We should go ahead and address the issue here as well. 


**Release note**:
```release-note
NONE
```

