### PR TITLE
import/upload tests should not look for pods if they may not exist

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -105,12 +105,9 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify the pod status is succeeded on the target PVC")
-		Eventually(func() string {
-			status, phaseAnnotation, err := utils.WaitForPVCAnnotation(f.K8sClient, f.Namespace.Name, pvc, controller.AnnPodPhase)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(phaseAnnotation).To(BeTrue())
-			return status
-		}, CompletionTimeout, assertionPollInterval).Should(BeEquivalentTo(v1.PodSucceeded))
+		found, err := utils.WaitPVCPodStatusSucceeded(f.K8sClient, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
 
 		By("Verify the image contents")
 		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, BlankImageMD5, false)

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -81,7 +81,7 @@ func WaitForPVCAnnotation(clientSet *kubernetes.Clientset, namespace string, pvc
 	return result, called, err
 }
 
-// WaitForPVCAnnotationWithValue waits  for an annotation with a specific value on a PVC
+// WaitForPVCAnnotationWithValue waits for an annotation with a specific value on a PVC
 func WaitForPVCAnnotationWithValue(clientSet *kubernetes.Clientset, namespace string, pvc *k8sv1.PersistentVolumeClaim, annotation, expected string) (bool, error) {
 	var result bool
 	err := pollPVCAnnotation(clientSet, namespace, pvc, annotation, func(value string) bool {
@@ -89,6 +89,21 @@ func WaitForPVCAnnotationWithValue(clientSet *kubernetes.Clientset, namespace st
 		return result
 	})
 	return result, err
+}
+
+// WaitPVCPodStatusRunning waits for the pod status annotation to be Running
+func WaitPVCPodStatusRunning(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
+	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadStatusAnnotation, string(k8sv1.PodRunning))
+}
+
+// WaitPVCPodStatusSucceeded waits for the pod status annotation to be Succeeded
+func WaitPVCPodStatusSucceeded(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
+	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadStatusAnnotation, string(k8sv1.PodSucceeded))
+}
+
+// WaitPVCPodStatusFailed waits for the pod status annotation to be Failed
+func WaitPVCPodStatusFailed(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
+	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadStatusAnnotation, string(k8sv1.PodFailed))
 }
 
 type pollPVCAnnotationFunc = func(string) bool

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -3,7 +3,6 @@ package utils
 import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	cdiuploadv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/upload/v1alpha1"
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
@@ -26,11 +25,6 @@ func UploadPodName(pvc *k8sv1.PersistentVolumeClaim) string {
 func UploadPVCDefinition() *k8sv1.PersistentVolumeClaim {
 	annotations := map[string]string{uploadTargetAnnotation: ""}
 	return NewPVCDefinition("upload-test", "1G", annotations, nil)
-}
-
-// WaitPVCUploadPodStatusRunning waits for the upload server pod status annotation to be Running
-func WaitPVCUploadPodStatusRunning(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
-	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadStatusAnnotation, string(k8sv1.PodRunning))
 }
 
 // RequestUploadToken sends an upload token request to the server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Import/upload controllers delete their pods when they complete successfully, therefore the unit tests should not always expect them to be there.  They should only be there for tests that expect failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

