### PR TITLE
make CDIConfig client cluster scoped and fix occasional crash

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1610,6 +1610,16 @@
       }
      }
     }
+   },
+   "/healthz": {
+    "get": {
+     "operationId": "healthzHandler",
+     "responses": {
+      "200": {
+       "description": "OK"
+      }
+     }
+    }
    }
   },
   "definitions": {

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -175,6 +175,11 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 		glog.Fatalf("Error initializing upload controller: %+v", err)
 	}
 
+	err = configController.Init()
+	if err != nil {
+		glog.Fatalf("Error initializing config controller: %+v", err)
+	}
+
 	go cdiInformerFactory.Start(stopCh)
 	go pvcInformerFactory.Start(stopCh)
 	go podInformerFactory.Start(stopCh)

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -162,6 +162,10 @@ const (
 	Unknown DataVolumePhase = "Unknown"
 )
 
+// this has to be here otherwise informer-gen doesn't recognize it
+// see https://github.com/kubernetes/code-generator/issues/59
+// +genclient:nonNamespaced
+
 // CDI is the CDI Operator CRD
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -235,7 +239,11 @@ type CDIList struct {
 	Items []CDI `json:"items"`
 }
 
-//CDIConfig provides a user configuration for CDI
+// this has to be here otherwise informer-gen doesn't recognize it
+// see https://github.com/kubernetes/code-generator/issues/59
+// +genclient:nonNamespaced
+
+// CDIConfig provides a user configuration for CDI
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CDIConfig struct {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/cdi.go
@@ -30,7 +30,7 @@ import (
 // CDIsGetter has a method to return a CDIInterface.
 // A group's client should implement this interface.
 type CDIsGetter interface {
-	CDIs(namespace string) CDIInterface
+	CDIs() CDIInterface
 }
 
 // CDIInterface has methods to work with CDI resources.
@@ -50,14 +50,12 @@ type CDIInterface interface {
 // cDIs implements CDIInterface
 type cDIs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCDIs returns a CDIs
-func newCDIs(c *CdiV1alpha1Client, namespace string) *cDIs {
+func newCDIs(c *CdiV1alpha1Client) *cDIs {
 	return &cDIs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newCDIs(c *CdiV1alpha1Client, namespace string) *cDIs {
 func (c *cDIs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDI, err error) {
 	result = &v1alpha1.CDI{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("cdis").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *cDIs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDI, er
 func (c *cDIs) List(opts v1.ListOptions) (result *v1alpha1.CDIList, err error) {
 	result = &v1alpha1.CDIList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("cdis").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *cDIs) List(opts v1.ListOptions) (result *v1alpha1.CDIList, err error) {
 func (c *cDIs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("cdis").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *cDIs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *cDIs) Create(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 	result = &v1alpha1.CDI{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("cdis").
 		Body(cDI).
 		Do().
@@ -112,7 +106,6 @@ func (c *cDIs) Create(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 func (c *cDIs) Update(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 	result = &v1alpha1.CDI{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("cdis").
 		Name(cDI.Name).
 		Body(cDI).
@@ -127,7 +120,6 @@ func (c *cDIs) Update(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 func (c *cDIs) UpdateStatus(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 	result = &v1alpha1.CDI{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("cdis").
 		Name(cDI.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *cDIs) UpdateStatus(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error)
 // Delete takes name of the cDI and deletes it. Returns an error if one occurs.
 func (c *cDIs) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("cdis").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *cDIs) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *cDIs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("cdis").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *cDIs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOp
 func (c *cDIs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CDI, err error) {
 	result = &v1alpha1.CDI{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("cdis").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/cdiconfig.go
@@ -30,7 +30,7 @@ import (
 // CDIConfigsGetter has a method to return a CDIConfigInterface.
 // A group's client should implement this interface.
 type CDIConfigsGetter interface {
-	CDIConfigs(namespace string) CDIConfigInterface
+	CDIConfigs() CDIConfigInterface
 }
 
 // CDIConfigInterface has methods to work with CDIConfig resources.
@@ -50,14 +50,12 @@ type CDIConfigInterface interface {
 // cDIConfigs implements CDIConfigInterface
 type cDIConfigs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCDIConfigs returns a CDIConfigs
-func newCDIConfigs(c *CdiV1alpha1Client, namespace string) *cDIConfigs {
+func newCDIConfigs(c *CdiV1alpha1Client) *cDIConfigs {
 	return &cDIConfigs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newCDIConfigs(c *CdiV1alpha1Client, namespace string) *cDIConfigs {
 func (c *cDIConfigs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDIConfig, err error) {
 	result = &v1alpha1.CDIConfig{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *cDIConfigs) Get(name string, options v1.GetOptions) (result *v1alpha1.C
 func (c *cDIConfigs) List(opts v1.ListOptions) (result *v1alpha1.CDIConfigList, err error) {
 	result = &v1alpha1.CDIConfigList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *cDIConfigs) List(opts v1.ListOptions) (result *v1alpha1.CDIConfigList, 
 func (c *cDIConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *cDIConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *cDIConfigs) Create(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDIConfig, err error) {
 	result = &v1alpha1.CDIConfig{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		Body(cDIConfig).
 		Do().
@@ -112,7 +106,6 @@ func (c *cDIConfigs) Create(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDI
 func (c *cDIConfigs) Update(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDIConfig, err error) {
 	result = &v1alpha1.CDIConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		Name(cDIConfig.Name).
 		Body(cDIConfig).
@@ -127,7 +120,6 @@ func (c *cDIConfigs) Update(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDI
 func (c *cDIConfigs) UpdateStatus(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDIConfig, err error) {
 	result = &v1alpha1.CDIConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		Name(cDIConfig.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *cDIConfigs) UpdateStatus(cDIConfig *v1alpha1.CDIConfig) (result *v1alph
 // Delete takes name of the cDIConfig and deletes it. Returns an error if one occurs.
 func (c *cDIConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *cDIConfigs) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *cDIConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *cDIConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 func (c *cDIConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CDIConfig, err error) {
 	result = &v1alpha1.CDIConfig{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("cdiconfigs").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -37,12 +37,12 @@ type CdiV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *CdiV1alpha1Client) CDIs(namespace string) CDIInterface {
-	return newCDIs(c, namespace)
+func (c *CdiV1alpha1Client) CDIs() CDIInterface {
+	return newCDIs(c)
 }
 
-func (c *CdiV1alpha1Client) CDIConfigs(namespace string) CDIConfigInterface {
-	return newCDIConfigs(c, namespace)
+func (c *CdiV1alpha1Client) CDIConfigs() CDIConfigInterface {
+	return newCDIConfigs(c)
 }
 
 func (c *CdiV1alpha1Client) DataVolumes(namespace string) DataVolumeInterface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdi.go
@@ -31,7 +31,6 @@ import (
 // FakeCDIs implements CDIInterface
 type FakeCDIs struct {
 	Fake *FakeCdiV1alpha1
-	ns   string
 }
 
 var cdisResource = schema.GroupVersionResource{Group: "cdi.kubevirt.io", Version: "v1alpha1", Resource: "cdis"}
@@ -41,8 +40,7 @@ var cdisKind = schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1alp
 // Get takes name of the cDI, and returns the corresponding cDI object, and an error if there is any.
 func (c *FakeCDIs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDI, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(cdisResource, c.ns, name), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootGetAction(cdisResource, name), &v1alpha1.CDI{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeCDIs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDI
 // List takes label and field selectors, and returns the list of CDIs that match those selectors.
 func (c *FakeCDIs) List(opts v1.ListOptions) (result *v1alpha1.CDIList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(cdisResource, cdisKind, c.ns, opts), &v1alpha1.CDIList{})
-
+		Invokes(testing.NewRootListAction(cdisResource, cdisKind, opts), &v1alpha1.CDIList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeCDIs) List(opts v1.ListOptions) (result *v1alpha1.CDIList, err erro
 // Watch returns a watch.Interface that watches the requested cDIs.
 func (c *FakeCDIs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(cdisResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(cdisResource, opts))
 }
 
 // Create takes the representation of a cDI and creates it.  Returns the server's representation of the cDI, and an error, if there is any.
 func (c *FakeCDIs) Create(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(cdisResource, c.ns, cDI), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootCreateAction(cdisResource, cDI), &v1alpha1.CDI{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeCDIs) Create(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 // Update takes the representation of a cDI and updates it. Returns the server's representation of the cDI, and an error, if there is any.
 func (c *FakeCDIs) Update(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(cdisResource, c.ns, cDI), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootUpdateAction(cdisResource, cDI), &v1alpha1.CDI{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeCDIs) Update(cDI *v1alpha1.CDI) (result *v1alpha1.CDI, err error) {
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCDIs) UpdateStatus(cDI *v1alpha1.CDI) (*v1alpha1.CDI, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(cdisResource, "status", c.ns, cDI), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(cdisResource, "status", cDI), &v1alpha1.CDI{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeCDIs) UpdateStatus(cDI *v1alpha1.CDI) (*v1alpha1.CDI, error) {
 // Delete takes name of the cDI and deletes it. Returns an error if one occurs.
 func (c *FakeCDIs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(cdisResource, c.ns, name), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootDeleteAction(cdisResource, name), &v1alpha1.CDI{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCDIs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(cdisResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(cdisResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CDIList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeCDIs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 // Patch applies the patch and returns the patched cDI.
 func (c *FakeCDIs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CDI, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cdisResource, c.ns, name, data, subresources...), &v1alpha1.CDI{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(cdisResource, name, data, subresources...), &v1alpha1.CDI{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdiconfig.go
@@ -31,7 +31,6 @@ import (
 // FakeCDIConfigs implements CDIConfigInterface
 type FakeCDIConfigs struct {
 	Fake *FakeCdiV1alpha1
-	ns   string
 }
 
 var cdiconfigsResource = schema.GroupVersionResource{Group: "cdi.kubevirt.io", Version: "v1alpha1", Resource: "cdiconfigs"}
@@ -41,8 +40,7 @@ var cdiconfigsKind = schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: 
 // Get takes name of the cDIConfig, and returns the corresponding cDIConfig object, and an error if there is any.
 func (c *FakeCDIConfigs) Get(name string, options v1.GetOptions) (result *v1alpha1.CDIConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(cdiconfigsResource, c.ns, name), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootGetAction(cdiconfigsResource, name), &v1alpha1.CDIConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeCDIConfigs) Get(name string, options v1.GetOptions) (result *v1alph
 // List takes label and field selectors, and returns the list of CDIConfigs that match those selectors.
 func (c *FakeCDIConfigs) List(opts v1.ListOptions) (result *v1alpha1.CDIConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(cdiconfigsResource, cdiconfigsKind, c.ns, opts), &v1alpha1.CDIConfigList{})
-
+		Invokes(testing.NewRootListAction(cdiconfigsResource, cdiconfigsKind, opts), &v1alpha1.CDIConfigList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeCDIConfigs) List(opts v1.ListOptions) (result *v1alpha1.CDIConfigLi
 // Watch returns a watch.Interface that watches the requested cDIConfigs.
 func (c *FakeCDIConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(cdiconfigsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(cdiconfigsResource, opts))
 }
 
 // Create takes the representation of a cDIConfig and creates it.  Returns the server's representation of the cDIConfig, and an error, if there is any.
 func (c *FakeCDIConfigs) Create(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDIConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(cdiconfigsResource, c.ns, cDIConfig), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootCreateAction(cdiconfigsResource, cDIConfig), &v1alpha1.CDIConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeCDIConfigs) Create(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1
 // Update takes the representation of a cDIConfig and updates it. Returns the server's representation of the cDIConfig, and an error, if there is any.
 func (c *FakeCDIConfigs) Update(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1.CDIConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(cdiconfigsResource, c.ns, cDIConfig), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootUpdateAction(cdiconfigsResource, cDIConfig), &v1alpha1.CDIConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeCDIConfigs) Update(cDIConfig *v1alpha1.CDIConfig) (result *v1alpha1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCDIConfigs) UpdateStatus(cDIConfig *v1alpha1.CDIConfig) (*v1alpha1.CDIConfig, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(cdiconfigsResource, "status", c.ns, cDIConfig), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(cdiconfigsResource, "status", cDIConfig), &v1alpha1.CDIConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeCDIConfigs) UpdateStatus(cDIConfig *v1alpha1.CDIConfig) (*v1alpha1.
 // Delete takes name of the cDIConfig and deletes it. Returns an error if one occurs.
 func (c *FakeCDIConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(cdiconfigsResource, c.ns, name), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootDeleteAction(cdiconfigsResource, name), &v1alpha1.CDIConfig{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCDIConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(cdiconfigsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(cdiconfigsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CDIConfigList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeCDIConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions
 // Patch applies the patch and returns the patched cDIConfig.
 func (c *FakeCDIConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CDIConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cdiconfigsResource, c.ns, name, data, subresources...), &v1alpha1.CDIConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(cdiconfigsResource, name, data, subresources...), &v1alpha1.CDIConfig{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -28,12 +28,12 @@ type FakeCdiV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeCdiV1alpha1) CDIs(namespace string) v1alpha1.CDIInterface {
-	return &FakeCDIs{c, namespace}
+func (c *FakeCdiV1alpha1) CDIs() v1alpha1.CDIInterface {
+	return &FakeCDIs{c}
 }
 
-func (c *FakeCdiV1alpha1) CDIConfigs(namespace string) v1alpha1.CDIConfigInterface {
-	return &FakeCDIConfigs{c, namespace}
+func (c *FakeCdiV1alpha1) CDIConfigs() v1alpha1.CDIConfigInterface {
+	return &FakeCDIConfigs{c}
 }
 
 func (c *FakeCdiV1alpha1) DataVolumes(namespace string) v1alpha1.DataVolumeInterface {

--- a/pkg/client/informers/externalversions/core/v1alpha1/cdi.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/cdi.go
@@ -41,33 +41,32 @@ type CDIInformer interface {
 type cDIInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCDIInformer constructs a new informer for CDI type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCDIInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCDIInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCDIInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCDIInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCDIInformer constructs a new informer for CDI type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCDIInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCDIInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CdiV1alpha1().CDIs(namespace).List(options)
+				return client.CdiV1alpha1().CDIs().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CdiV1alpha1().CDIs(namespace).Watch(options)
+				return client.CdiV1alpha1().CDIs().Watch(options)
 			},
 		},
 		&corev1alpha1.CDI{},
@@ -77,7 +76,7 @@ func NewFilteredCDIInformer(client versioned.Interface, namespace string, resync
 }
 
 func (f *cDIInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCDIInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCDIInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *cDIInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/externalversions/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/cdiconfig.go
@@ -41,33 +41,32 @@ type CDIConfigInformer interface {
 type cDIConfigInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCDIConfigInformer constructs a new informer for CDIConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCDIConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCDIConfigInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCDIConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCDIConfigInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCDIConfigInformer constructs a new informer for CDIConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCDIConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCDIConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CdiV1alpha1().CDIConfigs(namespace).List(options)
+				return client.CdiV1alpha1().CDIConfigs().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CdiV1alpha1().CDIConfigs(namespace).Watch(options)
+				return client.CdiV1alpha1().CDIConfigs().Watch(options)
 			},
 		},
 		&corev1alpha1.CDIConfig{},
@@ -77,7 +76,7 @@ func NewFilteredCDIConfigInformer(client versioned.Interface, namespace string, 
 }
 
 func (f *cDIConfigInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCDIConfigInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCDIConfigInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *cDIConfigInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/externalversions/core/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/interface.go
@@ -45,12 +45,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CDIs returns a CDIInformer.
 func (v *version) CDIs() CDIInformer {
-	return &cDIInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &cDIInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // CDIConfigs returns a CDIConfigInformer.
 func (v *version) CDIConfigs() CDIConfigInformer {
-	return &cDIConfigInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &cDIConfigInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // DataVolumes returns a DataVolumeInformer.

--- a/pkg/client/listers/core/v1alpha1/cdi.go
+++ b/pkg/client/listers/core/v1alpha1/cdi.go
@@ -29,8 +29,8 @@ import (
 type CDILister interface {
 	// List lists all CDIs in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.CDI, err error)
-	// CDIs returns an object that can list and get CDIs.
-	CDIs(namespace string) CDINamespaceLister
+	// Get retrieves the CDI from the index for a given name.
+	Get(name string) (*v1alpha1.CDI, error)
 	CDIListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *cDILister) List(selector labels.Selector) (ret []*v1alpha1.CDI, err err
 	return ret, err
 }
 
-// CDIs returns an object that can list and get CDIs.
-func (s *cDILister) CDIs(namespace string) CDINamespaceLister {
-	return cDINamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CDINamespaceLister helps list and get CDIs.
-type CDINamespaceLister interface {
-	// List lists all CDIs in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.CDI, err error)
-	// Get retrieves the CDI from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.CDI, error)
-	CDINamespaceListerExpansion
-}
-
-// cDINamespaceLister implements the CDINamespaceLister
-// interface.
-type cDINamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CDIs in the indexer for a given namespace.
-func (s cDINamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CDI, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CDI))
-	})
-	return ret, err
-}
-
-// Get retrieves the CDI from the indexer for a given namespace and name.
-func (s cDINamespaceLister) Get(name string) (*v1alpha1.CDI, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CDI from the index for a given name.
+func (s *cDILister) Get(name string) (*v1alpha1.CDI, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/listers/core/v1alpha1/cdiconfig.go
@@ -29,8 +29,8 @@ import (
 type CDIConfigLister interface {
 	// List lists all CDIConfigs in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.CDIConfig, err error)
-	// CDIConfigs returns an object that can list and get CDIConfigs.
-	CDIConfigs(namespace string) CDIConfigNamespaceLister
+	// Get retrieves the CDIConfig from the index for a given name.
+	Get(name string) (*v1alpha1.CDIConfig, error)
 	CDIConfigListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *cDIConfigLister) List(selector labels.Selector) (ret []*v1alpha1.CDICon
 	return ret, err
 }
 
-// CDIConfigs returns an object that can list and get CDIConfigs.
-func (s *cDIConfigLister) CDIConfigs(namespace string) CDIConfigNamespaceLister {
-	return cDIConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CDIConfigNamespaceLister helps list and get CDIConfigs.
-type CDIConfigNamespaceLister interface {
-	// List lists all CDIConfigs in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.CDIConfig, err error)
-	// Get retrieves the CDIConfig from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.CDIConfig, error)
-	CDIConfigNamespaceListerExpansion
-}
-
-// cDIConfigNamespaceLister implements the CDIConfigNamespaceLister
-// interface.
-type cDIConfigNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CDIConfigs in the indexer for a given namespace.
-func (s cDIConfigNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CDIConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CDIConfig))
-	})
-	return ret, err
-}
-
-// Get retrieves the CDIConfig from the indexer for a given namespace and name.
-func (s cDIConfigNamespaceLister) Get(name string) (*v1alpha1.CDIConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CDIConfig from the index for a given name.
+func (s *cDIConfigLister) Get(name string) (*v1alpha1.CDIConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/core/v1alpha1/expansion_generated.go
@@ -22,17 +22,9 @@ package v1alpha1
 // CDILister.
 type CDIListerExpansion interface{}
 
-// CDINamespaceListerExpansion allows custom methods to be added to
-// CDINamespaceLister.
-type CDINamespaceListerExpansion interface{}
-
 // CDIConfigListerExpansion allows custom methods to be added to
 // CDIConfigLister.
 type CDIConfigListerExpansion interface{}
-
-// CDIConfigNamespaceListerExpansion allows custom methods to be added to
-// CDIConfigNamespaceLister.
-type CDIConfigNamespaceListerExpansion interface{}
 
 // DataVolumeListerExpansion allows custom methods to be added to
 // DataVolumeLister.

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -152,19 +152,9 @@ func (c *ConfigController) handleObject(obj interface{}, verb string) {
 	glog.V(3).Infof("Processing object: %s", object.GetName())
 
 	var config *cdiv1.CDIConfig
-	configs, err := c.configLister.CDIConfigs(metav1.NamespaceAll).List(labels.NewSelector())
+	config, err := c.configLister.Get(c.configName)
 	if err != nil {
-		runtime.HandleError(errors.Errorf("error listing CDI configs: %s", err))
-		return
-	}
-	for _, conf := range configs {
-		if conf.Name == c.configName {
-			config = conf
-		}
-	}
-
-	if config == nil {
-		runtime.HandleError(errors.Errorf("error getting CDI config"))
+		runtime.HandleError(errors.Errorf("error getting CDI config: %s", err))
 		return
 	}
 
@@ -237,24 +227,14 @@ func (c *ConfigController) processNextWorkItem() bool {
 }
 
 func (c *ConfigController) syncHandler(key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		runtime.HandleError(errors.Errorf("invalid resource key: %s", key))
 		return nil
 	}
 
-	var config *cdiv1.CDIConfig
-	configs, err := c.configLister.CDIConfigs(namespace).List(labels.NewSelector())
+	config, err := c.configLister.Get(name)
 	if err != nil {
-		return err
-	}
-	for _, conf := range configs {
-		if conf.Name == name {
-			config = conf
-		}
-	}
-
-	if config == nil {
 		runtime.HandleError(errors.Errorf("CDIConfig '%s' in work queue no longer exists", key))
 		return nil
 	}
@@ -308,17 +288,23 @@ func (c *ConfigController) syncHandler(key string) error {
 	return nil
 }
 
+// Init is meant to be called synchroniously when the the controller is starting
+func (c *ConfigController) Init() error {
+	glog.V(3).Infoln("Creating CDI config if necessary")
+
+	if err := EnsureCDIConfigExists(c.client, c.cdiClientSet, c.configName); err != nil {
+		runtime.HandleError(err)
+		return errors.Wrap(err, "Error creating CDI config")
+	}
+
+	return nil
+}
+
 // Run sets up ConfigController state and executes main event loop
 func (c *ConfigController) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer func() {
 		c.queue.ShutDown()
 	}()
-
-	glog.V(3).Infoln("Creating CDI config")
-	if _, err := CreateCDIConfig(c.client, c.cdiClientSet, c.configName); err != nil {
-		runtime.HandleError(err)
-		return errors.Wrap(err, "Error creating CDI config")
-	}
 
 	glog.V(3).Infoln("Starting config controller Run loop")
 	if threadiness < 1 {

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -279,7 +279,7 @@ func (f *configFixture) expectUpdateConfigAction(config *cdiv1.CDIConfig) {
 
 func TestCreatesCDIConfig(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 
 	f.configLister = append(f.configLister, config)
 	f.objects = append(f.objects, config)
@@ -289,7 +289,7 @@ func TestCreatesCDIConfig(t *testing.T) {
 
 func TestCDIConfigStatusChanged(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 	url := "www.example.com"
 	config.Spec.UploadProxyURLOverride = &url
 
@@ -306,7 +306,7 @@ func TestCDIConfigStatusChanged(t *testing.T) {
 
 func TestCreatesRoute(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 
 	f.configLister = append(f.configLister, config)
 	f.objects = append(f.objects, config)
@@ -327,7 +327,7 @@ func TestCreatesRoute(t *testing.T) {
 
 func TestCreatesRouteOverrideExists(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 	newURL := "www.override.com"
 	config.Spec.UploadProxyURLOverride = &newURL
 
@@ -348,7 +348,7 @@ func TestCreatesRouteOverrideExists(t *testing.T) {
 
 func TestCreatesRouteDifferentService(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 
 	f.configLister = append(f.configLister, config)
 	f.objects = append(f.objects, config)
@@ -361,7 +361,7 @@ func TestCreatesRouteDifferentService(t *testing.T) {
 }
 func TestCreatesIngress(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 
 	f.configLister = append(f.configLister, config)
 	f.objects = append(f.objects, config)
@@ -381,7 +381,7 @@ func TestCreatesIngress(t *testing.T) {
 
 func TestCreatesIngressOverrideExists(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 	newURL := "www.override.com"
 	config.Spec.UploadProxyURLOverride = &newURL
 
@@ -403,7 +403,7 @@ func TestCreatesIngressOverrideExists(t *testing.T) {
 
 func TestCreatesIngressDifferentService(t *testing.T) {
 	f := newConfigFixture(t)
-	config := createCDIConfig("testConfig", "default")
+	config := createCDIConfig("testConfig")
 
 	f.configLister = append(f.configLister, config)
 	f.objects = append(f.objects, config)

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -848,7 +848,7 @@ func TestMakeCDIConfigSpec(t *testing.T) {
 	type args struct {
 		name string
 	}
-	config := createCDIConfig("testConfig", "")
+	config := createCDIConfig("testConfig")
 
 	tests := []struct {
 		name          string
@@ -863,10 +863,10 @@ func TestMakeCDIConfigSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MakeCDIConfigSpec(tt.args.name)
+			got := MakeEmptyCDIConfigSpec(tt.args.name)
 
 			if !reflect.DeepEqual(got, tt.wantCDIConfig) {
-				t.Errorf("MakeCDIConfigSpec() =\n%v\n, want\n%v", got, tt.wantCDIConfig)
+				t.Errorf("MakeEmptyCDIConfigSpec() =\n%v\n, want\n%v", got, tt.wantCDIConfig)
 			}
 
 		})
@@ -1683,23 +1683,14 @@ func createUploadService(pvc *v1.PersistentVolumeClaim) *v1.Service {
 	return service
 }
 
-func createCDIConfig(name, ns string) *cdiv1.CDIConfig {
+func createCDIConfig(name string) *cdiv1.CDIConfig {
 	return &cdiv1.CDIConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CDIConfig",
-			APIVersion: "cdi.kubevirt.io/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
+			Name: name,
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue,
 				common.CDIComponentLabel: "",
 			},
-		},
-		Spec: cdiv1.CDIConfigSpec{},
-		Status: cdiv1.CDIConfigStatus{
-			UploadProxyURL: nil,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The controller was crashing occasionally.  I think this will fix it.  Basically, update was being called with an object not returned from the API (and had no resource version)

Also, made the generated clients cluster scoped and therefor less awkward to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

