### PR TITLE
Add type metadata to cdi-insecure registries ConfigMap

### DIFF
--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -131,6 +131,10 @@ func createPrometheusService() *corev1.Service {
 
 func createInsecureRegConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   common.InsecureRegistryConfigMap,
 			Labels: withCommonLabels(nil),


### PR DESCRIPTION
Without TypeMeta, controller manifest generated by manifest-generator
lacks Kind attribute for the ConfigMap, which makes `oc` fail as
follows:

error validating "cdi-controller.yaml": error validating data:
[apiVersion not set, kind not set]; if you choose to ignore these
errors, turn validation off with --validate=false

```release-note
NONE
```