### PR TITLE
Upload to the same target PVC should have a meaningful error

### DIFF
--- a/pkg/operator/resources/cluster/factory.go
+++ b/pkg/operator/resources/cluster/factory.go
@@ -45,6 +45,8 @@ const (
 	CdiRBAC string = "cdi-rbac"
 	//APIServerRBAC - groupCode to generate only apiserver rbac manifest
 	APIServerRBAC string = "apiserver-rbac"
+	//UploadProxyRBAC - groupCode to generate only apiserver rbac manifest
+	UploadProxyRBAC string = "uploadproxy-rbac"
 	//ControllerRBAC - groupCode to generate only controller rbac manifest
 	ControllerRBAC string = "controller-rbac"
 	//CRDResources - groupCode to generate only resources' manifest
@@ -52,10 +54,11 @@ const (
 )
 
 var factoryFunctions = map[string]factoryFunc{
-	CdiRBAC:        createCdiRBAC,
-	APIServerRBAC:  createAPIServerResources,
-	ControllerRBAC: createControllerResources,
-	CRDResources:   createCRDResources,
+	CdiRBAC:         createCdiRBAC,
+	APIServerRBAC:   createAPIServerResources,
+	ControllerRBAC:  createControllerResources,
+	CRDResources:    createCRDResources,
+	UploadProxyRBAC: createUploadProxyResources,
 }
 
 //IsFactoryResource returns true id codeGroupo belolngs to factory functions

--- a/pkg/operator/resources/cluster/uploadproxy.go
+++ b/pkg/operator/resources/cluster/uploadproxy.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	uploadProxyResourceName = "cdi-uploadproxy"
+)
+
+func createUploadProxyResources(args *FactoryArgs) []runtime.Object {
+	return []runtime.Object{
+		createUploadProxyClusterRole(),
+		createUploadProxyClusterRoleBinding(args.Namespace),
+	}
+}
+
+//GetUploadProxyRolePermissions generates permissions for operator
+func GetUploadProxyRolePermissions() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"pods",
+			},
+			Verbs: []string{
+				"get",
+			},
+		},
+	}
+}
+
+func createUploadProxyClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return CreateClusterRoleBinding(uploadProxyResourceName, uploadProxyResourceName, uploadProxyResourceName, namespace)
+}
+
+func createUploadProxyClusterRole() *rbacv1.ClusterRole {
+	clusterRole := CreateClusterRole(uploadProxyResourceName)
+	clusterRole.Rules = GetUploadProxyRolePermissions()
+	return clusterRole
+}

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -30,6 +30,7 @@ const (
 
 func createUploadProxyResources(args *FactoryArgs) []runtime.Object {
 	return []runtime.Object{
+		createUploadProxyServiceAccount(),
 		createUploadProxyService(),
 		createUploadProxyDeployment(args.DockerRepo, args.UploadProxyImage, args.DockerTag, args.Verbosity, args.PullPolicy),
 	}
@@ -50,8 +51,12 @@ func createUploadProxyService() *corev1.Service {
 	return service
 }
 
+func createUploadProxyServiceAccount() *corev1.ServiceAccount {
+	return utils.CreateServiceAccount(uploadProxyResourceName)
+}
+
 func createUploadProxyDeployment(repo, image, tag, verbosity, pullPolicy string) *appsv1.Deployment {
-	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, "", int32(1))
+	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, uploadProxyResourceName, int32(1))
 	container := utils.CreateContainer(uploadProxyResourceName, repo, image, tag, verbosity, corev1.PullPolicy(pullPolicy))
 	container.Env = []corev1.EnvVar{
 		{

--- a/pkg/uploadproxy/uploadproxy_test.go
+++ b/pkg/uploadproxy/uploadproxy_test.go
@@ -15,6 +15,14 @@ import (
 	"k8s.io/client-go/util/cert"
 
 	"kubevirt.io/containerized-data-importer/pkg/apiserver"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+
+	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/cert"
 )
 
 type httpClientConfig struct {
@@ -148,7 +156,15 @@ func setupProxyTests(handler http.HandlerFunc) *uploadProxyApp {
 		return server.URL
 	}
 
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      controller.GetUploadResourceName("testpvc"),
+		Namespace: "default",
+	}}
+	pod.Status.Phase = v1.PodPending
+	objects := []runtime.Object{}
+	objects = append(objects, pod)
 	app := createApp()
+	app.client = k8sfake.NewSimpleClientset(objects...)
 	app.tokenVerifier = verifyTokenSuccess
 	app.urlResolver = urlResolver
 	app.uploadServerClient = server.Client()

--- a/pkg/uploadproxy/uploadproxy_test.go
+++ b/pkg/uploadproxy/uploadproxy_test.go
@@ -12,8 +12,6 @@ import (
 
 	"k8s.io/client-go/util/cert/triple"
 
-	"k8s.io/client-go/util/cert"
-
 	"kubevirt.io/containerized-data-importer/pkg/apiserver"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a backport of #830 
```
When trying to upload to a pvc, before trying to connect to the upload pod, we check if this pod exists.
If it doesn't exist it means we already uploaded to this pvc so we should fail before trying to connect:
The new check returns:
From `cdi-uploadproxy` logs:

Rejecting Upload Request for Pod cdi-upload-upload-datavolume that doesn't exist

```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: provide meaningful error if trying to upload again to the same pvc.
```

