### PR TITLE
Revert init container hack to enable block devices.

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -682,37 +682,15 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName string, pvc *v1.Per
 			},
 		},
 		Spec: v1.PodSpec{
-			// We create initContainer just to set the pod as privileged.
-			// The pod has to be privileged as it has to have access to the hostPath in the node.
-			// However, currently there is a bug that we cannot attach block device to the pod if the pod (container)
-			// is privileged:
-			//https://github.com/kubernetes/kubernetes/issues/58251
-			//https://github.com/kubernetes/kubernetes/issues/62560
-			// As a result of that, instead setting the SecurityContext field as Privileged, in the main container
-			// where we need to have access to  the hostPath, we set the SecurityContext field in the initContainer,
-			// and that will do it.
-			InitContainers: []v1.Container{
-				{
-					Name:  "init",
-					Image: image,
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:      socketPathName,
-							MountPath: common.ClonerSocketPath + "/" + id,
-						},
-					},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &[]bool{true}[0],
-						RunAsUser:  &[]int64{0}[0],
-					},
-					Command: []string{"sh", "-c", "echo setting the pod as privileged"},
-				},
-			},
 			Containers: []v1.Container{
 				{
 					Name:            common.ClonerSourcePodName,
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &[]bool{true}[0],
+						RunAsUser:  &[]int64{0}[0],
+					},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
@@ -860,38 +838,15 @@ func MakeCloneTargetPodSpec(image, pullPolicy, podAffinityNamespace string, pvc 
 					},
 				},
 			},
-			// We create initContainer just to set the pod as privileged.
-			// The pod has to be privileged as it has to have access to the hostPath in the node.
-			// However, currently there is a bug that we cannot attach block device to the pod if the pod (container)
-			// is privileged:
-			//https://github.com/kubernetes/kubernetes/issues/58251
-			//https://github.com/kubernetes/kubernetes/issues/62560
-			// As a result of that, instead setting the SecurityContext field as Privileged, in the main container
-			// where we need to have access to  the hostPath, we set the SecurityContext field in the initContainer,
-			// and that will do it.
-			InitContainers: []v1.Container{
-				{
-					Name:  "init",
-					Image: image,
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:      socketPathName,
-							MountPath: common.ClonerSocketPath + "/" + id,
-						},
-					},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &[]bool{true}[0],
-						RunAsUser:  &[]int64{0}[0],
-					},
-					Command: []string{"sh", "-c", "echo setting the pod as privileged"},
-				},
-			},
-
 			Containers: []v1.Container{
 				{
 					Name:            common.ClonerTargetPodName,
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &[]bool{true}[0],
+						RunAsUser:  &[]int64{0}[0],
+					},
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1616,28 +1616,15 @@ func createSourcePod(pvc *v1.PersistentVolumeClaim, pvcUID string) *v1.Pod {
 			},
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
-				{
-					Name:  "init",
-					Image: "test/mycloneimage",
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:      socketPathName,
-							MountPath: ClonerSocketPath + "/" + pvcUID,
-						},
-					},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &[]bool{true}[0],
-						RunAsUser:  &[]int64{0}[0],
-					},
-					Command: []string{"sh", "-c", "echo setting the pod as privileged"},
-				},
-			},
 			Containers: []v1.Container{
 				{
 					Name:            common.ClonerSourcePodName,
 					Image:           "test/mycloneimage",
 					ImagePullPolicy: v1.PullPolicy("Always"),
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &[]bool{true}[0],
+						RunAsUser:  &[]int64{0}[0],
+					},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
@@ -1740,29 +1727,15 @@ func createTargetPod(pvc *v1.PersistentVolumeClaim, pvcUID, podAffinityNamespace
 					},
 				},
 			},
-			InitContainers: []v1.Container{
-				{
-					Name:  "init",
-					Image: "test/mycloneimage",
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:      socketPathName,
-							MountPath: ClonerSocketPath + "/" + pvcUID,
-						},
-					},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &[]bool{true}[0],
-						RunAsUser:  &[]int64{0}[0],
-					},
-					Command: []string{"sh", "-c", "echo setting the pod as privileged"},
-				},
-			},
-
 			Containers: []v1.Container{
 				{
 					Name:            common.ClonerTargetPodName,
 					Image:           "test/mycloneimage",
 					ImagePullPolicy: v1.PullPolicy("Always"),
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &[]bool{true}[0],
+						RunAsUser:  &[]int64{0}[0],
+					},
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "metrics",


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Revert the privileged init container hack to make block devices work while having a fully privileged pod.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #870 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

