### PR TITLE
PVC accessModes should be a required field

### DIFF
--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -142,6 +142,7 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 									},
 									Required: []string{
 										"resources",
+										"accessModes",
 									},
 								},
 							},

--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -179,6 +179,7 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 			table.Entry("[test_id:1765]fail with invalid source PVC", "manifests/dvInvalidSourcePVC.yaml", true),
 			table.Entry("[test_id:1766][posneg:positive]succeed with valid source http", "manifests/datavolume.yaml", false),
 			table.Entry("[test_id:1767]fail with missing PVC spec", "manifests/dvMissingPVCSpec.yaml", true),
+			table.Entry("fail with missing PVC accessModes", "manifests/dvMissingPVCAccessModes.yaml", true),
 			table.Entry("[test_id:1768]fail with missing resources spec", "manifests/dvMissingResourcesSpec.yaml", true),
 			table.Entry("[test_id:1769]fail with 0 size PVC", "manifests/dv0SizePVC.yaml", true),
 		)

--- a/tests/manifests/dvMissingPVCAccessModes.yaml
+++ b/tests/manifests/dvMissingPVCAccessModes.yaml
@@ -1,0 +1,12 @@
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: test-dv
+spec:
+  source:
+      http:
+         url: "https://www.example.com/example.img"
+  pvc:
+    resources:
+      requests:
+        storage: 500Mi


### PR DESCRIPTION
Signed-off-by: Irit goihman <igoihman@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #735

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DataVolume creation is rejected if PVC accessModes field is missing
```

