### PR TITLE
watch extension-apiserver-authentication configmap and refresh client CA

### DIFF
--- a/cmd/cdi-apiserver/apiserver.go
+++ b/cmd/cdi-apiserver/apiserver.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
 package main
 
 import (
@@ -6,10 +25,14 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
 	"kubevirt.io/containerized-data-importer/pkg/apiserver"
 	"kubevirt.io/containerized-data-importer/pkg/version/verflag"
 )
@@ -65,17 +88,26 @@ func main() {
 
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(cfg)
 
-	authorizor, err := apiserver.NewAuthorizorFromConfig(cfg)
+	ch := signals.SetupSignalHandler()
+
+	authConfigWatcher := apiserver.NewAuthConfigWatcher(client, ch)
+
+	authorizor, err := apiserver.NewAuthorizorFromConfig(cfg, authConfigWatcher)
 	if err != nil {
 		klog.Fatalf("Unable to create authorizor: %v\n", errors.WithStack(err))
 	}
 
-	uploadApp, err := apiserver.NewCdiAPIServer(defaultHost, defaultPort, client, aggregatorClient, authorizor)
+	uploadApp, err := apiserver.NewCdiAPIServer(defaultHost,
+		defaultPort,
+		client,
+		aggregatorClient,
+		authorizor,
+		authConfigWatcher)
 	if err != nil {
 		klog.Fatalf("Upload api failed to initialize: %v\n", errors.WithStack(err))
 	}
 
-	err = uploadApp.Start()
+	err = uploadApp.Start(ch)
 	if err != nil {
 		klog.Fatalf("TLS server failed: %v\n", errors.WithStack(err))
 	}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -1,20 +1,40 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
 package apiserver
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 
 	restful "github.com/emicklei/go-restful"
 	"github.com/pkg/errors"
+
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,7 +75,7 @@ const (
 
 // CdiAPIServer is the public interface to the CDI API
 type CdiAPIServer interface {
-	Start() error
+	Start(<-chan struct{}) error
 }
 
 type uploadPossibleFunc func(*v1.PersistentVolumeClaim) error
@@ -67,17 +87,18 @@ type cdiAPIApp struct {
 	client           kubernetes.Interface
 	aggregatorClient aggregatorclient.Interface
 
-	authorizer CdiAPIAuthorizer
+	serverCACertBytes []byte
+	serverCertBytes   []byte
+	serverKeyBytes    []byte
 
-	signingCertBytes           []byte
-	certBytes                  []byte
-	keyBytes                   []byte
-	clientCABytes              []byte
-	requestHeaderClientCABytes []byte
+	serverCert *tls.Certificate
 
 	privateSigningKey *rsa.PrivateKey
 
 	container *restful.Container
+
+	authorizer        CdiAPIAuthorizer
+	authConfigWatcher AuthConfigWatcher
 
 	// test hook
 	uploadPossible uploadPossibleFunc
@@ -95,22 +116,20 @@ func NewCdiAPIServer(bindAddress string,
 	bindPort uint,
 	client kubernetes.Interface,
 	aggregatorClient aggregatorclient.Interface,
-	authorizor CdiAPIAuthorizer) (CdiAPIServer, error) {
+	authorizor CdiAPIAuthorizer,
+	authConfigWatcher AuthConfigWatcher) (CdiAPIServer, error) {
 	var err error
 	app := &cdiAPIApp{
-		bindAddress:      bindAddress,
-		bindPort:         bindPort,
-		client:           client,
-		aggregatorClient: aggregatorClient,
-		authorizer:       authorizor,
-		uploadPossible:   controller.UploadPossibleForPVC,
-	}
-	err = app.getClientCert()
-	if err != nil {
-		return nil, errors.Errorf("Unable to get client cert: %v\n", errors.WithStack(err))
+		bindAddress:       bindAddress,
+		bindPort:          bindPort,
+		client:            client,
+		aggregatorClient:  aggregatorClient,
+		authorizer:        authorizor,
+		uploadPossible:    controller.UploadPossibleForPVC,
+		authConfigWatcher: authConfigWatcher,
 	}
 
-	err = app.getSelfSignedCert()
+	err = app.getKeysAndCerts()
 	if err != nil {
 		return nil, errors.Errorf("Unable to get self signed cert: %v\n", errors.WithStack(err))
 	}
@@ -153,73 +172,11 @@ func NewCdiAPIServer(bindAddress string,
 	return app, nil
 }
 
-func (app *cdiAPIApp) Start() error {
-	return app.startTLS()
+func (app *cdiAPIApp) Start(ch <-chan struct{}) error {
+	return app.startTLS(ch)
 }
 
-func deserializeStrings(in string) ([]string, error) {
-	if len(in) == 0 {
-		return nil, nil
-	}
-	var ret []string
-	if err := json.Unmarshal([]byte(in), &ret); err != nil {
-		return nil, err
-	}
-	return ret, nil
-}
-
-func (app *cdiAPIApp) getClientCert() error {
-	authConfigMap, err := app.client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get("extension-apiserver-authentication", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	clientCA, ok := authConfigMap.Data["client-ca-file"]
-	if !ok {
-		return errors.Errorf("client-ca-file value not found in auth config map.")
-	}
-	app.clientCABytes = []byte(clientCA)
-
-	// request-header-ca-file doesn't always exist in all deployments.
-	// set it if the value is set though.
-	requestHeaderClientCA, ok := authConfigMap.Data["requestheader-client-ca-file"]
-	if ok {
-		app.requestHeaderClientCABytes = []byte(requestHeaderClientCA)
-	}
-
-	// This config map also contains information about what
-	// headers our authorizor should inspect
-	headers, ok := authConfigMap.Data["requestheader-username-headers"]
-	if ok {
-		headerList, err := deserializeStrings(headers)
-		if err != nil {
-			return err
-		}
-		app.authorizer.AddUserHeaders(headerList)
-	}
-
-	headers, ok = authConfigMap.Data["requestheader-group-headers"]
-	if ok {
-		headerList, err := deserializeStrings(headers)
-		if err != nil {
-			return err
-		}
-		app.authorizer.AddGroupHeaders(headerList)
-	}
-
-	headers, ok = authConfigMap.Data["requestheader-extra-headers-prefix"]
-	if ok {
-		headerList, err := deserializeStrings(headers)
-		if err != nil {
-			return err
-		}
-		app.authorizer.AddExtraPrefixHeaders(headerList)
-	}
-
-	return nil
-}
-
-func (app *cdiAPIApp) getSelfSignedCert() error {
+func (app *cdiAPIApp) getKeysAndCerts() error {
 	namespace := util.GetNamespace()
 	caKeyPair, err := triple.NewCA("api.cdi.kubevirt.io")
 	if err != nil {
@@ -239,96 +196,101 @@ func (app *cdiAPIApp) getSelfSignedCert() error {
 		return errors.Wrapf(err, "Error getting/creating secret %s", apiCertSecretName)
 	}
 
-	app.keyBytes = cert.EncodePrivateKeyPEM(keyPairAndCert.KeyPair.Key)
-	app.certBytes = cert.EncodeCertPEM(keyPairAndCert.KeyPair.Cert)
-	app.signingCertBytes = cert.EncodeCertPEM(keyPairAndCert.CACert)
+	serverKeyBytes := cert.EncodePrivateKeyPEM(keyPairAndCert.KeyPair.Key)
+	serverCertBytes := cert.EncodeCertPEM(keyPairAndCert.KeyPair.Cert)
+
+	serverCert, err := tls.X509KeyPair(serverCertBytes, serverKeyBytes)
+	if err != nil {
+		return err
+	}
 
 	privateKey, err := keys.GetOrCreatePrivateKey(app.client, namespace, apiSigningKeySecretName)
 	if err != nil {
 		return errors.Wrap(err, "Error getting/creating signing key")
 	}
 
+	app.serverKeyBytes = serverKeyBytes
+	app.serverCertBytes = serverCertBytes
+	app.serverCACertBytes = cert.EncodeCertPEM(keyPairAndCert.CACert)
+
+	app.serverCert = &serverCert
+
 	app.privateSigningKey = privateKey
 
 	return nil
 }
 
-func (app *cdiAPIApp) startTLS() error {
-	certsDirectory, err := ioutil.TempDir("", "certsdir")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(certsDirectory)
+func (app *cdiAPIApp) getTLSConfig() (*tls.Config, error) {
+	authConfig := app.authConfigWatcher.GetAuthConfig()
 
-	keyFile := filepath.Join(certsDirectory, "key.pem")
-	certFile := filepath.Join(certsDirectory, "cert.pem")
-	signingCertFile := filepath.Join(certsDirectory, "signingCert.pem")
-	clientCAFile := filepath.Join(certsDirectory, "clientCA.crt")
-
-	// Write the certs to disk
-	err = ioutil.WriteFile(clientCAFile, app.clientCABytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	if len(app.requestHeaderClientCABytes) != 0 {
-		f, err := os.OpenFile(clientCAFile, os.O_APPEND|os.O_WRONLY, 0600)
-		if err != nil {
-			return err
+	validName := func(name string) bool {
+		for _, n := range authConfig.AllowedNames {
+			if n == name {
+				return true
+			}
 		}
-		defer f.Close()
-
-		_, err = f.Write(app.requestHeaderClientCABytes)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = ioutil.WriteFile(keyFile, app.keyBytes, 0600)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(certFile, app.certBytes, 0600)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(signingCertFile, app.signingCertBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	errChan := make(chan error)
-
-	// create the client CA pool.
-	// This ensures we're talking to the k8s api server
-	pool, err := cert.NewPool(clientCAFile)
-	if err != nil {
-		return err
+		return false
 	}
 
 	tlsConfig := &tls.Config{
-		ClientCAs:  pool,
-		ClientAuth: tls.VerifyClientCertIfGiven,
+		Certificates: []tls.Certificate{*app.serverCert},
+		ClientCAs:    authConfig.CertPool,
+		ClientAuth:   tls.VerifyClientCertIfGiven,
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if len(verifiedChains) == 0 {
+				return nil
+			}
+			for i := range verifiedChains {
+				if validName(verifiedChains[i][0].Subject.CommonName) {
+					return nil
+				}
+			}
+			return fmt.Errorf("No valid subject specified")
+		},
 	}
 	tlsConfig.BuildNameToCertificate()
 
-	go func() {
-		server := &http.Server{
-			Addr:      fmt.Sprintf("%s:%d", app.bindAddress, app.bindPort),
-			TLSConfig: tlsConfig,
-			Handler:   app.container,
-		}
+	return tlsConfig, nil
+}
 
-		errChan <- server.ListenAndServeTLS(certFile, keyFile)
+func (app *cdiAPIApp) startTLS(stopChan <-chan struct{}) error {
+	errChan := make(chan error)
+
+	tlsConfig, err := app.getTLSConfig()
+	if err != nil {
+		return err
+	}
+
+	tlsConfig.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+		klog.V(3).Info("Getting TLS config")
+		config, err := app.getTLSConfig()
+		if err != nil {
+			klog.Errorf("Error %+v getting TLS config", err)
+		}
+		return config, err
+	}
+
+	server := &http.Server{
+		Addr:      fmt.Sprintf("%s:%d", app.bindAddress, app.bindPort),
+		TLSConfig: tlsConfig,
+		Handler:   app.container,
+	}
+
+	go func() {
+		errChan <- server.ListenAndServeTLS("", "")
 	}()
 
-	// wait for server to exit
-	return <-errChan
+	select {
+	case <-stopChan:
+		return server.Shutdown(context.Background())
+	case err = <-errChan:
+		return err
+	}
 }
 
 func (app *cdiAPIApp) uploadHandler(request *restful.Request, response *restful.Response) {
-
 	allowed, reason, err := app.authorizer.Authorize(request)
+
 	if err != nil {
 		klog.Error(err)
 		response.WriteHeader(http.StatusInternalServerError)
@@ -546,7 +508,7 @@ func (app *cdiAPIApp) createAPIService() error {
 			},
 			Group:                uploadTokenGroup,
 			Version:              uploadTokenVersion,
-			CABundle:             app.signingCertBytes,
+			CABundle:             app.serverCACertBytes,
 			GroupPriorityMinimum: 1000,
 			VersionPriority:      15,
 		},
@@ -608,7 +570,7 @@ func (app *cdiAPIApp) createWebhook() error {
 					Name:      apiServiceName,
 					Path:      &dvPathCreate,
 				},
-				CABundle: app.signingCertBytes,
+				CABundle: app.serverCACertBytes,
 			},
 		},
 	}

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
 package apiserver
 
 import (
@@ -17,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
+
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -30,89 +49,21 @@ import (
 var foo aggregatorapifake.Clientset
 
 type testAuthorizer struct {
-	allowed            bool
-	reason             string
-	err                error
-	userHeaders        []string
-	groupHeaders       []string
-	extraPrefixHeaders []string
+	allowed bool
+	reason  string
+	err     error
 }
 
 func (a *testAuthorizer) Authorize(req *restful.Request) (bool, string, error) {
 	return a.allowed, a.reason, a.err
 }
 
-func (a *testAuthorizer) AddUserHeaders(header []string) {
-	a.userHeaders = append(a.userHeaders, header...)
-}
-
-func (a *testAuthorizer) GetUserHeaders() []string {
-	return a.userHeaders
-}
-
-func (a *testAuthorizer) AddGroupHeaders(header []string) {
-	a.groupHeaders = append(a.groupHeaders, header...)
-}
-
-func (a *testAuthorizer) GetGroupHeaders() []string {
-	return a.groupHeaders
-}
-
-func (a *testAuthorizer) AddExtraPrefixHeaders(header []string) {
-	a.extraPrefixHeaders = append(a.extraPrefixHeaders, header...)
-}
-
-func (a *testAuthorizer) GetExtraPrefixHeaders() []string {
-	return a.extraPrefixHeaders
-}
-
 func newSuccessfulAuthorizer() CdiAPIAuthorizer {
-	return &testAuthorizer{true, "", nil, []string{}, []string{}, []string{}}
+	return &testAuthorizer{true, "", nil}
 }
 
 func newFailureAuthorizer() CdiAPIAuthorizer {
-	return &testAuthorizer{false, "You are a bad person", fmt.Errorf("Not authorized"), []string{}, []string{}, []string{}}
-}
-
-func getAPIServerConfigMap(t *testing.T) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "extension-apiserver-authentication",
-			Namespace: "kube-system",
-		},
-		Data: map[string]string{
-			"client-ca-file":                     "bunchofbytes",
-			"requestheader-allowed-names":        "[\"front-proxy-client\"]",
-			"requestheader-client-ca-file":       "morebytes",
-			"requestheader-extra-headers-prefix": "[\"X-Remote-Extra-\"]",
-			"requestheader-group-headers":        "[\"X-Remote-Group\"]",
-			"requestheader-username-headers":     "[\"X-Remote-User\"]",
-		},
-	}
-}
-
-func validateAPIServerConfig(t *testing.T, app *cdiAPIApp) {
-	if string(app.clientCABytes) != "bunchofbytes" {
-		t.Errorf("no match on client-ca-file")
-	}
-
-	if string(app.requestHeaderClientCABytes) != "morebytes" {
-		t.Errorf("no match on requestheader-client-ca-file")
-	}
-
-	if !reflect.DeepEqual(app.authorizer.GetExtraPrefixHeaders(), []string{"X-Remote-Extra-"}) {
-		t.Errorf("no match on requestheader-extra-headers-prefix")
-	}
-
-	if !reflect.DeepEqual(app.authorizer.GetGroupHeaders(), []string{"X-Remote-Group"}) {
-		t.Logf("%+v", app.authorizer.GetGroupHeaders())
-		t.Errorf("requestheader-group-headers")
-	}
-
-	if !reflect.DeepEqual(app.authorizer.GetUserHeaders(), []string{"X-Remote-User"}) {
-		t.Logf("%+v", app.authorizer.GetUserHeaders())
-		t.Errorf("requestheader-username-headers")
-	}
+	return &testAuthorizer{false, "You are a bad person", fmt.Errorf("Not authorized")}
 }
 
 func apiServerConfigMapGetAction() core.Action {
@@ -317,52 +268,6 @@ func Test_tokenEncrption(t *testing.T) {
 	}
 }
 
-func TestGetClientCert(t *testing.T) {
-	kubeobjects := []runtime.Object{}
-	kubeobjects = append(kubeobjects, getAPIServerConfigMap(t))
-
-	client := k8sfake.NewSimpleClientset(kubeobjects...)
-
-	app := &cdiAPIApp{client: client, authorizer: newSuccessfulAuthorizer()}
-
-	actions := []core.Action{}
-	actions = append(actions, apiServerConfigMapGetAction())
-
-	err := app.getClientCert()
-	if err != nil {
-		t.Errorf("getClientCert failed: %+v", err)
-	}
-
-	validateAPIServerConfig(t, app)
-
-	checkActions(actions, client.Actions(), t)
-}
-
-func TestNewCdiAPIServer(t *testing.T) {
-	kubeobjects := []runtime.Object{}
-	kubeobjects = append(kubeobjects, getAPIServerConfigMap(t))
-
-	client := k8sfake.NewSimpleClientset(kubeobjects...)
-	aggregatorClient := aggregatorapifake.NewSimpleClientset()
-	authorizer := &testAuthorizer{}
-
-	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer)
-	if err != nil {
-		t.Errorf("Upload api server creation failed: %+v", err)
-	}
-
-	app := server.(*cdiAPIApp)
-
-	req, _ := http.NewRequest("GET", "/apis", nil)
-	rr := httptest.NewRecorder()
-
-	app.container.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Errorf("Unexpected status code %d", rr.Code)
-	}
-}
-
 func TestGetSelfSignedCert(t *testing.T) {
 	signingKey, err := generateTestKey()
 	if err != nil {
@@ -400,7 +305,7 @@ func TestGetSelfSignedCert(t *testing.T) {
 		client: client,
 	}
 
-	err = app.getSelfSignedCert()
+	err = app.getKeysAndCerts()
 	if err != nil {
 		t.Errorf("error creating upload api app: %v", err)
 	}
@@ -417,7 +322,7 @@ func TestShouldGenerateCertsAndKeyFirstRun(t *testing.T) {
 		client: client,
 	}
 
-	err := app.getSelfSignedCert()
+	err := app.getKeysAndCerts()
 	if err != nil {
 		t.Errorf("error creating upload api app: %v", err)
 	}
@@ -425,7 +330,7 @@ func TestShouldGenerateCertsAndKeyFirstRun(t *testing.T) {
 	actions := []core.Action{}
 	actions = append(actions, tlsSecretGetAction())
 	actions = append(actions, cdiConfigMapGetAction())
-	actions = append(actions, tlsSecretCreateAction(app.keyBytes, app.certBytes, app.signingCertBytes))
+	actions = append(actions, tlsSecretCreateAction(app.serverKeyBytes, app.serverCertBytes, app.serverCACertBytes))
 	actions = append(actions, signingKeySecretGetAction())
 	actions = append(actions, cdiConfigMapGetAction())
 	actions = append(actions, signingKeySecretCreateAction(app.privateSigningKey))
@@ -438,9 +343,9 @@ func TestCreateAPIService(t *testing.T) {
 	aggregatorClient := aggregatorapifake.NewSimpleClientset()
 
 	app := &cdiAPIApp{
-		client:           client,
-		aggregatorClient: aggregatorClient,
-		signingCertBytes: []byte("data"),
+		client:            client,
+		aggregatorClient:  aggregatorClient,
+		serverCACertBytes: []byte("data"),
 	}
 
 	err := app.createAPIService()
@@ -450,7 +355,7 @@ func TestCreateAPIService(t *testing.T) {
 
 	actions := []core.Action{}
 	actions = append(actions, apiServiceGetAction())
-	actions = append(actions, apiServiceCreateAction(app.signingCertBytes))
+	actions = append(actions, apiServiceCreateAction(app.serverCACertBytes))
 
 	checkActions(actions, aggregatorClient.Actions(), t)
 }
@@ -466,9 +371,9 @@ func TestUpdateAPIService(t *testing.T) {
 	aggregatorClient := aggregatorapifake.NewSimpleClientset(kubeobjects...)
 
 	app := &cdiAPIApp{
-		client:           client,
-		aggregatorClient: aggregatorClient,
-		signingCertBytes: certBytes,
+		client:            client,
+		aggregatorClient:  aggregatorClient,
+		serverCACertBytes: certBytes,
 	}
 
 	err := app.createAPIService()
@@ -478,7 +383,7 @@ func TestUpdateAPIService(t *testing.T) {
 
 	actions := []core.Action{}
 	actions = append(actions, apiServiceGetAction())
-	actions = append(actions, apiServiceUpdateAction(app.signingCertBytes))
+	actions = append(actions, apiServiceUpdateAction(app.serverCACertBytes))
 
 	checkActions(actions, aggregatorClient.Actions(), t)
 }

--- a/pkg/apiserver/auth-config.go
+++ b/pkg/apiserver/auth-config.go
@@ -1,0 +1,159 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
+package apiserver
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
+)
+
+const (
+	configMapName = "extension-apiserver-authentication"
+)
+
+// AuthConfig contains extension-apiserver-authentication data
+type AuthConfig struct {
+	AllowedNames       []string
+	UserHeaders        []string
+	GroupHeaders       []string
+	ExtraPrefixHeaders []string
+
+	ClientCABytes              []byte
+	RequestheaderClientCABytes []byte
+
+	CertPool *x509.CertPool
+}
+
+// AuthConfigWatcher is the interface of authConfigWatcher
+type AuthConfigWatcher interface {
+	GetAuthConfig() *AuthConfig
+}
+
+type authConfigWatcher struct {
+	// keep this around for tests
+	informer cache.SharedIndexInformer
+
+	config *AuthConfig
+	mutex  sync.RWMutex
+}
+
+// NewAuthConfigWatcher crates a new authConfigWatcher
+func NewAuthConfigWatcher(client kubernetes.Interface, stopCh <-chan struct{}) AuthConfigWatcher {
+	informerFactory := informers.NewFilteredSharedInformerFactory(client,
+		common.DefaultResyncPeriod,
+		metav1.NamespaceSystem,
+		func(options *metav1.ListOptions) {
+			options.FieldSelector = "metadata.name=" + configMapName
+		},
+	)
+
+	configMapInformer := informerFactory.Core().V1().ConfigMaps().Informer()
+
+	acw := &authConfigWatcher{
+		informer: configMapInformer,
+	}
+
+	configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			klog.V(3).Infof("configMapInformer add callback: %+v", obj)
+			acw.updateConfig(obj.(*corev1.ConfigMap))
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			klog.V(3).Infof("configMapInformer update callback: %+v", obj)
+			acw.updateConfig(obj.(*corev1.ConfigMap))
+		},
+		DeleteFunc: func(obj interface{}) {
+			cm := obj.(*corev1.ConfigMap)
+			klog.Errorf("Configmap %s deleted", cm.Name)
+		},
+	})
+
+	go informerFactory.Start(stopCh)
+
+	klog.V(3).Infoln("Waiting for cache sync")
+	cache.WaitForCacheSync(stopCh, configMapInformer.HasSynced)
+	klog.V(3).Infoln("Cache sync complete")
+
+	return acw
+}
+
+func (acw *authConfigWatcher) GetAuthConfig() *AuthConfig {
+	acw.mutex.RLock()
+	defer acw.mutex.RUnlock()
+	return acw.config
+}
+
+func deserializeStringSlice(in string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	var ret []string
+	if err := json.Unmarshal([]byte(in), &ret); err != nil {
+		klog.Errorf("Error decoding %q", in)
+		return nil
+	}
+	return ret
+}
+
+func (acw *authConfigWatcher) updateConfig(cm *corev1.ConfigMap) {
+	newConfig := &AuthConfig{}
+	pool := x509.NewCertPool()
+
+	s, ok := cm.Data["client-ca-file"]
+	if ok {
+		newConfig.ClientCABytes = []byte(s)
+		// TODO don't think we've done enough testing to support this path (direct access to the apiserver)
+		// Have to write code to get user/groups/etc from cert
+		/*
+			if ok = pool.AppendCertsFromPEM(newConfig.ClientCABytes); !ok {
+				klog.Errorf("Error adding ClientCABytes to client cert pool")
+			}
+		*/
+	}
+
+	s, ok = cm.Data["requestheader-client-ca-file"]
+	if ok {
+		newConfig.RequestheaderClientCABytes = []byte(s)
+		if ok = pool.AppendCertsFromPEM(newConfig.RequestheaderClientCABytes); !ok {
+			klog.Errorf("Error adding RequestheaderClientCABytes to client cert pool")
+		}
+	}
+
+	newConfig.CertPool = pool
+
+	newConfig.AllowedNames = deserializeStringSlice(cm.Data["requestheader-allowed-names"])
+	newConfig.UserHeaders = deserializeStringSlice(cm.Data["requestheader-username-headers"])
+	newConfig.GroupHeaders = deserializeStringSlice(cm.Data["requestheader-group-headers"])
+	newConfig.ExtraPrefixHeaders = deserializeStringSlice(cm.Data["requestheader-extra-headers-prefix"])
+
+	acw.mutex.Lock()
+	defer acw.mutex.Unlock()
+	acw.config = newConfig
+}

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -1,0 +1,172 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/cert"
+	aggregatorapifake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+
+	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/pkg/util/cert/triple"
+)
+
+func generateCACert(t *testing.T) string {
+	keyPair, err := triple.NewCA(util.RandAlphaNum(10))
+	if err != nil {
+		t.Errorf("Error creating CA cert")
+	}
+	return string(cert.EncodeCertPEM(keyPair.Cert))
+}
+
+func getAPIServerConfigMap(t *testing.T) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "extension-apiserver-authentication",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"client-ca-file":                     generateCACert(t),
+			"requestheader-allowed-names":        "[\"front-proxy-client\"]",
+			"requestheader-client-ca-file":       generateCACert(t),
+			"requestheader-extra-headers-prefix": "[\"X-Remote-Extra-\"]",
+			"requestheader-group-headers":        "[\"X-Remote-Group\"]",
+			"requestheader-username-headers":     "[\"X-Remote-User\"]",
+		},
+	}
+}
+
+func verifyAuthConfig(t *testing.T, cm *corev1.ConfigMap, authConfig *AuthConfig) {
+	if !reflect.DeepEqual([]byte(cm.Data["client-ca-file"]), authConfig.ClientCABytes) {
+		t.Errorf("client-ca-file not stored correctly")
+	}
+
+	if !reflect.DeepEqual([]byte(cm.Data["requestheader-client-ca-file"]), authConfig.RequestheaderClientCABytes) {
+		t.Errorf("client-ca-file not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-username-headers"]), authConfig.UserHeaders) {
+		t.Errorf("requestheader-username-headers not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-group-headers"]), authConfig.GroupHeaders) {
+		t.Errorf("requestheader-group-headers not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-extra-headers-prefix"]), authConfig.ExtraPrefixHeaders) {
+		t.Errorf("requestheader-extra-headers-prefix not stored correctly")
+	}
+}
+
+func TestNewCdiAPIServer(t *testing.T) {
+	ch := make(chan struct{})
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, getAPIServerConfigMap(t))
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	authConfigWatcher := NewAuthConfigWatcher(client, ch)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, authConfigWatcher)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	req, _ := http.NewRequest("GET", "/apis", nil)
+	rr := httptest.NewRecorder()
+
+	app.container.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Unexpected status code %d", rr.Code)
+	}
+}
+
+func TestAuthConfigUpdate(t *testing.T) {
+	ch := make(chan struct{})
+	cm := getAPIServerConfigMap(t)
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, cm)
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	acw := NewAuthConfigWatcher(client, ch).(*authConfigWatcher)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, acw)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	verifyAuthConfig(t, cm, app.authConfigWatcher.GetAuthConfig())
+
+	cm.Data["requestheader-client-ca-file"] = generateCACert(t)
+
+	cm, err = client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Update(cm)
+	if err != nil {
+		t.Errorf("Updating configmap failed: %+v", err)
+	}
+
+	cache.WaitForCacheSync(ch, acw.informer.HasSynced)
+
+	verifyAuthConfig(t, cm, app.authConfigWatcher.GetAuthConfig())
+}
+
+func TestGetTLSConfig(t *testing.T) {
+	ch := make(chan struct{})
+	cm := getAPIServerConfigMap(t)
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, cm)
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	acw := NewAuthConfigWatcher(client, ch).(*authConfigWatcher)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, acw)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	tlsConfig, err := app.getTLSConfig()
+	if err != nil {
+		t.Errorf("Error getting tls conig")
+	}
+
+	if !reflect.DeepEqual(tlsConfig.ClientCAs, acw.GetAuthConfig().CertPool) {
+		t.Errorf("Client cert pools do not match")
+	}
+}

--- a/pkg/apiserver/util.go
+++ b/pkg/apiserver/util.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
 package apiserver
 
 import (

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -91,11 +91,6 @@ func UploadPossibleForPVC(pvc *v1.PersistentVolumeClaim) error {
 		return errors.Errorf("PVC %s is not an upload target", pvc.Name)
 	}
 
-	pvcPodStatus, ok := pvc.Annotations[AnnPodPhase]
-	if !ok || v1.PodPhase(pvcPodStatus) != v1.PodRunning {
-		return errors.Errorf("Upload Server pod not currently running for PVC %s", pvc.Name)
-	}
-
 	return nil
 }
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -504,15 +504,6 @@ func TestUploadPossible(t *testing.T) {
 				true,
 			},
 		},
-		{
-			"PVC not ready",
-			args{
-				map[string]string{"cdi.kubevirt.io/storage.upload.target": "",
-					"cdi.kubevirt.io/storage.pod.phase": "Pending",
-				},
-				true,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -99,6 +99,8 @@ func createExtensionAPIServerRole() *rbacv1.Role {
 			},
 			Verbs: []string{
 				"get",
+				"list",
+				"watch",
 			},
 			ResourceNames: []string{
 				extensionAPIConfigMapName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:  On OCP 4, the apiserver rotates the proxy CA cert daily.  This caused the CDI apiserver to be unusable after a day or so.  The cdi apiserver was rejecting the new client cert because it was not aware the rotation occurred.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

In my testing, the easiest way to reproduce the issue is with the kubevirtci os-3.11 build.  Do the following:

```bash
export KUBEVIRT_PROVIDER=os-3.11.0
make cluster-up cluster-sync
 k -v 8 apply -f manifests/example/upload-datavolume.yaml -o yaml
 k -v 8 apply -f manifests/example/upload-datavolume-token.yaml -o yaml
# rotate certs
./cluster/cli.sh ssh node01 'sudo ansible-playbook -i /root/inventory /root/openshift-ansible/playbooks/openshift-master/redeploy-certificates.yml'
# should succeed
 k -v 8 apply -f manifests/example/upload-datavolume-token.yaml -o yaml
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Watch extension-apiserver-authentication configmap for changes
```

