### PR TITLE
Set label operator.cdi.kubevirt.io to deployment spec of cdi-operator

### DIFF
--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -144,16 +144,15 @@ func CreateRole(name string) *rbacv1.Role {
 
 //CreateOperatorDeploymentSpec creates deployment
 func CreateOperatorDeploymentSpec(name, namespace, matchKey, matchValue, serviceAccount string, numReplicas int32) *appsv1.DeploymentSpec {
+	matchMap := map[string]string{matchKey: matchValue}
 	spec := &appsv1.DeploymentSpec{
 		Replicas: &numReplicas,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"name": "cdi-operator",
-			},
+			MatchLabels: WithOperatorLabels(matchMap),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"name": "cdi-operator"},
+				Labels: WithOperatorLabels(matchMap),
 			},
 		},
 	}
@@ -167,16 +166,12 @@ func CreateOperatorDeploymentSpec(name, namespace, matchKey, matchValue, service
 
 //CreateOperatorDeployment creates deployment
 func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount string, numReplicas int32) *appsv1.Deployment {
-	//matchMap := map[string]string{matchKey: matchValue}
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"operator.cdi.kubevirt.io": "",
-			},
 			Name:      name,
 			Namespace: namespace,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a backport of #818 

We would like all cdi pods to be labeled with cdi.kubevirt.io label when deployed via OLM.
Untill now cdi-operator pod did not have its operator.cdi.kubevirt.io label when deployed via OLM.
This PR fixes it. Now when deployed:
```
cdi-apiserver-799b86cd47-67lxq                   1/1       Running   0          2m        cdi.kubevirt.io=cdi-apiserver,pod-template-hash=799b86cd47
cdi-deployment-67855b764d-kscbn                  1/1       Running   0          2m        app=containerized-data-importer,cdi.kubevirt.io=,pod-template-hash=67855b764d
cdi-operator-694dc4dcd-zcwk2                     1/1       Running   0          4m        name=cdi-operator,operator.cdi.kubevirt.io=,pod-template-hash=694dc4dcd
cdi-uploadproxy-7cd5bdb789-4r247                 1/1       Running   0          2m        cdi.kubevirt.io=cdi-uploadproxy,pod-template-hash=7cd5bdb789

```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

