### PR TITLE
Resize on upload.

### DIFF
--- a/cmd/cdi-uploadserver/uploadserver.go
+++ b/cmd/cdi-uploadserver/uploadserver.go
@@ -64,6 +64,7 @@ func main() {
 		os.Getenv("TLS_KEY"),
 		os.Getenv("TLS_CERT"),
 		os.Getenv("CLIENT_CERT"),
+		os.Getenv(common.UploadImageSize),
 	)
 
 	klog.Infof("Upload destination: %s", destination)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -87,6 +87,8 @@ const (
 	UploadServerDataDir = ImporterDataDir
 	// UploadServerServiceLabel is the label selector for upload server services
 	UploadServerServiceLabel = "service"
+	// UploadImageSize provides a constant to capture our env variable "UPLOAD_IMAGE_SIZE"
+	UploadImageSize = "UPLOAD_IMAGE_SIZE"
 
 	// ConfigName is the name of default CDI Config
 	ConfigName = "config"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -858,6 +858,7 @@ func MakePodOwnerReference(pod *v1.Pod) metav1.OwnerReference {
 
 // MakeUploadPodSpec creates upload service pod manifest
 func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.PersistentVolumeClaim, scratchName, secretName string) *v1.Pod {
+	requestImageSize, _ := getRequestedImageSize(pvc)
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -926,6 +927,10 @@ func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.Persiste
 									Key: keys.KeyStoreTLSCAFile,
 								},
 							},
+						},
+						{
+							Name:  common.UploadImageSize,
+							Value: requestImageSize,
 						},
 					},
 					Args: []string{"-v=" + verbose},

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1587,6 +1587,7 @@ func getPvcKey(pvc *corev1.PersistentVolumeClaim, t *testing.T) string {
 func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 	name := "cdi-upload-" + pvc.Name
 	secretName := name + "-server-tls"
+	requestImageSize, _ := getRequestedImageSize(pvc)
 
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -1657,6 +1658,10 @@ func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 									Key: keys.KeyStoreTLSCAFile,
 								},
 							},
+						},
+						{
+							Name:  common.UploadImageSize,
+							Value: requestImageSize,
 						},
 					},
 					Args: []string{"-v=" + "5"},

--- a/pkg/importer/dataStream.go
+++ b/pkg/importer/dataStream.go
@@ -454,8 +454,8 @@ func CopyData(dso *DataStreamOptions) error {
 }
 
 // SaveStream reads from a stream and saves data to dest
-func SaveStream(stream io.ReadCloser, dest string, diskImageFileName, dataPath, scratchPath string) (int64, error) {
-	klog.V(1).Infof("Saving stream to %q...\n", dest)
+func SaveStream(stream io.ReadCloser, dest string, diskImageFileName, dataPath, scratchPath, imageSize string) (int64, error) {
+	klog.V(1).Infof("Saving stream to %q, size %s...\n", dest, imageSize)
 	ds, err := newDataStream(&DataStreamOptions{
 		Dest:           diskImageFileName,
 		DataDir:        dataPath,
@@ -464,7 +464,7 @@ func SaveStream(stream io.ReadCloser, dest string, diskImageFileName, dataPath, 
 		SecKey:         "",
 		Source:         controller.SourceHTTP,
 		ContentType:    string(cdiv1.DataVolumeKubeVirt),
-		ImageSize:      "", // Blank means don't resize
+		ImageSize:      imageSize,
 		AvailableSpace: util.GetAvailableSpace(dataPath),
 		CertDir:        "",
 		InsecureTLS:    false,
@@ -482,8 +482,8 @@ func SaveStream(stream io.ReadCloser, dest string, diskImageFileName, dataPath, 
 }
 
 // DefaultSaveStream reads from a stream and saves data to dest using the default disk image/data/scratch paths
-func DefaultSaveStream(stream io.ReadCloser, dest string) (int64, error) {
-	return SaveStream(stream, dest, common.ImporterWritePath, common.ImporterVolumePath, common.ScratchDataDir)
+func DefaultSaveStream(stream io.ReadCloser, dest, imageSize string) (int64, error) {
+	return SaveStream(stream, dest, common.ImporterWritePath, common.ImporterVolumePath, common.ScratchDataDir, imageSize)
 }
 
 // ResizeImage resizes the images to match the requested size. Sometimes provisioners misbehave and the available space

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -284,7 +284,7 @@ var _ = Describe("SaveStream", func() {
 			rdr, err := os.Open(cirrosFilePath)
 			Expect(err).NotTo(HaveOccurred())
 			defer rdr.Close()
-			_, err = SaveStream(rdr, "testqcow2file", filepath.Join(dataDir, "disk.img"), dataDir, tmpDir)
+			_, err = SaveStream(rdr, "testqcow2file", filepath.Join(dataDir, "disk.img"), dataDir, tmpDir, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -58,6 +58,7 @@ type uploadServerApp struct {
 	clientCert  string
 	keyFile     string
 	certFile    string
+	imageSize   string
 	mux         *http.ServeMux
 	uploading   bool
 	done        bool
@@ -74,7 +75,7 @@ func GetUploadServerURL(namespace, pvc string) string {
 }
 
 // NewUploadServer returns a new instance of uploadServerApp
-func NewUploadServer(bindAddress string, bindPort int, destination, tlsKey, tlsCert, clientCert string) UploadServer {
+func NewUploadServer(bindAddress string, bindPort int, destination, tlsKey, tlsCert, clientCert, imageSize string) UploadServer {
 	server := &uploadServerApp{
 		bindAddress: bindAddress,
 		bindPort:    bindPort,
@@ -82,6 +83,7 @@ func NewUploadServer(bindAddress string, bindPort int, destination, tlsKey, tlsC
 		tlsKey:      tlsKey,
 		tlsCert:     tlsCert,
 		clientCert:  clientCert,
+		imageSize:   imageSize,
 		mux:         http.NewServeMux(),
 		uploading:   false,
 		done:        false,
@@ -231,7 +233,7 @@ func (app *uploadServerApp) uploadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	sz, err := saveStremFunc(r.Body, app.destination)
+	sz, err := saveStremFunc(r.Body, app.destination, app.imageSize)
 
 	app.mutex.Lock()
 	defer app.mutex.Unlock()

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newServer() *uploadServerApp {
-	server := NewUploadServer("127.0.0.1", 0, "disk.img", "", "", "")
+	server := NewUploadServer("127.0.0.1", 0, "disk.img", "", "", "", "")
 	return server.(*uploadServerApp)
 }
 
@@ -59,7 +59,7 @@ func newTLSServer(t *testing.T) (*uploadServerApp, *triple.KeyPair, *x509.Certif
 	tlsCert := string(cert.EncodeCertPEM(serverKeyPair.Cert))
 	clientCert := string(cert.EncodeCertPEM(clientCA.Cert))
 
-	server := NewUploadServer("127.0.0.1", 0, "disk.img", tlsKey, tlsCert, clientCert).(*uploadServerApp)
+	server := NewUploadServer("127.0.0.1", 0, "disk.img", tlsKey, tlsCert, clientCert, "").(*uploadServerApp)
 
 	clientKeyPair, err := triple.NewClientKeyPair(clientCA, "client", []string{})
 	if err != nil {
@@ -98,11 +98,11 @@ func newRequest(t *testing.T) *http.Request {
 	return req
 }
 
-func saveStreamSuccess(stream io.ReadCloser, dest string) (int64, error) {
+func saveStreamSuccess(stream io.ReadCloser, dest, imageSize string) (int64, error) {
 	return 1024, nil
 }
 
-func saveStreamFailure(stream io.ReadCloser, dest string) (int64, error) {
+func saveStreamFailure(stream io.ReadCloser, dest, imageSize string) (int64, error) {
 	return 0, fmt.Errorf("Error using datastream")
 }
 
@@ -114,7 +114,7 @@ func withSaveStreamFailure(f func()) {
 	replaceStreamFunc(saveStreamFailure, f)
 }
 
-func replaceStreamFunc(replacement func(io.ReadCloser, string) (int64, error), f func()) {
+func replaceStreamFunc(replacement func(io.ReadCloser, string, string) (int64, error), f func()) {
 	origStreamFunc := saveStremFunc
 	saveStremFunc = replacement
 	defer func() {

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -87,3 +87,16 @@ func (f *Framework) VerifyTargetPVCContentMD5(namespace *k8sv1.Namespace, pvc *k
 	}
 	return strings.Compare(expectedHash, output[:32]) == 0, nil
 }
+
+// RunCommandAndCaptureOutput runs a command on a pod that has the passed in PVC mounted and captures the output.
+func (f *Framework) RunCommandAndCaptureOutput(pvc *k8sv1.PersistentVolumeClaim, cmd string) (string, error) {
+	executorPod, err := f.CreateExecutorPodWithPVC("execute-command", pvc)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	err = f.WaitTimeoutForPodReady(executorPod.Name, utils.PodWaitForTime)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	output, err := f.ExecShellInPod(executorPod.Name, f.Namespace.Name, cmd)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -113,6 +113,9 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
+			fileSize, err := f.RunCommandAndCaptureOutput(pvc, "stat -c \"%s\" /pvc/disk.img")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fileSize).To(Equal("1073741824")) // 1G
 		}
 	},
 		table.Entry("[test_id:1368]succeed given a valid token", true, http.StatusOK),
@@ -137,7 +140,7 @@ func startUploadProxyPortForward(f *framework.Framework) (string, *exec.Cmd, err
 func uploadImage(portForwardURL, token string, expectedStatus int) error {
 	url := portForwardURL + "/v1alpha1/upload"
 
-	f, err := os.Open("./images/tinyCore.iso")
+	f, err := os.Open("./images/cirros-qcow2.img")
 	if err != nil {
 		return err
 	}

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// UploadFileMD5 is the expected MD5 of the uploaded file
-	UploadFileMD5 = "2a7a52285c846314d1dbd79e9818270d"
+	UploadFileMD5 = "bf07a12664935c64c472e907e5cbce7e"
 
 	uploadTargetAnnotation = "cdi.kubevirt.io/storage.upload.target"
 	uploadStatusAnnotation = "cdi.kubevirt.io/storage.pod.phase"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR allows uploaded images to be resized to the PVC request size like with an import.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #698 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Uploaded images are now resized like import.
```

