### PR TITLE
Fix install instruction for 1.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Deploying the CDI controller is straightforward. In this document the _default_ 
   ```
   $ export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
   $ kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
-  $ kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
+  $ kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
   ```
 
 ## Use it


### PR DESCRIPTION
This got missed with the CR.yaml rename.

```release-note
NONE
```