### PR TITLE
BACKPORT to 1.8 - apiserver should return RootPaths

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -129,15 +129,16 @@ func NewCdiAPIServer(bindAddress string,
 			}
 		}
 		chain.ProcessFilter(req, resp)
-		klog.V(1).Infof("----------------------------")
-		klog.V(1).Infof("remoteAddress:%s", strings.Split(req.Request.RemoteAddr, ":")[0])
-		klog.V(1).Infof("username: %s", username)
-		klog.V(1).Infof("method: %s", req.Request.Method)
-		klog.V(1).Infof("url: %s", req.Request.URL.RequestURI())
-		klog.V(1).Infof("proto: %s", req.Request.Proto)
-		klog.V(1).Infof("headers: %v", req.Request.Header)
-		klog.V(1).Infof("statusCode: %d", resp.StatusCode())
-		klog.V(1).Infof("contentLength: %d", resp.ContentLength())
+
+		klog.V(3).Infof("----------------------------")
+		klog.V(3).Infof("remoteAddress:%s", strings.Split(req.Request.RemoteAddr, ":")[0])
+		klog.V(3).Infof("username: %s", username)
+		klog.V(3).Infof("method: %s", req.Request.Method)
+		klog.V(3).Infof("url: %s", req.Request.URL.RequestURI())
+		klog.V(3).Infof("proto: %s", req.Request.Proto)
+		klog.V(3).Infof("headers: %v", req.Request.Header)
+		klog.V(3).Infof("statusCode: %d", resp.StatusCode())
+		klog.V(3).Infof("contentLength: %d", resp.ContentLength())
 
 	})
 
@@ -461,6 +462,24 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 	app.container.Add(uploadTokenWs)
 
 	ws := new(restful.WebService)
+
+	ws.Route(ws.GET("/").
+		Produces("application/json").Writes(metav1.RootPaths{}).
+		To(func(request *restful.Request, response *restful.Response) {
+			response.WriteAsJson(&metav1.RootPaths{
+				Paths: []string{
+					"/apis",
+					"/apis/",
+					groupPath,
+					resourcePath,
+					healthzPath,
+				},
+			})
+		}).
+		Operation("getRootPaths").
+		Doc("Get a CDI API root paths").
+		Returns(http.StatusOK, "OK", metav1.RootPaths{}).
+		Returns(http.StatusNotFound, "Not Found", nil))
 
 	// K8s needs the ability to query info about a specific API group
 	ws.Route(ws.GET(groupPath).

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -529,6 +529,29 @@ func TestGetAPIGroup(t *testing.T) {
 
 	checkEqual(t, expectedAPIGroup, apiGroup)
 }
+
+func TestGetRootPaths(t *testing.T) {
+	rr := doGetRequest(t, "/")
+
+	rootPaths := metav1.RootPaths{}
+	err := json.Unmarshal(rr.Body.Bytes(), &rootPaths)
+	if err != nil {
+		t.Errorf("Couldn't convert to object from JSON: %+v", err)
+	}
+
+	expectedRootPaths := metav1.RootPaths{
+		Paths: []string{
+			"/apis",
+			"/apis/",
+			"/apis/upload.cdi.kubevirt.io",
+			"/apis/upload.cdi.kubevirt.io/v1alpha1",
+			"/healthz",
+		},
+	}
+
+	checkEqual(t, expectedRootPaths, rootPaths)
+}
+
 func TestGetAPIGroupList(t *testing.T) {
 	rr := doGetRequest(t, "/apis")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Would be nice to backport this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

