### PR TITLE
Add a datavolume test to use csi-rbd block mode

### DIFF
--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -110,9 +110,8 @@ func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL str
 }
 
 // NewDataVolumeWithHTTPImportToBlockPV initializes a DataVolume struct with HTTP annotations to import to block PV
-func NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
+func NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName, size, httpURL, storageClassName string) *cdiv1.DataVolume {
 	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
-	storageClassName := "manual"
 	dataVolume := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,

--- a/tests/utils/storageclass.go
+++ b/tests/utils/storageclass.go
@@ -57,3 +57,21 @@ func DeleteStorageClass(clientSet *kubernetes.Clientset, storageClass *storageV1
 		return false, err
 	})
 }
+
+// GetStorageClass uses the provided client to attempt to get the specified storage class by name
+func GetStorageClass(clientSet *kubernetes.Clientset, scName string) (*storageV1.StorageClass, error) {
+	sc, err := clientSet.StorageV1().StorageClasses().Get(scName, metav1.GetOptions{})
+	return sc, err
+}
+
+// StorageClassExists is a simple check to see if the given SC exists or not
+func StorageClassExists(clientSet *kubernetes.Clientset, scName string) (bool, error) {
+	_, err := GetStorageClass(clientSet, scName)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a simple enhancement to the existing datavolume functional
test by adding a context for csi-rbd storage class when available.

This only adds another iteration to the dv block mode test for now, more
enhancements to follow later.

**Special notes for your reviewer**:
This just runs a second iteration of the existing DV importer block mode functional test with the csi-rbd storage class if it's available.

**Release note**:

```release-note
None
```

