### PR TITLE
increase uploadproxy route timeout

### DIFF
--- a/pkg/operator/controller/route.go
+++ b/pkg/operator/controller/route.go
@@ -98,6 +98,9 @@ func (r *ReconcileCDI) ensureUploadProxyRouteExists(logger logr.Logger, cr *cdiv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      uploadProxyRouteName,
 			Namespace: r.namespace,
+			Annotations: map[string]string{
+				"haproxy.router.openshift.io/timeout": "3m",
+			},
 		},
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #854 
```
Increased cdi-uploadproxy timeout as a workaround to `virtctl` receiving OpenShift route timeout when uploading large qcow images.
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: set a higher connection timeout for cdi-uploadproxy route.
```

