### PR TITLE
Fix target pod cleanup across namespaces

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -168,20 +168,20 @@ func (cc *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 	if err != nil {
 		return errors.WithMessage(err, "could not update pvc %q annotation and/or label")
 	} else if pvc.Annotations[AnnCloneOf] == "true" {
-		cc.deleteClonePods(sourcePod.Namespace, sourcePod.Name, targetPod.Name)
+		cc.deleteClonePods(sourcePod.Namespace, sourcePod.Name, targetPod.Namespace, targetPod.Name)
 	}
 	return nil
 }
 
-func (cc *CloneController) deleteClonePods(namespace, srcName, tgtName string) {
+func (cc *CloneController) deleteClonePods(srcNamespace, srcName, tgtNamespace, tgtName string) {
 	srcReq := podDeleteRequest{
-		namespace: namespace,
+		namespace: srcNamespace,
 		podName:   srcName,
 		podLister: cc.Controller.podLister,
 		k8sClient: cc.Controller.clientset,
 	}
 	tgtReq := podDeleteRequest{
-		namespace: namespace,
+		namespace: tgtNamespace,
 		podName:   tgtName,
 		podLister: cc.Controller.podLister,
 		k8sClient: cc.Controller.clientset,


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes a bug where the target namespace pod cloning pod was not being cleaned up properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Target pod is now cleaned up properly when cloning across namespaces.
```

