### PR TITLE
Change name of new deployment in leader election test.

### DIFF
--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	cdiDeploymentName = "cdi-deployment"
-	newDeploymentName = "cdi-deployment-new"
+	newDeploymentName = "cdi-new-deployment"
 
 	pollingInterval = 2 * time.Second
 	timeout         = 90 * time.Second


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Change what we call the new deployment in the leader election test so it doesn't match the check to see if we have multiple deployments in pre test checks. Sometimes it takes a little bit before the test deployment is removed, and this causes test failures that aren't actually failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

