### PR TITLE
Display error message when importer pod is passed none source and arc…

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog"
@@ -108,6 +110,9 @@ func main() {
 			klog.Errorf("%+v", err)
 			os.Exit(1)
 		}
+	} else if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeArchive) {
+		klog.Errorf("%+v", errors.New("Cannot create empty disk with content type archive"))
+		os.Exit(1)
 	} else {
 		err = importer.CopyData(dso)
 		if err != nil {


### PR DESCRIPTION
…hive content type

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Display an appropriate error message in pod log when source: none and content type archive is passed in.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BUGFIX: Display error message when creating PVC with source: none and content type archive.
```

