### PR TITLE
bug fix: func test - registry buildah failure on outdated /etc/contai…

### DIFF
--- a/hack/build/docker/cdi-func-test-registry-populate/populate-registry.sh
+++ b/hack/build/docker/cdi-func-test-registry-populate/populate-registry.sh
@@ -110,6 +110,8 @@ function pushImages {
    done
 }
 
+#remove storage.conf if exists 
+rm -rf /etc/containers/storage.conf
 
 #start health beat
 health $HEALTH_PATH $HEALTH_PERIOD &


### PR DESCRIPTION
…ners/storage.conf

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
in func-test-registry-host pod, registry-populate container was failing to build and push images.
it utilizes buildah tool for that purpose.  The error was 
```bash
 'overlay' is not supported over xfs at "/var/lib/containers/storage/overlay" 
kernel does not support overlay fs: 'overlay' is not supported over xfs at "/var/lib/containers/storage/overlay": backing file system is unsupported for this graph driver
```

Solution:
The /etc/container/storage.conf file is outdated
removing it solves the issue for buildah tool

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

