### PR TITLE
Test using Ceph-RBD CSI plugin as default SC

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,6 +25,8 @@ elif [[ $image == $KUBERNETES_IMAGE ]]; then
     export KUBECONFIG=./cluster/.kubeconfig
     ./cluster/.kubectl config set-cluster kubernetes --server=https://127.0.0.1:$cluster_port
     ./cluster/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    ./cluster/.kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+    ./cluster/.kubectl patch storageclass csi-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
 elif [[ $image == $OPENSHIFT_IMAGE ]]; then
 


### PR DESCRIPTION
Testing this locally and in the CI pipeline to see if we can use a more
realistic storage class as our default for functional testing.

We wouldn't actually use this change, instead we'd modify the CI image; but for now as a sort of canary we can run this config a bit and see how things go.

