### PR TITLE
Fix wrong value being passed to validation.

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -76,23 +76,23 @@ func main() {
 
 	klog.V(1).Infoln("begin import process")
 	dso := &importer.DataStreamOptions{
-		Dest:           dest,
-		DataDir:        dataDir,
-		Endpoint:       ep,
-		AccessKey:      acc,
-		SecKey:         sec,
-		Source:         source,
-		ContentType:    contentType,
-		ImageSize:      imageSize,
-		AvailableSpace: util.GetAvailableSpace(common.ImporterVolumePath),
-		CertDir:        certDir,
-		InsecureTLS:    insecureTLS,
-		ScratchDataDir: common.ScratchDataDir,
+		Dest:               dest,
+		DataDir:            dataDir,
+		Endpoint:           ep,
+		AccessKey:          acc,
+		SecKey:             sec,
+		Source:             source,
+		ContentType:        contentType,
+		ImageSize:          imageSize,
+		AvailableDestSpace: util.GetAvailableSpace(common.ImporterVolumePath),
+		CertDir:            certDir,
+		InsecureTLS:        insecureTLS,
+		ScratchDataDir:     common.ScratchDataDir,
 	}
 
 	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {
 		requestImageSizeQuantity := resource.MustParse(imageSize)
-		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(dso.AvailableSpace, 0), &requestImageSizeQuantity)
+		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(dso.AvailableDestSpace, 0), &requestImageSizeQuantity)
 		if minSizeQuantity.Cmp(requestImageSizeQuantity) != 0 {
 			// Available dest space is smaller than the size we want to create
 			klog.Warningf("Available space less than requested size, creating blank image sized to available space: %s.\n", minSizeQuantity.String())

--- a/pkg/importer/dataStream_test.go
+++ b/pkg/importer/dataStream_test.go
@@ -117,18 +117,18 @@ var _ = Describe("Data Stream", func() {
 		}
 		By(fmt.Sprintf("Creating new datastream for %s", image))
 		ds, err := NewDataStream(&DataStreamOptions{
-			Dest:           dest,
-			DataDir:        "",
-			Endpoint:       image,
-			AccessKey:      accessKeyID,
-			SecKey:         secretKey,
-			Source:         controller.SourceHTTP,
-			ContentType:    contentType,
-			ImageSize:      "",
-			AvailableSpace: int64(1234567890),
-			CertDir:        "",
-			InsecureTLS:    false,
-			ScratchDataDir: "",
+			Dest:               dest,
+			DataDir:            "",
+			Endpoint:           image,
+			AccessKey:          accessKeyID,
+			SecKey:             secretKey,
+			Source:             controller.SourceHTTP,
+			ContentType:        contentType,
+			ImageSize:          "",
+			AvailableDestSpace: int64(1234567890),
+			CertDir:            "",
+			InsecureTLS:        false,
+			ScratchDataDir:     "",
 		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
@@ -158,18 +158,18 @@ var _ = Describe("Data Stream", func() {
 	It("can close all readers", func() {
 		By(fmt.Sprintf("Creating new datastream for %s", ts.URL+"/"+tinyCoreFileName))
 		ds, err := NewDataStream(&DataStreamOptions{
-			Dest:           common.ImporterWritePath,
-			DataDir:        "",
-			Endpoint:       ts.URL + "/" + tinyCoreFileName,
-			AccessKey:      "",
-			SecKey:         "",
-			Source:         controller.SourceHTTP,
-			ContentType:    string(cdiv1.DataVolumeKubeVirt),
-			ImageSize:      "1G",
-			AvailableSpace: int64(1234567890),
-			CertDir:        "",
-			InsecureTLS:    false,
-			ScratchDataDir: "",
+			Dest:               common.ImporterWritePath,
+			DataDir:            "",
+			Endpoint:           ts.URL + "/" + tinyCoreFileName,
+			AccessKey:          "",
+			SecKey:             "",
+			Source:             controller.SourceHTTP,
+			ContentType:        string(cdiv1.DataVolumeKubeVirt),
+			ImageSize:          "1G",
+			AvailableDestSpace: int64(1234567890),
+			CertDir:            "",
+			InsecureTLS:        false,
+			ScratchDataDir:     "",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		By("Closing data stream")
@@ -183,18 +183,18 @@ var _ = Describe("Data Stream", func() {
 		}
 		By(fmt.Sprintf("Creating new datastream for %s", ep+"/"+image))
 		ds, err := NewDataStream(&DataStreamOptions{
-			Dest:           common.ImporterWritePath,
-			DataDir:        "",
-			Endpoint:       ep + "/" + image,
-			AccessKey:      "",
-			SecKey:         "",
-			Source:         controller.SourceHTTP,
-			ContentType:    string(cdiv1.DataVolumeKubeVirt),
-			ImageSize:      "20M",
-			AvailableSpace: int64(1234567890),
-			CertDir:        "",
-			InsecureTLS:    false,
-			ScratchDataDir: "",
+			Dest:               common.ImporterWritePath,
+			DataDir:            "",
+			Endpoint:           ep + "/" + image,
+			AccessKey:          "",
+			SecKey:             "",
+			Source:             controller.SourceHTTP,
+			ContentType:        string(cdiv1.DataVolumeKubeVirt),
+			ImageSize:          "20M",
+			AvailableDestSpace: int64(1234567890),
+			CertDir:            "",
+			InsecureTLS:        false,
+			ScratchDataDir:     "",
 		})
 		if ds != nil && len(ds.Readers) > 0 {
 			defer ds.Close()
@@ -221,18 +221,18 @@ var _ = Describe("Data Stream", func() {
 		}
 		By(fmt.Sprintf("Creating new datastream to %s", tempTestServer.URL+"/"+filepath.Base(filename)))
 		ds, err := NewDataStream(&DataStreamOptions{
-			Dest:           dest,
-			DataDir:        "",
-			Endpoint:       tempTestServer.URL + "/" + filepath.Base(filename),
-			AccessKey:      "",
-			SecKey:         "",
-			Source:         controller.SourceHTTP,
-			ContentType:    contentType,
-			ImageSize:      "20M",
-			AvailableSpace: int64(1234567890),
-			CertDir:        "",
-			InsecureTLS:    false,
-			ScratchDataDir: "",
+			Dest:               dest,
+			DataDir:            "",
+			Endpoint:           tempTestServer.URL + "/" + filepath.Base(filename),
+			AccessKey:          "",
+			SecKey:             "",
+			Source:             controller.SourceHTTP,
+			ContentType:        contentType,
+			ImageSize:          "20M",
+			AvailableDestSpace: int64(1234567890),
+			CertDir:            "",
+			InsecureTLS:        false,
+			ScratchDataDir:     "",
 		})
 		defer func() {
 			tempTestServer.Close()
@@ -321,18 +321,18 @@ var _ = Describe("Copy", func() {
 		replaceQEMUOperations(qemuOperations, func() {
 			By("Copying image")
 			err := CopyData(&DataStreamOptions{
-				Dest:           dest,
-				DataDir:        dataDir,
-				Endpoint:       endpt,
-				AccessKey:      "",
-				SecKey:         "",
-				Source:         controller.SourceHTTP,
-				ContentType:    string(cdiv1.DataVolumeKubeVirt),
-				ImageSize:      "",
-				AvailableSpace: int64(1234567890),
-				CertDir:        "",
-				InsecureTLS:    false,
-				ScratchDataDir: tmpDir,
+				Dest:               dest,
+				DataDir:            dataDir,
+				Endpoint:           endpt,
+				AccessKey:          "",
+				SecKey:             "",
+				Source:             controller.SourceHTTP,
+				ContentType:        string(cdiv1.DataVolumeKubeVirt),
+				ImageSize:          "",
+				AvailableDestSpace: int64(1234567890),
+				CertDir:            "",
+				InsecureTLS:        false,
+				ScratchDataDir:     tmpDir,
 			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())
@@ -372,18 +372,18 @@ var _ = Describe("Copy", func() {
 		replaceQEMUOperations(qemuOperations, func() {
 			By(fmt.Sprintf("Importing %q to %q", tempTestServer.URL, testTarget))
 			err = CopyData(&DataStreamOptions{
-				Dest:           testTarget,
-				DataDir:        "",
-				Endpoint:       tempTestServer.URL + "/" + testBase,
-				AccessKey:      "",
-				SecKey:         "",
-				Source:         controller.SourceHTTP,
-				ContentType:    string(cdiv1.DataVolumeKubeVirt),
-				ImageSize:      "1G",
-				AvailableSpace: int64(1234567890),
-				CertDir:        "",
-				InsecureTLS:    false,
-				ScratchDataDir: "",
+				Dest:               testTarget,
+				DataDir:            "",
+				Endpoint:           tempTestServer.URL + "/" + testBase,
+				AccessKey:          "",
+				SecKey:             "",
+				Source:             controller.SourceHTTP,
+				ContentType:        string(cdiv1.DataVolumeKubeVirt),
+				ImageSize:          "1G",
+				AvailableDestSpace: int64(1234567890),
+				CertDir:            "",
+				InsecureTLS:        false,
+				ScratchDataDir:     "",
 			})
 			if wantErr {
 				Expect(err).To(HaveOccurred())

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -55,18 +55,18 @@ var _ = Describe("Copy from Registry", func() {
 		replaceSkopeoOperations(skopeoOperations, func() {
 			By("Copying image")
 			err := CopyData(&DataStreamOptions{
-				Dest:           destImage,
-				DataDir:        dataDir,
-				Endpoint:       url,
-				AccessKey:      "",
-				SecKey:         "",
-				Source:         controller.SourceRegistry,
-				ContentType:    string(cdiv1.DataVolumeKubeVirt),
-				ImageSize:      "1G",
-				AvailableSpace: int64(1234567890),
-				CertDir:        "",
-				InsecureTLS:    false,
-				ScratchDataDir: tmpDir,
+				Dest:               destImage,
+				DataDir:            dataDir,
+				Endpoint:           url,
+				AccessKey:          "",
+				SecKey:             "",
+				Source:             controller.SourceRegistry,
+				ContentType:        string(cdiv1.DataVolumeKubeVirt),
+				ImageSize:          "1G",
+				AvailableDestSpace: int64(1234567890),
+				CertDir:            "",
+				InsecureTLS:        false,
+				ScratchDataDir:     tmpDir,
 			})
 			if !wantErr {
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes an issue where validating how much space was available the wrong value was being passed to the validation, and thus it would fail in several instances. In particular it would fail for upload validation checking.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

