### PR TITLE
Adding code to not allow importing from registry when contenType is not kubevirt

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -57,6 +57,12 @@ func main() {
 	certDir, _ := util.ParseEnvVar(common.ImporterCertDirVar, false)
 	insecureTLS, _ := strconv.ParseBool(os.Getenv(common.InsecureTLSVar))
 
+	//Registry import currently support kubevirt content type only
+	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
+		klog.Errorf("Unsupported content type %s when importing from registry", contentType)
+		os.Exit(1)
+	}
+
 	volumeMode := v1.PersistentVolumeBlock
 	if _, err := os.Stat(common.ImporterWriteBlockPath); os.IsNotExist(err) {
 		volumeMode = v1.PersistentVolumeFilesystem

--- a/pkg/apiserver/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/apiserver/webhooks/validating-webhook/validating-webhook.go
@@ -147,6 +147,16 @@ func validateDataVolumeSpec(field *k8sfield.Path, spec *cdicorev1alpha1.DataVolu
 		return causes
 	}
 
+	if spec.Source.Registry != nil && spec.ContentType != "" && string(spec.ContentType) != string(cdicorev1alpha1.DataVolumeKubeVirt) {
+		sourceType = field.Child("contentType").String()
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("ContentType must be" + string(cdicorev1alpha1.DataVolumeKubeVirt) + "when Source is Registry"),
+			Field:   sourceType,
+		})
+		return causes
+	}
+
 	if spec.Source.PVC != nil {
 		if spec.Source.PVC.Namespace == "" || spec.Source.PVC.Name == "" {
 			causes = append(causes, metav1.StatusCause{

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -962,6 +962,7 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 	} else if dataVolume.Spec.Source.Registry != nil {
 		annotations[AnnSource] = SourceRegistry
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.Registry.URL
+		annotations[AnnContentType] = string(dataVolume.Spec.ContentType)
 		if dataVolume.Spec.Source.Registry.SecretRef != "" {
 			annotations[AnnSecret] = dataVolume.Spec.Source.Registry.SecretRef
 		}


### PR DESCRIPTION

Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fixing a bug where we allow import from registry when contentType is not kubevirt
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #808 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: The check not to allow import from registry if contentType is not 'kubevirt' was removed #808 
```

