### PR TITLE
tests: wait more time for cdi-upload pod to be ready

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -72,7 +72,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	table.DescribeTable("should", func(validToken bool, expectedStatus int) {
 
 		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*60)
+		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*90)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify PVC status annotation says running")
@@ -251,7 +251,7 @@ var _ = Describe("Block PV upload Test", func() {
 
 	table.DescribeTable("should", func(validToken bool, expectedStatus int) {
 		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*60)
+		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*90)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify PVC status annotation says running")

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -72,7 +72,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	table.DescribeTable("should", func(validToken bool, expectedStatus int) {
 
 		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*20)
+		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*60)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify PVC status annotation says running")
@@ -251,7 +251,7 @@ var _ = Describe("Block PV upload Test", func() {
 
 	table.DescribeTable("should", func(validToken bool, expectedStatus int) {
 		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*20)
+		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*60)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify PVC status annotation says running")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Upload tests from tests/transport_tests.go sometimes fail with the following error:

```
/go/src/kubevirt.io/containerized-data-importer/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:46
Unexpected error:
    <*errors.errorString | 0xc000079800>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
```

This PR increase the timeout for those tests so that the cdi-upload pod has enough time to start and get ready. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

