### PR TITLE
Fix cluster-clean

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -8,6 +8,12 @@ echo "Cleaning up ..."
 
 OPERATOR_CR_MANIFEST=./_out/manifests/release/cdi-cr.yaml
 OPERATOR_MANIFEST=./_out/manifests/release/cdi-operator.yaml
+LABELS=("operator.cdi.kubevirt.io" "cdi.kubevirt.io")
+NAMESPACES=(default cdi)
+
+set +e
+_kubectl patch cdi cdi --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
+set -e
 
 if [ -f "${OPERATOR_CR_MANIFEST}" ]; then
     if _kubectl get crd cdis.cdi.kubevirt.io ; then
@@ -21,25 +27,49 @@ if [ -f "${OPERATOR_MANIFEST}" ]; then
 fi
 
 # Everything should be deleted by now, but just to be sure
-namespaces=(default kube-system)
-for i in ${namespaces[@]}; do
-    _kubectl -n ${i} delete deployment -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete services -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete secrets -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete configmaps -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete pvc -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete pods -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete rolebinding -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete roles -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-    _kubectl -n ${i} delete serviceaccounts -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
+for n in ${NAMESPACES[@]}; do
+  for label in ${labels[@]}; do
+    _kubectl -n ${n} delete deployment -l ${label}
+    _kubectl -n ${n} delete services -l ${label}
+    _kubectl -n ${n} delete secrets -l ${label}
+    _kubectl -n ${n} delete configmaps -l ${label}
+    _kubectl -n ${n} delete pvc -l ${label}
+    _kubectl -n ${n} delete pods -l ${label}
+    _kubectl -n ${n} delete rolebinding -l ${label}
+    _kubectl -n ${n} delete roles -l ${lbael}
+    _kubectl -n ${n} delete serviceaccounts -l ${label}
+  done
 done
 
-_kubectl delete pv -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-_kubectl delete validatingwebhookconfiguration -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-_kubectl delete clusterrolebinding -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-_kubectl delete clusterroles -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
-_kubectl delete customresourcedefinitions -l 'operator.cdi.kubevirt.io' -l 'cdi.kubevirt.io'
+for label in ${labels[@]}; do
+    _kubectl delete pv -l ${label}
+    _kubectl delete validatingwebhookconfiguration -l ${label}
+    _kubectl delete clusterrolebinding -l ${label}
+    _kubectl delete clusterroles -l ${label}
+    _kubectl delete customresourcedefinitions -l ${label}
+    _kubectl get apiservices -l ${label} -o=custom-columns=NAME:.metadata.name,FINALIZERS:.metadata.finalizers --no-headers | grep foregroundDeletion | while read p; do
+        arr=($p)
+        name="${arr[0]}"
+        _kubectl -n ${i} patch apiservices $name --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
+    done
+done
 
+
+if [ -n "$(_kubectl get ns | grep "cdi ")" ]; then
+    echo "Clean cdi namespace"
+    _kubectl delete ns ${i}
+
+    start_time=0
+    sample=10
+    timeout=120 
+    echo "Waiting for cdi namespace to disappear ..."
+    while [ -n "$(_kubectl get ns | grep "cdi ")" ]; do
+        sleep $sample
+        start_time=$((current_time + sample))
+        if [[ $current_time -gt $timeout ]]; then
+            exit 1
+        fi
+    done
+fi
 sleep 2
-
 echo "Done"


### PR DESCRIPTION
We were missing some resources in the cleanup on make cluster-clean
(when running against an external cluster).  We also weren't patching
any of the finalizers so the result is a delete of the cdi namespace
would hang in terminating state forever.

This change explicitly checks all resources on the cluster for a cdi
label and it also patches the cdi objects to clear out the finalizer.

Fixes #774

```release-note
NONE
```

