### PR TITLE
Added support for hostpath-provisioner in functional tests: (#912)

### DIFF
--- a/tests/test.go
+++ b/tests/test.go
@@ -18,3 +18,13 @@
  */
 
 package tests
+
+import (
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+func init() {
+	f := framework.NewFrameworkOrDie("tests")
+	utils.CacheTestsData(f.K8sClient)
+}

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,5 +1,12 @@
 package utils
 
+import (
+	"github.com/onsi/ginkgo"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
 // cdi-file-host pod/service relative values
 const (
 	//RegistryHostName provides a deploymnet and service name for registry
@@ -25,3 +32,52 @@ const (
 	// RegistryConfigMap is the ConfigMap where the cert for the docker registry is stored
 	RegistryConfigMap = "cdi-docker-registry-host-certs"
 )
+
+var (
+	// DefaultNodeName the default node to use in tests
+	DefaultNodeName string
+	// DefaultStorageClass the defauld storage class used in tests
+	DefaultStorageClass *storagev1.StorageClass
+)
+
+func getDefaultNodeName(client *kubernetes.Clientset) string {
+	nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		ginkgo.Fail("Unable to list nodes")
+	}
+	return nodes.Items[0].Name
+}
+
+func getDefaultStorageClass(client *kubernetes.Clientset) *storagev1.StorageClass {
+	storageclasses, err := client.StorageV1().StorageClasses().List(metav1.ListOptions{})
+	if err != nil {
+		ginkgo.Fail("Unable to list storage classes")
+		return nil
+	}
+	for _, storageClass := range storageclasses.Items {
+		if storageClass.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return &storageClass
+		}
+	}
+	ginkgo.Fail("Unable to find default storage classes")
+	return nil
+}
+
+// IsHostpathProvisioner returns true if hostpath-provisioner is the default storage class
+func IsHostpathProvisioner() bool {
+	if DefaultStorageClass == nil {
+		return false
+	}
+	return DefaultStorageClass.Provisioner == "kubevirt.io/hostpath-provisioner"
+}
+
+// AddProvisionOnNodeToAnn adds 'kubevirt.io/provisionOnNode' annotaion
+func AddProvisionOnNodeToAnn(pvcAnn map[string]string) {
+	pvcAnn["kubevirt.io/provisionOnNode"] = DefaultNodeName
+}
+
+// CacheTestsData fetch and cache data required for tests
+func CacheTestsData(client *kubernetes.Clientset) {
+	DefaultNodeName = getDefaultNodeName(client)
+	DefaultStorageClass = getDefaultStorageClass(client)
+}

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -30,6 +30,12 @@ const (
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume
 func CreateDataVolumeFromDefinition(clientSet *cdiclientset.Clientset, namespace string, def *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	if IsHostpathProvisioner() {
+		if def.ObjectMeta.Annotations == nil {
+			def.ObjectMeta.Annotations = map[string]string{}
+		}
+		AddProvisionOnNodeToAnn(def.ObjectMeta.Annotations)
+	}
 	var dataVolume *cdiv1.DataVolume
 	err := wait.PollImmediate(dataVolumePollInterval, dataVolumeCreateTime, func() (bool, error) {
 		var err error

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -137,6 +137,12 @@ func NewPVCDefinitionWithSelector(pvcName, size string, selector map[string]stri
 // AnnCloneRequest
 // You can also pass in any label you want.
 func NewPVCDefinition(pvcName string, size string, annotations, labels map[string]string) *k8sv1.PersistentVolumeClaim {
+	if IsHostpathProvisioner() {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		AddProvisionOnNodeToAnn(annotations)
+	}
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,


### PR DESCRIPTION
Introduced 'AddProvisionOnNodeToAnn' func for adding
'kubevirt.io/provisionOnNode' annotaion when hostpath-provisioner
is the default storage class.
pvc -> NewPVCDefinition and datavolume -> CreateDataVolumeFromDefinition:
invoke 'AddProvisionOnNodeToAnn' when needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

