### PR TITLE
use pullPolicy=Always for openshift

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -17,7 +17,7 @@ registry_port=$($gocli ports registry | tr -d '\r')
 registry=localhost:$registry_port
 
 DOCKER_REPO=${registry} make docker push
-DOCKER_REPO="registry:5000" make manifests
+DOCKER_REPO="registry:5000" PULL_POLICY=$(getTestPullPolicy) make manifests
 
 # Make sure that all nodes use the newest images
 container=""

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -93,3 +93,16 @@ function getClusterType() {
     esac
     echo "$image"
 }
+
+function getTestPullPolicy() {
+    local pp
+    case "${KUBEVIRT_PROVIDER}" in
+    "k8s-1.11.0")
+        pp=$PULL_POLICY
+        ;;
+    "os-3.11.0")
+        pp=Always
+        ;;
+    esac
+    echo "$pp"
+}

--- a/manifests/templates/cdi-operator.yaml.in
+++ b/manifests/templates/cdi-operator.yaml.in
@@ -60,7 +60,7 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .PullPolicy }}
           env:
           - name: DEPLOY_CLUSTER_RESOURCES
             value: 'true'

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -79,6 +79,10 @@ func createControllerDeployment(repo, controllerImage, importerImage, clonerImag
 			Name:  "UPLOADPROXY_SERVICE",
 			Value: uploadProxyResourceName,
 		},
+		{
+			Name:  "PULL_POLICY",
+			Value: pullPolicy,
+		},
 	}
 	container.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Did you ever notice that `make cluster sync` doesn't work so great on OpenShift?  Like, if you make a change locally, it doesn't get reflected in the cluster?

Turns out that OpenShift actually respects the pullPolicy param when the tag is `latest`.  Looks like k8s always pulls `latest` regardless of pullPolicy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

