### PR TITLE
Ingress should not be required to have a label

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -121,9 +121,7 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 	serviceInformerFactory := k8sinformers.NewFilteredSharedInformerFactory(client, common.DefaultResyncPeriod, "", func(options *v1.ListOptions) {
 		options.LabelSelector = common.CDILabelSelector
 	})
-	ingressInformerFactory := k8sinformers.NewFilteredSharedInformerFactory(client, common.DefaultResyncPeriod, "", func(options *v1.ListOptions) {
-		options.LabelSelector = common.CDILabelSelector
-	})
+	ingressInformerFactory := k8sinformers.NewSharedInformerFactory(client, common.DefaultResyncPeriod)
 	routeInformerFactory := routeinformers.NewSharedInformerFactory(openshiftClient, common.DefaultResyncPeriod)
 
 	pvcInformer := pvcInformerFactory.Core().V1().PersistentVolumeClaims()

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -74,7 +74,7 @@ func NewConfigController(client kubernetes.Interface,
 
 	// Bind the ingress SharedIndexInformer to the ingress queue
 	c.ingressInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: c.handleObjAdd,
+		AddFunc: c.handleObject,
 		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*extensionsv1beta1.Ingress)
 			oldDepl := old.(*extensionsv1beta1.Ingress)
@@ -82,15 +82,15 @@ func NewConfigController(client kubernetes.Interface,
 				// Periodic resync will send update events for all known ingresses.
 				return
 			}
-			c.handleObjUpdate(new)
+			c.handleObject(new)
 		},
 
-		DeleteFunc: c.handleObjDelete,
+		DeleteFunc: c.handleObject,
 	})
 
 	// Bind the route SharedIndexInformer to the route queue
 	c.routeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: c.handleObjAdd,
+		AddFunc: c.handleObject,
 		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*routev1.Route)
 			oldDepl := old.(*routev1.Route)
@@ -98,15 +98,15 @@ func NewConfigController(client kubernetes.Interface,
 				// Periodic resync will send update events for all known routes.
 				return
 			}
-			c.handleObjUpdate(new)
+			c.handleObject(new)
 		},
 
-		DeleteFunc: c.handleObjDelete,
+		DeleteFunc: c.handleObject,
 	})
 
 	// Bind the CDIconfig SharedIndexInformer to the CDIconfig queue
 	c.configInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: c.handleObjAdd,
+		AddFunc: c.handleObject,
 		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*cdiv1.CDIConfig)
 			oldDepl := old.(*cdiv1.CDIConfig)
@@ -114,26 +114,16 @@ func NewConfigController(client kubernetes.Interface,
 				// Periodic resync will send update events for all known CDIconfigs.
 				return
 			}
-			c.handleObjUpdate(new)
+			c.handleObject(new)
 		},
 
-		DeleteFunc: c.handleObjDelete,
+		DeleteFunc: c.handleObject,
 	})
 
 	return c
 }
 
-func (c *ConfigController) handleObjAdd(obj interface{}) {
-	c.handleObject(obj, "add")
-}
-func (c *ConfigController) handleObjUpdate(obj interface{}) {
-	c.handleObject(obj, "update")
-}
-func (c *ConfigController) handleObjDelete(obj interface{}) {
-	c.handleObject(obj, "delete")
-}
-
-func (c *ConfigController) handleObject(obj interface{}, verb string) {
+func (c *ConfigController) handleObject(obj interface{}) {
 
 	var object metav1.Object
 	var ok bool

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -86,7 +86,7 @@ func createRoute(name, ns, service string) *routev1.Route {
 	return route
 }
 
-func createIngress(name, ns, service, url string, labels map[string]string) *extensionsv1beta1.Ingress {
+func createIngress(name, ns, service, url string) *extensionsv1beta1.Ingress {
 	return &extensionsv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "extensions/v1beta1",
@@ -94,7 +94,6 @@ func createIngress(name, ns, service, url string, labels map[string]string) *ext
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
-			Labels:    labels,
 		},
 		Spec: extensionsv1beta1.IngressSpec{
 			Backend: &extensionsv1beta1.IngressBackend{
@@ -377,7 +376,7 @@ func TestCreatesIngress(t *testing.T) {
 	f.objects = append(f.objects, config)
 
 	url := "www.example.com"
-	ing := createIngress("ing", "default", "cdi-uploadproxy", url, map[string]string{"app": ""})
+	ing := createIngress("ing", "default", "cdi-uploadproxy", url)
 
 	f.ingressLister = append(f.ingressLister, ing)
 	f.kubeobjects = append(f.kubeobjects, ing)
@@ -400,7 +399,7 @@ func TestCreatesIngressOverrideExists(t *testing.T) {
 	f.objects = append(f.objects, config)
 
 	url := "www.example.com"
-	ing := createIngress("ing", "default", "cdi-uploadproxy", url, map[string]string{"app": ""})
+	ing := createIngress("ing", "default", "cdi-uploadproxy", url)
 
 	f.ingressLister = append(f.ingressLister, ing)
 	f.kubeobjects = append(f.kubeobjects, ing)
@@ -421,7 +420,7 @@ func TestCreatesIngressDifferentService(t *testing.T) {
 	f.objects = append(f.objects, config)
 
 	url := "www.example.com"
-	ing := createIngress("ing", "default", "other-service", url, map[string]string{"app": ""})
+	ing := createIngress("ing", "default", "other-service", url)
 
 	f.ingressLister = append(f.ingressLister, ing)
 	f.kubeobjects = append(f.kubeobjects, ing)


### PR DESCRIPTION
Signed-off-by: Irit goihman <igoihman@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removed label from Ingress Informer Factory. Ingress created for CDI services doesn't need a label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #761 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

