### PR TITLE
Correct datavol src:registry example manifest

### DIFF
--- a/manifests/example/registry-image-datavolume.yaml
+++ b/manifests/example/registry-image-datavolume.yaml
@@ -5,7 +5,8 @@ metadata:
   name: registry-image-datavolume
 spec:
   source:
-      registry: "docker://kubevirt/fedora-cloud-registry-disk-demo"
+    registry:
+      url: "docker://kubevirt/fedora-cloud-registry-disk-demo"
   pvc:
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
**What this PR does / why we need it**: fix example manifest

Correct syntax as per code: https://github.com/kubevirt/containerized-data-importer/blob/master/pkg/apis/core/v1alpha1/types.go#L92