### PR TITLE
* make file fix: all target requires manifests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 DO=eval
 endif
 
-all: docker
+all: manifests docker
 
 clean:
 	${DO} "./hack/build/build-go.sh clean; rm -rf bin/* _out/* manifests/generated/* .coverprofile release-announcement"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
make docker failswith error, since it expects olm manifests
since olm catalog source support, docker target in Makefile requires manifests to be prepared
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
since olm catalog source support, docker target in Makefile requires manifests to be prepared
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

