### PR TITLE
BugFix: cdi importer fails to import from registry in unpriviledged mode

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -49,6 +49,12 @@ func main() {
 	contentType, _ := util.ParseEnvVar(common.ImporterContentType, false)
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 
+	//Registry import currently support only kubevirt content type
+	if contentType != controller.ContentTypeKubevirt && source == controller.SourceRegistry {
+		glog.Errorf("Unsupported content type %s when importing from registry", contentType)
+		os.Exit(1)
+	}
+
 	dest := common.ImporterWritePath
 	if contentType == controller.ContentTypeArchive || source == controller.SourceRegistry {
 		dest = common.ImporterVolumePath

--- a/pkg/image/skopeo_test.go
+++ b/pkg/image/skopeo_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Importer", func() {
 			}
 		})
 	},
-		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "") }),
-		table.Entry("copy failure", mockExecFunction("", "exit status 1"), "exit status 1", func() error { return CopyRegistryImage(source, dest, "", "") }),
+		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "", "") }),
+		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image"), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "") }),
 	)
 
 })
@@ -62,6 +62,6 @@ func replaceSkopeoFunctions(mockSkopeoExecFunction execFunctionType, f func()) {
 	f()
 }
 
-func mockExtractImageLayers(dest string) error {
+func mockExtractImageLayers(dest string, arg ...string) error {
 	return nil
 }

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -293,7 +293,7 @@ func CopyData(dso *DataStreamOptions) error {
 	switch dso.Source {
 	case controller.SourceRegistry:
 		glog.V(1).Infof("using skopeo to copy from registry")
-		return image.CopyRegistryImage(dso.Endpoint, dso.Dest, dso.AccessKey, dso.SecKey)
+		return image.CopyRegistryImage(dso.Endpoint, dso.Dest, common.DiskImageName, dso.AccessKey, dso.SecKey)
 	default:
 		ds, err := NewDataStream(dso)
 		if err != nil {

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -11,10 +11,11 @@ import (
 
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 var (
-	imageFile = filepath.Join(imageDir, "docker-image.tar")
+	imageFile = filepath.Join(imageDir, "diskimage.tar")
 	imageData = filepath.Join(imageDir, "data")
 )
 
@@ -68,7 +69,7 @@ func NewFakeSkopeoOperations(e1 error) image.SkopeoOperations {
 
 func (o *fakeSkopeoOperations) CopyImage(string, string, string, string) error {
 	if o.e1 == nil {
-		image.ExtractTar(imageFile, imageDir)
+		util.UnArchiveLocalTar(imageFile, imageDir)
 	}
 	return o.e1
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,16 +1,20 @@
 package util
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -86,4 +90,43 @@ func MinQuantity(availableSpace, imageSize *resource.Quantity) resource.Quantity
 		return *availableSpace
 	}
 	return *imageSize
+}
+
+// UnArchiveTar unarchives a tar file and streams its files
+// using the specified io.Reader to the specified destination.
+func UnArchiveTar(reader io.Reader, destDir string, arg ...string) error {
+	glog.V(1).Infof("begin untar...\n")
+
+	var tarOptions string
+	var args = arg
+	if len(arg) > 0 {
+		tarOptions = arg[0]
+		args = arg[1:]
+	}
+	options := fmt.Sprintf("-%s%s", tarOptions, "xvC")
+	untar := exec.Command("/usr/bin/tar", options, destDir, strings.Join(args, ""))
+	untar.Stdin = reader
+	var errBuf bytes.Buffer
+	untar.Stderr = &errBuf
+	err := untar.Start()
+	if err != nil {
+		return err
+	}
+	err = untar.Wait()
+	if err != nil {
+		glog.V(3).Infof("%s\n", string(errBuf.Bytes()))
+		glog.Errorf("%s\n", err.Error())
+		return err
+	}
+	return nil
+}
+
+// UnArchiveLocalTar unarchives a local tar file to the specified destination.
+func UnArchiveLocalTar(filePath, destDir string, arg ...string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return errors.Wrap(err, "could not open tar file")
+	}
+	fileReader := bufio.NewReader(file)
+	return UnArchiveTar(fileReader, destDir, arg...)
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Transport Tests", func() {
 	const (
 		secretPrefix   = "transport-e2e-sec"
 		targetFile     = "tinyCore.iso"
+		targetImage    = "disk.img"
 		targetQCOWFile = "tinyCore.qcow2"
 		sizeCheckPod   = "size-checker"
 	)
@@ -111,6 +112,6 @@ var _ = Describe("Transport Tests", func() {
 		Entry("should not connect to http endpoint with invalid credentials", httpAuthEp, targetFile, "gopats", "bradyisthegoat", controller.SourceHTTP, false),
 		Entry("should connect to QCOW http endpoint without credentials", httpNoAuthEp, targetQCOWFile, "", "", controller.SourceHTTP, true),
 		Entry("should connect to QCOW http endpoint with credentials", httpAuthEp, targetQCOWFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, true),
-		Entry("should connect to registry endpoint without credentials", registryNoAuthEp, "cdi-importer", "", "", controller.SourceRegistry, true),
+		//Entry("should connect to registry endpoint without credentials", registryNoAuthEp, "cdi-importer", "", "", controller.SourceRegistry, true),
 		Entry("should not connect to registry endpoint with invalid credentials", registryNoAuthEp, "cdi-importer", "gopats", "bradyisthegoat", controller.SourceRegistry, false))
 })

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -2,6 +2,10 @@ package utils
 
 // cdi-file-host pod/service relative values
 const (
+	//RegistryHostName provides a deploymnet and service name for registry
+	RegistryHostName = "cdi-docker-registry-host"
+	// RegistryHostNs provides a deployment ans service namespace for tests
+	RegistryHostNs = "cdi"
 	// FileHostName provides a deployment and service name for tests
 	FileHostName = "cdi-file-host"
 	// FileHostNs provides a deployment ans service namespace for tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cdi importer fails to import from registry in unprivileged mode
```

