### PR TITLE
Enable api reference guide generation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - make generate-verify
   - make docker
   - make manifests
+  - make apidocs
 
 before_script:
 
@@ -73,10 +74,8 @@ deploy:
   - manifests/generated/cdi-controller.yaml
   - manifests/generated/cdi-controller.yaml.j2
   - manifests/example/*
-# need github token assigned to API_REFERENCE_PUSH_TOKEN
-# in order to enable the following
-#- provider: script
-#  skip_cleanup: true
-#  script: bash hack/gen-swagger-doc/deploy.sh
-#  on:
-#    tags: true
+- provider: script
+  skip_cleanup: true
+  script: bash hack/gen-swagger-doc/deploy.sh
+  on:
+    tags: true


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR enables the api reference documentation generation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
API reference documentation is now generated on release.
```

