### PR TITLE
Delete importer pod on pvc delete request

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -13,7 +15,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"kubevirt.io/containerized-data-importer/pkg/expectations"
-	"time"
 )
 
 const (
@@ -66,6 +67,7 @@ func NewController(client kubernetes.Interface,
 		UpdateFunc: func(old, new interface{}) {
 			c.enqueuePVC(new)
 		},
+		DeleteFunc: c.enqueuePVC,
 	})
 
 	// Bind the pod SharedIndexInformer to the pod queue
@@ -81,7 +83,6 @@ func NewController(client kubernetes.Interface,
 			}
 			c.handlePodUpdate(new)
 		},
-
 		DeleteFunc: c.handlePodDelete,
 	})
 

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -370,7 +370,7 @@ func (c *UploadController) syncHandler(key string) error {
 	_, isUploadPod := pvc.ObjectMeta.Annotations[AnnUploadRequest]
 	resourceName := GetUploadResourceName(pvc.Name)
 
-	// force cleanup if PVC pending delete and pod running or the upoad annotation was removed
+	// force cleanup if PVC pending delete and pod running or the upload annotation was removed
 	if !isUploadPod || (pvc.DeletionTimestamp != nil && !podSucceededFromPVC(pvc)) {
 		// delete everything
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -74,6 +74,20 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		_, phaseAnnotation, err := utils.WaitForPVCAnnotation(f.K8sClient, f.Namespace.Name, pvc, controller.AnnPodPhase)
 		Expect(phaseAnnotation).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
+
+		By("deleting PVC")
+		err = utils.DeletePVC(f.K8sClient, pvc.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("verifying pod was deleted")
+		deleted, err := utils.WaitPodDeleted(f.K8sClient, importer.Name, f.Namespace.Name, timeout)
+		Expect(deleted).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		By("verifying pvc was deleted")
+		deleted, err = utils.WaitPVCDeleted(f.K8sClient, pvc.Name, f.Namespace.Name, timeout)
+		Expect(deleted).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
 	})
 	It("Should create import pod for blank raw image", func() {
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition(


### PR DESCRIPTION
Related to issue #525, we have a similar situation when using PVCs
without DataVolumes.  The user requests a PVC with CDI Importer
annotations, if the Importer POD is in a fail/retry loop and the user
requests deletion of the PVC the PVC will be stuck in terminating
waiting for the user to forcibly delete the running Import POD.

This PR adds a check for PVC delete in the import controller and
will delete the POD explicitly if it sees a PVC delete request.  This
will also be picked up for Import DataVolumes, so we can remove the
extra checks that were previously added in the DV controller.

fixes #649
fixes #525


```release-note
NONE
```

