### PR TITLE
Switch to default namespace after creating local storage.

### DIFF
--- a/cluster-sync/okd-4.1.2/provider.sh
+++ b/cluster-sync/okd-4.1.2/provider.sh
@@ -41,6 +41,9 @@ function configure_local_storage() {
 	done
     #Set the default storage class.
     _kubectl patch storageclass local-sc -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+	#Switch back to default project
+	_kubectl project default
     set -e
   fi
 }


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes issue where using the okd-4.1.2 provider you end up in the local-storage namespace instead of the default namespace after syncing the first time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

