### PR TITLE
Set RunAsUser to the one defined in the docker file.

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -437,6 +437,7 @@ func MakeImporterPodSpec(image, verbose, pullPolicy string, podEnvVar *importPod
 		pod.Spec.Containers[0].VolumeMounts = addVolumeMounts()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
+			RunAsUser:    &[]int64{1001}[0],
 		}
 	}
 
@@ -1133,6 +1134,7 @@ func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.Persiste
 		pod.Spec.Containers[0].VolumeMounts = addVolumeMountsForUpload()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
+			RunAsUser:    &[]int64{1001}[0],
 		}
 	}
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1310,6 +1310,7 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string, scratchPvc *v1.Pers
 		pod.Spec.Containers[0].VolumeMounts = addVolumeMounts()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
+			RunAsUser:    &[]int64{1001}[0],
 		}
 	}
 
@@ -1854,6 +1855,7 @@ func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 		Spec: v1.PodSpec{
 			SecurityContext: &v1.PodSecurityContext{
 				RunAsNonRoot: &[]bool{true}[0],
+				RunAsUser:    &[]int64{1001}[0],
 			},
 			Containers: []v1.Container{
 				{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sets the user the importer and upload are running as so we have no issues when trying to read the home directory (for instance skopeo uses /home/cdi-importer/.docker/ to get some user information. If the user is not set this will fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

