### PR TITLE
dump logs when functional tests fail

### DIFF
--- a/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
+++ b/hack/build/docker/cdi-func-test-file-host-http/nginx.conf
@@ -3,12 +3,16 @@ daemon off;
 
 events { worker_connections 1024; }
 
+error_log stderr error;
+
 http {
     types_hash_max_size 4096;
 
     include    /etc/nginx/mime.types;
 
     sendfile on;
+
+    access_log /dev/stdout;
 
     # no auth
     server {

--- a/manifests/templates/cdi-operator.yaml.in
+++ b/manifests/templates/cdi-operator.yaml.in
@@ -52,6 +52,7 @@ spec:
     metadata:
       labels:
         name: cdi-operator
+        operator.cdi.kubevirt.io: ""
     spec:
       serviceAccountName: cdi-operator
       containers:

--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -5,16 +5,16 @@ metadata:
   name: cdi-file-host
   namespace: {{ .Namespace }}
   labels:
-    cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing: ""
 spec:
   selector:
     matchLabels:
-      cdi.kubevirt.io/testing: ""
+      name: cdi-file-host
   replicas: 1
   template:
     metadata:
       labels:
+        name: cdi-file-host
         cdi.kubevirt.io/testing: ""
     spec:
       securityContext:
@@ -89,11 +89,10 @@ metadata:
   name: cdi-file-host
   namespace: {{ .Namespace }}
   labels:
-    cdi.kubevirt.io: ""
     cdi.kubevirt.io/testing: ""
 spec:
   selector:
-      cdi.kubevirt.io/testing: ""
+      name: cdi-file-host
   type: NodePort
   ports:
   - name: rate-limit

--- a/manifests/templates/registry-host.yaml.in
+++ b/manifests/templates/registry-host.yaml.in
@@ -4,17 +4,17 @@ metadata:
   name: cdi-docker-registry-host
   namespace: {{ .Namespace }}
   labels:
-    cdi.kubevirt.io: ""
-    cdi.kubevirt.io/testing.registry: ""
+    cdi.kubevirt.io/testing: ""
 spec:
   selector:
     matchLabels:
-      cdi.kubevirt.io/testing.registry: ""
+      name: cdi-docker-registry-host
   replicas: 1
   template:
     metadata:
       labels:
-        cdi.kubevirt.io/testing.registry: ""
+        name: cdi-docker-registry-host
+        cdi.kubevirt.io/testing: ""
     spec:
       securityContext:
         runAsUser: 0
@@ -82,11 +82,10 @@ metadata:
   name: cdi-docker-registry-host
   namespace: {{ .Namespace }}
   labels:
-    cdi.kubevirt.io: ""
-    cdi.kubevirt.io/testing.registry: ""
+    cdi.kubevirt.io/testing: ""
 spec:
   selector:
-    cdi.kubevirt.io/testing.registry: ""
+    name: cdi-docker-registry-host
   ports:
   - name: sec-docker-reg
     port: 443

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -3,11 +3,14 @@ package framework
 import (
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
+
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -219,6 +223,11 @@ func (f *Framework) AfterEach() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	}()
+
+	if ginkgo.CurrentGinkgoTestDescription().Failed {
+		f.dumpLogs()
+	}
+
 	return
 }
 
@@ -337,4 +346,61 @@ func (f *Framework) CreatePrometheusServiceInNs(namespace string) (*v1.Service, 
 		},
 	}
 	return f.K8sClient.CoreV1().Services(namespace).Create(service)
+}
+
+func (f *Framework) dumpLogs() {
+	namespaces := []string{f.CdiInstallNs}
+
+	for _, nsp := range []*v1.Namespace{f.Namespace, f.Namespace2} {
+		if nsp != nil {
+			ns := *nsp
+			namespaces = append(namespaces, ns.Name)
+		}
+	}
+
+	for _, ns := range namespaces {
+		var allPods []v1.Pod
+
+		for _, label := range []string{"cdi.kubevirt.io", "operator.cdi.kubevirt.io", "cdi.kubevirt.io/testing"} {
+			podList, err := f.K8sClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: label})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error %+v getting pods in ns: %s, with label %s\n", err, ns, label)
+				continue
+			}
+
+			allPods = append(allPods, podList.Items...)
+		}
+
+		for _, pod := range allPods {
+			fmt.Printf("\n Dumping data for %s/%s\n", pod.Namespace, pod.Name)
+
+			data, err := yaml.Marshal(pod)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error %+v dumping %s/%s to yaml\n", err, pod.Namespace, pod.Name)
+				continue
+			}
+
+			fmt.Printf("\n%s\n", string(data))
+
+			for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+				logOpts := &v1.PodLogOptions{
+					Container: c.Name,
+				}
+
+				// get all logs from "worker" pods, less from infra
+				if pod.Namespace == f.CdiInstallNs {
+					logLines := int64(64)
+					logOpts.TailLines = &logLines
+				}
+
+				log, err := f.K8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOpts).DoRaw()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error %+v dumping logs for %s/%s.%s\n", err, pod.Namespace, pod.Name, c.Name)
+					continue
+				}
+
+				fmt.Printf("\nLogs for container %s\n%s\n", c.Name, string(log))
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Looks like all the registry related functional tests have been failing for awhile.  Maybe this long overdue change will help us figure out what's going on.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

