### PR TITLE
Change the prometheus label used by cdi.

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,7 +21,7 @@ const (
 	CDIComponentLabel = "cdi.kubevirt.io"
 
 	// PrometheusLabel provides the label to indicate prometheus metrics are available in the pods.
-	PrometheusLabel = "prometheus.kubevirt.io"
+	PrometheusLabel = "prometheus.cdi.kubevirt.io"
 
 	// ImporterVolumePath provides a constant for the directory where the PV is mounted.
 	ImporterVolumePath = "/data"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Changes the prometheus label used by CDI components to not clash with kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #753 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

