### PR TITLE
Check space before importing to report correct image resize size.

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -71,11 +71,12 @@ func main() {
 		source,
 		contentType,
 		imageSize,
+		util.GetAvailableSpace(common.ImporterVolumePath),
 	}
 
 	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {
 		requestImageSizeQuantity := resource.MustParse(imageSize)
-		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(util.GetAvailableSpace(common.ImporterVolumePath), 0), &requestImageSizeQuantity)
+		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(dso.AvailableSpace, 0), &requestImageSizeQuantity)
 		if minSizeQuantity.Cmp(requestImageSizeQuantity) != 0 {
 			// Available dest space is smaller than the size we want to create
 			glog.Warningf("Available space less than requested size, creating blank image sized to available space: %s.\n", minSizeQuantity.String())

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -52,6 +52,7 @@ var imageDir, _ = filepath.Abs(TestImagesDir)
 var cirrosFileName = "cirros-qcow2.img"
 var tinyCoreFileName = "tinyCore.iso"
 var archiveFileName = "archive.tar"
+var cirrosRaw = "cirros.raw"
 var archiveFileNameWithoutExt = strings.TrimSuffix(archiveFileName, filepath.Ext(archiveFileName))
 var cirrosFilePath = filepath.Join(imageDir, cirrosFileName)
 var tinyCoreFilePath = filepath.Join(imageDir, tinyCoreFileName)
@@ -120,7 +121,9 @@ var _ = Describe("Data Stream", func() {
 			secretKey,
 			controller.SourceHTTP,
 			contentType,
-			""})
+			"",
+			int64(1234567890),
+		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
 		}
@@ -155,7 +158,9 @@ var _ = Describe("Data Stream", func() {
 			"",
 			controller.SourceHTTP,
 			string(cdiv1.DataVolumeKubeVirt),
-			"1G"})
+			"1G",
+			int64(1234567890),
+		})
 		Expect(err).NotTo(HaveOccurred())
 		By("Closing data stream")
 		err = ds.Close()
@@ -174,7 +179,9 @@ var _ = Describe("Data Stream", func() {
 			"",
 			controller.SourceHTTP,
 			string(cdiv1.DataVolumeKubeVirt),
-			"20M"})
+			"20M",
+			int64(1234567890),
+		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
 		}
@@ -206,7 +213,9 @@ var _ = Describe("Data Stream", func() {
 			"",
 			controller.SourceHTTP,
 			contentType,
-			"20M"})
+			"20M",
+			int64(1234567890),
+		})
 		defer func() {
 			tempTestServer.Close()
 		}()
@@ -278,7 +287,9 @@ var _ = Describe("Copy", func() {
 				"",
 				controller.SourceHTTP,
 				string(cdiv1.DataVolumeKubeVirt),
-				""})
+				"",
+				int64(1234567890),
+			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
 			} else {
@@ -323,7 +334,9 @@ var _ = Describe("Copy", func() {
 				"",
 				controller.SourceHTTP,
 				string(cdiv1.DataVolumeKubeVirt),
-				"1G"})
+				"1G",
+				int64(1234567890),
+			})
 			if wantErr {
 				Expect(err).To(HaveOccurred())
 			} else {
@@ -378,6 +391,67 @@ var _ = Describe("http", func() {
 			By("Having context be done, we confirm finishing of transfer")
 		}
 	})
+})
+
+var _ = Describe("ResizeImage", func() {
+	var tmpDir string
+	var err error
+
+	BeforeEach(func() {
+		tmpDir, err = ioutil.TempDir("", "imagedir")
+		Expect(err).NotTo(HaveOccurred())
+		input, err := ioutil.ReadFile(filepath.Join(imageDir, cirrosRaw))
+		Expect(err).NotTo(HaveOccurred())
+		err = ioutil.WriteFile(filepath.Join(tmpDir, cirrosRaw), input, 0644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.Remove(tmpDir)
+	})
+
+	It("Should successfully resize, to smaller available", func() {
+		dest := filepath.Join(tmpDir, cirrosRaw)
+		err := ResizeImage(dest, "20M", int64(18874368))
+		Expect(err).NotTo(HaveOccurred())
+		info, err := qemuOperations.Info(dest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.VirtualSize).To(Equal(int64(18874368)))
+	})
+
+	It("Should fail with invalid file", func() {
+		err := ResizeImage(filepath.Join(tmpDir, "invalid"), "20M", int64(18874368))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should successfully resize even if more space available", func() {
+		dest := filepath.Join(tmpDir, cirrosRaw)
+		err := ResizeImage(dest, "20M", int64(200000000))
+		Expect(err).NotTo(HaveOccurred())
+		info, err := qemuOperations.Info(dest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.VirtualSize).To(Equal(int64(20971520)))
+	})
+
+	It("Should successfully not resize if sizes are same.", func() {
+		dest := filepath.Join(tmpDir, cirrosRaw)
+		info, err := qemuOperations.Info(dest)
+		originalSize := info.VirtualSize
+		Expect(err).NotTo(HaveOccurred())
+		err = ResizeImage(dest, strconv.FormatInt(originalSize, 10), int64(200000000))
+		Expect(err).NotTo(HaveOccurred())
+		info, err = qemuOperations.Info(dest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.VirtualSize).To(Equal(originalSize))
+	})
+
+	It("Should fail with valid file, but empty imageSize", func() {
+		dest := filepath.Join(tmpDir, cirrosRaw)
+		err := ResizeImage(dest, "", int64(200000000))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Image resize called with blank resize"))
+	})
+
 })
 
 var _ = Describe("close readers", func() {

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -37,7 +37,9 @@ var _ = Describe("Copy from Registry", func() {
 				"",
 				controller.SourceRegistry,
 				string(cdiv1.DataVolumeKubeVirt),
-				"1G"})
+				"1G",
+				int64(1234567890),
+			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
 			} else {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes an issue where we check the available space after we have downloaded the image, but before we resize the image. This causes the resize to be of the wrong size (available - image size). This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resize now properly counts the available space before downloading an image.
```

