### PR TITLE
Downgrade to 4.1.0 version, 4.2.0 is broken.

### DIFF
--- a/hack/build/docker/cdi-olm-catalog/Dockerfile
+++ b/hack/build/docker/cdi-olm-catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:4.2.0
+FROM quay.io/openshift/origin-operator-registry:4.1.0
 
 COPY olm-catalog /registry
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Set testing olm catalog container version to 4.1.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

