### PR TITLE
Better document certConfigMap

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -18,7 +18,7 @@ The following statuses are possible.
 * Unknown: Unknown status.
 
 ## HTTP/S3/Registry source
-Data Volumes are an abstraction on top of the annotations one can put on PVCs to trigger CDI. As such DVs have the notion of a 'source' that allows one to specify the source of the data. To import data from an external source, the source has to be either 'http' ,'S3' or 'registry'. If your source requires authentication, you can also pass in a secretRef to a Kubernetes [Secret](../manifest/example/endpoint-secret.yaml) containing the authentication information.
+DataVolumes are an abstraction on top of the annotations one can put on PVCs to trigger CDI. As such DVs have the notion of a 'source' that allows one to specify the source of the data. To import data from an external source, the source has to be either 'http' ,'S3' or 'registry'. If your source requires authentication, you can also pass in a `secretRef` to a Kubernetes [Secret](../manifest/example/endpoint-secret.yaml) containing the authentication information.  TLS certificates for https/registry sources may be specified in a [ConfigMap](../manifests/example/cert-configmap.yaml) and referenced by `certConfigMap`.  `secretRef` and `certConfigMap` must be in the same namespace as the DataVolume.
 
 ```yaml
 apiVersion: cdi.kubevirt.io/v1alpha1

--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -95,7 +95,7 @@ spec:
 
 If your registry TLS certificate is not signed by a trusted CA:
 
-Create a `ConfigMap` containing all certificates required to trust the registry.
+Create a `ConfigMap`  in the same namespace as the DataVolume containing all certificates required to trust the registry.
 
 ```bash
 kubectl create configmap my-registry-certs --from-file=my-registry.crt
@@ -103,7 +103,7 @@ kubectl create configmap my-registry-certs --from-file=my-registry.crt
 
 The `ConfigMap` may contain multiple entries if necessary.  Key name is irrelevant.
 
-Add `CertConfigMap` to `DataVolume` spec.
+Add `certConfigMap` to `DataVolume` spec.
 
 ```yaml
 apiVersion: cdi.kubevirt.io/v1alpha1


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:    

Not clear to users that certConfigMap must be in the same namespace as as theDataVolum/PVC.

Relevant bz: https://bugzilla.redhat.com/show_bug.cgi?id=1715413

I hope this helps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

