### PR TITLE
Fix issue with the cdi config controller hanging in k8s

### DIFF
--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -1,0 +1,37 @@
+package tests_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+	"kubevirt.io/containerized-data-importer/tests/framework"
+)
+
+var _ = Describe("CDI config tests", func() {
+	f := framework.NewFrameworkOrDie("cdiconfig-test")
+
+	It("should have the default storage class as its scratchSpaceStorageClass", func() {
+		storageClasses, err := f.K8sClient.StorageV1().StorageClasses().List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		var expectedSc string
+		for _, sc := range storageClasses.Items {
+			if defaultClassValue, ok := sc.Annotations[controller.AnnDefaultStorageClass]; ok {
+				if defaultClassValue == "true" {
+					expectedSc = sc.Name
+					break
+				}
+			}
+		}
+		By("Expecting default storage class to be: " + expectedSc)
+		config, err := f.CdiClient.CdiV1alpha1().CDIConfigs().Get(common.ConfigName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(expectedSc).To(Equal(config.Status.ScratchSpaceStorageClass))
+	})
+
+	//TODO: Once get multiple storage classes, write a test to update the scratch space storage class to something besides the default.
+})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The cdi config controller would hang waiting for a cache sync on routes that will never happen in k8s, thus it would not update the CDIConfig object and the scratch storage class would not be correctly found.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

