### PR TITLE
Enable return of CDI objects from `get all`

### DIFF
--- a/pkg/operator/resources/cluster/cdiconfig.go
+++ b/pkg/operator/resources/cluster/cdiconfig.go
@@ -23,6 +23,9 @@ func createCDIConfigCRD() *extv1beta1.CustomResourceDefinition {
 				Kind:     "CDIConfig",
 				Plural:   "cdiconfigs",
 				Singular: "cdiconfig",
+				Categories: []string{
+					"all",
+				},
 			},
 			Version: "v1alpha1",
 			Scope:   "Cluster",

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -43,6 +43,9 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 					"dvs",
 				},
 				Singular: "datavolume",
+				Categories: []string{
+					"all",
+				},
 			},
 			Version: "v1alpha1",
 			Scope:   "Namespaced",

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -462,6 +462,9 @@ func createCDIListCRD() *extv1beta1.CustomResourceDefinition {
 				ListKind: "CDIList",
 				Plural:   "cdis",
 				Singular: "cdi",
+				Categories: []string{
+					"all",
+				},
 			},
 			Version: "v1alpha1",
 			Scope:   "Cluster",


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the `all` category to the CDI objects.  Currently CDI objects
aren't returned from a get all request, adding the category all
parameter to the objects fixes that.

With this change a `get all` will include things like a users DataVolumes.

Note, this is NOT allowed for tokens, so we don't set that on upload
tokens.

**Release note**:

```release-note
Make CDI objects visible to `get all` queries.
```

