### PR TITLE
Add pod messages to PVC events.

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -89,10 +90,18 @@ func main() {
 		err := image.CreateBlankImage(common.ImporterWritePath, minSizeQuantity)
 		if err != nil {
 			klog.Errorf("%+v", err)
+			err = util.WriteTerminationMessage(fmt.Sprintf("Unable to create blank image: %+v", err))
+			if err != nil {
+				klog.Errorf("%+v", err)
+			}
 			os.Exit(1)
 		}
 	} else if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeArchive) {
 		klog.Errorf("%+v", errors.New("Cannot create empty disk with content type archive"))
+		err = util.WriteTerminationMessage("Cannot create empty disk with content type archive")
+		if err != nil {
+			klog.Errorf("%+v", err)
+		}
 		os.Exit(1)
 	} else {
 		klog.V(1).Infoln("begin import process")
@@ -102,6 +111,10 @@ func main() {
 			dp, err = importer.NewHTTPDataSource(ep, acc, sec, certDir, cdiv1.DataVolumeContentType(contentType))
 			if err != nil {
 				klog.Errorf("%+v", err)
+				err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to http data source: %+v", err))
+				if err != nil {
+					klog.Errorf("%+v", err)
+				}
 				os.Exit(1)
 			}
 		case controller.SourceRegistry:
@@ -110,10 +123,18 @@ func main() {
 			dp, err = importer.NewS3DataSource(ep, acc, sec)
 			if err != nil {
 				klog.Errorf("%+v", err)
+				err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to s3 data source: %+v", err))
+				if err != nil {
+					klog.Errorf("%+v", err)
+				}
 				os.Exit(1)
 			}
 		default:
 			klog.Errorf("Unknown source type %s\n", source)
+			err = util.WriteTerminationMessage(fmt.Sprintf("Unknown data source: %s", source))
+			if err != nil {
+				klog.Errorf("%+v", err)
+			}
 			os.Exit(1)
 		}
 		defer dp.Close()
@@ -124,8 +145,17 @@ func main() {
 			if err == importer.ErrRequiresScratchSpace {
 				os.Exit(common.ScratchSpaceNeededExitCode)
 			}
+			err = util.WriteTerminationMessage(fmt.Sprintf("%+v", err))
+			if err != nil {
+				klog.Errorf("%+v", err)
+			}
 			os.Exit(1)
 		}
 	}
-	klog.V(1).Infoln("import complete")
+	err = util.WriteTerminationMessage("Import Complete")
+	if err != nil {
+		klog.Errorf("%+v", err)
+		os.Exit(1)
+	}
+	klog.V(1).Infoln("Import complete")
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -31,6 +31,8 @@ const (
 	ImporterWritePath = ImporterVolumePath + "/" + DiskImageName
 	// ImporterWriteBlockPath provides a constant for the path where the PV is mounted.
 	ImporterWriteBlockPath = "/dev/blockDevice"
+	// PodTerminationMessageFile is the name of the file to write the termination message to.
+	PodTerminationMessageFile = "/dev/termination-log"
 	// ImporterPodName provides a constant to use as a prefix for Pods created by CDI (controller only)
 	ImporterPodName = "importer"
 	// ImporterDataDir provides a constant for the controller pkg to use as a hardcoded path to where content is transferred to/from (controller only)

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
-	cdischeme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
@@ -50,9 +49,6 @@ func NewCloneController(client kubernetes.Interface,
 	verbose string) *CloneController {
 
 	// Create event broadcaster
-	// Add datavolume-controller types to the default Kubernetes Scheme so Events can be
-	// logged for datavolume-controller types.
-	cdischeme.AddToScheme(scheme.Scheme)
 	klog.V(3).Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.V(2).Infof)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -200,7 +200,6 @@ func NewDataVolumeController(
 		recorder:          recorder,
 		pvcExpectations:   expectations.NewUIDTrackingControllerExpectations(expectations.NewControllerExpectations()),
 	}
-
 	klog.V(2).Info("Setting up event handlers")
 
 	// Set up an event handler for when DataVolume resources change

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -120,7 +120,7 @@ func (dp *DataProcessor) ProcessData() error {
 		// Clean up before trying to write, in case a previous attempt left a mess. Note the deferred cleanup is intentional.
 		err = CleanDir(dp.scratchDataDir)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failure cleaning up temporary scratch space")
 		}
 		// Attempt to be a good citizen and clean up my mess at the end.
 		defer CleanDir(dp.scratchDataDir)
@@ -129,34 +129,53 @@ func (dp *DataProcessor) ProcessData() error {
 		// Clean up data dir before trying to write in case a previous attempt failed and left some stuff behind.
 		err = CleanDir(dp.dataDir)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failure cleaning up target space")
 		}
 	}
 	for dp.currentPhase != ProcessingPhaseComplete {
 		switch dp.currentPhase {
 		case ProcessingPhaseInfo:
 			dp.currentPhase, err = dp.source.Info()
+			if err != nil {
+				err = errors.Wrap(err, "Unable to obtain information about data source")
+			}
 		case ProcessingPhaseTransferScratch:
 			dp.currentPhase, err = dp.source.Transfer(dp.scratchDataDir)
 			if err == ErrInvalidPath {
 				// Passed in invalid scratch space path, return scratch space needed error.
 				err = ErrRequiresScratchSpace
+			} else if err != nil {
+				err = errors.Wrap(err, "Unable to transfer source data to scratch space")
 			}
 		case ProcessingPhaseTransferDataDir:
 			dp.currentPhase, err = dp.source.Transfer(dp.dataDir)
+			if err != nil {
+				err = errors.Wrap(err, "Unable to transfer source data to target directory")
+			}
 		case ProcessingPhaseTransferDataFile:
 			dp.currentPhase, err = dp.source.TransferFile(dp.dataFile)
 			if err == nil {
 				// dataFile is a known good url, so we know parse will never fail.
 				url, _ := url.Parse(dp.dataFile)
 				err = dp.validate(url)
+			} else {
+				err = errors.Wrap(err, "Unable to transfer source data to target file")
 			}
 		case ProcessingPhaseProcess:
 			dp.currentPhase, err = dp.source.Process()
+			if err != nil {
+				err = errors.Wrap(err, "Unable to process source data to intermediate state before transferring to target")
+			}
 		case ProcessingPhaseConvert:
 			dp.currentPhase, err = dp.convert(dp.source.GetURL())
+			if err != nil {
+				err = errors.Wrap(err, "Unable to convert source data to target format")
+			}
 		case ProcessingPhaseResize:
 			dp.currentPhase, err = dp.resize()
+			if err != nil {
+				err = errors.Wrap(err, "Unable to resize disk image to requested size")
+			}
 		default:
 			return errors.Errorf("Unknown processing phase %s", dp.currentPhase)
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -206,3 +206,21 @@ func CopyFile(src, dst string) error {
 	}
 	return out.Close()
 }
+
+// WriteTerminationMessage writes the passed in message to the default termination message file
+func WriteTerminationMessage(message string) error {
+	return WriteTerminationMessageToFile(common.PodTerminationMessageFile, message)
+}
+
+// WriteTerminationMessageToFile writes the passed in message to the passed in message file
+func WriteTerminationMessageToFile(file, message string) error {
+	// Only write the first line of the message.
+	scanner := bufio.NewScanner(strings.NewReader(message))
+	if scanner.Scan() {
+		err := ioutil.WriteFile(file, []byte(scanner.Text()), os.ModeAppend)
+		if err != nil {
+			return errors.Wrap(err, "could not create termination message file")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR sends importer pod errors to the PVC event log to indicate why imports failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
PVC event log now contains import failure messages.
```

