### PR TITLE
func-tests: support hostpath-provisioner

### DIFF
--- a/tests/test.go
+++ b/tests/test.go
@@ -18,3 +18,13 @@
  */
 
 package tests
+
+import (
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+func init() {
+	f := framework.NewFrameworkOrDie("tests")
+	utils.CacheTestsData(f.K8sClient)
+}

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -38,6 +38,12 @@ const (
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume
 func CreateDataVolumeFromDefinition(clientSet *cdiclientset.Clientset, namespace string, def *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	if IsHostpathProvisioner() {
+		if def.ObjectMeta.Annotations == nil {
+			def.ObjectMeta.Annotations = map[string]string{}
+		}
+		AddProvisionOnNodeToAnn(def.ObjectMeta.Annotations)
+	}
 	var dataVolume *cdiv1.DataVolume
 	err := wait.PollImmediate(dataVolumePollInterval, dataVolumeCreateTime, func() (bool, error) {
 		var err error

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -172,6 +172,12 @@ func NewPVCDefinitionWithSelector(pvcName, size, storageClassName string, select
 // AnnCloneRequest
 // You can also pass in any label you want.
 func NewPVCDefinition(pvcName string, size string, annotations, labels map[string]string) *k8sv1.PersistentVolumeClaim {
+	if IsHostpathProvisioner() {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		AddProvisionOnNodeToAnn(annotations)
+	}
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,


### PR DESCRIPTION
Added support for hostpath-provisioner in functional tests:
* Introduced 'AddProvisionOnNodeToAnn' func for adding
  'kubevirt.io/provisionOnNode' annotaion when hostpath-provisioner
  is the default storage class.
* pvc -> NewPVCDefinition and datavolume -> CreateDataVolumeFromDefinition:
  invoke 'AddProvisionOnNodeToAnn' when needed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

