### PR TITLE
BugFix: cdi importer fails to import from registry when run in unpriv…

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -51,6 +51,12 @@ func main() {
 	contentType, _ := util.ParseEnvVar(common.ImporterContentType, false)
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 
+	//Registry import currently support only kubevirt content type
+	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
+		glog.Errorf("Unsupported content type %s when importing from registry", contentType)
+		os.Exit(1)
+	}
+
 	dest := common.ImporterWritePath
 	if contentType == string(cdiv1.DataVolumeArchive) || source == controller.SourceRegistry {
 		dest = common.ImporterVolumePath

--- a/hack/build/docker/cdi-func-test-registry-populate/populate-registry.sh
+++ b/hack/build/docker/cdi-func-test-registry-populate/populate-registry.sh
@@ -32,6 +32,7 @@ function health {
 #Convert all images to docker build consumable format
 DIR="-dir"
 DOCKERFILE="Dockerfile"
+VMIMAGEFILENAME="disk.img"
 
 function prepareImages {
    images_in=$1
@@ -45,12 +46,11 @@ function prepareImages {
 
    for FILENAME in $(ls); do
         mkdir -p $FILENAME$DIR
-        cp  $FILENAME $FILENAME$DIR
-
+        cp  $FILENAME $FILENAME$DIR"/"$VMIMAGEFILENAME
         FILE=$FILENAME$DIR"/"$DOCKERFILE
         /bin/cat  >$FILE <<-EOF
                 FROM scratch
-                ADD / $FILENAME
+                COPY $VMIMAGEFILENAME /
 EOF
 
         rm $FILENAME

--- a/pkg/image/skopeo_test.go
+++ b/pkg/image/skopeo_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Registry Importer", func() {
 			}
 		})
 	},
-		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "") }),
-		table.Entry("copy failure", mockExecFunction("", "exit status 1"), "exit status 1", func() error { return CopyRegistryImage(source, dest, "", "") }),
+		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "", "") }),
+		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image"), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "") }),
 	)
 
 })
@@ -168,7 +168,7 @@ func replaceSkopeoFunctions(mockSkopeoExecFunction execFunctionType, f func()) {
 	f()
 }
 
-func mockExtractImageLayers(dest string) error {
+func mockExtractImageLayers(dest string, arg ...string) error {
 	return nil
 }
 

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -294,7 +294,7 @@ func CopyData(dso *DataStreamOptions) error {
 	switch dso.Source {
 	case controller.SourceRegistry:
 		glog.V(1).Infof("using skopeo to copy from registry")
-		return image.CopyRegistryImage(dso.Endpoint, dso.Dest, dso.AccessKey, dso.SecKey)
+		return image.CopyRegistryImage(dso.Endpoint, dso.Dest, common.DiskImageName, dso.AccessKey, dso.SecKey)
 	default:
 		ds, err := NewDataStream(dso)
 		if err != nil {

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	imageFile = filepath.Join(imageDir, "docker-image.tar")
+	imageFile = filepath.Join(imageDir, "diskimage.tar")
 	imageData = filepath.Join(imageDir, "data")
 )
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -95,8 +95,15 @@ func MinQuantity(availableSpace, imageSize *resource.Quantity) resource.Quantity
 // using the specified io.Reader to the specified destination.
 func UnArchiveTar(reader io.Reader, destDir string, arg ...string) error {
 	glog.V(1).Infof("begin untar...\n")
-	args := fmt.Sprintf("-%s%s", strings.Join(arg, ""), "xvC")
-	untar := exec.Command("/usr/bin/tar", args, destDir)
+
+	var tarOptions string
+	var args = arg
+	if len(arg) > 0 {
+		tarOptions = arg[0]
+		args = arg[1:]
+	}
+	options := fmt.Sprintf("-%s%s", tarOptions, "xvC")
+	untar := exec.Command("/usr/bin/tar", options, destDir, strings.Join(args, ""))
 	untar.Stdin = reader
 	var errBuf bytes.Buffer
 	untar.Stderr = &errBuf

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Transport Tests", func() {
 	const (
 		secretPrefix   = "transport-e2e-sec"
 		targetFile     = "tinyCore.iso"
+		targetImage    = "disk.img"
 		targetQCOWFile = "tinyCore.qcow2"
 		sizeCheckPod   = "size-checker"
 	)
@@ -108,12 +109,6 @@ var _ = Describe("Transport Tests", func() {
 				exitCode, _ := f.ExecShellInPod(pod.Name, ns, command)
 				// A 0 exitCode should indicate that $expSize == $haveSize
 				Expect(strconv.Atoi(exitCode)).To(BeZero())
-			case controller.SourceRegistry:
-				binFile := "/pvc/bin/" + file
-				command := fmt.Sprintf("[ -e %s ]; echo $?", binFile)
-				exitCode, _ := f.ExecShellInPod(pod.Name, ns, command)
-				// A 0 exitCode should indicate that the bin file exists
-				Expect(strconv.Atoi(exitCode)).To(BeZero())
 			}
 		} else {
 			By("Verifying PVC is empty")
@@ -123,14 +118,14 @@ var _ = Describe("Transport Tests", func() {
 
 	httpNoAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPNoAuthPort)
 	httpAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPAuthPort)
-	registryNoAuthEp := fmt.Sprintf("docker://%s", "docker.io")
+	registryNoAuthEp := fmt.Sprintf("docker://%s", utils.RegistryHostName+"."+utils.RegistryHostNs)
 	DescribeTable("Transport Test Table", it,
 		Entry("should connect to http endpoint without credentials", httpNoAuthEp, targetFile, "", "", controller.SourceHTTP, true),
 		Entry("should connect to http endpoint with credentials", httpAuthEp, targetFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, true),
 		Entry("should not connect to http endpoint with invalid credentials", httpAuthEp, targetFile, "gopats", "bradyisthegoat", controller.SourceHTTP, false),
 		Entry("should connect to QCOW http endpoint without credentials", httpNoAuthEp, targetQCOWFile, "", "", controller.SourceHTTP, true),
 		Entry("should connect to QCOW http endpoint with credentials", httpAuthEp, targetQCOWFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, true),
-		Entry("should connect to registry endpoint without credentials", registryNoAuthEp, "registry", "", "", controller.SourceRegistry, true),
+		Entry("should connect to registry endpoint without credentials", registryNoAuthEp, targetImage, "", "", controller.SourceRegistry, true),
 		//		Entry("should not connect to registry endpoint with invalid credentials", registryNoAuthEp, "registry", "gopats", "bradyisthegoat", controller.SourceRegistry, false),
 	)
 })

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -2,6 +2,10 @@ package utils
 
 // cdi-file-host pod/service relative values
 const (
+	//RegistryHostName provides a deploymnet and service name for registry
+	RegistryHostName = "cdi-docker-registry-host"
+	// RegistryHostNs provides a deployment ans service namespace for tests
+	RegistryHostNs = "cdi"
 	// FileHostName provides a deployment and service name for tests
 	FileHostName = "cdi-file-host"
 	// FileHostNs provides a deployment ans service namespace for tests

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -25,7 +25,7 @@ const (
 	// TinyCoreIsoURL provides a test url for the tineyCore iso image
 	TinyCoreIsoURL = "http://cdi-file-host.cdi/tinyCore.iso"
 	// TinyCoreIsoRegistryURL provides a test url for the tineyCore iso image stored in docker registry
-	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.cdi/tinycore.qcow2"
+	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.cdi/disk.img"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
…iledged container

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Now import from registry will succeed on images with content type kubevirt if the image contains VM disk image file in the root of the container. The filename has to be disk.img.
The following errors are reported by the importer:
- On container image that does not contain VM disk image file on its root  - "Failed to find VM disk image file in the container image"
- On import PVC with registry source and contentType archive - "Content type \"archive\" is currently not supported when importing from registry"
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug Fix: cdi import from registry fails when runs in unprivileged mode.
```

