### PR TITLE
Add a --version flag to cdi-apiserver

### DIFF
--- a/cmd/cdi-apiserver/apiserver.go
+++ b/cmd/cdi-apiserver/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/klog"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"kubevirt.io/containerized-data-importer/pkg/apiserver"
+	"kubevirt.io/containerized-data-importer/pkg/version/verflag"
 )
 
 const (
@@ -58,6 +59,8 @@ func init() {
 
 func main() {
 	defer klog.Flush()
+
+	verflag.PrintAndExitIfRequested()
 
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, configPath)
 	if err != nil {

--- a/hack/build/build-go.sh
+++ b/hack/build/build-go.sh
@@ -19,6 +19,7 @@ set -eo pipefail
 script_dir="$(readlink -f $(dirname $0))"
 source "${script_dir}"/common.sh
 source "${script_dir}"/config.sh
+source "${script_dir}"/version.sh
 
 mkdir -p ${BIN_DIR}
 mkdir -p ${CMD_OUT_DIR}
@@ -57,7 +58,7 @@ elif [ "${go_opt}" == "build" ]; then
             cd $tgt
 
             # Only build executables for linux amd64
-            GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"'
+            GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"' -ldflags "$(cdi::version::ldflags)"
 
             ln -sf ${outFile} ${outLink}
         )

--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -13,6 +13,7 @@
 #limitations under the License.
 
 CDI_DIR="$(readlink -f $(dirname $0)/../../)"
+CDI_GO_PACKAGE=kubevirt.io/containerized-data-importer
 BIN_DIR=${CDI_DIR}/bin
 OUT_DIR=${CDI_DIR}/_out
 CMD_OUT_DIR=${OUT_DIR}/cmd

--- a/hack/build/version.sh
+++ b/hack/build/version.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Used https://github.com/kubernetes/kubernetes/blob/master/hack/lib/version.sh as a template
+
+# -----------------------------------------------------------------------------
+# Version management helpers.  These functions help to set, save and load the
+# following variables:
+#
+#    CDI_GIT_COMMIT - The git commit id corresponding to this
+#          source code.
+#    CDI_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#        "dirty" indicates source code changes after the git commit id
+#        "archive" indicates the tree was produced by 'git archive'
+#    CDI_GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    CDI_SOURCE_DATE_EPOCH - unix timestamp.  Set to ' ' to generate using
+#          'date' instead of 'git'.
+#
+
+# Grovels through git to set a set of env variables.
+
+function cdi::version::get_version_vars() {
+    # If the cdi source was exported through git archive, then
+    # we likely don't have a git tree, but these magic values may be filled in.
+    if [[ '$Format:%%$' == "%" ]]; then
+        CDI_GIT_COMMIT='$Format:%H$'
+        CDI_GIT_TREE_STATE="archive"
+        # When a 'git archive' is exported, the '$Format:%D$' below will look
+        # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
+        # can be extracted from it.
+        if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
+            CDI_GIT_VERSION="${BASH_REMATCH[1]}"
+        fi
+    fi
+
+    local git=(git --work-tree "${CDI_DIR}")
+
+    if [[ -n ${CDI_GIT_COMMIT-} ]] || CDI_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
+        if [[ -z ${CDI_GIT_TREE_STATE-} ]]; then
+            # Check if the tree is dirty.  default to dirty
+            if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+                CDI_GIT_TREE_STATE="clean"
+            else
+                CDI_GIT_TREE_STATE="dirty"
+            fi
+        fi
+
+        # Use git describe to find the version based on tags.
+        if [[ -n ${CDI_GIT_VERSION-} ]] || CDI_GIT_VERSION=$("${git[@]}" describe --match='v[0-9]*' --tags --abbrev=14 "${CDI_GIT_COMMIT}^{commit}" 2>/dev/null); then
+            # This translates the "git describe" to an actual semver.org
+            # compatible semantic version that looks something like this:
+            #   v1.1.0-alpha.0.6+84c76d1142ea4d
+            #
+            # TODO: We continue calling this "git version" because so many
+            # downstream consumers are expecting it there.
+            DASHES_IN_VERSION=$(echo "${CDI_GIT_VERSION}" | sed "s/[^-]//g")
+            if [[ "${DASHES_IN_VERSION}" == "---" ]]; then
+                # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+                CDI_GIT_VERSION=$(echo "${CDI_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+            elif [[ "${DASHES_IN_VERSION}" == "--" ]]; then
+                # We have distance to base tag (v1.1.0-1-gCommitHash)
+                CDI_GIT_VERSION=$(echo "${CDI_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+            fi
+            if [[ "${CDI_GIT_TREE_STATE}" == "dirty" ]]; then
+                # git describe --dirty only considers changes to existing files, but
+                # that is problematic since new untracked .go files affect the build,
+                # so use our idea of "dirty" from git status instead.
+                CDI_GIT_VERSION+="-dirty"
+            fi
+
+            # If CDI_GIT_VERSION is not a valid Semantic Version, then refuse to build.
+            if ! [[ "${CDI_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+                echo "CDI_GIT_VERSION should be a valid Semantic Version. Current value: ${CDI_GIT_VERSION}"
+                echo "Please see more details here: https://semver.org"
+                exit 1
+            fi
+        fi
+    fi
+}
+
+function cdi::version::ldflag() {
+    local key=${1}
+    local val=${2}
+
+    echo "-X '${CDI_GO_PACKAGE}/pkg/version.${key}=${val}'"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+# in order to set CDI version based on the git tree status.
+function cdi::version::ldflags() {
+    cdi::version::get_version_vars
+
+    SOURCE_DATE_EPOCH=${CDI_SOURCE_DATE_EPOCH-$(git show -s --format=format:%ct HEAD)}
+
+    local buildDate=
+    [[ -z ${SOURCE_DATE_EPOCH-} ]] || buildDate="--date=@${SOURCE_DATE_EPOCH}"
+    local -a ldflags=($(cdi::version::ldflag "buildDate" "$(date ${buildDate} -u +'%Y-%m-%dT%H:%M:%SZ')"))
+    if [[ -n ${CDI_GIT_COMMIT-} ]]; then
+        ldflags+=($(cdi::version::ldflag "gitCommit" "${CDI_GIT_COMMIT}"))
+        ldflags+=($(cdi::version::ldflag "gitTreeState" "${CDI_GIT_TREE_STATE}"))
+    fi
+
+    if [[ -n ${CDI_GIT_VERSION-} ]]; then
+        ldflags+=($(cdi::version::ldflag "gitVersion" "${CDI_GIT_VERSION}"))
+    fi
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+}

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Retrieved from https://github.com/kubevirt/kubevirt/blob/master/pkg/version/base.go
+
+package version
+
+var (
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)

--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Retrieved from https://github.com/kubevirt/kubevirt/blob/master/pkg/version/types.go
+
+package version
+
+type Info struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}

--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -18,6 +18,7 @@ limitations under the License.
 
 package version
 
+// Info contains versioning information.
 type Info struct {
 	GitVersion   string `json:"gitVersion"`
 	GitCommit    string `json:"gitCommit"`

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Used https://github.com/kubernetes/kubernetes/blob/master/pkg/version/verflag/verflag.go as a template
+
+// Package verflag defines utility functions to handle command line flags
+// related to version of Kubernetes.
+package verflag
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"kubevirt.io/containerized-data-importer/pkg/version"
+)
+
+type versionValue int
+
+const (
+	VersionFalse versionValue = 0
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// The type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+}
+
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+const versionFlagName = "version"
+
+var (
+	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+)
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", version.Get())
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("Containerized Data Importer %s\n", version.Get())
+		os.Exit(0)
+	}
+}

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Used https://github.com/kubernetes/kubernetes/blob/master/pkg/version/verflag/verflag.go as a template
 
 // Package verflag defines utility functions to handle command line flags
-// related to version of Kubernetes.
+// related to version of CDI.
 package verflag
 
 import (
@@ -31,10 +31,11 @@ import (
 
 type versionValue int
 
+// Enum specifying which format to use for printing CDI version
 const (
-	VersionFalse versionValue = 0
-	VersionTrue  versionValue = 1
-	VersionRaw   versionValue = 2
+	versionFalse versionValue = 0
+	versionTrue  versionValue = 1
+	versionRaw   versionValue = 2
 )
 
 const strRawVersion string = "raw"
@@ -49,23 +50,23 @@ func (v *versionValue) Get() interface{} {
 
 func (v *versionValue) Set(s string) error {
 	if s == strRawVersion {
-		*v = VersionRaw
+		*v = versionRaw
 		return nil
 	}
 	boolVal, err := strconv.ParseBool(s)
 	if boolVal {
-		*v = VersionTrue
+		*v = versionTrue
 	} else {
-		*v = VersionFalse
+		*v = versionFalse
 	}
 	return err
 }
 
 func (v *versionValue) String() string {
-	if *v == VersionRaw {
+	if *v == versionRaw {
 		return strRawVersion
 	}
-	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+	return fmt.Sprintf("%v", bool(*v == versionTrue))
 }
 
 // The type of the flag as required by the pflag.Value interface
@@ -73,30 +74,31 @@ func (v *versionValue) Type() string {
 	return "version"
 }
 
-func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+// versionVar defines a "version" flag
+func versionVar(p *versionValue, name string, value versionValue, usage string) {
 	*p = value
 	flag.Var(p, name, usage)
 }
 
-func Version(name string, value versionValue, usage string) *versionValue {
+func verflag(name string, value versionValue, usage string) *versionValue {
 	p := new(versionValue)
-	VersionVar(p, name, value, usage)
+	versionVar(p, name, value, usage)
 	return p
 }
 
 const versionFlagName = "version"
 
 var (
-	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	versionFlag = verflag(versionFlagName, versionFalse, "Print version information and quit")
 )
 
 // PrintAndExitIfRequested will check if the -version flag was passed
 // and, if so, print the version and exit.
 func PrintAndExitIfRequested() {
-	if *versionFlag == VersionRaw {
+	if *versionFlag == versionRaw {
 		fmt.Printf("%#v\n", version.Get())
 		os.Exit(0)
-	} else if *versionFlag == VersionTrue {
+	} else if *versionFlag == versionTrue {
 		fmt.Printf("Containerized Data Importer %s\n", version.Get())
 		os.Exit(0)
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Retrieved from https://github.com/kubevirt/kubevirt/blob/master/pkg/version/version.go
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func Get() Info {
+	return Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,6 +23,8 @@ import (
 	"runtime"
 )
 
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
 func Get() Info {
 	return Info{
 		GitVersion:   gitVersion,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds a `--version` command line flag to cdi-apiserver to help identify CDI version running in a container.

Example output:

    > kubectl --namespace=cdi exec cdi-apiserver-7dcd78644b-jztpw -- virt-cdi-apiserver --version
    Containerized Data Importer v1.6.0-86+cbadd09168e863

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #667

**Special notes for your reviewer**:

This code has been copy/pasted from KubeVirt and Kubernetes implementations.

The command line flag has been added only to cdi-apiserver command. It's just a matter of one import and one function call to add it to other cdi-* commands (e.g: cdi-operator) if needed.

The version information is not exposed as part of CDI API unlike KubeVirt or Kubernetes since I didn't really see the value of it. It can be added later if needed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cdi-apiserver now supports a `--version` flag to print version information
```

