### PR TITLE
watch extension-apiserver-authentication configmap and refresh client…

### DIFF
--- a/cmd/cdi-apiserver/apiserver.go
+++ b/cmd/cdi-apiserver/apiserver.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
 package main
 
 import (
@@ -6,10 +25,14 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
 	"kubevirt.io/containerized-data-importer/pkg/apiserver"
 	"kubevirt.io/containerized-data-importer/pkg/version/verflag"
 )
@@ -73,17 +96,26 @@ func main() {
 
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(cfg)
 
-	authorizor, err := apiserver.NewAuthorizorFromConfig(cfg)
+	ch := signals.SetupSignalHandler()
+
+	authConfigWatcher := apiserver.NewAuthConfigWatcher(client, ch)
+
+	authorizor, err := apiserver.NewAuthorizorFromConfig(cfg, authConfigWatcher)
 	if err != nil {
 		klog.Fatalf("Unable to create authorizor: %v\n", errors.WithStack(err))
 	}
 
-	uploadApp, err := apiserver.NewCdiAPIServer(defaultHost, defaultPort, client, aggregatorClient, authorizor)
+	uploadApp, err := apiserver.NewCdiAPIServer(defaultHost,
+		defaultPort,
+		client,
+		aggregatorClient,
+		authorizor,
+		authConfigWatcher)
 	if err != nil {
 		klog.Fatalf("Upload api failed to initialize: %v\n", errors.WithStack(err))
 	}
 
-	err = uploadApp.Start()
+	err = uploadApp.Start(ch)
 	if err != nil {
 		klog.Fatalf("TLS server failed: %v\n", errors.WithStack(err))
 	}

--- a/pkg/apiserver/auth-config.go
+++ b/pkg/apiserver/auth-config.go
@@ -1,0 +1,159 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
+package apiserver
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
+)
+
+const (
+	configMapName = "extension-apiserver-authentication"
+)
+
+// AuthConfig contains extension-apiserver-authentication data
+type AuthConfig struct {
+	AllowedNames       []string
+	UserHeaders        []string
+	GroupHeaders       []string
+	ExtraPrefixHeaders []string
+
+	ClientCABytes              []byte
+	RequestheaderClientCABytes []byte
+
+	CertPool *x509.CertPool
+}
+
+// AuthConfigWatcher is the interface of authConfigWatcher
+type AuthConfigWatcher interface {
+	GetAuthConfig() *AuthConfig
+}
+
+type authConfigWatcher struct {
+	// keep this around for tests
+	informer cache.SharedIndexInformer
+
+	config *AuthConfig
+	mutex  sync.RWMutex
+}
+
+// NewAuthConfigWatcher crates a new authConfigWatcher
+func NewAuthConfigWatcher(client kubernetes.Interface, stopCh <-chan struct{}) AuthConfigWatcher {
+	informerFactory := informers.NewFilteredSharedInformerFactory(client,
+		common.DefaultResyncPeriod,
+		metav1.NamespaceSystem,
+		func(options *metav1.ListOptions) {
+			options.FieldSelector = "metadata.name=" + configMapName
+		},
+	)
+
+	configMapInformer := informerFactory.Core().V1().ConfigMaps().Informer()
+
+	acw := &authConfigWatcher{
+		informer: configMapInformer,
+	}
+
+	configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			klog.V(3).Infof("configMapInformer add callback: %+v", obj)
+			acw.updateConfig(obj.(*corev1.ConfigMap))
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			klog.V(3).Infof("configMapInformer update callback: %+v", obj)
+			acw.updateConfig(obj.(*corev1.ConfigMap))
+		},
+		DeleteFunc: func(obj interface{}) {
+			cm := obj.(*corev1.ConfigMap)
+			klog.Errorf("Configmap %s deleted", cm.Name)
+		},
+	})
+
+	go informerFactory.Start(stopCh)
+
+	klog.V(3).Infoln("Waiting for cache sync")
+	cache.WaitForCacheSync(stopCh, configMapInformer.HasSynced)
+	klog.V(3).Infoln("Cache sync complete")
+
+	return acw
+}
+
+func (acw *authConfigWatcher) GetAuthConfig() *AuthConfig {
+	acw.mutex.RLock()
+	defer acw.mutex.RUnlock()
+	return acw.config
+}
+
+func deserializeStringSlice(in string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	var ret []string
+	if err := json.Unmarshal([]byte(in), &ret); err != nil {
+		klog.Errorf("Error decoding %q", in)
+		return nil
+	}
+	return ret
+}
+
+func (acw *authConfigWatcher) updateConfig(cm *corev1.ConfigMap) {
+	newConfig := &AuthConfig{}
+	pool := x509.NewCertPool()
+
+	s, ok := cm.Data["client-ca-file"]
+	if ok {
+		newConfig.ClientCABytes = []byte(s)
+		// TODO don't think we've done enough testing to support this path (direct access to the apiserver)
+		// Have to write code to get user/groups/etc from cert
+		/*
+			if ok = pool.AppendCertsFromPEM(newConfig.ClientCABytes); !ok {
+				klog.Errorf("Error adding ClientCABytes to client cert pool")
+			}
+		*/
+	}
+
+	s, ok = cm.Data["requestheader-client-ca-file"]
+	if ok {
+		newConfig.RequestheaderClientCABytes = []byte(s)
+		if ok = pool.AppendCertsFromPEM(newConfig.RequestheaderClientCABytes); !ok {
+			klog.Errorf("Error adding RequestheaderClientCABytes to client cert pool")
+		}
+	}
+
+	newConfig.CertPool = pool
+
+	newConfig.AllowedNames = deserializeStringSlice(cm.Data["requestheader-allowed-names"])
+	newConfig.UserHeaders = deserializeStringSlice(cm.Data["requestheader-username-headers"])
+	newConfig.GroupHeaders = deserializeStringSlice(cm.Data["requestheader-group-headers"])
+	newConfig.ExtraPrefixHeaders = deserializeStringSlice(cm.Data["requestheader-extra-headers-prefix"])
+
+	acw.mutex.Lock()
+	defer acw.mutex.Unlock()
+	acw.config = newConfig
+}

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -31,10 +31,10 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/cert/triple"
 	aggregatorapifake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
 	"kubevirt.io/containerized-data-importer/pkg/util"
-	"kubevirt.io/containerized-data-importer/pkg/util/cert/triple"
 )
 
 func generateCACert(t *testing.T) string {

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -1,0 +1,172 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/cert"
+	aggregatorapifake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+
+	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/pkg/util/cert/triple"
+)
+
+func generateCACert(t *testing.T) string {
+	keyPair, err := triple.NewCA(util.RandAlphaNum(10))
+	if err != nil {
+		t.Errorf("Error creating CA cert")
+	}
+	return string(cert.EncodeCertPEM(keyPair.Cert))
+}
+
+func getAPIServerConfigMap(t *testing.T) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "extension-apiserver-authentication",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"client-ca-file":                     generateCACert(t),
+			"requestheader-allowed-names":        "[\"front-proxy-client\"]",
+			"requestheader-client-ca-file":       generateCACert(t),
+			"requestheader-extra-headers-prefix": "[\"X-Remote-Extra-\"]",
+			"requestheader-group-headers":        "[\"X-Remote-Group\"]",
+			"requestheader-username-headers":     "[\"X-Remote-User\"]",
+		},
+	}
+}
+
+func verifyAuthConfig(t *testing.T, cm *corev1.ConfigMap, authConfig *AuthConfig) {
+	if !reflect.DeepEqual([]byte(cm.Data["client-ca-file"]), authConfig.ClientCABytes) {
+		t.Errorf("client-ca-file not stored correctly")
+	}
+
+	if !reflect.DeepEqual([]byte(cm.Data["requestheader-client-ca-file"]), authConfig.RequestheaderClientCABytes) {
+		t.Errorf("client-ca-file not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-username-headers"]), authConfig.UserHeaders) {
+		t.Errorf("requestheader-username-headers not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-group-headers"]), authConfig.GroupHeaders) {
+		t.Errorf("requestheader-group-headers not stored correctly")
+	}
+
+	if !reflect.DeepEqual(deserializeStringSlice(cm.Data["requestheader-extra-headers-prefix"]), authConfig.ExtraPrefixHeaders) {
+		t.Errorf("requestheader-extra-headers-prefix not stored correctly")
+	}
+}
+
+func TestNewCdiAPIServer(t *testing.T) {
+	ch := make(chan struct{})
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, getAPIServerConfigMap(t))
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	authConfigWatcher := NewAuthConfigWatcher(client, ch)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, authConfigWatcher)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	req, _ := http.NewRequest("GET", "/apis", nil)
+	rr := httptest.NewRecorder()
+
+	app.container.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Unexpected status code %d", rr.Code)
+	}
+}
+
+func TestAuthConfigUpdate(t *testing.T) {
+	ch := make(chan struct{})
+	cm := getAPIServerConfigMap(t)
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, cm)
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	acw := NewAuthConfigWatcher(client, ch).(*authConfigWatcher)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, acw)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	verifyAuthConfig(t, cm, app.authConfigWatcher.GetAuthConfig())
+
+	cm.Data["requestheader-client-ca-file"] = generateCACert(t)
+
+	cm, err = client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Update(cm)
+	if err != nil {
+		t.Errorf("Updating configmap failed: %+v", err)
+	}
+
+	cache.WaitForCacheSync(ch, acw.informer.HasSynced)
+
+	verifyAuthConfig(t, cm, app.authConfigWatcher.GetAuthConfig())
+}
+
+func TestGetTLSConfig(t *testing.T) {
+	ch := make(chan struct{})
+	cm := getAPIServerConfigMap(t)
+	kubeobjects := []runtime.Object{}
+	kubeobjects = append(kubeobjects, cm)
+
+	client := k8sfake.NewSimpleClientset(kubeobjects...)
+	aggregatorClient := aggregatorapifake.NewSimpleClientset()
+	authorizer := &testAuthorizer{}
+	acw := NewAuthConfigWatcher(client, ch).(*authConfigWatcher)
+
+	server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, authorizer, acw)
+	if err != nil {
+		t.Errorf("Upload api server creation failed: %+v", err)
+	}
+
+	app := server.(*cdiAPIApp)
+
+	tlsConfig, err := app.getTLSConfig()
+	if err != nil {
+		t.Errorf("Error getting tls conig")
+	}
+
+	if !reflect.DeepEqual(tlsConfig.ClientCAs, acw.GetAuthConfig().CertPool) {
+		t.Errorf("Client cert pools do not match")
+	}
+}

--- a/pkg/apiserver/util.go
+++ b/pkg/apiserver/util.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
 package apiserver
 
 import (

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -91,11 +91,6 @@ func UploadPossibleForPVC(pvc *v1.PersistentVolumeClaim) error {
 		return errors.Errorf("PVC %s is not an upload target", pvc.Name)
 	}
 
-	pvcPodStatus, ok := pvc.Annotations[AnnPodPhase]
-	if !ok || v1.PodPhase(pvcPodStatus) != v1.PodRunning {
-		return errors.Errorf("Upload Server pod not currently running for PVC %s", pvc.Name)
-	}
-
 	return nil
 }
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -505,15 +505,6 @@ func TestUploadPossible(t *testing.T) {
 				true,
 			},
 		},
-		{
-			"PVC not ready",
-			args{
-				map[string]string{"cdi.kubevirt.io/storage.upload.target": "",
-					"cdi.kubevirt.io/storage.pod.phase": "Pending",
-				},
-				true,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -99,6 +99,8 @@ func createExtensionAPIServerRole() *rbacv1.Role {
 			},
 			Verbs: []string{
 				"get",
+				"list",
+				"watch",
 			},
 			ResourceNames: []string{
 				extensionAPIConfigMapName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 
This is a backport of #807
```
On OCP 4, the apiserver rotates the proxy CA cert daily.  This caused the CDI apiserver to be unusable after a day or so.  The cdi apiserver was rejecting the new client cert because it was not aware the rotation occurred.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
In my testing, the easiest way to reproduce the issue is with the kubevirtci os-3.11 build.  Do the following:

```bash
export KUBEVIRT_PROVIDER=os-3.11.0
make cluster-up cluster-sync
 k -v 8 apply -f manifests/example/upload-datavolume.yaml -o yaml
 k -v 8 apply -f manifests/example/upload-datavolume-token.yaml -o yaml
# rotate certs
./cluster/cli.sh ssh node01 'sudo ansible-playbook -i /root/inventory /root/openshift-ansible/playbooks/openshift-master/redeploy-certificates.yml'
# should succeed
 k -v 8 apply -f manifests/example/upload-datavolume-token.yaml -o yaml
```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Watch extension-apiserver-authentication configmap for changes
```

