### PR TITLE
Fix for issue #1690415 - CDI appends 'source pod' to a label and may fail on error that label must not be longer than 63 characters

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -53,7 +53,7 @@ func (cc *CloneController) findClonePodsFromCache(pvc *v1.PersistentVolumeClaim)
 			return nil, nil, errors.Errorf("Bad CloneRequest Annotation")
 		}
 		//find the source pod
-		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{CloneUniqueID: pvc.Name + "-source-pod"}})
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{CloneUniqueID: string(pvc.GetUID()) + "-source-pod"}})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -68,7 +68,7 @@ func (cc *CloneController) findClonePodsFromCache(pvc *v1.PersistentVolumeClaim)
 		}
 		sourcePod = podList[0]
 		//find target pod
-		selector, err = metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{CloneUniqueID: pvc.Name + "-target-pod"}})
+		selector, err = metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{CloneUniqueID: string(pvc.GetUID()) + "-target-pod"}})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -126,7 +126,7 @@ func (cc *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 		if err != nil {
 			return err
 		}
-		//create random string to be used for pod labeling and hostpath name
+
 		if sourcePod == nil {
 			cr, err := getCloneRequestPVC(pvc)
 			if err != nil {

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -234,6 +234,8 @@ func TestCloneFindPodsInCacheUpdating(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, tests[0].sourcePod)
 	f.kubeobjects = append(f.kubeobjects, tests[0].targetPod)
 
+	tests[1].pvc.SetUID("pvc-uid-clone1")
+	id = string(tests[1].pvc.GetUID())
 	tests[1].sourcePod = createSourcePod(tests[1].pvc, id)
 	tests[1].sourcePod.Namespace = "source-ns"
 	tests[1].sourcePod.Name = fmt.Sprintf("fakesourcename%d", 2)

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -603,6 +603,7 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName string, pvc *v1.Per
 	id := string(pvc.GetUID())
 	blockOwnerDeletion := true
 	isController := true
+
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -619,7 +620,7 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName string, pvc *v1.Per
 				common.CDIComponentLabel: common.ClonerSourcePodName,
 				common.CloningLabelKey:   common.CloningLabelValue + "-" + id, //used by podAffity
 				// this label is used when searching for a pvc's cloner source pod.
-				CloneUniqueID: pvc.Name + "-source-pod",
+				CloneUniqueID: id + "-source-pod",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -722,7 +723,7 @@ func MakeCloneTargetPodSpec(image, pullPolicy, podAffinityNamespace string, pvc 
 				common.CDILabelKey:       common.CDILabelValue, //filtered by the podInformer
 				common.CDIComponentLabel: common.ClonerTargetPodName,
 				// this label is used when searching for a pvc's cloner target pod.
-				CloneUniqueID:          pvc.Name + "-target-pod",
+				CloneUniqueID:          id + "-target-pod",
 				common.PrometheusLabel: "",
 			},
 			OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION

Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Description of problem:
When a VM is created with long enough name, and than this VM is cloned, the cloning process fails on error:
E0319 12:24:27.745852       1 clone-controller.go:215] error processing pvc "default/vm-url-test-jwbfh-clone-vm-url-test-jwbfh-rootdisk-clone": invalid label value: "vm-url-test-jwbfh-clone-vm-url-test-jwbfh-rootdisk-clone-source-pod": must be no more than 63 characters

Result: Cloned VM is stuck on pending, cdi-deployment pod fails on error mentioned above

Fixes #1690415

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

