### PR TITLE
Fix microdnf not using the repo files in /etc/yum.repos.d

### DIFF
--- a/automation/check-patch.yumrepos
+++ b/automation/check-patch.yumrepos
@@ -1,7 +1,6 @@
 [fedora-base-fc30]
 clean_requirements_on_remove=True
 tsflags=nodocs
-reposdir=/dev/null
 name=Fedora $releasever - $basearch
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
@@ -17,7 +16,6 @@ skip_if_unavailable=False
 [fedora-updates-fc30]
 clean_requirements_on_remove=True
 tsflags=nodocs
-reposdir=/dev/null
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/

--- a/hack/build/docker/builder/fedora.repo
+++ b/hack/build/docker/builder/fedora.repo
@@ -1,7 +1,6 @@
 [fedora-base-fc30]
 clean_requirements_on_remove=True
 tsflags=nodocs
-reposdir=/dev/null
 name=Fedora $releasever - $basearch
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
@@ -17,7 +16,6 @@ skip_if_unavailable=False
 [fedora-updates-fc30]
 clean_requirements_on_remove=True
 tsflags=nodocs
-reposdir=/dev/null
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Accidentally put in directive to ignore /etc/yum.repos.d where I put the altered repo files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

