### PR TITLE
Check if target size < virtual size, if so reject import.

### DIFF
--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -52,6 +52,24 @@ const goodValidateJSON = `
 }
 `
 
+const hugeValidateJSON = `
+{
+    "virtual-size": 52949672960,
+    "filename": "myimage.qcow2",
+    "cluster-size": 65536,
+    "format": "qcow2",
+    "actual-size": 262152192,
+    "format-specific": {
+        "type": "qcow2",
+        "data": {
+            "compat": "0.10",
+            "refcount-bits": 16
+        }
+    },
+    "dirty-flag": false
+}
+`
+
 const badValidateJSON = `
 {
     "virtual-size": 4294967296,
@@ -137,7 +155,7 @@ var _ = Describe("Importer", func() {
 
 	table.DescribeTable("Validate should", func(execfunc execFunctionType, errString string) {
 		replaceExecFunction(execfunc, func() {
-			err := Validate(imageName, "qcow2")
+			err := Validate(imageName, "qcow2", 42949672960)
 
 			if errString == "" {
 				Expect(err).NotTo(HaveOccurred())
@@ -155,6 +173,7 @@ var _ = Describe("Importer", func() {
 		table.Entry("validate bad json", mockExecFunction(badValidateJSON, ""), "unexpected end of JSON input"),
 		table.Entry("validate bad format", mockExecFunction(badFormatValidateJSON, ""), fmt.Sprintf("Invalid format raw for image %s", imageName)),
 		table.Entry("validate has backing file", mockExecFunction(backingFileValidateJSON, ""), fmt.Sprintf("Image %s is invalid because it has backing file backing-file.qcow2", imageName)),
+		table.Entry("validate shrink", mockExecFunction(hugeValidateJSON, ""), fmt.Sprintf("Virtual image size %d is larger than available size %d, shrink not yet supported.", 52949672960, 42949672960)),
 	)
 
 })

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -483,7 +483,7 @@ func (o *fakeQEMUOperations) ConvertQcow2ToRawStream(*url.URL, string) error {
 	return o.e2
 }
 
-func (o *fakeQEMUOperations) Validate(string, string) error {
+func (o *fakeQEMUOperations) Validate(string, string, int64) error {
 	return o.e5
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We 'shrink' the disk if the virtual size is larger than the requested size, but we don't shrink the guest OS fs before we shrink the disk, this is causing corruption of images. This PR will reject an import into a smaller PVC than the virtual size.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reject import if virtual size is larger than target size to avoid corruption of the image.
```

