### PR TITLE
refresh docs for uploadproxy reencrypt routes

### DIFF
--- a/doc/upload.md
+++ b/doc/upload.md
@@ -52,19 +52,9 @@ EOF
 ### Minishift
 
 ```bash
-cat <<EOF | oc apply -f -
-apiVersion: v1
-kind: Route
-metadata:
-  name: cdi-uploadproxy
-  namespace: cdi
-spec:
-  to:
-    kind: Service
-    name: cdi-uploadproxy 
-  tls:
-    termination: passthrough
-EOF
+oc get secret -n cdi cdi-upload-proxy-ca-key -o=jsonpath="{.data['tls\.crt']}" | base64 -d > tls.crt && \
+oc create route reencrypt -n cdi --service=cdi-uploadproxy --dest-ca-cert=tls.crt && \
+rm tls.crt
 ```
 
 ### Port forwarding via the API server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Uploadproxy routs should be reencrypt by default.  But show how to do passthrough with customer generated certs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

