### PR TITLE
Use CDIConfig for scratch storage class.

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -140,7 +140,9 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 		pvcInformer,
 		dataVolumeInformer)
 
-	importController := controller.NewImportController(client,
+	importController := controller.NewImportController(
+		client,
+		cdiClient,
 		pvcInformer,
 		podInformer,
 		importerImage,
@@ -154,7 +156,9 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 		pullPolicy,
 		verbose)
 
-	uploadController := controller.NewUploadController(client,
+	uploadController := controller.NewUploadController(
+		client,
+		cdiClient,
 		pvcInformer,
 		podInformer,
 		serviceInformer,

--- a/doc/cdi-config.md
+++ b/doc/cdi-config.md
@@ -9,11 +9,12 @@ Currently it is used only for holding Upload Proxy URL details.
 
 | Name                    | Default value         |                                                     |
 |-------------------------|-----------------------|-----------------------------------------------------|
-| uploadProxyURLOverride  |    nil                | a user defined URL for Upload Proxy service.         |
+| uploadProxyURLOverride  | nil                   | A user defined URL for Upload Proxy service.        |
+| scratchSpaceStorageClass| nil                   | The storage class used to create scratch space      |
 
 ## Configuration Status Fields
 
 | Name                    | Default value         |                                                     |
 |-------------------------|-----------------------|-----------------------------------------------------|
-| uploadProxyURL          |      nil              | updated when a new Ingress or Route (Openshift) is created. If `uploadProxyURLOverride` is set, Ingress/Route URL will be ignored and `uploadProxyURL` will be updated with the user defined URL. |
+| uploadProxyURL          | nil                   | updated when a new Ingress or Route (Openshift) is created. If `uploadProxyURLOverride` is set, Ingress/Route URL will be ignored and `uploadProxyURL` will be updated with the user defined URL. |
 

--- a/doc/scratch-space.md
+++ b/doc/scratch-space.md
@@ -1,0 +1,20 @@
+# CDI Scratch space
+Containerized Data Importer(CDI) requires scratch space for certain operations to complete, this temporary space needs to be obtained from somewhere. Kubernetes has some options available to get temporary space like emptyDir volumes, however that space is shared among pods and it is uncertain how much space is available or what the node behavior will be if CDI fills up that space with a large image. For this and other reasons CDI will create scratch space from available PVs using a storage class. This scratch space will then be used to process the data before writing it to the target PVC.
+
+CDI uses the following mechanism to determine which storage class to use:
+
+1. Read the CDI config field _scratchSpaceStorageClass_ if that field exists, and the value matches one of the storage classes in the cluster, it will be used to create scratch space.
+2. If 1 is empty or didn't match a storage class, look up the _default_ storage class in the cluster, if that exists use that storage class.
+3. If there is no default storage class in the cluster, then use the storage class of the PersistentVolumeClaim(PVC) that is backing the DataVolume(DV) that started the CDI operation.
+
+If none of those exist, then CDI will be unable to create scratch space. This means that none of the operations that require scratch space will work, however operations that do not require scratch space will continue to operate normally.
+
+Operations that require scratch space are:
+
+| Type | Reason|
+|------|-------|
+| Registry imports | In order to import from registry container images, CDI has to first download the image to a scratch space, extract the layers to find the image file, and then pass that image file to QEMU-IMG for conversion to a raw disk |
+| Upload image | Because QEMU-IMG does not accept inputs from stdin yet, we cannot stream the upload directly to QEMU-IMG, so we have to save the upload to a scratch space first and then pass it to QEMU-IMG for conversion |
+| Http imports of archived images | QEMU-IMG does not know how to handle the archive formats CDI supports, so we can't have QEMU-IMG collect the data directly, so we save the image after running it through an unarchive process before passing it to QEMU-IMG |
+| Http imports of authenticated images | CDI currently supports basic authentication of images, it doesn't pass the authentication to QEMU-IMG so we save the file to a scratch space before passing the file to QEMU-IMG |
+| Http imports of custom certificates | QEMU-IMG doesn't handle custom certificates of https endpoints well, so CDI downloads the image to a scratch space first before passing the file to QEMU-IMG |

--- a/pkg/apis/core/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/core/v1alpha1/deepcopy_generated.go
@@ -140,6 +140,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ScratchSpaceStorageClass != nil {
+		in, out := &in.ScratchSpaceStorageClass, &out.ScratchSpaceStorageClass
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -248,6 +248,12 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigSpec(ref common.ReferenceCallback) c
 							Format: "",
 						},
 					},
+					"scratchSpaceStorageClass": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -262,6 +268,12 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigStatus(ref common.ReferenceCallback)
 				Description: "CDIConfigStatus provides",
 				Properties: map[string]spec.Schema{
 					"uploadProxyURL": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"scratchSpaceStorageClass": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -256,12 +256,14 @@ type CDIConfig struct {
 
 //CDIConfigSpec defines specification for user configuration
 type CDIConfigSpec struct {
-	UploadProxyURLOverride *string `json:"uploadProxyURLOverride,omitempty"`
+	UploadProxyURLOverride   *string `json:"uploadProxyURLOverride,omitempty"`
+	ScratchSpaceStorageClass *string `json:"scratchSpaceStorageClass,omitempty"`
 }
 
 //CDIConfigStatus provides
 type CDIConfigStatus struct {
-	UploadProxyURL *string `json:"uploadProxyURL,omitempty"`
+	UploadProxyURL           *string `json:"uploadProxyURL,omitempty"`
+	ScratchSpaceStorageClass string  `json:"scratchSpaceStorageClass,omitempty"`
 }
 
 //CDIConfigList provides the needed parameters to do request a list of CDIConfigs from the system


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow admins to specify which storage class to use for scratch space using the CDIConfig object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Scratch storage class can be specified using the CDIConfig CRD
```

