### PR TITLE
Imported iso image file should not be resized

### DIFF
--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -22,14 +22,13 @@ import (
 var _ = Describe("Transport Tests", func() {
 
 	const (
-		secretPrefix               = "transport-e2e-sec"
-		targetFile                 = "tinyCore.iso"
-		targetQCOWFile             = "tinyCore.qcow2"
-		targetQCOWImage            = "tinycoreqcow2"
-		targetRawImage             = "tinycoreqcow2"
-		targetRegistryInvalidImage = "tinycoreisotargz"
-		targetArchivedImage        = "tinycoreisotar"
-		sizeCheckPod               = "size-checker"
+		secretPrefix        = "transport-e2e-sec"
+		targetFile          = "tinyCore.iso"
+		targetQCOWFile      = "tinyCore.qcow2"
+		targetQCOWImage     = "tinycoreqcow2"
+		targetRawImage      = "tinycoreqcow2"
+		targetArchivedImage = "tinycoreisotar"
+		sizeCheckPod        = "size-checker"
 	)
 
 	var (
@@ -108,10 +107,12 @@ var _ = Describe("Transport Tests", func() {
 
 			switch pvcAnn[controller.AnnSource] {
 			case controller.SourceHTTP, controller.SourceRegistry:
-				command := `expSize=20971520; haveSize=$(wc -c < /pvc/disk.img); (( $expSize == $haveSize )); echo $?`
-				exitCode, _ := f.ExecShellInPod(pod.Name, ns, command)
-				// A 0 exitCode should indicate that $expSize == $haveSize
-				Expect(strconv.Atoi(exitCode)).To(BeZero())
+				if file != targetFile {
+					command := `expSize=20971520; haveSize=$(wc -c < /pvc/disk.img); (( $expSize == $haveSize )); echo $?`
+					exitCode, _ := f.ExecShellInPod(pod.Name, ns, command)
+					// A 0 exitCode should indicate that $expSize == $haveSize
+					Expect(strconv.Atoi(exitCode)).To(BeZero())
+				}
 			}
 		} else {
 			By("Verifying PVC is empty")


### PR DESCRIPTION
Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
An ISO file should not be resized to the requested PVC size as an iso file is likely an installation media and resizing it doesn't make sense.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Imported iso image file should not be resized
```

