### PR TITLE
Requiring replica 2 for CDI deployment

### DIFF
--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -127,7 +127,7 @@ func createAPIServerService() *corev1.Service {
 }
 
 func createAPIServerDeployment(repo, image, tag, verbosity, pullPolicy string) *appsv1.Deployment {
-	deployment := utils.CreateDeployment(apiServerRessouceName, cdiLabel, apiServerRessouceName, apiServerRessouceName, 1)
+	deployment := utils.CreateDeployment(apiServerRessouceName, cdiLabel, apiServerRessouceName, apiServerRessouceName, int32(2))
 	container := utils.CreateContainer(apiServerRessouceName, repo, image, tag, verbosity, corev1.PullPolicy(pullPolicy))
 	container.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -63,7 +63,7 @@ func createControllerServiceAccount() *corev1.ServiceAccount {
 }
 
 func createControllerDeployment(repo, controllerImage, importerImage, clonerImage, uploadServerImage, tag, verbosity, pullPolicy string) *appsv1.Deployment {
-	deployment := utils.CreateDeployment("cdi-deployment", "app", "containerized-data-importer", controllerServiceAccount, int32(1))
+	deployment := utils.CreateDeployment("cdi-deployment", "app", "containerized-data-importer", controllerServiceAccount, int32(2))
 	container := utils.CreateContainer("cdi-controller", repo, controllerImage, tag, verbosity, corev1.PullPolicy(pullPolicy))
 	container.Env = []corev1.EnvVar{
 		{

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -56,7 +56,7 @@ func createUploadProxyServiceAccount() *corev1.ServiceAccount {
 }
 
 func createUploadProxyDeployment(repo, image, tag, verbosity, pullPolicy string) *appsv1.Deployment {
-	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, uploadProxyResourceName, int32(1))
+	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, uploadProxyResourceName, int32(2))
 	container := utils.CreateContainer(uploadProxyResourceName, repo, image, tag, verbosity, corev1.PullPolicy(pullPolicy))
 	container.Env = []corev1.EnvVar{
 		{

--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -45,10 +45,10 @@ var _ = Describe("[rfe_id:1347][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			Expect(err).To(BeNil())
 			Expect(result).To(ContainSubstring("cdi-deployment"))
 		})
-		It("[test_id:1352]There should be 1 replica", func() {
+		It("[test_id:1352]There should be 2 replica", func() {
 			result, err := tests.RunKubectlCommand(f, "get", "deployment", "cdi-deployment", "-o", "jsonpath={.spec.replicas}", "-n", f.CdiInstallNs)
 			Expect(err).To(BeNil())
-			Expect(result).To(ContainSubstring("1"))
+			Expect(result).To(ContainSubstring("2"))
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to increase CDI availability in case of node failure, the number of replicas for cdi-deployment, cdi-apiserver, cdi-uploadproxy is updated to "2".

```release-note
NONE
```

