### PR TITLE
fix host:port not allowed in insecure registry configmap 

### DIFF
--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -124,6 +124,6 @@ To disable TLS security for a registry:
 Add the registry to the `cdi-insecure-registries` `ConfigMap` in the `cdi` namespace.
 
 ```bash
-patch configmap cdi-insecure-registries -n cdi \
-  --type merge -p '{"data":{"my-private-registry:5000": ""}}'
+kubectl patch configmap cdi-insecure-registries -n cdi \
+  --type merge -p '{"data":{"mykey": "my-private-registry-host:5000"}}'
 ```

--- a/manifests/templates/registry-host.yaml.in
+++ b/manifests/templates/registry-host.yaml.in
@@ -90,3 +90,6 @@ spec:
   - name: sec-docker-reg
     port: 443
     targetPort: 443
+  - name: alt-sec-docker-reg
+    port: 5000
+    targetPort: 443

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1403,17 +1403,22 @@ func isInsecureTLS(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (
 		return false, nil
 	}
 
+	klog.V(3).Infof("Checking configmap %s for host %s", configMapName, url.Host)
+
 	cm, err := client.CoreV1().ConfigMaps(util.GetNamespace()).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
+			klog.Warningf("Configmap %s does not exist", configMapName)
 			return false, nil
 		}
 
 		return false, err
 	}
 
-	for host := range cm.Data {
-		if host == url.Host {
+	for key, value := range cm.Data {
+		klog.V(3).Infof("Checking %q against %q: %q", url.Host, key, value)
+
+		if value == url.Host {
 			return true, nil
 		}
 	}

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1102,7 +1102,7 @@ func Test_getInsecureTLS(t *testing.T) {
 
 			if arg.insecureHost != "" {
 				cm.Data = map[string]string{
-					arg.insecureHost: "",
+					"test-registry": arg.insecureHost,
 				}
 			}
 

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Transport Tests", func() {
 		}
 
 		if insecureRegistry {
-			err = utils.SetInsecureRegistry(c)
+			err = utils.SetInsecureRegistry(c, f.CdiInstallNs, ep)
 			Expect(err).To(BeNil())
 			defer utils.ClearInsecureRegistry(c)
 		}
@@ -122,10 +122,11 @@ var _ = Describe("Transport Tests", func() {
 		}
 	}
 
-	httpNoAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPNoAuthPort)
-	httpsNoAuthEp := fmt.Sprintf("https://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPSNoAuthPort)
-	httpAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+utils.FileHostNs, utils.HTTPAuthPort)
-	registryNoAuthEp := fmt.Sprintf("docker://%s", utils.RegistryHostName+"."+utils.RegistryHostNs)
+	httpNoAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPNoAuthPort)
+	httpsNoAuthEp := fmt.Sprintf("https://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPSNoAuthPort)
+	httpAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPAuthPort)
+	registryNoAuthEp := fmt.Sprintf("docker://%s", utils.RegistryHostName+"."+f.CdiInstallNs)
+	altRegistryNoAuthEp := fmt.Sprintf("docker://%s.%s:%d", utils.RegistryHostName, f.CdiInstallNs, 5000)
 	DescribeTable("Transport Test Table", it,
 		Entry("should connect to http endpoint without credentials", httpNoAuthEp, targetFile, "", "", controller.SourceHTTP, "", false, true),
 		Entry("should connect to http endpoint with credentials", httpAuthEp, targetFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, "", false, true),
@@ -134,6 +135,7 @@ var _ = Describe("Transport Tests", func() {
 		Entry("should connect to QCOW http endpoint with credentials", httpAuthEp, targetQCOWFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, "", false, true),
 		Entry("should succeed to import from registry when image contains valid qcow file", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "cdi-docker-registry-host-certs", false, true),
 		Entry("should succeed to import from registry when image contains valid qcow file", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
+		Entry("should succeed to import from registry when image contains valid qcow file", altRegistryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
 		Entry("should fail no certs", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", false, false),
 		Entry("should fail bad certs", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "cdi-file-host-certs", false, false),
 		Entry("should succeed to import from registry when image contains valid raw file", registryNoAuthEp, targetRawImage, "", "", controller.SourceRegistry, "cdi-docker-registry-host-certs", false, true),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a backport of PR #832 

```
Turns out you can't have : in a configmap key. Which means no host:port combos in the cdi-insecure-registries configmap. Which is probably necessary for many internal registries.

Didn't catch this in testing because our functional test registry listens on port 443.
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#833 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

