### PR TITLE
Initial upgrade support

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -226,6 +226,10 @@ func shouldTakeUpdatePath(targetVersion, currentVersion string) (bool, error) {
 		return false, nil
 	}
 
+	if targetVersion == currentVersion {
+		return false, nil
+	}
+
 	// semver doesn't like the 'v' prefix
 	targetVersion = strings.TrimPrefix(targetVersion, "v")
 	currentVersion = strings.TrimPrefix(currentVersion, "v")

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -55,6 +55,8 @@ import (
 
 const (
 	finalizerName = "operator.cdi.kubevirt.io"
+
+	maxTypeCallBacks = 5
 )
 
 var log = logf.Log.WithName("cdi-operator")

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -154,6 +154,12 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, err
 	}
 
+	// mid delete
+	if cr.DeletionTimestamp != nil {
+		reqLogger.Info("Doing reconcile delete")
+		return r.reconcileDelete(reqLogger, cr)
+	}
+
 	//compare target and observed
 	//Retriveed CR will contain previous version ImageTag and ImageRegistry
 	//while namespaced arguments will contain new version
@@ -170,12 +176,6 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if err := r.crUpdate(cdiv1alpha1.CDIPhaseDeploying, cr); err != nil {
 			return reconcile.Result{}, err
 		}
-	}
-
-	// mid delete
-	if cr.DeletionTimestamp != nil {
-		reqLogger.Info("Doing reconcile delete")
-		return r.reconcileDelete(reqLogger, cr)
 	}
 
 	configMap, err := r.getConfigMap()

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -55,8 +55,6 @@ import (
 
 const (
 	finalizerName = "operator.cdi.kubevirt.io"
-
-	maxTypeCallBacks = 5
 )
 
 var log = logf.Log.WithName("cdi-operator")
@@ -163,7 +161,7 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			err := r.cleanupUnusedResources(reqLogger, cr)
 			if err != nil {
 				reqLogger.Info("Failed to cleanupUnused resource prior to CDI cr deletion during upgrade")
-				return reconcile.Result{}, nil
+				return reconcile.Result{}, err
 			}
 		}
 		reqLogger.Info("Doing reconcile delete")

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -18,6 +18,12 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	generrors "errors"
+	"fmt"
+
+	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
+
 	"os"
 	"reflect"
 	"strings"
@@ -34,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -48,6 +55,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cdiviaplha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	cluster "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
 	clusterResources "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
 	namespaceResources "kubevirt.io/containerized-data-importer/pkg/operator/resources/namespaced"
 )
@@ -88,6 +96,12 @@ func init() {
 	secv1.Install(scheme.Scheme)
 	routev1.Install(scheme.Scheme)
 }
+
+type modifyResource func(toModify runtime.Object) (runtime.Object, runtime.Object, error)
+type isModifySubject func(resource runtime.Object) bool
+type isUpgraded func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool
+
+type createUnusedObject func() (runtime.Object, error)
 
 var _ = Describe("Controller", func() {
 	Describe("controller runtime bootstrap test", func() {
@@ -446,7 +460,659 @@ var _ = Describe("Controller", func() {
 		Entry("Tag override", &registryOverride{"v1.100.0"}),
 		Entry("Pull override", &pullOverride{corev1.PullNever}),
 	)
+
+	Describe("Upgrading CDI", func() {
+
+		DescribeTable("check detects upgrade correctly", func(prevVersion, newVersion string, shouldUpgrade bool) {
+			registry := "kubevirt"
+
+			//verify on int version is set
+			args := createFromArgs("cdi", newVersion, registry)
+			doReconcile(args)
+			Expect(args.cdi.Status.ObservedVersion).Should(Equal(newVersion))
+			Expect(args.cdi.Status.OperatorVersion).Should(Equal(newVersion))
+			Expect(args.cdi.Status.TargetVersion).Should(Equal(newVersion))
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+
+			//Modify CRD to be of previousVersion
+			args.cdi.Spec.ImageRegistry = registry
+			args.cdi.Spec.ImageTag = prevVersion
+			args.cdi.Status.ObservedVersion = prevVersion
+			args.cdi.Status.TargetVersion = prevVersion
+			args.cdi.Status.OperatorVersion = prevVersion
+
+			err := args.client.Update(context.TODO(), args.cdi)
+			Expect(err).ToNot(HaveOccurred())
+
+			doReconcile(args)
+
+			if shouldUpgrade {
+				//verify upgraded has started
+				Expect(args.cdi.Status.OperatorVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.ObservedVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.TargetVersion).Should(Equal(newVersion))
+				Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeploying))
+			} else {
+				//verify upgraded hasn't started
+				Expect(args.cdi.Status.OperatorVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.ObservedVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.TargetVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+			}
+
+			//change deployment to ready
+			isReady := setDeploymentsReady(args)
+			Expect(isReady).Should(Equal(true))
+
+			//now should be upgraded
+			if shouldUpgrade {
+				//verify versions were updated
+				Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+				Expect(args.cdi.Status.OperatorVersion).Should(Equal(newVersion))
+				Expect(args.cdi.Status.TargetVersion).Should(Equal(newVersion))
+				Expect(args.cdi.Status.ObservedVersion).Should(Equal(newVersion))
+			} else {
+				//verify versions remained unchaged
+				Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+				Expect(args.cdi.Status.OperatorVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.TargetVersion).Should(Equal(prevVersion))
+				Expect(args.cdi.Status.ObservedVersion).Should(Equal(prevVersion))
+			}
+		},
+			Entry("increasing semver ", "v1.9.5", "v1.10.0", true),
+			Entry("decreasing semver", "v1.10.0", "v1.9.5", false),
+			Entry("identical semver", "v1.10.0", "v1.10.0", false),
+			Entry("invalid semver", "devel", "v1.9.5", true),
+			Entry("increasing  semver no prefix", "1.9.5", "1.10.0", true),
+			Entry("decreasing  semver no prefix", "1.10.0", "1.9.5", false),
+			Entry("identical  semver no prefix", "1.10.0", "1.10.0", false),
+			Entry("invalid  semver no prefix", "devel", "1.9.5", true),
+			Entry("no current no prefix", "", "invalid", false),
+		)
+
+		DescribeTable("Updates objects on upgrade", func(
+			modify modifyResource,
+			tomodify isModifySubject,
+			upgraded isUpgraded) {
+
+			var args *args
+			registry := "kubevirt"
+			newVersion := "1.10.0"
+			prevVersion := "1.9.5"
+
+			args = createFromArgs("cdi", newVersion, registry)
+			doReconcile(args)
+
+			//verify on int version is set
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+
+			//Modify CRD to be of previousVersion
+			args.reconciler.crSetVersion(args.cdi, prevVersion, registry)
+			err := args.client.Update(context.TODO(), args.cdi)
+			Expect(err).ToNot(HaveOccurred())
+
+			//find the resource to modify
+			oOriginal, oModified, err := getModifiedResource(args.reconciler, modify, tomodify)
+			Expect(err).ToNot(HaveOccurred())
+
+			//update object via client, with curObject
+			err = args.client.Update(context.TODO(), oModified)
+			Expect(err).ToNot(HaveOccurred())
+
+			doReconcile(args)
+
+			//verify upgraded has started
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeploying))
+
+			//change deployment to ready
+			isReady := setDeploymentsReady(args)
+			Expect(isReady).Should(Equal(true))
+
+			doReconcile(args)
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+
+			//verify that stored object equals to object in getResources
+			storedObj, err := getObject(args.client, oModified)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(upgraded(storedObj, oOriginal)).Should(Equal(true))
+
+		},
+			//Deployment update
+			Entry("verify - deployment updated on upgrade - annotation changed",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					deploymentOrig, ok := toModify.(*appsv1.Deployment)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					deployment := deploymentOrig.DeepCopy()
+					deployment.Annotations = map[string]string{
+						"fake.anno.1": "fakeannotation1",
+						"fake.anno.2": "fakeannotation2",
+						"fake.anno.3": "fakeannotation3",
+					}
+					return toModify, deployment, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//return true if object is the one we want to test
+					_, ok := resource.(*appsv1.Deployment)
+					return ok
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					desiredDep, ok := deisredObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					for key, ann := range desiredDep.Annotations {
+						if postDep.Annotations[key] != ann {
+							return false
+						}
+					}
+
+					if len(desiredDep.Annotations) > len(postDep.Annotations) {
+						return false
+					}
+
+					return true
+				}),
+			Entry("verify - deployment updated on upgrade - labels changed",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					deploymentOrig, ok := toModify.(*appsv1.Deployment)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					deployment := deploymentOrig.DeepCopy()
+					deployment.Labels = map[string]string{
+						"fake.label.1": "fakelabel1",
+						"fake.label.2": "fakelabel2",
+						"fake.label.3": "fakelabel3",
+					}
+					return toModify, deployment, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//return true if object is the one we want to test
+					_, ok := resource.(*appsv1.Deployment)
+					return ok
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					desiredDep, ok := deisredObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					for key, label := range desiredDep.Labels {
+						if postDep.Labels[key] != label {
+							return false
+						}
+					}
+
+					if len(desiredDep.Labels) > len(postDep.Labels) {
+						return false
+					}
+
+					return true
+				}),
+			Entry("verify - deployment updated on upgrade - deployment spec changed - modify container",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					deploymentOrig, ok := toModify.(*appsv1.Deployment)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					deployment := deploymentOrig.DeepCopy()
+
+					containers := deployment.Spec.Template.Spec.Containers
+					containers[0].Env = []corev1.EnvVar{
+						{
+							Name:  "FAKE_ENVVAR",
+							Value: fmt.Sprintf("%s/%s:%s", "fake_repo", "importerImage", "tag"),
+						},
+					}
+
+					return toModify, deployment, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//search for cdi-deployment - to test ENV virables change
+					deployment, ok := resource.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+					if deployment.Name == "cdi-deployment" {
+						return true
+					}
+					return false
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					desiredDep, ok := deisredObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					for key, envVar := range desiredDep.Spec.Template.Spec.Containers[0].Env {
+						if postDep.Spec.Template.Spec.Containers[0].Env[key].Name != envVar.Name {
+							return false
+						}
+					}
+
+					if len(desiredDep.Spec.Template.Spec.Containers[0].Env) != len(postDep.Spec.Template.Spec.Containers[0].Env) {
+						return false
+					}
+
+					return true
+				}),
+			Entry("verify - deployment updated on upgrade - deployment spec changed - add new container",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					deploymentOrig, ok := toModify.(*appsv1.Deployment)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					deployment := deploymentOrig.DeepCopy()
+
+					containers := deployment.Spec.Template.Spec.Containers
+					container := corev1.Container{
+						Name:            "FAKE_CONTAINER",
+						Image:           fmt.Sprintf("%s/%s:%s", "fake-repo", "fake-image", "fake-tag"),
+						ImagePullPolicy: "FakePullPolicy",
+						Args:            []string{"-v=10"},
+					}
+					containers = append(containers, container)
+
+					return toModify, deployment, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//search for cdi-deployment - to test container change
+					deployment, ok := resource.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+					if deployment.Name == "cdi-deployment" {
+						return true
+					}
+					return false
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					desiredDep, ok := deisredObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					for key, container := range desiredDep.Spec.Template.Spec.Containers {
+						if postDep.Spec.Template.Spec.Containers[key].Name != container.Name {
+							return false
+						}
+					}
+
+					if len(desiredDep.Spec.Template.Spec.Containers) > len(postDep.Spec.Template.Spec.Containers) {
+						return false
+					}
+
+					return true
+				}),
+			Entry("verify - deployment updated on upgrade - deployment spec changed - remove existing container",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					deploymentOrig, ok := toModify.(*appsv1.Deployment)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					deployment := deploymentOrig.DeepCopy()
+
+					deployment.Spec.Template.Spec.Containers = nil
+
+					return toModify, deployment, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//search for cdi-deployment - to test container change
+					deployment, ok := resource.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+					if deployment.Name == "cdi-deployment" {
+						return true
+					}
+					return false
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					desiredDep, ok := deisredObj.(*appsv1.Deployment)
+					if !ok {
+						return false
+					}
+
+					return (len(postDep.Spec.Template.Spec.Containers) == len(desiredDep.Spec.Template.Spec.Containers))
+				}),
+
+			//Services update
+			Entry("verify - services updated on upgrade - annotation changed",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					serviceOrig, ok := toModify.(*corev1.Service)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					service := serviceOrig.DeepCopy()
+					service.Annotations = map[string]string{
+						"fake.anno.1": "fakeannotation1",
+						"fake.anno.2": "fakeannotation2",
+						"fake.anno.3": "fakeannotation3",
+					}
+					return toModify, service, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//return true if object is the one we want to test
+					_, ok := resource.(*corev1.Service)
+					return ok
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					post, ok := postUpgradeObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					desired, ok := deisredObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					for key, ann := range desired.Annotations {
+						if post.Annotations[key] != ann {
+							return false
+						}
+					}
+
+					if len(desired.Annotations) > len(post.Annotations) {
+						return false
+					}
+					return true
+				}),
+
+			Entry("verify - services updated on upgrade - label changed",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					serviceOrig, ok := toModify.(*corev1.Service)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					service := serviceOrig.DeepCopy()
+					service.Labels = map[string]string{
+						"fake.label.1": "fakelabel1",
+						"fake.label.2": "fakelabel2",
+						"fake.label.3": "fakelabel3",
+					}
+					return toModify, service, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//return true if object is the one we want to test
+					_, ok := resource.(*corev1.Service)
+					return ok
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					post, ok := postUpgradeObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					desired, ok := deisredObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					for key, label := range desired.Labels {
+						if post.Labels[key] != label {
+							return false
+						}
+					}
+
+					if len(desired.Labels) > len(post.Labels) {
+						return false
+					}
+
+					return true
+				}),
+
+			Entry("verify - services updated on upgrade - service port changed",
+				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
+					serviceOrig, ok := toModify.(*corev1.Service)
+					if !ok {
+						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+					}
+					service := serviceOrig.DeepCopy()
+					service.Spec.Ports = []corev1.ServicePort{
+						{
+							Port:     999999,
+							Protocol: corev1.ProtocolUDP,
+						},
+					}
+					return toModify, service, nil
+				},
+				func(resource runtime.Object) bool { //find resource for test
+					//return true if object is the one we want to test
+					_, ok := resource.(*corev1.Service)
+					return ok
+				},
+				func(postUpgradeObj runtime.Object, deisredObj runtime.Object) bool { //check resource was upgraded
+					//return true if postUpgrade has teh same fields as desired
+					post, ok := postUpgradeObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					desired, ok := deisredObj.(*corev1.Service)
+					if !ok {
+						return false
+					}
+
+					for key, port := range desired.Spec.Ports {
+						if post.Spec.Ports[key].Port != port.Port {
+							return false
+						}
+					}
+
+					if len(desired.Spec.Ports) != len(post.Spec.Ports) {
+						return false
+					}
+
+					return true
+				}),
+
+			//CRD update
+			// - update CRD label
+			// - update CRD annotation
+			// - update CRD version
+			// - update CRD spec
+			// - update CRD status
+			// - add new CRD
+			// -
+
+			//RBAC update
+			// - update RoleBinding/ClusterRoleBinding
+			// - Update Role/ClusterRole
+
+			//ServiceAccount upgrade
+			// - update ServiceAccount SCC
+
+		) //updates objects on upgrade
+
+		DescribeTable("Removes unused objects on upgrade", func(
+			createObj createUnusedObject) {
+
+			var args *args
+			registry := "kubevirt"
+			newVersion := "1.10.0"
+			prevVersion := "1.9.5"
+
+			args = createFromArgs("cdi", newVersion, registry)
+			doReconcile(args)
+
+			//verify on int version is set
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+
+			//Modify CRD to be of previousVersion
+			args.reconciler.crSetVersion(args.cdi, prevVersion, registry)
+			err := args.client.Update(context.TODO(), args.cdi)
+			Expect(err).ToNot(HaveOccurred())
+
+			unusedObj, err := createObj()
+			Expect(err).ToNot(HaveOccurred())
+
+			//add unused object via client, with curObject
+			err = args.client.Create(context.TODO(), unusedObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			doReconcile(args)
+
+			//verify upgraded has started
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeploying))
+
+			//verify unused exists before upgrade is done
+			_, err = getObject(args.client, unusedObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			//change deployment to ready
+			isReady := setDeploymentsReady(args)
+			Expect(isReady).Should(Equal(true))
+
+			doReconcile(args)
+			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
+
+			//verify that object no longer exists after upgrade
+			_, err = getObject(args.client, unusedObj)
+			Expect(errors.IsNotFound(err)).Should(Equal(true))
+
+		},
+
+			Entry("verify - unused deployment deleted",
+				func() (runtime.Object, error) {
+					deployment := utils.CreateDeployment("fake-cdi-deployment", "app", "containerized-data-importer", "fake-sa", int32(1))
+					return deployment, nil
+				}),
+			Entry("verify - unused service deleted",
+				func() (runtime.Object, error) {
+					service := utils.CreateService("fake-cdi-service", "fake-service", "fake")
+					return service, nil
+				}),
+			Entry("verify - unused sa deleted",
+				func() (runtime.Object, error) {
+					sa := utils.CreateServiceAccount("fake-cdi-sa")
+					return sa, nil
+				}),
+
+			Entry("verify - unused crd deleted",
+				func() (runtime.Object, error) {
+					crd := &extv1beta1.CustomResourceDefinition{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "apiextensions.k8s.io/v1beta1",
+							Kind:       "CustomResourceDefinition",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "fake.cdis.cdi.kubevirt.io",
+							Labels: map[string]string{
+								"operator.cdi.kubevirt.io": "",
+							},
+						},
+						Spec: extv1beta1.CustomResourceDefinitionSpec{
+							Group:   "cdi.kubevirt.io",
+							Version: "v1alpha1",
+							Scope:   "Cluster",
+
+							Versions: []extv1beta1.CustomResourceDefinitionVersion{
+								{
+									Name:    "v1alpha1",
+									Served:  true,
+									Storage: true,
+								},
+							},
+							Names: extv1beta1.CustomResourceDefinitionNames{
+								Kind:     "FakeCDI",
+								ListKind: "FakeCDIList",
+								Plural:   "fakecdis",
+								Singular: "fakecdi",
+								Categories: []string{
+									"all",
+								},
+								ShortNames: []string{"fakecdi", "fakecdis"},
+							},
+
+							AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+								{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+								{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+							},
+						},
+					}
+					return crd, nil
+				}),
+
+			Entry("verify - unused role deleted",
+				func() (runtime.Object, error) {
+					role := utils.CreateRole("fake-role")
+					return role, nil
+				}),
+
+			Entry("verify - unused role binding deleted",
+				func() (runtime.Object, error) {
+					role := utils.CreateRoleBinding("fake-role", "fake-role", "fake-role", "fake-role")
+					return role, nil
+				}),
+			Entry("verify - unused cluster role deleted",
+				func() (runtime.Object, error) {
+					role := cluster.CreateClusterRole("fake-cluster-role")
+					return role, nil
+				}),
+			Entry("verify - unused cluster role binding deleted",
+				func() (runtime.Object, error) {
+					role := cluster.CreateClusterRoleBinding("fake-cluster-role", "fake-cluster-role", "fake-cluster-role", "fake-cluster-role")
+					return role, nil
+				}),
+		)
+
+	})
 })
+
+func getModifiedResource(reconciler *ReconcileCDI, modify modifyResource, tomodify isModifySubject) (runtime.Object, runtime.Object, error) {
+	resources, err := getAllResources(reconciler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	//find the resource to modify
+	var orig runtime.Object
+	for _, resource := range resources {
+		if tomodify(resource) {
+			orig = resource
+			break
+		}
+	}
+	//apply modify function on resource and return modified one
+	return modify(orig)
+}
 
 type cdiOverride interface {
 	Set(cr *cdiviaplha1.CDI)
@@ -508,12 +1174,76 @@ func getSCC(client realClient.Client, scc *secv1.SecurityContextConstraints) (*s
 	return result.(*secv1.SecurityContextConstraints), nil
 }
 
+func setDeploymentsReady(args *args) bool {
+	resources, err := getAllResources(args.reconciler)
+	Expect(err).ToNot(HaveOccurred())
+	running := false
+
+	createUploadProxyCACertSecret(args.client)
+
+	for _, r := range resources {
+		d, ok := r.(*appsv1.Deployment)
+		if !ok {
+			continue
+		}
+
+		Expect(running).To(BeFalse())
+
+		d, err := getDeployment(args.client, d)
+		Expect(err).ToNot(HaveOccurred())
+		if d.Spec.Replicas != nil {
+			d.Status.Replicas = *d.Spec.Replicas
+			d.Status.ReadyReplicas = d.Status.Replicas
+			err = args.client.Update(context.TODO(), d)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		doReconcile(args)
+
+		if len(args.cdi.Status.Conditions) == 1 &&
+			args.cdi.Status.Conditions[0].Type == cdiviaplha1.CDIConditionRunning &&
+			args.cdi.Status.Conditions[0].Status == corev1.ConditionTrue {
+			running = true
+		}
+	}
+
+	return running
+}
+
 func getDeployment(client realClient.Client, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 	result, err := getObject(client, deployment)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*appsv1.Deployment), nil
+}
+
+func equalObjects(a, b runtime.Object) (bool, error) {
+
+	res := true
+
+	ajsonBytes, err := json.Marshal(a)
+	if err != nil {
+		return false, err
+	}
+
+	bjsonBytes, err := json.Marshal(b)
+	if err != nil {
+		return false, err
+	}
+
+	if len(ajsonBytes) != len(bjsonBytes) {
+		return false, nil
+	}
+
+	for i := range ajsonBytes {
+		if ajsonBytes[i] != bjsonBytes[i] {
+			res = false
+			break
+		}
+	}
+
+	return res, nil
 }
 
 func getObject(client realClient.Client, obj runtime.Object) (runtime.Object, error) {
@@ -528,6 +1258,46 @@ func getObject(client realClient.Client, obj runtime.Object) (runtime.Object, er
 	}
 
 	return result, nil
+}
+
+func updateObject(client realClient.Client, obj runtime.Object) error {
+	if err := client.Update(context.TODO(), obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getObjectFromResources(reconciler *ReconcileCDI, obj runtime.Object) (runtime.Object, error) {
+	var resultObj runtime.Object
+	var result []runtime.Object
+
+	metaObj := obj.(metav1.Object)
+
+	crs, err := clusterResources.CreateAllResources(reconciler.clusterArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, crs...)
+
+	nrs, err := namespaceResources.CreateAllResources(reconciler.namespacedArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, nrs...)
+
+	for cur := range result {
+		curMetaObj := result[cur].(metav1.Object)
+		if curMetaObj.GetName() == metaObj.GetName() &&
+			curMetaObj.GetNamespace() == metaObj.GetNamespace() {
+			resultObj = result[cur]
+			break
+		}
+	}
+
+	return resultObj, nil
 }
 
 func getAllResources(reconciler *ReconcileCDI) ([]runtime.Object, error) {
@@ -551,6 +1321,20 @@ func getAllResources(reconciler *ReconcileCDI) ([]runtime.Object, error) {
 
 func reconcileRequest(name string) reconcile.Request {
 	return reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}
+}
+
+func createFromArgs(namespace, version, repo string) *args {
+	cdi := createCDI("cdi", "good uid")
+	scc := createSCC()
+	client := createClient(cdi, scc)
+	reconciler := createReconcilerWithVersion(client, version, repo, namespace)
+
+	return &args{
+		cdi:        cdi,
+		scc:        scc,
+		client:     client,
+		reconciler: reconciler,
+	}
 }
 
 func createArgs() *args {
@@ -590,6 +1374,32 @@ func createSCC() *secv1.SecurityContextConstraints {
 			Name: "anyuid",
 		},
 		Users: []string{},
+	}
+}
+
+func createReconcilerWithVersion(client realClient.Client, version, repo, namespace string) *ReconcileCDI {
+	clusterArgs := &clusterResources.FactoryArgs{Namespace: namespace}
+	namespacedArgs := &namespaceResources.FactoryArgs{
+		DockerRepo:             "kubevirt",
+		DockerTag:              version,
+		DeployClusterResources: "true",
+		ControllerImage:        "cdi-controller",
+		ImporterImage:          "cdi-importer",
+		ClonerImage:            "cdi-cloner",
+		APIServerImage:         "cdi-apiserver",
+		UploadProxyImage:       "cdi-uploadproxy",
+		UploadServerImage:      "cdi-uploadserver",
+		Verbosity:              "1",
+		PullPolicy:             "Always",
+		Namespace:              namespace,
+	}
+
+	return &ReconcileCDI{
+		client:         client,
+		scheme:         scheme.Scheme,
+		namespace:      namespace,
+		clusterArgs:    clusterArgs,
+		namespacedArgs: namespacedArgs,
 	}
 }
 

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -468,19 +468,14 @@ var _ = Describe("Controller", func() {
 			//verify on int version is set
 			args := createFromArgs("cdi", newVersion, registry)
 			doReconcile(args)
+
 			Expect(args.cdi.Status.ObservedVersion).Should(Equal(newVersion))
 			Expect(args.cdi.Status.OperatorVersion).Should(Equal(newVersion))
 			Expect(args.cdi.Status.TargetVersion).Should(Equal(newVersion))
 			Expect(args.cdi.Status.Phase).Should(Equal(cdiviaplha1.CDIPhaseDeployed))
 
 			//Modify CRD to be of previousVersion
-			args.cdi.Spec.ImageRegistry = registry
-			args.cdi.Spec.ImageTag = prevVersion
-			args.cdi.Status.ObservedVersion = prevVersion
-			args.cdi.Status.TargetVersion = prevVersion
-			args.cdi.Status.OperatorVersion = prevVersion
-
-			err := args.client.Update(context.TODO(), args.cdi)
+			err := args.reconciler.crSetVersion(args.cdi, prevVersion, registry)
 			Expect(err).ToNot(HaveOccurred())
 
 			doReconcile(args)
@@ -525,6 +520,7 @@ var _ = Describe("Controller", func() {
 			Entry("increasing  semver no prefix", "1.9.5", "1.10.0", true),
 			Entry("decreasing  semver no prefix", "1.10.0", "1.9.5", false),
 			Entry("identical  semver no prefix", "1.10.0", "1.10.0", false),
+			Entry("invalid  semver with prefix", "devel1.9.5", "devel1.9.5", false),
 			Entry("invalid  semver no prefix", "devel", "1.9.5", true),
 			Entry("no current no prefix", "", "invalid", false),
 		)

--- a/pkg/operator/controller/cr.go
+++ b/pkg/operator/controller/cr.go
@@ -42,6 +42,18 @@ var (
 	}
 )
 
+func (r *ReconcileCDI) isUpgrading(cr *cdiv1alpha1.CDI) bool {
+	if cr.Status.ObservedVersion == "" {
+		return false
+	}
+
+	if cr.Status.ObservedVersion != cr.Status.TargetVersion {
+		return true
+	}
+
+	return false
+}
+
 func (r *ReconcileCDI) crInit(cr *cdiv1alpha1.CDI) error {
 	cr.Finalizers = append(cr.Finalizers, finalizerName)
 	cr.Status.OperatorVersion = r.namespacedArgs.DockerTag

--- a/pkg/operator/controller/cr.go
+++ b/pkg/operator/controller/cr.go
@@ -54,6 +54,15 @@ func (r *ReconcileCDI) isUpgrading(cr *cdiv1alpha1.CDI) bool {
 	return false
 }
 
+func (r *ReconcileCDI) crSetVersion(cr *cdiv1alpha1.CDI, version, repo string) error {
+	cr.Spec.ImageTag = version
+	cr.Spec.ImageRegistry = repo
+	cr.Status.ObservedVersion = version
+	cr.Status.OperatorVersion = version
+	cr.Status.TargetVersion = version
+	return r.crUpdate(cdiv1alpha1.CDIPhaseDeploying, cr)
+}
+
 func (r *ReconcileCDI) crInit(cr *cdiv1alpha1.CDI) error {
 	cr.Finalizers = append(cr.Finalizers, finalizerName)
 	cr.Status.OperatorVersion = r.namespacedArgs.DockerTag

--- a/pkg/operator/controller/cr.go
+++ b/pkg/operator/controller/cr.go
@@ -60,7 +60,7 @@ func (r *ReconcileCDI) crSetVersion(cr *cdiv1alpha1.CDI, version, repo string) e
 	cr.Status.ObservedVersion = version
 	cr.Status.OperatorVersion = version
 	cr.Status.TargetVersion = version
-	return r.crUpdate(cdiv1alpha1.CDIPhaseDeploying, cr)
+	return r.crUpdate(cdiv1alpha1.CDIPhaseDeployed, cr)
 }
 
 func (r *ReconcileCDI) crInit(cr *cdiv1alpha1.CDI) error {


### PR DESCRIPTION
* - Detect from reconcile loop that it is uograde flow
* - Set ObeservedVersion to target when upgrade is finished
* - Delete unused objects at the end of upgrade

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR provides initial upgrade support of CDI:
- Detection of upgrade from operator Reconcile loop  - done
- Cleanup of unused resources at the end of upgrade
- Implement unit tests for upgrade flows of controller of cdi operator


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR provides initial upgrade support of CDI:
- Detection of upgrade from operator Reconcile loop  - done
- Cleanup of unused resources at the end of upgrade
- Implement unit tests for upgrade flows of controller of cdi operator

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Initial cdi upgrade detection and handling
```

