### PR TITLE
Fix target pod cleanup across namespaces

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -168,20 +168,20 @@ func (cc *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 	if err != nil {
 		return errors.WithMessage(err, "could not update pvc %q annotation and/or label")
 	} else if pvc.Annotations[AnnCloneOf] == "true" {
-		cc.deleteClonePods(sourcePod.Namespace, sourcePod.Name, targetPod.Name)
+		cc.deleteClonePods(sourcePod.Namespace, sourcePod.Name, targetPod.Namespace, targetPod.Name)
 	}
 	return nil
 }
 
-func (cc *CloneController) deleteClonePods(namespace, srcName, tgtName string) {
+func (cc *CloneController) deleteClonePods(srcNamespace, srcName, tgtNamespace, tgtName string) {
 	srcReq := podDeleteRequest{
-		namespace: namespace,
+		namespace: srcNamespace,
 		podName:   srcName,
 		podLister: cc.Controller.podLister,
 		k8sClient: cc.Controller.clientset,
 	}
 	tgtReq := podDeleteRequest{
-		namespace: namespace,
+		namespace: tgtNamespace,
 		podName:   tgtName,
 		podLister: cc.Controller.podLister,
 		k8sClient: cc.Controller.clientset,

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2018 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importer
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog"
+	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+var qemuOperations = image.NewQEMUOperations()
+
+// ProcessingPhase is the current phase being processed.
+type ProcessingPhase string
+
+const (
+	// Info is the first phase, durlng this phase the provider obtains information needed to determine which phase to go to next.
+	Info ProcessingPhase = "Info"
+	// Transfer is the phase in which the data provider writes data to the scratch space.
+	Transfer ProcessingPhase = "Transfer"
+	// TransferTarget is the phase in which the data provider writes data directly to the target space without conversion.
+	TransferTarget ProcessingPhase = "TransferTarget"
+	// Process is the phase in which the data provider processes the data just written to the scratch space.
+	Process ProcessingPhase = "Process"
+	// Convert is the phase in which the data is taken from the url provided by the provider, and it is converted to the target RAW disk image format.
+	// The url can be an http end point or file system end point.
+	Convert ProcessingPhase = "Convert"
+	// Resize the disk image, this is only needed when the target contains a file system (block device do not need a resize)
+	Resize ProcessingPhase = "Resize"
+	// Complete is the phase where the entire process completed successfully and we can exit gracefully.
+	Complete ProcessingPhase = "Complete"
+	// Error is the phase in which we encountered an error and need to exit ungracefully.
+	Error ProcessingPhase = "Error"
+)
+
+// ErrRequiresScratchSpace indicates that we require scratch space.
+var ErrRequiresScratchSpace = fmt.Errorf("Scratch space required and none found")
+
+// ErrInvalidPath indicates that the path is invalid.
+var ErrInvalidPath = fmt.Errorf("Invalid transfer path")
+
+// DataSourceInterface is the interface all data providers should implement.
+type DataSourceInterface interface {
+	// Info() is called to get initial information about the data.
+	Info() (ProcessingPhase, error)
+	// Transfer() is called to transfer the data from the source to a temporary location.
+	Transfer(path string) (ProcessingPhase, error)
+	// Process() is called to do any special processing before giving the url to the data back to the processor
+	Process() (ProcessingPhase, error)
+	// Geturl returns the url that the data processor can use when converting the data.
+	GetURL() *url.URL
+	// Close closes any readers or other open resources.
+	Close() error
+}
+
+// DataProcessor holds the fields needed to process data from a data provider.
+type DataProcessor struct {
+	// currentPhase is the phase the processing is in currently.
+	currentPhase ProcessingPhase
+	// provider provides the data for processing.
+	source DataSourceInterface
+	// destination file. will be DataDir/disk.img if file system, or a block device (if a block device, then DataDir will not exist).
+	dataFile string
+	// dataDir path to target directory if it contains a file system.
+	dataDir string
+	// scratchDataDir path to the scratch space.
+	scratchDataDir string
+	// requestImageSize is the size we want the resulting image to be.
+	requestImageSize string
+	// available space is the available space before downloading the image
+	availableSpace int64
+}
+
+// NewDataProcessor create a new instance of a data processor using the passed in data provider.
+func NewDataProcessor(dataSource DataSourceInterface, dataFile, dataDir, scratchDataDir, requestImageSize string) *DataProcessor {
+	dp := &DataProcessor{
+		currentPhase:     Info,
+		source:           dataSource,
+		dataFile:         dataFile,
+		dataDir:          dataDir,
+		scratchDataDir:   scratchDataDir,
+		requestImageSize: requestImageSize,
+	}
+	// Calculate available space before doing anything.
+	dp.availableSpace = dp.calculateTargetSize()
+	return dp
+}
+
+// ProcessData is the main processing loop.
+func (dp *DataProcessor) ProcessData() error {
+	var err error
+	if util.GetAvailableSpace(dp.scratchDataDir) > int64(0) {
+		defer CleanDir(dp.scratchDataDir)
+	}
+	for dp.currentPhase != Complete {
+		switch dp.currentPhase {
+		case Info:
+			dp.currentPhase, err = dp.source.Info()
+		case Transfer:
+			dp.currentPhase, err = dp.source.Transfer(dp.scratchDataDir)
+			if err == ErrInvalidPath {
+				// Passed in invalid scratch space path, return scratch space needed error.
+				err = ErrRequiresScratchSpace
+			}
+		case TransferTarget:
+			dp.currentPhase, err = dp.source.Transfer(dp.dataDir)
+		case Process:
+			dp.currentPhase, err = dp.source.Process()
+		case Convert:
+			dp.currentPhase, err = dp.convert(dp.source.GetURL())
+		case Resize:
+			dp.currentPhase, err = dp.resize()
+		default:
+			return errors.Errorf("Unknown processing phase %s", dp.currentPhase)
+		}
+		if err != nil {
+			klog.Errorf("%v", err)
+			return err
+		}
+		klog.V(1).Infof("New phase: %s\n", dp.currentPhase)
+	}
+	return err
+}
+
+// convert is called when convert the image from the url to a RAW disk image. Source formats include RAW/QCOW2 (Raw to raw conversion is a copy)
+func (dp *DataProcessor) convert(url *url.URL) (ProcessingPhase, error) {
+	klog.V(3).Infoln("Validating source file")
+
+	err := qemuOperations.Validate(url, dp.availableSpace)
+	if err != nil {
+		return Error, errors.Wrap(err, "Image validation failed")
+	}
+	klog.V(3).Infoln("Converting to Raw")
+	err = qemuOperations.ConvertToRawStream(url, dp.dataFile)
+	if err != nil {
+		return Error, errors.Wrap(err, "Conversion to Raw failed")
+	}
+
+	return Resize, nil
+}
+
+func (dp *DataProcessor) resize() (ProcessingPhase, error) {
+	// Resize only if we have a resize request, and if the image is on a file system pvc.
+	klog.V(3).Infof("Available space in dataFile: %d", util.GetAvailableSpaceBlock(dp.dataFile))
+	if dp.requestImageSize != "" && util.GetAvailableSpaceBlock(dp.dataFile) < int64(0) {
+		klog.V(3).Infoln("Resizing image")
+		err := ResizeImage(dp.dataFile, dp.requestImageSize, dp.availableSpace)
+		if err != nil {
+			return Error, errors.Wrap(err, "Resize of image failed")
+		}
+	}
+	return Complete, nil
+}
+
+// ResizeImage resizes the images to match the requested size. Sometimes provisioners misbehave and the available space
+// is not the same as the requested space. For those situations we compare the available space to the requested space and
+// use the smallest of the two values.
+func ResizeImage(dataFile, imageSize string, totalTargetSpace int64) error {
+	dataFileURL, _ := url.Parse(dataFile)
+	info, err := qemuOperations.Info(dataFileURL)
+	if err != nil {
+		return err
+	}
+	if imageSize != "" {
+		currentImageSizeQuantity := resource.NewScaledQuantity(info.VirtualSize, 0)
+		newImageSizeQuantity := resource.MustParse(imageSize)
+		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(totalTargetSpace, 0), &newImageSizeQuantity)
+		if minSizeQuantity.Cmp(newImageSizeQuantity) != 0 {
+			// Available destination space is smaller than the size we want to resize to
+			klog.Warningf("Available space less than requested size, resizing image to available space %s.\n", minSizeQuantity.String())
+		}
+		if currentImageSizeQuantity.Cmp(minSizeQuantity) == 0 {
+			klog.V(1).Infof("No need to resize image. Requested size: %s, Image size: %d.\n", imageSize, info.VirtualSize)
+			return nil
+		}
+		klog.V(1).Infof("Expanding image size to: %s\n", minSizeQuantity.String())
+		return qemuOperations.Resize(dataFile, minSizeQuantity)
+	}
+	return errors.New("Image resize called with blank resize")
+}
+
+func (dp *DataProcessor) calculateTargetSize() int64 {
+	var targetQuantity *resource.Quantity
+	if util.GetAvailableSpace(dp.dataDir) > int64(0) {
+		// File system volume.
+		targetQuantity = resource.NewScaledQuantity(util.GetAvailableSpace(dp.dataDir), 0)
+	} else {
+		// Block volume.
+		targetQuantity = resource.NewScaledQuantity(util.GetAvailableSpaceBlock(dp.dataFile), 0)
+	}
+	if dp.requestImageSize != "" {
+		newImageSizeQuantity := resource.MustParse(dp.requestImageSize)
+		minQuantity := util.MinQuantity(targetQuantity, &newImageSizeQuantity)
+		targetQuantity = &minQuantity
+	}
+	targetSize, _ := targetQuantity.AsInt64()
+	return targetSize
+}

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -1,0 +1,344 @@
+package importer
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/pkg/errors"
+
+	"kubevirt.io/containerized-data-importer/pkg/image"
+)
+
+type fakeInfoOpRetVal struct {
+	imgInfo *image.ImgInfo
+	e       error
+}
+
+const TestImagesDir = "../../tests/images"
+
+const (
+	SmallActualSize  = 1024
+	SmallVirtualSize = 1024
+)
+
+var (
+	fakeSmallImageInfo = image.ImgInfo{Format: "", BackingFile: "", VirtualSize: SmallVirtualSize, ActualSize: SmallActualSize}
+	fakeZeroImageInfo  = image.ImgInfo{Format: "", BackingFile: "", VirtualSize: 0, ActualSize: 0}
+	fakeInfoRet        = fakeInfoOpRetVal{imgInfo: &fakeSmallImageInfo, e: nil}
+)
+
+type fakeQEMUOperations struct {
+	e2             error
+	e3             error
+	ret4           fakeInfoOpRetVal
+	e5             error
+	e6             error
+	resizeQuantity *resource.Quantity
+}
+
+type MockDataProvider struct {
+	infoResponse     ProcessingPhase
+	transferResponse ProcessingPhase
+	processResponse  ProcessingPhase
+	url              *url.URL
+	transferPath     string
+	calledPhases     []ProcessingPhase
+}
+
+// Info() is called to get initial information about the data
+func (m *MockDataProvider) Info() (ProcessingPhase, error) {
+	m.calledPhases = append(m.calledPhases, Info)
+	if m.infoResponse == Error {
+		return Error, errors.New("Info errored")
+	}
+	return m.infoResponse, nil
+}
+
+// Transfer() is called to transfer the data from the source to a temporary location.
+func (m *MockDataProvider) Transfer(path string) (ProcessingPhase, error) {
+	m.calledPhases = append(m.calledPhases, Transfer)
+	m.transferPath = path
+	if m.transferResponse == Error {
+		return Error, errors.New("Transfer errored")
+	}
+	return m.transferResponse, nil
+}
+
+// Process() is called to do any special processing before giving the url to the data back to the processor
+func (m *MockDataProvider) Process() (ProcessingPhase, error) {
+	m.calledPhases = append(m.calledPhases, Process)
+	if m.processResponse == Error {
+		return Error, errors.New("Process errored")
+	}
+	return m.processResponse, nil
+}
+
+// Geturl returns the url that the data processor can use when converting the data.
+func (m *MockDataProvider) GetURL() *url.URL {
+	return m.url
+}
+
+// Close closes any readers or other open resources.
+func (m *MockDataProvider) Close() error {
+	return nil
+}
+
+var _ = Describe("Data Processor", func() {
+	It("should call the right phases based on the responses from the provider, Transfer should pass the scratch data dir as a path", func() {
+		mdp := &MockDataProvider{
+			infoResponse:     Transfer,
+			transferResponse: Process,
+			processResponse:  Complete,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		err := dp.ProcessData()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(3).To(Equal(len(mdp.calledPhases)))
+		Expect(Info).To(Equal(mdp.calledPhases[0]))
+		Expect(Transfer).To(Equal(mdp.calledPhases[1]))
+		Expect(Process).To(Equal(mdp.calledPhases[2]))
+		Expect("scratchDataDir").To(Equal(mdp.transferPath))
+	})
+
+	It("should call the right phases based on the responses from the provider, TransferTarget should pass the data dir as a path", func() {
+		mdp := &MockDataProvider{
+			infoResponse:     TransferTarget,
+			transferResponse: Process,
+			processResponse:  Complete,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		err := dp.ProcessData()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(3).To(Equal(len(mdp.calledPhases)))
+		Expect(Info).To(Equal(mdp.calledPhases[0]))
+		Expect(Transfer).To(Equal(mdp.calledPhases[1]))
+		Expect(Process).To(Equal(mdp.calledPhases[2]))
+		Expect("dataDir").To(Equal(mdp.transferPath))
+	})
+
+	It("should error on Transfer phase", func() {
+		mdp := &MockDataProvider{
+			infoResponse:     TransferTarget,
+			transferResponse: Error,
+			processResponse:  Complete,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		err := dp.ProcessData()
+		Expect(err).To(HaveOccurred())
+		Expect(2).To(Equal(len(mdp.calledPhases)))
+		Expect(Info).To(Equal(mdp.calledPhases[0]))
+		Expect(Transfer).To(Equal(mdp.calledPhases[1]))
+	})
+
+	It("should error on Unknown phase", func() {
+		mdp := &MockDataProvider{
+			infoResponse: ProcessingPhase("invalidphase"),
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		err := dp.ProcessData()
+		Expect(err).To(HaveOccurred())
+		Expect(1).To(Equal(len(mdp.calledPhases)))
+		Expect(Info).To(Equal(mdp.calledPhases[0]))
+	})
+
+	It("should call Convert after Process phase", func() {
+		tmpDir, err := ioutil.TempDir("", "scratch")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			infoResponse:     TransferTarget,
+			transferResponse: Process,
+			processResponse:  Convert,
+			url:              url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", tmpDir, "1G")
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0))
+		replaceQEMUOperations(qemuOperations, func() {
+			err = dp.ProcessData()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(3).To(Equal(len(mdp.calledPhases)))
+			Expect(Info).To(Equal(mdp.calledPhases[0]))
+			Expect(Transfer).To(Equal(mdp.calledPhases[1]))
+			Expect(Process).To(Equal(mdp.calledPhases[2]))
+			Expect("dataDir").To(Equal(mdp.transferPath))
+		})
+	})
+})
+
+var _ = Describe("Convert", func() {
+	It("Should successfully convert and return resize", func() {
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
+		replaceQEMUOperations(qemuOperations, func() {
+			nextPhase, err := dp.convert(mdp.GetURL())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(Resize).To(Equal(nextPhase))
+		})
+	})
+
+	It("Should fail when validation fails and return Error", func() {
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, errors.New("Validation failure"), nil, nil)
+		replaceQEMUOperations(qemuOperations, func() {
+			nextPhase, err := dp.convert(mdp.GetURL())
+			Expect(err).To(HaveOccurred())
+			Expect(Error).To(Equal(nextPhase))
+		})
+	})
+
+	It("Should fail when conversion fails and return Error", func() {
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		qemuOperations := NewFakeQEMUOperations(errors.New("Conversion failure"), nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
+		replaceQEMUOperations(qemuOperations, func() {
+			nextPhase, err := dp.convert(mdp.GetURL())
+			Expect(err).To(HaveOccurred())
+			Expect(Error).To(Equal(nextPhase))
+		})
+	})
+})
+
+var _ = Describe("Resize", func() {
+	It("Should not resize and return complete, when requestedSize is blank", func() {
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "")
+		nextPhase, err := dp.resize()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(Complete).To(Equal(nextPhase))
+	})
+
+	It("Should not resize and return complete, when requestedSize is valid, but datadir doesn't exist (block device)", func() {
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G")
+		nextPhase, err := dp.resize()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(Complete).To(Equal(nextPhase))
+	})
+
+	It("Should resize and return complete, when requestedSize is valid, and datadir exists", func() {
+		tmpDir, err := ioutil.TempDir("", "data")
+		Expect(err).ToNot(HaveOccurred())
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G")
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
+		replaceQEMUOperations(qemuOperations, func() {
+			nextPhase, err := dp.resize()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(Complete).To(Equal(nextPhase))
+		})
+	})
+
+	It("Should not resize and return error, when ResizeImage fails", func() {
+		tmpDir, err := ioutil.TempDir("", "data")
+		Expect(err).ToNot(HaveOccurred())
+		url, err := url.Parse("http://fakeurl-notreal.fake")
+		Expect(err).ToNot(HaveOccurred())
+		mdp := &MockDataProvider{
+			url: url,
+		}
+		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G")
+		qemuOperations := NewQEMUAllErrors()
+		replaceQEMUOperations(qemuOperations, func() {
+			nextPhase, err := dp.resize()
+			Expect(err).To(HaveOccurred())
+			Expect(Error).To(Equal(nextPhase))
+		})
+	})
+})
+
+var _ = Describe("ResizeImage", func() {
+	//fakeInfoRet has info.VirtualSize=1024
+	table.DescribeTable("calling ResizeImage", func(qemuOperations image.QEMUOperations, imageSize string, totalSpace int64, wantErr bool) {
+		replaceQEMUOperations(qemuOperations, func() {
+			err := ResizeImage("dest", imageSize, totalSpace)
+			if !wantErr {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	},
+		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0)), "1500", int64(2048), false),
+		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false),
+		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024), 0)), "1024", int64(1024), false),
+		table.Entry("fail to resize to with blank imageSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "", int64(2048), true),
+		table.Entry("fail to resize to with blank imageSize", NewQEMUAllErrors(), "", int64(2048), true),
+	)
+})
+
+func replaceQEMUOperations(replacement image.QEMUOperations, f func()) {
+	orig := qemuOperations
+	if replacement != nil {
+		qemuOperations = replacement
+		defer func() { qemuOperations = orig }()
+	}
+	f()
+}
+
+func NewFakeQEMUOperations(e2, e3 error, ret4 fakeInfoOpRetVal, e5 error, e6 error, targetResize *resource.Quantity) image.QEMUOperations {
+	return &fakeQEMUOperations{e2, e3, ret4, e5, e6, targetResize}
+}
+
+func (o *fakeQEMUOperations) ConvertToRawStream(*url.URL, string) error {
+	return o.e2
+}
+
+func (o *fakeQEMUOperations) Validate(*url.URL, int64) error {
+	return o.e5
+}
+
+func (o *fakeQEMUOperations) Resize(dest string, size resource.Quantity) error {
+	if o.resizeQuantity != nil {
+		Expect(o.resizeQuantity.Cmp(size)).To(Equal(0))
+	}
+	return o.e3
+}
+
+func (o *fakeQEMUOperations) Info(url *url.URL) (*image.ImgInfo, error) {
+	return o.ret4.imgInfo, o.ret4.e
+}
+
+func (o *fakeQEMUOperations) CreateBlankImage(dest string, size resource.Quantity) error {
+	return o.e6
+}
+
+func NewQEMUAllErrors() image.QEMUOperations {
+	err := errors.New("qemu should not be called from this test override with replaceQEMUOperations")
+	return NewFakeQEMUOperations(err, err, fakeInfoOpRetVal{nil, err}, err, err, nil)
+}

--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2018 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importer
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/ulikunitz/xz"
+
+	"k8s.io/klog"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/image"
+)
+
+type reader struct {
+	rdrType int
+	rdr     io.ReadCloser
+}
+
+// FormatReaders contains the stack of readers needed to get information from the input stream (io.ReadCloser)
+type FormatReaders struct {
+	readers     []reader
+	buf         []byte // holds file headers
+	Qemu        bool
+	Archived    bool
+	Size        int64
+	contentType cdiv1.DataVolumeContentType
+}
+
+const (
+	rdrGz = iota
+	rdrMulti
+	rdrTar
+	rdrXz
+	rdrStream
+)
+
+// map scheme and format to rdrType
+var rdrTypM = map[string]int{
+	"gz":     rdrGz,
+	"tar":    rdrTar,
+	"xz":     rdrXz,
+	"stream": rdrStream,
+}
+
+// NewFormatReaders creates a new instance of FormatReaders using the input stream and content type passed in.
+func NewFormatReaders(stream io.ReadCloser, contentType cdiv1.DataVolumeContentType) (*FormatReaders, error) {
+	readers := &FormatReaders{
+		buf:         make([]byte, image.MaxExpectedHdrSize),
+		contentType: contentType,
+	}
+	err := readers.constructReaders(stream)
+	return readers, err
+}
+
+func (fr *FormatReaders) constructReaders(r io.ReadCloser) error {
+	fr.appendReader(rdrTypM["stream"], r)
+	knownHdrs := image.CopyKnownHdrs() // need local copy since keys are removed
+	klog.V(3).Infof("constructReaders: checking compression and archive formats\n")
+	var isTarFile bool
+	for {
+		hdr, err := fr.matchHeader(&knownHdrs)
+		if err != nil {
+			return errors.WithMessage(err, "could not process image header")
+		}
+		if hdr == nil {
+			break // done processing headers, we have the orig source file
+		}
+		klog.V(2).Infof("found header of type %q\n", hdr.Format)
+		// create format-specific reader and append it to dataStream readers stack
+		fr.fileFormatSelector(hdr)
+		isTarFile = isTarFile || hdr.Format == "tar"
+		// exit loop if hdr is qcow2 since that's the equivalent of a raw (iso) file,
+		// mentioned above as the orig source file
+		if hdr.Format == "qcow2" {
+			break
+		}
+	}
+
+	if fr.contentType == cdiv1.DataVolumeArchive && !isTarFile {
+		return errors.Errorf("cannot process a non tar file as an archive")
+	}
+
+	// if the endpoint's file size is zero and it's an iso file then compute its orig size
+	if fr.Size == 0 {
+		var err error
+		fr.Size, err = fr.rawSize()
+		if err != nil {
+			return errors.Wrapf(err, "unable to calculate RAW file size")
+		}
+		// at that point, only if ds.size != 0 we know for sure that this is an iso file
+		if fr.Size != 0 {
+			fr.Qemu = true
+		}
+	}
+
+	return nil
+}
+
+// Append to the receiver's reader stack the passed in reader. If the reader type is multi-reader
+// then wrap a multi-reader around the passed in reader. If the reader is not a Closer then wrap a
+// nop closer.
+func (fr *FormatReaders) appendReader(rType int, x interface{}) {
+	if x == nil {
+		return
+	}
+	r, ok := x.(io.Reader)
+	if !ok {
+		klog.Errorf("internal error: unexpected reader type passed to appendReader()")
+		return
+	}
+	if rType == rdrMulti {
+		r = io.MultiReader(r, fr.TopReader())
+	}
+	if _, ok := r.(io.Closer); !ok {
+		r = ioutil.NopCloser(r)
+	}
+	fr.readers = append(fr.readers, reader{rdrType: rType, rdr: r.(io.ReadCloser)})
+}
+
+// TopReader return the top-level io.ReadCloser from the receiver Reader "stack".
+func (fr *FormatReaders) TopReader() io.ReadCloser {
+	return fr.readers[len(fr.readers)-1].rdr
+}
+
+// Based on the passed in header, append the format-specific reader to the readers stack,
+// and update the receiver Size field. Note: a bool is set in the receiver for qcow2 files.
+func (fr *FormatReaders) fileFormatSelector(hdr *image.Header) {
+	var r io.Reader
+	var err error
+	fFmt := hdr.Format
+	switch fFmt {
+	case "gz":
+		r, fr.Size, err = fr.gzReader()
+		if err == nil {
+			fr.Archived = true
+		}
+	case "qcow2":
+		r, fr.Size, err = fr.qcow2NopReader(hdr)
+		fr.Qemu = true
+	case "tar":
+		r, fr.Size, err = fr.tarReader()
+		if err == nil {
+			fr.Archived = true
+		}
+	case "xz":
+		r, fr.Size, err = fr.xzReader()
+		if err == nil {
+			fr.Archived = true
+		}
+	}
+	if err == nil && r != nil {
+		fr.appendReader(rdrTypM[fFmt], r)
+	}
+}
+
+// Return the gz reader and the size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was gzipped.
+//NOTE: size in gz is stored in the last 4 bytes of the file. This probably requires the file
+//  to be decompressed in order to get its original size. For now 0 is returned.
+//TODO: support gz size.
+func (fr *FormatReaders) gzReader() (io.ReadCloser, int64, error) {
+	gz, err := gzip.NewReader(fr.TopReader())
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "could not create gzip reader")
+	}
+	klog.V(2).Infof("gzip: extracting %q\n", gz.Name)
+	size := int64(0) //TODO: implement size
+	return gz, size, nil
+}
+
+// Return the size of the endpoint "through the eye" of the previous reader. Note: there is no
+// qcow2 reader so nil is returned so that nothing is appended to the reader stack.
+// Note: size is stored at offset 24 in the qcow2 header.
+func (fr *FormatReaders) qcow2NopReader(h *image.Header) (io.Reader, int64, error) {
+	s := hex.EncodeToString(fr.buf[h.SizeOff : h.SizeOff+h.SizeLen])
+	size, err := strconv.ParseInt(s, 16, 64)
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "unable to determine original qcow2 file size from %+v", s)
+	}
+	return nil, size, nil
+}
+
+// Return the xz reader and size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was compressed. Note: the xz reader is not a closer so we wrap a
+// nop Closer around it.
+//NOTE: size is not stored in the xz header. This may require the file to be decompressed in
+//  order to get its original size. For now 0 is returned.
+//TODO: support gz size.
+func (fr *FormatReaders) xzReader() (io.Reader, int64, error) {
+	xz, err := xz.NewReader(fr.TopReader())
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "could not create xz reader")
+	}
+	size := int64(0) //TODO: implement size
+	return xz, size, nil
+}
+
+// Return the tar reader and size of the endpoint "through the eye" of the previous reader.
+// Assumes a single file was archived.
+// Note: the size stored in the header is used rather than raw metadata.
+func (fr *FormatReaders) tarReader() (io.Reader, int64, error) {
+	if fr.contentType == cdiv1.DataVolumeArchive {
+		return fr.mulFileTarReader()
+	}
+	tr := tar.NewReader(fr.TopReader())
+	hdr, err := tr.Next() // advance cursor to 1st (and only) file in tarball
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "could not read tar header")
+	}
+	klog.V(2).Infof("tar: extracting %q\n", hdr.Name)
+	return tr, hdr.Size, nil
+}
+
+func (fr *FormatReaders) mulFileTarReader() (io.Reader, int64, error) {
+	buf, err := ioutil.ReadAll(fr.TopReader())
+	if err != nil {
+		return nil, 0, err
+	}
+	tr := tar.NewReader(bytes.NewReader(buf))
+	var size int64
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, 0, err
+		}
+		size += header.Size
+	}
+	return bytes.NewReader(buf), size, nil
+}
+
+// If the raw endpoint is an ISO file then set the receiver's Size via the iso metadata.
+// ISO reference: http://alumnus.caltech.edu/~pje/iso9660.html
+// Note: no error is returned if the enpoint does not match the expected iso format.
+func (fr *FormatReaders) rawSize() (int64, error) {
+	// iso id values
+	const (
+		id        = "CD001"
+		primaryVD = 1
+	)
+	// primary volume descriptor sector offset in iso file
+	const (
+		isoSectorSize        = 2048
+		primVolDescriptorOff = 16 * isoSectorSize
+	)
+	// single volume descriptor layout (independent of location within file)
+	// note: offsets are zero-relative and lengths are in bytes
+	const (
+		vdTypeOff       = 0
+		typeLen         = 1
+		vdIDOff         = 1
+		idLen           = 5
+		vdNumSectorsOff = 84
+		numSectorsLen   = 4
+		vdSectorSizeOff = 130
+		sectorSizeLen   = 2
+	)
+	// primary volume descriptor layout within full iso file (lengths are defined above)
+	const (
+		typeOff       = vdTypeOff + primVolDescriptorOff
+		idOff         = vdIDOff + primVolDescriptorOff
+		numSectorsOff = vdNumSectorsOff + primVolDescriptorOff
+		sectorSizeOff = vdSectorSizeOff + primVolDescriptorOff // last field we care about
+	)
+	const bufSize = sectorSizeOff + sectorSizeLen
+
+	buf := make([]byte, bufSize)
+	_, err := fr.read(buf) // read primary volume descriptor
+	if err != nil {
+		return 0, errors.Wrapf(err, "attempting to read ISO primary volume descriptor")
+	}
+	// append multi-reader so that the iso data can be re-read by subsequent readers
+	fr.appendReader(rdrMulti, bytes.NewReader(buf))
+
+	// ensure we have an iso file by checking the type and id value
+	vdtyp, err := strconv.Atoi(hex.EncodeToString(buf[typeOff : typeOff+typeLen]))
+	if err != nil {
+		klog.Errorf("rawSize: Atoi error reading RAW: %v", err)
+		return 0, nil
+	}
+	if vdtyp != primaryVD && string(buf[idOff:idOff+idLen]) != id {
+		klog.V(3).Infof("rawSize: endpoint is not an RAW file")
+		return 0, nil
+	}
+
+	// get the logical block/sector size (expect 2048)
+	s := hex.EncodeToString(buf[sectorSizeOff : sectorSizeOff+sectorSizeLen])
+	sectSize, err := strconv.ParseInt(s, 16, 64)
+	if err != nil {
+		klog.Errorf("rawSize: sector size ParseInt error on RAW: %v", err)
+		return 0, nil
+	}
+	// get the number sectors
+	s = hex.EncodeToString(buf[numSectorsOff : numSectorsOff+numSectorsLen])
+	numSects, err := strconv.ParseInt(s, 16, 64)
+	if err != nil {
+		klog.Errorf("rawSize: sector count ParseInt error on RAW: %v", err)
+		return 0, nil
+	}
+	return int64(numSects * sectSize), nil
+}
+
+// Return the matching header, if one is found, from the passed-in map of known headers. After a
+// successful read append a multi-reader to the receiver's reader stack.
+// Note: .iso files are not detected here but rather in the Size() function.
+// Note: knownHdrs is passed by reference and modified.
+func (fr *FormatReaders) matchHeader(knownHdrs *image.Headers) (*image.Header, error) {
+	_, err := fr.read(fr.buf) // read current header
+	if err != nil {
+		return nil, err
+	}
+	// append multi-reader so that the header data can be re-read by subsequent readers
+	fr.appendReader(rdrMulti, bytes.NewReader(fr.buf))
+
+	// loop through known headers until a match
+	for format, kh := range *knownHdrs {
+		if kh.Match(fr.buf) {
+			// delete this header format key so that it's not processed again
+			delete(*knownHdrs, format)
+			return &kh, nil
+		}
+	}
+	return nil, nil // no match
+}
+
+// Read from top-most reader. Note: ReadFull is needed since there may be intermediate,
+// smaller multi-readers in the reader stack, and we need to be able to fill buf.
+func (fr *FormatReaders) read(buf []byte) (int, error) {
+	return io.ReadFull(fr.TopReader(), buf)
+}
+
+// Close Readers in reverse order.
+func (fr *FormatReaders) Close() (rtnerr error) {
+	var err error
+	for i := len(fr.readers) - 1; i >= 0; i-- {
+		err = fr.readers[i].rdr.Close()
+		if err != nil {
+			rtnerr = err // tracking last error
+		}
+	}
+	return rtnerr
+}

--- a/pkg/importer/format-readers_test.go
+++ b/pkg/importer/format-readers_test.go
@@ -1,0 +1,95 @@
+package importer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var (
+	archiveFileName           = "archive.tar"
+	imageDir, _               = filepath.Abs(TestImagesDir)
+	tinyCoreFileName          = "tinyCore.iso"
+	tinyCoreFilePath          = filepath.Join(imageDir, tinyCoreFileName)
+	tinyCoreXzFilePath, _     = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtXz)
+	tinyCoreGzFilePath, _     = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtGz)
+	tinyCoreTarFilePath, _    = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtTar)
+	archiveFilePath, _        = utils.ArchiveFiles(archiveFileNameWithoutExt, os.TempDir(), tinyCoreFilePath, cirrosFilePath)
+	archiveFileNameWithoutExt = strings.TrimSuffix(archiveFileName, filepath.Ext(archiveFileName))
+	cirrosFilePath            = filepath.Join(imageDir, cirrosFileName)
+	stringRdr                 = strings.NewReader("test data for reader 1")
+)
+
+var _ = Describe("Format Readers", func() {
+	var fr *FormatReaders
+	BeforeEach(func() {
+		fr = nil
+	})
+
+	AfterEach(func() {
+		if fr != nil {
+			fr.Close()
+		}
+	})
+
+	table.DescribeTable("can construct readers", func(filename string, contentType cdiv1.DataVolumeContentType, numRdrs int, wantErr, archived, qemu bool) {
+		f, err := os.Open(filename)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+
+		fr, err = NewFormatReaders(f, contentType)
+		if wantErr {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+			for _, r := range fr.readers {
+				fmt.Fprintf(GinkgoWriter, "INFO: Reader type: %d\n", r.rdrType)
+			}
+			Expect(len(fr.readers)).To(Equal(numRdrs))
+			Expect(qemu).To(Equal(fr.Qemu))
+			Expect(archived).To(Equal(fr.Archived))
+		}
+	},
+		table.Entry("successfully construct a xz reader", tinyCoreXzFilePath, cdiv1.DataVolumeKubeVirt, 5, false, true, true),      // [stream, multi-r, xz, multi-r, raw] qemu = true
+		table.Entry("successfully construct a gz reader", tinyCoreGzFilePath, cdiv1.DataVolumeKubeVirt, 5, false, true, true),      // [stream, multi-r, gz, multi-r, raw] qemu = true
+		table.Entry("successfully construct a tar reader", tinyCoreTarFilePath, cdiv1.DataVolumeKubeVirt, 4, false, true, false),   // [stream, multi-r, tar, multi-r] qemu = true
+		table.Entry("successfully constructed an archive reader", archiveFilePath, cdiv1.DataVolumeArchive, 4, false, true, false), // [stream, multi-r, mul-tar, multi-r] qemu = false
+		table.Entry("successfully construct qcow2 reader", cirrosFilePath, cdiv1.DataVolumeKubeVirt, 2, false, false, true),        // [stream, multi-r]
+		table.Entry("successfully construct .iso reader", tinyCoreFilePath, cdiv1.DataVolumeKubeVirt, 3, false, false, true),       // [stream, multi-r, raw]
+		table.Entry("Fail to construct a gz reader with archive contentType", tinyCoreGzFilePath, cdiv1.DataVolumeArchive, 0, true, false, false),
+	)
+
+	table.DescribeTable("can append readers", func(rType int, r interface{}, numRdrs int, isCloser bool) {
+		f, err := os.Open(cirrosFilePath)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		fr, err = NewFormatReaders(f, cdiv1.DataVolumeKubeVirt)
+		Expect(err).ToNot(HaveOccurred())
+		By("Verifying there are currently 2 readers")
+		Expect(len(fr.readers)).To(Equal(2))
+		fr.appendReader(rType, r)
+		By("Verifying there expected number of readers are there")
+		Expect(len(fr.readers)).To(Equal(numRdrs))
+		if isCloser {
+			By("Verifying the type of the new reader is io.Closer")
+			if _, ok := fr.TopReader().(io.Closer); !ok {
+				Expect(ok).To(BeTrue())
+			}
+		}
+	},
+		table.Entry("should not append nil reader", rdrTar, nil, 2, false),
+		table.Entry("should not append non reader", rdrTar, cdiv1.DataVolumeKubeVirt, 2, false),
+		table.Entry("should append io.reader", rdrTar, stringRdr, 3, false),
+		table.Entry("should append io.Multireader", rdrMulti, stringRdr, 3, false),
+	)
+})

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2018 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importer
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/klog"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+const (
+	tempFile = "tmpimage"
+)
+
+// HTTPDataSource is the data provider for http(s) endpoints.
+// Sequence of phases:
+// 1a. Info -> Convert (In Info phase the format readers are configured), if the source Reader image is not archived, and no custom CA is used, and can be converted by QEMU-IMG (RAW/QCOW2)
+// 1b. Info -> TransferArchive if the content type is archive
+// 1c. Info -> Transfer in all other cases.
+// 2a. Transfer -> Process if content type is kube virt
+// 2b. Transfer -> Complete if content type is archive (Transfer is called with the target instead of the scratch space). Non block PVCs only.
+// 3. Process -> Convert
+type HTTPDataSource struct {
+	httpReader io.ReadCloser
+	ctx        context.Context
+	cancel     context.CancelFunc
+	cancelLock sync.Mutex
+	// content type expected by the to live on the endpoint.
+	contentType cdiv1.DataVolumeContentType
+	// stack of readers
+	readers *FormatReaders
+	// endpoint the http endpoint to retrieve the data from.
+	endpoint *url.URL
+	// url the url to report to the caller of getURL, could be the endpoint, or a file in scratch space.
+	url *url.URL
+	// true if we are using a custom CA (and thus have to use scratch storage)
+	customCA bool
+}
+
+// NewHTTPDataSource creates a new instance of the http data provider.
+func NewHTTPDataSource(endpoint, accessKey, secKey, certDir string, contentType cdiv1.DataVolumeContentType) (*HTTPDataSource, error) {
+	ep, err := ParseEndpoint(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, fmt.Sprintf("unable to parse endpoint %q", endpoint))
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	httpReader, err := createHTTPReader(ctx, ep, accessKey, secKey, certDir)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	if accessKey != "" && secKey != "" {
+		ep.User = url.UserPassword(accessKey, secKey)
+	}
+	dataProvider := &HTTPDataSource{
+		ctx:         ctx,
+		cancel:      cancel,
+		httpReader:  httpReader,
+		contentType: contentType,
+		endpoint:    ep,
+		customCA:    certDir != "",
+	}
+	// We know this is a counting reader, so no need to check.
+	countingReader := httpReader.(*util.CountingReader)
+	go dataProvider.pollProgress(countingReader, 10*time.Minute, time.Second)
+	return dataProvider, nil
+}
+
+// Info is called to get initial information about the data.
+func (dp *HTTPDataSource) Info() (ProcessingPhase, error) {
+	var err error
+	dp.readers, err = NewFormatReaders(dp.httpReader, dp.contentType)
+	if err != nil {
+		klog.Errorf("Error creating readers: %v", err)
+		return Error, err
+	}
+	// The readers now contain all the information needed to determine if we can stream directly or if we need scratch space to download
+	// the file to, before converting.
+	if dp.readers.Qemu && !dp.readers.Archived && !dp.customCA {
+		// We can pass straight to conversion from the endpoint. No scratch required.
+		dp.url = dp.endpoint
+		return Convert, nil
+	}
+	if dp.contentType == cdiv1.DataVolumeArchive {
+		return TransferTarget, nil
+	}
+	return Transfer, nil
+}
+
+// Transfer is called to transfer the data from the source to a scratch location.
+func (dp *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
+	if dp.contentType == cdiv1.DataVolumeKubeVirt {
+		if util.GetAvailableSpace(path) <= int64(0) {
+			//Path provided is invalid.
+			return Error, ErrInvalidPath
+		}
+		file := filepath.Join(path, tempFile)
+		err := StreamDataToFile(dp.readers.TopReader(), file)
+		if err != nil {
+			return Error, err
+		}
+		// If we successfully wrote to the file, then the parse will succeed.
+		dp.url, _ = url.Parse(file)
+		return Process, nil
+	} else if dp.contentType == cdiv1.DataVolumeArchive {
+		if err := util.UnArchiveTar(dp.readers.TopReader(), path); err != nil {
+			return Error, errors.Wrap(err, "unable to untar files from endpoint")
+		}
+		dp.url = nil
+		return Complete, nil
+	}
+	return Error, errors.Errorf("Unknown content type: %s", dp.contentType)
+}
+
+// Process is called to do any special processing before giving the URI to the data back to the processor
+func (dp *HTTPDataSource) Process() (ProcessingPhase, error) {
+	return Convert, nil
+}
+
+// GetURL returns the URI that the data processor can use when converting the data.
+func (dp *HTTPDataSource) GetURL() *url.URL {
+	return dp.url
+}
+
+// Close all readers.
+func (dp *HTTPDataSource) Close() error {
+	var err error
+	if dp.readers != nil {
+		err = dp.readers.Close()
+	}
+	dp.cancelLock.Lock()
+	if dp.cancel != nil {
+		dp.cancel()
+		dp.cancel = nil
+	}
+	dp.cancelLock.Unlock()
+	return err
+}
+
+func createHTTPClient(certDir string) (*http.Client, error) {
+	client := &http.Client{
+		// Don't set timeout here, since that will be an absolute timeout, we need a relative to last progress timeout.
+	}
+
+	if certDir == "" {
+		return client, nil
+	}
+
+	// let's get system certs as well
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting system certs")
+	}
+
+	files, err := ioutil.ReadDir(certDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error listing files in %s", certDir)
+	}
+
+	for _, file := range files {
+		if file.IsDir() || file.Name()[0] == '.' {
+			continue
+		}
+
+		fp := path.Join(certDir, file.Name())
+
+		klog.Infof("Attempting to get certs from %s", fp)
+
+		certs, err := ioutil.ReadFile(fp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error reading file %s", fp)
+		}
+
+		if ok := certPool.AppendCertsFromPEM(certs); !ok {
+			klog.Warningf("No certs in %s", fp)
+		}
+	}
+
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certPool,
+		},
+	}
+
+	return client, nil
+}
+
+func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certDir string) (io.ReadCloser, error) {
+	client, err := createHTTPClient(certDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating http client")
+	}
+
+	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
+		if len(accessKey) > 0 && len(secKey) > 0 {
+			r.SetBasicAuth(accessKey, secKey) // Redirects will lose basic auth, so reset them manually
+		}
+		return nil
+	}
+
+	// http.NewRequest can only return error on invalid METHOD, or invalid url. Here the METHOD is always GET, and the url is always valid, thus error cannot happen.
+	req, _ := http.NewRequest("GET", ep.String(), nil)
+
+	req = req.WithContext(ctx)
+	if len(accessKey) > 0 && len(secKey) > 0 {
+		req.SetBasicAuth(accessKey, secKey)
+	}
+	klog.V(2).Infof("Attempting to get object %q via http client\n", ep.String())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request errored")
+	}
+	if resp.StatusCode != 200 {
+		klog.Errorf("http: expected status code 200, got %d", resp.StatusCode)
+		return nil, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
+	}
+	countingReader := &util.CountingReader{
+		Reader:  resp.Body,
+		Current: 0,
+	}
+	return countingReader, nil
+}
+
+func (dp *HTTPDataSource) pollProgress(reader *util.CountingReader, idleTime, pollInterval time.Duration) {
+	count := reader.Current
+	lastUpdate := time.Now()
+	for {
+		if count < reader.Current {
+			// Some progress was made, reset now.
+			lastUpdate = time.Now()
+			count = reader.Current
+		}
+
+		if time.Until(lastUpdate.Add(idleTime)).Nanoseconds() < 0 {
+			dp.cancelLock.Lock()
+			if dp.cancel != nil {
+				// No progress for the idle time, cancel http client.
+				dp.cancel() // This will trigger dp.ctx.Done()
+			}
+			dp.cancelLock.Unlock()
+		}
+		select {
+		case <-time.After(pollInterval):
+			continue
+		case <-dp.ctx.Done():
+			return // Don't leak, once the transfer is cancelled or completed this is called.
+		}
+	}
+}

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -1,0 +1,363 @@
+package importer
+
+import (
+	"context"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/cert/triple"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+var (
+	cirrosFileName          = "cirros-qcow2.img"
+	diskimageTarFileName    = "cirros.tar"
+	cirrosData, _           = readFile(cirrosFilePath)
+	diskimageArchiveData, _ = readFile(diskimageTarFileName)
+)
+
+var _ = Describe("Http data source", func() {
+	var (
+		ts        *httptest.Server
+		dp        *HTTPDataSource
+		err       error
+		flushRead []byte
+		tmpDir    string
+	)
+
+	BeforeEach(func() {
+		By("[BeforeEach] Creating test server")
+		ts = createTestServer(imageDir)
+		dp = nil
+		tmpDir, err = ioutil.TempDir("", "scratch")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+	})
+
+	AfterEach(func() {
+		if dp != nil {
+			resultBuffer := make([]byte, len(flushRead))
+			if dp.readers != nil {
+				By("flushing data from readers we can finish test")
+				dp.readers.read(resultBuffer)
+			}
+			By("[AfterEach] closing data provider")
+			err = dp.Close()
+			Expect(err).NotTo(HaveOccurred())
+		}
+		os.RemoveAll(tmpDir)
+		By("[AfterEach] closing test server")
+		ts.Close()
+	})
+
+	It("NewHTTPDataSource should fail when called with an invalid endpoint", func() {
+		_, err = NewHTTPDataSource("httpd://!@#$%^&*()dgsdd&3r53/invalid", "", "", "", cdiv1.DataVolumeKubeVirt)
+		Expect(err).To(HaveOccurred())
+		Expect(strings.Contains(err.Error(), "unable to parse endpoint")).To(BeTrue())
+	})
+
+	It("endpoint User object should be set when accessKey and secKey are not blank", func() {
+		image := ts.URL + "/" + cirrosFileName
+		dp, err = NewHTTPDataSource(image, "user", "password", "", cdiv1.DataVolumeKubeVirt)
+		Expect(err).NotTo(HaveOccurred())
+		user := dp.endpoint.User
+		Expect("user").To(Equal(user.Username()))
+		pw, set := user.Password()
+		Expect("password").To(Equal(pw))
+		Expect(set).To(BeTrue())
+	})
+
+	It("NewHTTPDataSource should fail when called with an invalid certdir", func() {
+		image := ts.URL + "/" + cirrosFileName
+		_, err = NewHTTPDataSource(image, "", "", "/invaliddir", cdiv1.DataVolumeKubeVirt)
+		Expect(err).To(HaveOccurred())
+	})
+
+	table.DescribeTable("calling info should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, want []byte, wantErr bool) {
+		flushRead = want
+		if image != "" {
+			image = ts.URL + "/" + image
+		}
+		dp, err = NewHTTPDataSource(image, "", "", "", contentType)
+		Expect(err).NotTo(HaveOccurred())
+		newPhase, err := dp.Info()
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(expectedPhase).To(Equal(newPhase))
+			if newPhase == Convert {
+				expectURL, err := url.Parse(image)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expectURL).To(Equal(dp.GetURL()))
+			}
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		table.Entry("return Convert phase ", cirrosFileName, cdiv1.DataVolumeKubeVirt, Convert, cirrosData, false),
+		table.Entry("return Error with archive content type but not archive endpoint ", cirrosFileName, cdiv1.DataVolumeArchive, Error, cirrosData, true),
+		table.Entry("return TransferTarget with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, TransferTarget, diskimageArchiveData, false),
+		table.Entry("return Transfer with kubevirt content type and archive qemu endpoint ", diskimageTarFileName, cdiv1.DataVolumeKubeVirt, Transfer, diskimageArchiveData, false),
+	)
+
+	table.DescribeTable("calling transfer should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, scratchPath string, want []byte, wantErr bool) {
+		flushRead = want
+		if scratchPath == "" {
+			scratchPath = tmpDir
+		}
+		if image != "" {
+			image = ts.URL + "/" + image
+		}
+		dp, err = NewHTTPDataSource(image, "", "", "", contentType)
+		Expect(err).NotTo(HaveOccurred())
+		_, err := dp.Info()
+		Expect(err).NotTo(HaveOccurred())
+		newPhase, err := dp.Transfer(scratchPath)
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(expectedPhase).To(Equal(newPhase))
+			if newPhase == Process {
+				file, err := os.Open(filepath.Join(scratchPath, tempFile))
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+				fileStat, err := file.Stat()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(int64(len(want))).To(Equal(fileStat.Size()))
+				resultBuffer, err := ioutil.ReadAll(file)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
+			}
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		table.Entry("return Error with missing scratch space", cirrosFileName, cdiv1.DataVolumeKubeVirt, Error, "/imaninvalidpath", cirrosData, true),
+		table.Entry("return Error with invalid content type ", cirrosFileName, cdiv1.DataVolumeContentType("invalid"), Error, "", cirrosData, true),
+		table.Entry("return Complete with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, Complete, "", diskimageArchiveData, false),
+		table.Entry("return Error with invalid target path and archive", diskimageTarFileName, cdiv1.DataVolumeArchive, Error, "/imaninvalidpath", cirrosData, true),
+		table.Entry("return Process with scratch space and valid qcow file", cirrosFileName, cdiv1.DataVolumeKubeVirt, Process, "", cirrosData, false),
+	)
+
+	It("Transfer should fail on reader error", func() {
+		image := ts.URL + "/" + diskimageTarFileName
+		dp, err = NewHTTPDataSource(image, "", "", "", cdiv1.DataVolumeKubeVirt)
+		Expect(err).NotTo(HaveOccurred())
+
+		nextPhase, err := dp.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(nextPhase))
+		err = dp.Close()
+		Expect(err).NotTo(HaveOccurred())
+		result, err := dp.Transfer(tmpDir)
+		Expect(err).To(HaveOccurred())
+		Expect(Error).To(Equal(result))
+	})
+
+	It("calling Process should return Convert", func() {
+		flushRead = cirrosData
+		dp, err = NewHTTPDataSource(ts.URL+"/"+cirrosFileName, "", "", "", cdiv1.DataVolumeKubeVirt)
+		Expect(err).NotTo(HaveOccurred())
+		_, err := dp.Info()
+		Expect(err).NotTo(HaveOccurred())
+		newPhase, err := dp.Process()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Convert).To(Equal(newPhase))
+	})
+})
+
+var _ = Describe("Http client", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+
+		tempDir, err = ioutil.TempDir("/tmp", "cert-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		keyPair, err := triple.NewCA("datastream.cdi.kubevirt.io")
+		Expect(err).ToNot(HaveOccurred())
+
+		certBytes := cert.EncodeCertPEM(keyPair.Cert)
+
+		err = ioutil.WriteFile(path.Join(tempDir, "tls.crt"), certBytes, 0644)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+	})
+
+	It("should load the cert", func() {
+		client, err := createHTTPClient(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		transport := client.Transport.(*http.Transport)
+		Expect(transport).ToNot(BeNil())
+
+		activeCAs := transport.TLSClientConfig.RootCAs
+		Expect(transport).ToNot(BeNil())
+
+		systemCAs, err := x509.SystemCertPool()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(activeCAs.Subjects())).Should(Equal(len(systemCAs.Subjects()) + 1))
+	})
+
+})
+
+var _ = Describe("Http reader", func() {
+	It("should fail when passed an invalid cert directory", func() {
+		_, err := createHTTPReader(context.Background(), nil, "", "", "/invalid")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should pass auth info in request if set", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			defer w.WriteHeader(200)
+			Expect(ok).To(BeTrue())
+			Expect("user").To(Equal(user))
+			Expect("password").To(Equal(pass))
+		}))
+		defer ts.Close()
+		ep, err := url.Parse(ts.URL)
+		Expect(err).ToNot(HaveOccurred())
+		r, err := createHTTPReader(context.Background(), ep, "user", "password", "")
+		Expect(err).ToNot(HaveOccurred())
+		err = r.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should pass auth info in request if set and redirected", func() {
+		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			defer w.WriteHeader(http.StatusOK)
+			Expect(ok).To(BeTrue())
+			Expect("user").To(Equal(user))
+			Expect("password").To(Equal(pass))
+		}))
+		defer redirTs.Close()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirTs.URL, http.StatusFound)
+		}))
+		defer ts.Close()
+		ep, err := url.Parse(ts.URL)
+		Expect(err).ToNot(HaveOccurred())
+		r, err := createHTTPReader(context.Background(), ep, "user", "password", "")
+		Expect(err).ToNot(HaveOccurred())
+		err = r.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should redirect properly without auth if not set", func() {
+		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _, ok := r.BasicAuth()
+			defer w.WriteHeader(http.StatusOK)
+			Expect(ok).To(BeFalse())
+		}))
+		defer redirTs.Close()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirTs.URL, http.StatusFound)
+		}))
+		defer ts.Close()
+		ep, err := url.Parse(ts.URL)
+		Expect(err).ToNot(HaveOccurred())
+		r, err := createHTTPReader(context.Background(), ep, "", "", "")
+		Expect(err).ToNot(HaveOccurred())
+		err = r.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail if server returns error code", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(500)
+		}))
+		defer ts.Close()
+		ep, err := url.Parse(ts.URL)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = createHTTPReader(context.Background(), ep, "", "", "")
+		Expect(err).To(HaveOccurred())
+		Expect("expected status code 200, got 500. Status: 500 Internal Server Error").To(Equal(err.Error()))
+	})
+})
+
+var _ = Describe("http pollprogress", func() {
+	It("Should properly finish with valid reader", func() {
+		By("Creating context for the transfer, we have the ability to cancel it")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dp := &HTTPDataSource{
+			ctx:    ctx,
+			cancel: cancel,
+		}
+		By("Creating string reader we can test just the poll progress part")
+		stringReader := ioutil.NopCloser(strings.NewReader("This is a test string"))
+		endlessReader := EndlessReader{
+			Reader: stringReader,
+		}
+		countingReader := &util.CountingReader{
+			Reader:  &endlessReader,
+			Current: 0,
+		}
+		By("Creating pollProgress as go routine, we can use channels to monitor progress")
+		go dp.pollProgress(countingReader, 5*time.Second, time.Second)
+		By("Waiting for timeout or success")
+		select {
+		case <-time.After(10 * time.Second):
+			Fail("Transfer not cancelled after 10 seconds")
+		case <-dp.ctx.Done():
+			By("Having context be done, we confirm finishing of transfer")
+		}
+	})
+})
+
+func createTestServer(imageDir string) *httptest.Server {
+	return httptest.NewServer(http.FileServer(http.Dir(imageDir)))
+}
+
+// Read the contents of the file into a byte array, don't use this on really huge files.
+func readFile(fileName string) ([]byte, error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	result, err := ioutil.ReadAll(f)
+	return result, err
+}
+
+// EndlessReader doesn't return any value read, te r
+type EndlessReader struct {
+	Reader io.ReadCloser
+}
+
+// Read doesn't return any values
+func (r *EndlessReader) Read(p []byte) (int, error) {
+	_, err := r.Reader.Read(p)
+	Expect(err).ToNot(HaveOccurred())
+	return 0, nil
+}
+
+// Close closes the stream
+func (r *EndlessReader) Close() error {
+	return r.Reader.Close()
+}

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2018 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importer
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/klog"
+
+	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+const (
+	//containerDiskImageDir - Expected disk image location in container image as described in
+	//https://github.com/kubevirt/kubevirt/blob/master/docs/container-register-disks.md
+	containerDiskImageDir = "disk"
+)
+
+// RegistryDataSource is the struct containing the information needed to import from a registry data source.
+// Sequence of phases:
+// 1. Info -> Transfer
+// 2. Transfer -> Process
+// 3. Process -> Convert (In the process phase the container image layers are extracted, and the url is pointed to the file determined to be the disk image)
+type RegistryDataSource struct {
+	endpoint    string
+	accessKey   string
+	secKey      string
+	certDir     string
+	insecureTLS bool
+	imageDir    string
+	//The discovered image file in scratch space.
+	url *url.URL
+}
+
+// NewRegistryDataSource creates a new instance of the Registry Data Source.
+func NewRegistryDataSource(endpoint, accessKey, secKey, certDir string, insecureTLS bool) *RegistryDataSource {
+	return &RegistryDataSource{
+		endpoint:    endpoint,
+		accessKey:   accessKey,
+		secKey:      secKey,
+		certDir:     certDir,
+		insecureTLS: insecureTLS,
+	}
+}
+
+// Info is called to get initial information about the data. No information available for registry currently.
+func (rd *RegistryDataSource) Info() (ProcessingPhase, error) {
+	return Transfer, nil
+}
+
+// Transfer is called to transfer the data from the source registry to a temporary location.
+func (rd *RegistryDataSource) Transfer(path string) (ProcessingPhase, error) {
+	if util.GetAvailableSpace(path) <= int64(0) {
+		// Path provided is invalid.
+		return Error, ErrInvalidPath
+	}
+	rd.imageDir = filepath.Join(path, containerDiskImageDir)
+
+	klog.V(1).Infof("Copying registry image to scratch space.")
+	err := image.CopyRegistryImage(rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.certDir, rd.insecureTLS)
+	if err != nil {
+		return Error, errors.Wrapf(err, "Failed to read registry image")
+	}
+
+	return Process, nil
+}
+
+// Process is called to do any special processing before giving the url to the data back to the processor
+func (rd *RegistryDataSource) Process() (ProcessingPhase, error) {
+	imageFile, err := getImageFileName(rd.imageDir)
+	if err != nil {
+		return Error, errors.Wrapf(err, "Cannot locate image file")
+	}
+
+	// imageFile and rd.imageDir are both valid, thus the Join will be valid, and the parse will work, no need to check for parse errors
+	rd.url, _ = url.Parse(filepath.Join(rd.imageDir, imageFile))
+	klog.V(3).Infof("Successfully found file. VM disk image filename is %s", rd.url.String())
+	return Convert, nil
+}
+
+// GetURL returns the url that the data processor can use when converting the data.
+func (rd *RegistryDataSource) GetURL() *url.URL {
+	return rd.url
+}
+
+// Close closes any readers or other open resources.
+func (rd *RegistryDataSource) Close() error {
+	// No-op, no open readers
+	return nil
+}
+
+func getImageFileName(dir string) (string, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		klog.Errorf("image directory does not exist")
+		return "", errors.Errorf("image directory does not exist")
+	}
+
+	entries, err := ioutil.ReadDir(dir)
+	if err != nil {
+		klog.Errorf("Error reading directory")
+		return "", errors.Wrapf(err, "image file does not exist in image directory")
+	}
+
+	if len(entries) == 0 {
+		klog.Errorf("image file does not exist in image directory - directory is empty ")
+		return "", errors.New("image file does not exist in image directory - directory is empty")
+	}
+
+	fileinfo := entries[len(entries)-1]
+	if fileinfo.IsDir() {
+		klog.Errorf("image file does not exist in image directory contains another directory ")
+		return "", errors.New("image directory contains another directory")
+	}
+
+	filename := fileinfo.Name()
+
+	if len(strings.TrimSpace(filename)) == 0 {
+		klog.Errorf("image file does not exist in image directory - file has no name ")
+		return "", errors.New("image file does has no name")
+	}
+
+	klog.V(1).Infof("VM disk image filename is %s", filename)
+
+	return filename, nil
+}

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -1,0 +1,195 @@
+package importer
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+var (
+	imageFile = filepath.Join(imageDir, "registry-image.tar")
+)
+
+var _ = Describe("Registry data source", func() {
+	var tmpDir string
+	var err error
+	var ds *RegistryDataSource
+
+	BeforeEach(func() {
+		tmpDir, err = ioutil.TempDir("", "scratch")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+		if ds != nil {
+			err = ds.Close()
+			Expect(err).NotTo(HaveOccurred())
+			ds = nil
+		}
+	})
+
+	It("should return transfer after info is called", func() {
+		ds = NewRegistryDataSource("", "", "", "", true)
+		result, err := ds.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(result))
+	})
+
+	table.DescribeTable("Transfer should ", func(ep, accKey, secKey, certDir, scratchPath string, insecureRegistry bool, skopeoOperations image.SkopeoOperations, wantErr bool) {
+		if scratchPath == "" {
+			scratchPath = tmpDir
+		}
+		ds = NewRegistryDataSource(ep, accKey, secKey, certDir, insecureRegistry)
+		By("Replacing Skopeo Operations")
+		replaceSkopeoOperations(skopeoOperations, func() {
+			// Need to pass in a real path if we don't want scratch space needed error.
+			result, err := ds.Transfer(scratchPath)
+			if !wantErr {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(Process).To(Equal(result))
+				Expect(filepath.Join(scratchPath, containerDiskImageDir)).To(Equal(ds.imageDir))
+			} else {
+				Expect(err).To(HaveOccurred())
+				Expect(Error).To(Equal(result))
+			}
+		})
+	},
+		table.Entry("successfully return Process on valid scratch space and empty user parameters", "endpoint", "", "", "", "", true, NewFakeSkopeoOperations("endpoint", "", "", "", true, nil), false),
+		table.Entry("successfully return Process on valid scratch space and parameters", "endpoint", "username", "password", "/path/to/cert", "", true, NewFakeSkopeoOperations("endpoint", "username", "password", "/path/to/cert", true, nil), false),
+		table.Entry("return Error on invalid scratch space", "endpoint", "", "", "", "/invalid", true, NewFakeSkopeoOperations("endpoint", "", "", "", true, nil), true),
+		table.Entry("return Error on valid scratch space, but CopyImage failed", "endpoint", "", "", "", "", true, NewSkopeoAllErrors(), true),
+	)
+
+	table.DescribeTable("Process should ", func(scratchPath string, wantErr bool) {
+		ds = NewRegistryDataSource("", "", "", "", true)
+		if scratchPath == "" {
+			scratchPath = tmpDir
+			err := os.Mkdir(filepath.Join(scratchPath, containerDiskImageDir), os.ModeDir)
+			Expect(err).NotTo(HaveOccurred())
+			err = util.CopyFile(cirrosFilePath, filepath.Join(scratchPath, containerDiskImageDir, cirrosFileName))
+			Expect(err).NotTo(HaveOccurred())
+		}
+		ds.imageDir = filepath.Join(scratchPath, containerDiskImageDir)
+		result, err := ds.Process()
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(Convert).To(Equal(result))
+			imageFileName, err := url.Parse(filepath.Join(scratchPath, containerDiskImageDir, cirrosFileName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageFileName).To(Equal(ds.GetURL()))
+		} else {
+			Expect(err).To(HaveOccurred())
+			Expect(Error).To(Equal(result))
+		}
+	},
+		table.Entry("successfully return Convert on valid image file", "", false),
+		table.Entry("return Error on invalid image file", "/invalid", true),
+	)
+
+	It("getImageFileName should return an error with non-existing image directory", func() {
+		_, err := getImageFileName("/invalid")
+		Expect(err).To(HaveOccurred())
+		Expect("image directory does not exist").To(Equal(err.Error()))
+	})
+
+	It("getImageFileName should return an error with invalid image directory", func() {
+		file, err := os.Create(filepath.Join(tmpDir, "test"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getImageFileName(file.Name())
+		Expect(err).To(HaveOccurred())
+		Expect(strings.Contains(err.Error(), "image file does not exist in image directory")).To(BeTrue())
+	})
+
+	It("getImageFileName should return an error with empty image directory", func() {
+		err := os.Mkdir(filepath.Join(tmpDir, containerDiskImageDir), os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getImageFileName(filepath.Join(tmpDir, containerDiskImageDir))
+		Expect(err).To(HaveOccurred())
+		Expect("image file does not exist in image directory - directory is empty").To(Equal(err.Error()))
+	})
+
+	It("getImageFileName should return an error with image directory containing another directory", func() {
+		err := os.Mkdir(filepath.Join(tmpDir, containerDiskImageDir), os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Mkdir(filepath.Join(tmpDir, containerDiskImageDir, "anotherdir"), os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getImageFileName(filepath.Join(tmpDir, containerDiskImageDir))
+		Expect(err).To(HaveOccurred())
+		Expect("image directory contains another directory").To(Equal(err.Error()))
+	})
+
+	It("getImageFileName should return an error with zero length filename", func() {
+		err := os.Mkdir(filepath.Join(tmpDir, containerDiskImageDir), os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Create(filepath.Join(tmpDir, containerDiskImageDir, " "))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getImageFileName(filepath.Join(tmpDir, containerDiskImageDir))
+		Expect(err).To(HaveOccurred())
+		Expect("image file does has no name").To(Equal(err.Error()))
+	})
+})
+
+type fakeSkopeoOperations struct {
+	ep               string
+	accKey           string
+	secKey           string
+	certDir          string
+	insecureRegistry bool
+	e1               error
+}
+
+func replaceSkopeoOperations(replacement image.SkopeoOperations, f func()) {
+	orig := image.SkopeoInterface
+	if replacement != nil {
+		image.SkopeoInterface = replacement
+		defer func() { image.SkopeoInterface = orig }()
+	}
+	f()
+}
+
+func NewSkopeoAllErrors() image.SkopeoOperations {
+	err := errors.New("skopeo should not be called from this test override with replaceSkopeoOperations")
+	return &fakeSkopeoOperations{
+		e1: err,
+	}
+}
+
+func NewFakeSkopeoOperations(ep, accKey, secKey, certDir string, insecureRegistry bool, e1 error) image.SkopeoOperations {
+	return &fakeSkopeoOperations{
+		ep:               ep,
+		accKey:           accKey,
+		secKey:           secKey,
+		certDir:          certDir,
+		insecureRegistry: insecureRegistry,
+		e1:               e1,
+	}
+}
+
+func (o *fakeSkopeoOperations) CopyImage(url, dest, accessKey, secKey, certDir string, insecureRegistry bool) error {
+	if o.e1 != nil {
+		return o.e1
+	}
+	dest = filepath.Dir(dest)
+	dest = strings.Replace(dest, "dir:", "", 1)
+	if err := util.UnArchiveLocalTar(imageFile, dest); err != nil {
+		return errors.Wrap(err, "could not extract layer tar")
+	}
+	Expect(o.ep).To(Equal(url))
+	Expect(o.accKey).To(Equal(accessKey))
+	Expect(o.secKey).To(Equal(secKey))
+	Expect(o.certDir).To(Equal(certDir))
+	Expect(o.insecureRegistry).To(Equal(insecureRegistry))
+	return nil
+}

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -1,0 +1,130 @@
+package importer
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	minio "github.com/minio/minio-go"
+	"github.com/pkg/errors"
+
+	"k8s.io/klog"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+// S3Client is the interface to the used S3 client.
+type S3Client interface {
+	GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (*minio.Object, error)
+}
+
+// may be overridden in tests
+var newClientFunc = getS3Client
+
+// S3DataSource is the struct containing the information needed to import from an S3 data source.
+// Sequence of phases:
+// 1. Info -> Transfer
+// 2. Transfer -> Process
+// 3. Process -> Convert
+type S3DataSource struct {
+	// S3 end point
+	ep *url.URL
+	// User name
+	accessKey string
+	// Password
+	secKey string
+	// Reader
+	s3Reader io.ReadCloser
+	// stack of readers
+	readers *FormatReaders
+	// The image file in scratch space.
+	url *url.URL
+}
+
+// NewS3DataSource creates a new instance of the S3DataSource
+func NewS3DataSource(endpoint, accessKey, secKey string) (*S3DataSource, error) {
+	ep, err := ParseEndpoint(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, fmt.Sprintf("unable to parse endpoint %q", endpoint))
+	}
+	s3Reader, err := createS3Reader(ep, accessKey, secKey)
+	if err != nil {
+		return nil, err
+	}
+	return &S3DataSource{
+		ep:        ep,
+		accessKey: accessKey,
+		secKey:    secKey,
+		s3Reader:  s3Reader,
+	}, nil
+}
+
+// Info is called to get initial information about the data.
+func (sd *S3DataSource) Info() (ProcessingPhase, error) {
+	var err error
+	sd.readers, err = NewFormatReaders(sd.s3Reader, cdiv1.DataVolumeKubeVirt)
+	if err != nil {
+		klog.Errorf("Error creating readers: %v", err)
+		return Error, err
+	}
+	return Transfer, nil
+}
+
+// Transfer is called to transfer the data from the source to a temporary location.
+func (sd *S3DataSource) Transfer(path string) (ProcessingPhase, error) {
+	if util.GetAvailableSpace(path) <= int64(0) {
+		//Path provided is invalid.
+		return Error, ErrInvalidPath
+	}
+	file := filepath.Join(path, tempFile)
+	err := StreamDataToFile(sd.readers.TopReader(), file)
+	if err != nil {
+		return Error, err
+	}
+	// If streaming succeeded, then parsing the file into URL will also succeed, no need to check error status
+	sd.url, _ = url.Parse(file)
+	return Process, nil
+}
+
+// Process is called to do any special processing before giving the url to the data back to the processor
+func (sd *S3DataSource) Process() (ProcessingPhase, error) {
+	return Convert, nil
+}
+
+// GetURL returns the url that the data processor can use when converting the data.
+func (sd *S3DataSource) GetURL() *url.URL {
+	return sd.url
+}
+
+// Close closes any readers or other open resources.
+func (sd *S3DataSource) Close() error {
+	var err error
+	if sd.readers != nil {
+		err = sd.readers.Close()
+	}
+	return err
+}
+
+func createS3Reader(ep *url.URL, accessKey, secKey string) (io.ReadCloser, error) {
+	klog.V(3).Infoln("Using S3 client to get data")
+	bucket := ep.Host
+	object := strings.Trim(ep.Path, "/")
+	mc, err := newClientFunc(accessKey, secKey, false)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not build minio client for %q", ep.Host)
+	}
+	klog.V(2).Infof("Attempting to get object %q via S3 client\n", ep.String())
+	objectReader, err := mc.GetObject(bucket, object, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get s3 object: \"%s/%s\"", bucket, object)
+	}
+	return objectReader, nil
+}
+
+func getS3Client(accessKey, secKey string, secure bool) (S3Client, error) {
+	return minio.NewV4(common.ImporterS3Host, accessKey, secKey, secure)
+}

--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -1,0 +1,188 @@
+package importer
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	minio "github.com/minio/minio-go"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("S3 data source", func() {
+	var (
+		sd     *S3DataSource
+		tmpDir string
+		err    error
+	)
+
+	BeforeEach(func() {
+		newClientFunc = createMockS3Client
+		tmpDir, err = ioutil.TempDir("", "scratch")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+	})
+
+	AfterEach(func() {
+		newClientFunc = getS3Client
+		if sd != nil {
+			sd.Close()
+		}
+		os.RemoveAll(tmpDir)
+	})
+
+	It("NewS3DataSource should Error, when passed in an invalid endpoint", func() {
+		sd, err = NewS3DataSource("thisisinvalid#$%#ep", "", "")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("NewS3DataSource should Error, when failing to create minio client", func() {
+		newClientFunc = failMockS3Client
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("NewS3DataSource should Error, when failing to get object", func() {
+		newClientFunc = createErrMockS3Client
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Info should return Error, when passed in an invalid image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(filepath.Join(imageDir, "content.tar"))
+		Expect(err).NotTo(HaveOccurred())
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		// Replace minio.Object with a reader we can use.
+		sd.s3Reader = file
+		result, err := sd.Info()
+		Expect(err).To(HaveOccurred())
+		Expect(Error).To(Equal(result))
+	})
+
+	It("Info should return Transfer, when passed in a valid image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		// Replace minio.Object with a reader we can use.
+		sd.s3Reader = file
+		result, err := sd.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(result))
+	})
+
+	table.DescribeTable("calling transfer should", func(fileName, scratchPath string, want []byte, wantErr bool) {
+		if scratchPath == "" {
+			scratchPath = tmpDir
+		}
+		sourceFile, err := os.Open(fileName)
+		Expect(err).NotTo(HaveOccurred())
+
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		// Replace minio.Object with a reader we can use.
+		sd.s3Reader = sourceFile
+		nextPhase, err := sd.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(nextPhase))
+		result, err := sd.Transfer(scratchPath)
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(Process))
+			file, err := os.Open(filepath.Join(scratchPath, tempFile))
+			Expect(err).NotTo(HaveOccurred())
+			defer file.Close()
+			fileStat, err := file.Stat()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(int64(len(want))).To(Equal(fileStat.Size()))
+			resultBuffer, err := ioutil.ReadAll(file)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
+			Expect(file.Name()).To(Equal(sd.GetURL().String()))
+		} else {
+			Expect(err).To(HaveOccurred())
+			Expect(Error).To(Equal(result))
+		}
+	},
+		table.Entry("return Error with missing scratch space", cirrosFilePath, "/imaninvalidpath", nil, true),
+		table.Entry("return Process with scratch space and valid qcow file", cirrosFilePath, "", cirrosData, false),
+	)
+
+	It("Transfer should fail on reader error", func() {
+		sourceFile, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		// Replace minio.Object with a reader we can use.
+		sd.s3Reader = sourceFile
+		nextPhase, err := sd.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(nextPhase))
+		err = sourceFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+		result, err := sd.Transfer(tmpDir)
+		Expect(err).To(HaveOccurred())
+		Expect(Error).To(Equal(result))
+	})
+
+	It("Process should return Convert", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		sd, err = NewS3DataSource("http://amazon.com", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		// Replace minio.Object with a reader we can use.
+		sd.s3Reader = file
+		result, err := sd.Process()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Convert).To(Equal(result))
+	})
+
+	It("GetS3Client should return a real client", func() {
+		_, err := getS3Client("", "", false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+// MockMinioClient is a mock minio client
+type MockMinioClient struct {
+	accKey string
+	secKey string
+	secure bool
+	doErr  bool
+}
+
+func failMockS3Client(accKey, secKey string, secure bool) (S3Client, error) {
+	return nil, errors.New("Failed to create client")
+}
+
+func createMockS3Client(accKey, secKey string, secure bool) (S3Client, error) {
+	return &MockMinioClient{
+		accKey: accKey,
+		secKey: secKey,
+		secure: secure,
+		doErr:  false,
+	}, nil
+}
+
+func createErrMockS3Client(accKey, secKey string, secure bool) (S3Client, error) {
+	return &MockMinioClient{
+		doErr: true,
+	}, nil
+}
+
+func (mc *MockMinioClient) GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (*minio.Object, error) {
+	if !mc.doErr {
+		return &minio.Object{}, nil
+	}
+	return nil, errors.New("Failed to get object")
+}

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -1,0 +1,78 @@
+package importer
+
+import (
+	"io"
+	"net/url"
+	"path/filepath"
+
+	"k8s.io/klog"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+// UploadDataSource contains all the information need to upload data into a data volume.
+// Sequence of phases:
+// 1. Info -> Transfer (In Info phase the format readers are configured)
+// 2. Transfer -> Process
+// 3. Process -> Convert
+type UploadDataSource struct {
+	// Data strean
+	stream io.ReadCloser
+	// stack of readers
+	readers *FormatReaders
+	// url to a file in scratch space.
+	url *url.URL
+}
+
+// NewUploadDataSource creates a new instance of an UploadDataSource
+func NewUploadDataSource(stream io.ReadCloser) *UploadDataSource {
+	return &UploadDataSource{
+		stream: stream,
+	}
+}
+
+// Info is called to get initial information about the data.
+func (ud *UploadDataSource) Info() (ProcessingPhase, error) {
+	var err error
+	// Hardcoded to only accept kubevirt content type.
+	ud.readers, err = NewFormatReaders(ud.stream, cdiv1.DataVolumeKubeVirt)
+	if err != nil {
+		klog.Errorf("Error creating readers: %v", err)
+		return Error, err
+	}
+	return Transfer, nil
+}
+
+// Transfer is called to transfer the data from the source to a temporary location.
+func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
+	if util.GetAvailableSpace(path) <= int64(0) {
+		//Path provided is invalid.
+		return Error, ErrInvalidPath
+	}
+	file := filepath.Join(path, tempFile)
+	err := StreamDataToFile(ud.readers.TopReader(), file)
+	if err != nil {
+		return Error, err
+	}
+	// If we successfully wrote to the file, then the parse will succeed.
+	ud.url, _ = url.Parse(file)
+	return Process, nil
+}
+
+// Process is called to do any special processing before giving the url to the data back to the processor
+func (ud *UploadDataSource) Process() (ProcessingPhase, error) {
+	return Convert, nil
+}
+
+// GetURL returns the url that the data processor can use when converting the data.
+func (ud *UploadDataSource) GetURL() *url.URL {
+	return ud.url
+}
+
+// Close closes any readers or other open resources.
+func (ud *UploadDataSource) Close() error {
+	if ud.stream != nil {
+		return ud.stream.Close()
+	}
+	return nil
+}

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -1,0 +1,117 @@
+package importer
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Upload data source", func() {
+	var (
+		ud     *UploadDataSource
+		tmpDir string
+		err    error
+	)
+
+	BeforeEach(func() {
+		tmpDir, err = ioutil.TempDir("", "scratch")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+	})
+
+	AfterEach(func() {
+		if ud != nil {
+			ud.Close()
+		}
+		os.RemoveAll(tmpDir)
+	})
+
+	It("Info should return Error, when passed in an invalid image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(filepath.Join(imageDir, "content.tar"))
+		Expect(err).NotTo(HaveOccurred())
+		ud = NewUploadDataSource(file)
+		result, err := ud.Info()
+		Expect(err).To(HaveOccurred())
+		Expect(Error).To(Equal(result))
+	})
+
+	It("Info should return Transfer, when passed in a valid image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		ud = NewUploadDataSource(file)
+		result, err := ud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(result))
+	})
+
+	table.DescribeTable("calling transfer should", func(fileName, scratchPath string, want []byte, wantErr bool) {
+		if scratchPath == "" {
+			scratchPath = tmpDir
+		}
+		sourceFile, err := os.Open(fileName)
+		Expect(err).NotTo(HaveOccurred())
+
+		ud = NewUploadDataSource(sourceFile)
+		nextPhase, err := ud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(nextPhase))
+		result, err := ud.Transfer(scratchPath)
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(Process))
+			file, err := os.Open(filepath.Join(scratchPath, tempFile))
+			Expect(err).NotTo(HaveOccurred())
+			defer file.Close()
+			fileStat, err := file.Stat()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(int64(len(want))).To(Equal(fileStat.Size()))
+			resultBuffer, err := ioutil.ReadAll(file)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
+			Expect(file.Name()).To(Equal(ud.GetURL().String()))
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		table.Entry("return Error with missing scratch space", cirrosFilePath, "/imaninvalidpath", nil, true),
+		table.Entry("return Process with scratch space and valid qcow file", cirrosFilePath, "", cirrosData, false),
+	)
+
+	It("Transfer should fail on reader error", func() {
+		sourceFile, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+
+		ud = NewUploadDataSource(sourceFile)
+		nextPhase, err := ud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Transfer).To(Equal(nextPhase))
+		err = sourceFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+		result, err := ud.Transfer(tmpDir)
+		Expect(err).To(HaveOccurred())
+		Expect(Error).To(Equal(result))
+	})
+
+	It("Process should return Convert", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		ud = NewUploadDataSource(file)
+		result, err := ud.Process()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(Convert).To(Equal(result))
+	})
+
+	It("Close with nil stream should not fail", func() {
+		ud = NewUploadDataSource(nil)
+		err := ud.Close()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes a bug where the target namespace pod cloning pod was not being cleaned up properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Target pod is now cleaned up properly when cloning across namespaces.
```

