### PR TITLE
Fallback to Fedora29 minimal for images

### DIFF
--- a/automation/check-patch.yumrepos
+++ b/automation/check-patch.yumrepos
@@ -1,4 +1,4 @@
-[fedora-base-fc30]
+[fedora-base-fc29]
 clean_requirements_on_remove=True
 tsflags=nodocs
 name=Fedora $releasever - $basearch
@@ -13,7 +13,7 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 skip_if_unavailable=False
 
-[fedora-updates-fc30]
+[fedora-updates-fc29]
 clean_requirements_on_remove=True
 tsflags=nodocs
 name=Fedora $releasever - $basearch - Updates

--- a/hack/build/build-cdi-func-test-file-host.sh
+++ b/hack/build/build-cdi-func-test-file-host.sh
@@ -35,3 +35,4 @@ cp ${BUILD_DIR}/docker/${FILE_HOST}/* ${OUT_PATH}/${FILE_HOST}/
 cp "${CDI_DIR}/tests/images/tinyCore.iso" "${OUT_PATH}/${FILE_INIT}/"
 cp "${CDI_DIR}/tests/images/archive.tar" "${OUT_PATH}/${FILE_INIT}/"
 cp -R "${CDI_DIR}/tests/images/invalid_qcow_images" "${OUT_PATH}/${FILE_INIT}/"
+cp "${CDI_DIR}/tests/images/cirros-qcow2.img" "${OUT_PATH}/${FILE_INIT}/"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/builder/fedora.repo
+++ b/hack/build/docker/builder/fedora.repo
@@ -1,4 +1,4 @@
-[fedora-base-fc30]
+[fedora-base-fc29]
 clean_requirements_on_remove=True
 tsflags=nodocs
 name=Fedora $releasever - $basearch
@@ -13,7 +13,7 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 skip_if_unavailable=False
 
-[fedora-updates-fc30]
+[fedora-updates-fc29]
 clean_requirements_on_remove=True
 tsflags=nodocs
 name=Fedora $releasever - $basearch - Updates

--- a/hack/build/docker/cdi-apiserver/Dockerfile
+++ b/hack/build/docker/cdi-apiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-cloner/Dockerfile
+++ b/hack/build/docker/cdi-cloner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-controller/Dockerfile
+++ b/hack/build/docker/cdi-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-func-test-block-device/Dockerfile
+++ b/hack/build/docker/cdi-func-test-block-device/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
+++ b/hack/build/docker/cdi-func-test-file-host-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 RUN mkdir -p /tmp/shared /tmp/source
@@ -20,5 +20,6 @@ RUN chmod u+x /usr/bin/cdi-func-test-file-host-init
 COPY tinyCore.iso /tmp/source/tinyCore.iso
 COPY archive.tar /tmp/source/archive.tar
 COPY invalid_qcow_images /tmp/source/invalid_qcow_images
+COPY cirros-qcow2.img /tmp/source/cirros-qcow2.img
 
 ENTRYPOINT ["cdi-func-test-file-host-init", "-alsologtostderr"]

--- a/hack/build/docker/cdi-func-test-registry-init/Dockerfile
+++ b/hack/build/docker/cdi-func-test-registry-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 RUN mkdir -p /tmp/shared /tmp/source

--- a/hack/build/docker/cdi-func-test-registry-populate/Dockerfile
+++ b/hack/build/docker/cdi-func-test-registry-populate/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 RUN mkdir -p /tmp/shared /tmp/source

--- a/hack/build/docker/cdi-importer/Dockerfile
+++ b/hack/build/docker/cdi-importer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-operator/Dockerfile
+++ b/hack/build/docker/cdi-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-uploadproxy/Dockerfile
+++ b/hack/build/docker/cdi-uploadproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/hack/build/docker/cdi-uploadserver/Dockerfile
+++ b/hack/build/docker/cdi-uploadserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:29
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -41,6 +41,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 	tinyCoreIsoRegistryURL := fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs)
 	tarArchiveURL := fmt.Sprintf(utils.TarArchiveURL, f.CdiInstallNs)
 	InvalidQcowImagesURL := fmt.Sprintf(utils.InvalidQcowImagesURL, f.CdiInstallNs)
+	cirrosURL := fmt.Sprintf(utils.CirrosURL, f.CdiInstallNs)
 
 	// Invalid (malicious) QCOW images:
 	// An image that causes qemu-img to allocate 152T (original image is 516 bytes)
@@ -136,11 +137,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			table.Entry("[rfe_id:1115][crit:high][test_id:1478]succeed creating import dv with given valid registry url", "import-registry", "", tinyCoreIsoRegistryURL, "dv-phase-test-4", "", controller.ImportSucceeded, cdiv1.Succeeded),
 			table.Entry("[rfe_id:1115][crit:high][test_id:1379]succeed creating import dv with given valid url (https)", "import-https", "", httpsTinyCoreIsoURL, "dv-phase-test-1", "", controller.ImportSucceeded, cdiv1.Succeeded),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2555]fail creating import dv: invalid qcow large size", "import-http", "", invalidQcowLargeSizeURL, "dv-invalid-qcow-large-size", "Unable to process data: Invalid format qcow for image", controller.ImportFailed, cdiv1.Failed),
-			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2554]fail creating import dv: invalid qcow large json", "import-http", "", invalidQcowLargeJSONURL, "dv-invalid-qcow-large-json", "Unable to process data: signal: killed", controller.ImportFailed, cdiv1.ImportInProgress),
+			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2554]fail creating import dv: invalid qcow large json", "import-http", "", invalidQcowLargeJSONURL, "dv-invalid-qcow-large-json", "Unable to process data: exit status 1", controller.ImportFailed, cdiv1.Failed),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2253]fail creating import dv: invalid qcow large memory", "import-http", "", invalidQcowLargeMemoryURL, "dv-invalid-qcow-large-memory", "Unable to process data: exit status 1", controller.ImportFailed, cdiv1.Failed),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2139]fail creating import dv: invalid qcow backing file", "import-http", "", invalidQcowBackingFileURL, "dv-invalid-qcow-backing-file", "Unable to process data: exit status 1", controller.ImportFailed, cdiv1.Failed),
 			table.Entry("[rfe_id:1947][crit:high][test_id:2145]succeed creating import dv with given tar archive url", "import-archive", "", tarArchiveURL, "tar-archive-dv", "", controller.ImportSucceeded, cdiv1.Succeeded),
 			table.Entry("[rfe_id:1947][crit:high][test_id:2220]fail creating import dv with non tar archive url", "import-archive", "", tinyCoreIsoURL, "non-tar-archive-dv", "Unable to process data: exit status 2", controller.ImportFailed, cdiv1.Failed),
+			table.Entry("succeed creating import dv with streaming image conversion", "import-http", "", cirrosURL, "dv-phase-test-1", "", controller.ImportSucceeded, cdiv1.Succeeded),
 		)
 	})
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -36,6 +36,8 @@ const (
 	InvalidQcowImagesURL = "http://cdi-file-host.%s/invalid_qcow_images/"
 	// TarArchiveURL provides a test url for a tar achive file
 	TarArchiveURL = "http://cdi-file-host.%s/archive.tar"
+	// CirrosURL provides the standard cirros image qcow image
+	CirrosURL = "http://cdi-file-host.%s/cirros-qcow2.img"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -62,7 +62,7 @@ func NewPodWithPVC(podName, cmd string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1
 			Containers: []k8sv1.Container{
 				{
 					Name:    "runner",
-					Image:   "registry.fedoraproject.org/fedora-minimal:30",
+					Image:   "registry.fedoraproject.org/fedora-minimal:29",
 					Command: []string{"/bin/sh", "-c", cmd},
 				},
 			},

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -70,6 +70,11 @@ func main() {
 		klog.Fatal(err)
 	}
 
+	// copy cirros qcow file
+	if err := util.CopyFile("/tmp/source/cirros-qcow2.img", filepath.Join(*outDir, "cirros-qcow2.img")); err != nil {
+		klog.Fatal(err)
+	}
+
 	klog.Info("File initialization completed without error.")
 }
 


### PR DESCRIPTION
The newer version of qemu-img (3.1.0) that ships in Fedora 30 has issues
with streaming conversions whereby it hangs during the conversion
process.  Rather than try to force a downgrade of qemu when building
images instead, let's try reverting back to Fedora29 minimal which has
qemu-img version  3.0.0.

This issue has also exposed the fact that we aren't performing any
testing against streaming external images, we're only testing against
images that we've pulled in to our test infrastructure.  So add a
functional test that builds a DataVolume directly from the cirros site.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

It's been discovered that qemu-img version 3.1.0 which ships in Fedora-30 hangs when trying to do a streaming conversion of the external cirros image.  It also turns out that we weren't detecting this via our test automation because we're running in an air gapped env with our own VM images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #914 

**Special notes for your reviewer**:

**Release note**:

```release-note
Downgrade base images from Fedora30 to Fedora29
```

