### PR TITLE
Import pod status should not be 'Failed' when starting up

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -2,9 +2,10 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -124,7 +125,7 @@ func (ic *ImportController) processPvcItem(pvc *v1.PersistentVolumeClaim) error 
 		//this is for a case where the import container is failing and the restartPolicy is OnFailure. In such case
 		//the pod phase is "Running" although the container state is Waiting. When the container recovers, its state
 		//changes back to "Running".
-		if pod.Status.ContainerStatuses != nil && pod.Status.ContainerStatuses[0].State.Waiting != nil {
+		if pod.Status.Phase != v1.PodPending && pod.Status.ContainerStatuses != nil && pod.Status.ContainerStatuses[0].State.Waiting != nil {
 			anno[AnnPodPhase] = string(v1.PodFailed)
 		}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The import controller was marking import pods as failed when they were starting up.  This was not playing well with kubevirt as it deletes/recreates dataolumes on when they enter failed state.  Basically, datavolumes were getting deleted before they were populated.

For now, just making sure we don't mark failure when starting up but bigger conversation is necessary to determine exactly if/when an import pod should be marked as failed.

#646 and #495 related

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

