### PR TITLE
Set fsGroup to match user that is running in pod

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -438,6 +438,7 @@ func MakeImporterPodSpec(image, verbose, pullPolicy string, podEnvVar *importPod
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
 			RunAsUser:    &[]int64{1001}[0],
+			FSGroup:      &[]int64{1001}[0],
 		}
 	}
 
@@ -1135,6 +1136,7 @@ func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.Persiste
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
 			RunAsUser:    &[]int64{1001}[0],
+			FSGroup:      &[]int64{1001}[0],
 		}
 	}
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1311,6 +1311,7 @@ func createPod(pvc *v1.PersistentVolumeClaim, dvname string, scratchPvc *v1.Pers
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
 			RunAsUser:    &[]int64{1001}[0],
+			FSGroup:      &[]int64{1001}[0],
 		}
 	}
 
@@ -1856,6 +1857,7 @@ func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 			SecurityContext: &v1.PodSecurityContext{
 				RunAsNonRoot: &[]bool{true}[0],
 				RunAsUser:    &[]int64{1001}[0],
+				FSGroup:      &[]int64{1001}[0],
 			},
 			Containers: []v1.Container{
 				{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR makes it so that the mounted volumes are accessible by the user we are running as.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

