### PR TITLE
Allow missing storage class for scratch space, if none exists, create scratch PVC without SC

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -233,10 +233,7 @@ func (ic *ImportController) createScratchPvcForPod(pvc *v1.PersistentVolumeClaim
 		return err
 	}
 	if scratchPvc == nil {
-		storageClassName, err := GetScratchPvcStorageClass(ic.clientset, ic.cdiClient, pvc)
-		if err != nil {
-			return err
-		}
+		storageClassName := GetScratchPvcStorageClass(ic.clientset, ic.cdiClient, pvc)
 		// Scratch PVC doesn't exist yet, create it. Determine which storage class to use.
 		scratchPvc, err = CreateScratchPersistentVolumeClaim(ic.clientset, pvc, pod, storageClassName)
 		if err != nil {

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -484,10 +484,8 @@ func (c *UploadController) getOrCreateScratchPvc(pvc *v1.PersistentVolumeClaim, 
 		}
 		return nil, errors.New("Scratch PVC exists, but is not owned by the right pod")
 	}
-	storageClassName, err := GetScratchPvcStorageClass(c.client, c.cdiClient, pvc)
-	if err != nil {
-		return nil, err
-	}
+	storageClassName := GetScratchPvcStorageClass(c.client, c.cdiClient, pvc)
+
 	// Scratch PVC doesn't exist yet, create it. Determine which storage class to use.
 	scratchPvc, err = CreateScratchPersistentVolumeClaim(c.client, pvc, pod, storageClassName)
 	if err != nil {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1032,11 +1032,8 @@ func Test_GetScratchPvcStorageClassDefault(t *testing.T) {
 	cdiclient := cdifake.NewSimpleClientset(cdiObjs...)
 
 	pvc := createPvc("test", "test", nil, nil)
-	result, err := GetScratchPvcStorageClass(client, cdiclient, pvc)
+	result := GetScratchPvcStorageClass(client, cdiclient, pvc)
 
-	if err != nil {
-		t.Errorf("Enexpected error %+v", err)
-	}
 	if result != storageClassName {
 		t.Error("Storage class is not test3")
 	}
@@ -1059,11 +1056,8 @@ func Test_GetScratchPvcStorageClassConfig(t *testing.T) {
 	cdiclient := cdifake.NewSimpleClientset(cdiObjs...)
 
 	pvc := createPvc("test", "test", nil, nil)
-	result, err := GetScratchPvcStorageClass(client, cdiclient, pvc)
+	result := GetScratchPvcStorageClass(client, cdiclient, pvc)
 
-	if err != nil {
-		t.Errorf("Enexpected error %+v", err)
-	}
 	if result != storageClassName {
 		t.Error("Storage class is not test1")
 	}
@@ -1079,11 +1073,8 @@ func Test_GetScratchPvcStorageClassPvc(t *testing.T) {
 	cdiclient := cdifake.NewSimpleClientset(cdiObjs...)
 
 	pvc := createPvcInStorageClass("test", "test", &storageClass, nil, nil)
-	result, err := GetScratchPvcStorageClass(client, cdiclient, pvc)
+	result := GetScratchPvcStorageClass(client, cdiclient, pvc)
 
-	if err != nil {
-		t.Errorf("Enexpected error %+v", err)
-	}
 	if result != storageClass {
 		t.Error("Storage class is not storageClass")
 	}


### PR DESCRIPTION

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow scratch space without storage class.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#726

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow scratch space without requiring storage class.
```

