### PR TITLE
controller leader election broken because controller had to become le…

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -232,10 +232,6 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 			klog.Fatalf("Error running config controller: %+v", err)
 		}
 	}()
-
-	if err = createReadyFile(); err != nil {
-		klog.Fatalf("Error creating ready file: %+v", err)
-	}
 }
 
 func main() {
@@ -254,6 +250,10 @@ func main() {
 
 	if err != nil {
 		klog.Fatalf("Unable to start leader election: %v\n", errors.WithStack(err))
+	}
+
+	if err = createReadyFile(); err != nil {
+		klog.Fatalf("Error creating ready file: %+v", err)
 	}
 
 	<-stopCh


### PR DESCRIPTION
…ader to be ready.  Classic deadlock

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a backport of PR #823 

```
Make the controller be "Ready" once the leader election thread is started.  Not after becoming leader.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

