### PR TITLE
add configmap for insecure registries

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -52,7 +52,7 @@ func main() {
 	contentType, _ := util.ParseEnvVar(common.ImporterContentType, false)
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 	certDir, _ := util.ParseEnvVar(common.ImporterCertDirVar, false)
-	insecureRegistry, _ := strconv.ParseBool(os.Getenv(common.InsecureRegistryVar))
+	insecureTLS, _ := strconv.ParseBool(os.Getenv(common.InsecureTLSVar))
 
 	//Registry import currently support only kubevirt content type
 	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
@@ -68,17 +68,17 @@ func main() {
 
 	glog.V(1).Infoln("begin import process")
 	dso := &importer.DataStreamOptions{
-		Dest:             dest,
-		DataDir:          dataDir,
-		Endpoint:         ep,
-		AccessKey:        acc,
-		SecKey:           sec,
-		Source:           source,
-		ContentType:      contentType,
-		ImageSize:        imageSize,
-		AvailableSpace:   util.GetAvailableSpace(common.ImporterVolumePath),
-		CertDir:          certDir,
-		InsecureRegistry: insecureRegistry,
+		Dest:           dest,
+		DataDir:        dataDir,
+		Endpoint:       ep,
+		AccessKey:      acc,
+		SecKey:         sec,
+		Source:         source,
+		ContentType:    contentType,
+		ImageSize:      imageSize,
+		AvailableSpace: util.GetAvailableSpace(common.ImporterVolumePath),
+		CertDir:        certDir,
+		InsecureTLS:    insecureTLS,
 	}
 
 	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	"github.com/golang/glog"
 
@@ -51,6 +52,7 @@ func main() {
 	contentType, _ := util.ParseEnvVar(common.ImporterContentType, false)
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 	certDir, _ := util.ParseEnvVar(common.ImporterCertDirVar, false)
+	insecureRegistry, _ := strconv.ParseBool(os.Getenv(common.InsecureRegistryVar))
 
 	//Registry import currently support only kubevirt content type
 	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
@@ -66,16 +68,17 @@ func main() {
 
 	glog.V(1).Infoln("begin import process")
 	dso := &importer.DataStreamOptions{
-		Dest:           dest,
-		DataDir:        dataDir,
-		Endpoint:       ep,
-		AccessKey:      acc,
-		SecKey:         sec,
-		Source:         source,
-		ContentType:    contentType,
-		ImageSize:      imageSize,
-		AvailableSpace: util.GetAvailableSpace(common.ImporterVolumePath),
-		CertDir:        certDir,
+		Dest:             dest,
+		DataDir:          dataDir,
+		Endpoint:         ep,
+		AccessKey:        acc,
+		SecKey:           sec,
+		Source:           source,
+		ContentType:      contentType,
+		ImageSize:        imageSize,
+		AvailableSpace:   util.GetAvailableSpace(common.ImporterVolumePath),
+		CertDir:          certDir,
+		InsecureRegistry: insecureRegistry,
 	}
 
 	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -57,8 +57,8 @@ const (
 	ImporterImageSize = "IMPORTER_IMAGE_SIZE"
 	// ImporterCertDirVar provides a constant to capture our env variable "IMPORTER_CERT_DIR"
 	ImporterCertDirVar = "IMPORTER_CERT_DIR"
-	// InsecureRegistryVar provides a constant to capture our env variable "INSECURE_REGISTRY"
-	InsecureRegistryVar = "INSECURE_REGISTRY"
+	// InsecureTLSVar provides a constant to capture our env variable "INSECURE_TLS"
+	InsecureTLSVar = "INSECURE_TLS"
 
 	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)
 	CloningLabelKey = "cloning"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -57,6 +57,8 @@ const (
 	ImporterImageSize = "IMPORTER_IMAGE_SIZE"
 	// ImporterCertDirVar provides a constant to capture our env variable "IMPORTER_CERT_DIR"
 	ImporterCertDirVar = "IMPORTER_CERT_DIR"
+	// InsecureRegistryVar provides a constant to capture our env variable "INSECURE_REGISTRY"
+	InsecureRegistryVar = "INSECURE_REGISTRY"
 
 	// CloningLabelKey provides a constant to use as a label name for pod affinity (controller pkg only)
 	CloningLabelKey = "cloning"
@@ -97,4 +99,7 @@ const (
 
 	// DefaultResyncPeriod sets a 10 minute resync period, used in the controller pkg and the controller cmd executable
 	DefaultResyncPeriod = 10 * time.Minute
+
+	// InsecureRegistryConfigMap is the name of the ConfigMap for insecure registries
+	InsecureRegistryConfigMap = "cdi-insecure-registries"
 )

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -40,7 +40,7 @@ type ImportController struct {
 
 type importPodEnvVar struct {
 	ep, secretName, source, contentType, imageSize, certConfigMap string
-	inserureRegistry                                              bool
+	inserureTLS                                                   bool
 }
 
 // NewImportController sets up an Import Controller, and returns a pointer to

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -40,7 +40,7 @@ type ImportController struct {
 
 type importPodEnvVar struct {
 	ep, secretName, source, contentType, imageSize, certConfigMap string
-	inserureTLS                                                   bool
+	insecureTLS                                                   bool
 }
 
 // NewImportController sets up an Import Controller, and returns a pointer to

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -40,6 +40,7 @@ type ImportController struct {
 
 type importPodEnvVar struct {
 	ep, secretName, source, contentType, imageSize, certConfigMap string
+	inserureRegistry                                              bool
 }
 
 // NewImportController sets up an Import Controller, and returns a pointer to

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -376,7 +376,7 @@ func makeEnv(podEnvVar *importPodEnvVar, uid types.UID) []v1.EnvVar {
 		},
 		{
 			Name:  common.InsecureTLSVar,
-			Value: strconv.FormatBool(podEnvVar.inserureTLS),
+			Value: strconv.FormatBool(podEnvVar.insecureTLS),
 		},
 	}
 	if podEnvVar.secretName != "" {
@@ -998,7 +998,7 @@ func createImportEnvVar(client kubernetes.Interface, pvc *v1.PersistentVolumeCla
 		if err != nil {
 			return nil, err
 		}
-		podEnvVar.inserureTLS, err = isInsecureTLS(client, pvc)
+		podEnvVar.insecureTLS, err = isInsecureTLS(client, pvc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1003,6 +1004,10 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string) *v1.Pod {
 			Name:  OwnerUID,
 			Value: string(pvc.UID),
 		},
+		{
+			Name:  InsecureTLSVar,
+			Value: "false",
+		},
 	}
 	pod.Spec.Containers[0].Env = env
 	return pod
@@ -1095,6 +1100,10 @@ func createEnv(podEnvVar *importPodEnvVar, uid string) []v1.EnvVar {
 		{
 			Name:  OwnerUID,
 			Value: string(uid),
+		},
+		{
+			Name:  InsecureTLSVar,
+			Value: strconv.FormatBool(podEnvVar.inserureTLS),
 		},
 	}
 	if podEnvVar.secretName != "" {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -758,8 +758,8 @@ func TestCreateImporterPod(t *testing.T) {
 	}{
 		{
 			name:    "expect pod to be created",
-			args:    args{k8sfake.NewSimpleClientset(pvc), "test/image", "-v=5", "Always", &importPodEnvVar{"", "", "", "", "1G", ""}, pvc},
-			want:    MakeImporterPodSpec("test/image", "-v=5", "Always", &importPodEnvVar{"", "", "", "", "1G", ""}, pvc),
+			args:    args{k8sfake.NewSimpleClientset(pvc), "test/image", "-v=5", "Always", &importPodEnvVar{"", "", "", "", "1G", "", false}, pvc},
+			want:    MakeImporterPodSpec("test/image", "-v=5", "Always", &importPodEnvVar{"", "", "", "", "1G", "", false}, pvc),
 			wantErr: false,
 		},
 	}
@@ -797,7 +797,7 @@ func TestMakeImporterPodSpec(t *testing.T) {
 	}{
 		{
 			name:    "expect pod to be created",
-			args:    args{"test/myimage", "5", "Always", &importPodEnvVar{"", "", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", ""}, pvc},
+			args:    args{"test/myimage", "5", "Always", &importPodEnvVar{"", "", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", "", false}, pvc},
 			wantPod: pod,
 		},
 	}
@@ -827,8 +827,8 @@ func Test_makeEnv(t *testing.T) {
 	}{
 		{
 			name: "env should match",
-			args: args{&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", ""}},
-			want: createEnv(&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", ""}, mockUID),
+			args: args{&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", "", false}},
+			want: createEnv(&importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", "", false}, mockUID),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/image/skopeo.go
+++ b/pkg/image/skopeo.go
@@ -35,7 +35,7 @@ const whFilePrefix string = ".wh."
 
 // SkopeoOperations defines the interface for executing skopeo subprocesses
 type SkopeoOperations interface {
-	CopyImage(string, string, string, string, string) error
+	CopyImage(string, string, string, string, string, bool) error
 }
 
 type skopeoOperations struct{}
@@ -61,7 +61,7 @@ func NewSkopeoOperations() SkopeoOperations {
 	return &skopeoOperations{}
 }
 
-func (o *skopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir string) error {
+func (o *skopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir string, insecureRegistry bool) error {
 	var err error
 	args := []string{"copy", url, dest}
 	if accessKey != "" && secKey != "" {
@@ -70,6 +70,8 @@ func (o *skopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir strin
 	}
 	if certDir != "" {
 		args = append(args, "--src-cert-dir="+certDir)
+	} else if insecureRegistry {
+		args = append(args, "--src-tls-verify=false")
 	}
 	_, err = skopeoExecFunction(nil, nil, "skopeo", args...)
 	if err != nil {
@@ -79,9 +81,9 @@ func (o *skopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir strin
 }
 
 // CopyRegistryImage download image from registry with skopeo
-func CopyRegistryImage(url, dest, destFile, accessKey, secKey, certDir string) error {
+func CopyRegistryImage(url, dest, destFile, accessKey, secKey, certDir string, insecureRegistry bool) error {
 	skopeoDest := "dir:" + dest + dataTmpDir
-	err := SkopeoInterface.CopyImage(url, skopeoDest, accessKey, secKey, certDir)
+	err := SkopeoInterface.CopyImage(url, skopeoDest, accessKey, secKey, certDir, insecureRegistry)
 	if err != nil {
 		os.RemoveAll(dest + dataTmpDir)
 		return errors.Wrap(err, "Failed to download from registry")

--- a/pkg/image/skopeo.go
+++ b/pkg/image/skopeo.go
@@ -69,8 +69,10 @@ func (o *skopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir strin
 		args = append(args, creds)
 	}
 	if certDir != "" {
+		glog.Infof("Using user specified TLS certs at %s", certDir)
 		args = append(args, "--src-cert-dir="+certDir)
 	} else if insecureRegistry {
+		glog.Infof("Disabling TLS verification for URL %s", url)
 		args = append(args, "--src-tls-verify=false")
 	}
 	_, err = skopeoExecFunction(nil, nil, "skopeo", args...)

--- a/pkg/image/skopeo_test.go
+++ b/pkg/image/skopeo_test.go
@@ -52,8 +52,10 @@ var _ = Describe("Registry Importer", func() {
 			}
 		})
 	},
-		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
-		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image"), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
+		table.Entry("copy success", mockExecFunction("", "", nil), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
+		table.Entry("copy success with certs", mockExecFunction("", "", nil, "--src-cert-dir=/foo/bar"), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "/foo/bar", false) }),
+		table.Entry("copy success insecure", mockExecFunction("", "", nil, "--src-tls-verify=false"), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "", true) }),
+		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image", nil), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
 	)
 
 })

--- a/pkg/image/skopeo_test.go
+++ b/pkg/image/skopeo_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Registry Importer", func() {
 			}
 		})
 	},
-		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "") }),
-		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image"), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "", "") }),
+		table.Entry("copy success", mockExecFunction("", ""), "", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
+		table.Entry("copy failure", mockExecFunction("", "Failed to find VM disk image file in the container image"), "Failed to find VM disk image file in the container image", func() error { return CopyRegistryImage(source, dest, "", "", "", "", false) }),
 	)
 
 })

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -110,8 +110,8 @@ type DataStreamOptions struct {
 	AvailableSpace int64
 	// CertDir is a directory containing tls certs
 	CertDir string
-	// InsecureRegistry is it okay to skip TLS verification
-	InsecureRegistry bool
+	// InsecureTLS is it okay to skip TLS verification
+	InsecureTLS bool
 }
 
 const (
@@ -383,7 +383,7 @@ func (d *DataStream) registry() (io.ReadCloser, error) {
 
 	//2. copy image from registry to the temporary location
 	glog.V(1).Infof("using skopeo to copy from registry")
-	err := image.CopyRegistryImage(d.Endpoint, tmpData.dataDir, ContainerDiskImageDir, d.AccessKey, d.SecKey, d.CertDir, d.InsecureRegistry)
+	err := image.CopyRegistryImage(d.Endpoint, tmpData.dataDir, ContainerDiskImageDir, d.AccessKey, d.SecKey, d.CertDir, d.InsecureTLS)
 	if err != nil {
 		glog.Errorf("Failed to read data from registry")
 		return nil, errors.Wrapf(err, fmt.Sprintf("Failed ro read from registry"))

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -110,6 +110,8 @@ type DataStreamOptions struct {
 	AvailableSpace int64
 	// CertDir is a directory containing tls certs
 	CertDir string
+	// InsecureRegistry is it okay to skip TLS verification
+	InsecureRegistry bool
 }
 
 const (
@@ -172,6 +174,7 @@ func newDataStreamFromStream(stream io.ReadCloser) (*DataStream, error) {
 		"", // Blank means don't resize
 		util.GetAvailableSpace(common.ImporterVolumePath),
 		"",
+		false,
 	}, stream)
 }
 
@@ -380,7 +383,7 @@ func (d *DataStream) registry() (io.ReadCloser, error) {
 
 	//2. copy image from registry to the temporary location
 	glog.V(1).Infof("using skopeo to copy from registry")
-	err := image.CopyRegistryImage(d.Endpoint, tmpData.dataDir, ContainerDiskImageDir, d.AccessKey, d.SecKey, d.CertDir)
+	err := image.CopyRegistryImage(d.Endpoint, tmpData.dataDir, ContainerDiskImageDir, d.AccessKey, d.SecKey, d.CertDir, d.InsecureRegistry)
 	if err != nil {
 		glog.Errorf("Failed to read data from registry")
 		return nil, errors.Wrapf(err, fmt.Sprintf("Failed ro read from registry"))

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Data Stream", func() {
 			"",
 			int64(1234567890),
 			"",
+			false,
 		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
@@ -164,6 +165,7 @@ var _ = Describe("Data Stream", func() {
 			"1G",
 			int64(1234567890),
 			"",
+			false,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		By("Closing data stream")
@@ -187,6 +189,7 @@ var _ = Describe("Data Stream", func() {
 			"20M",
 			int64(1234567890),
 			"",
+			false,
 		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
@@ -223,6 +226,7 @@ var _ = Describe("Data Stream", func() {
 			"20M",
 			int64(1234567890),
 			"",
+			false,
 		})
 		defer func() {
 			tempTestServer.Close()
@@ -299,6 +303,7 @@ var _ = Describe("Copy", func() {
 				"",
 				int64(1234567890),
 				"",
+				false,
 			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
@@ -348,6 +353,7 @@ var _ = Describe("Copy", func() {
 				"1G",
 				int64(1234567890),
 				"",
+				false,
 			})
 			if wantErr {
 				Expect(err).To(HaveOccurred())

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Copy from Registry", func() {
 				"1G",
 				int64(1234567890),
 				"",
+				false,
 			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
@@ -91,7 +92,7 @@ func NewFakeSkopeoOperations(e1 error) image.SkopeoOperations {
 	return &fakeSkopeoOperations{e1}
 }
 
-func (o *fakeSkopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir string) error {
+func (o *fakeSkopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir string, insecureRegistry bool) error {
 	if o.e1 == nil {
 		if strings.Contains(url, invalidDestIndicator) {
 			if err := util.UnArchiveLocalTar(invalidImageFile, tmpData); err != nil {

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -221,6 +221,10 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 				"name", desiredMetaObj.GetName(),
 				"type", fmt.Sprintf("%T", desiredMetaObj))
 		} else {
+			if !r.shouldUpdateObject(currentRuntimeObj) {
+				continue
+			}
+
 			currentMetaObj := currentRuntimeObj.(metav1.Object)
 
 			// allow users to add new annotations (but not change ours)
@@ -260,6 +264,15 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileCDI) shouldUpdateObject(obj runtime.Object) bool {
+	switch obj.(type) {
+	case *corev1.ConfigMap:
+	case *corev1.Secret:
+		return false
+	}
+	return true
 }
 
 // I hate that this function exists, but major refactoring required to make CDI CR the owner of all the things

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -268,8 +268,8 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 
 func (r *ReconcileCDI) shouldUpdateObject(obj runtime.Object) bool {
 	switch obj.(type) {
-	case *corev1.ConfigMap:
 	case *corev1.Secret:
+	case *corev1.ConfigMap:
 		return false
 	}
 	return true

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -51,6 +51,7 @@ func createControllerResources(args *FactoryArgs) []runtime.Object {
 			args.DockerTag,
 			args.Verbosity,
 			args.PullPolicy),
+		createInsecureRegConfigMap(),
 	}
 }
 
@@ -111,6 +112,15 @@ func createPrometheusService() *corev1.Service {
 					Protocol: corev1.ProtocolTCP,
 				},
 			},
+		},
+	}
+}
+
+func createInsecureRegConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   common.InsecureRegistryConfigMap,
+			Labels: withCommonLabels(nil),
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allow users to specify insecure registries via `cdi-insecure-registries` configmap.

Whenever a user imports from registry, the controller will check if the registry exists in the configmap.  If so, the importer pod is allowed to do an insecure import.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Insecure registry support
```

