### PR TITLE
fix for issue #636: can't create/delete/create the same datavolume

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -181,6 +181,7 @@ func NewDataVolumeController(
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueDataVolume(new)
 		},
+		DeleteFunc: controller.enqueueDataVolume,
 	})
 	// Set up an event handler for when PVC resources change
 	// handleObject function ensures we filter PVCs not created by this controller
@@ -319,6 +320,10 @@ func (c *DataVolumeController) syncHandler(key string) error {
 		}
 
 		return err
+	}
+
+	if dataVolume.DeletionTimestamp != nil {
+		return nil
 	}
 
 	// Get the pvc with the name specified in DataVolume.spec

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -154,4 +154,29 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			})
 		})
 	})
+
+	Describe("Create/Delete same datavolume in a loop", func() {
+		Context("retry loop", func() {
+			dataVolumeName := "dv1"
+			url := utils.TinyCoreIsoURL
+			numTries := 5
+			for i := 1; i <= numTries; i++ {
+				It(fmt.Sprintf("should succeed on loop %d", i), func() {
+					dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", url)
+
+					By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+					dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+					Expect(err).ToNot(HaveOccurred())
+
+					By(fmt.Sprintf("waiting for datavolume to match phase %s", cdiv1.Succeeded))
+					utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+
+					By("deleting DataVolume")
+					err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolumeName)
+					Expect(err).ToNot(HaveOccurred())
+
+				})
+			}
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Sometimes, creating/deleting/creating the same datavolume causes datavolume controller to be in a sad state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #636 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

