### PR TITLE
* Prevent pushing OLM bundle with CSV_VERSION = 0.0.0 to quay

### DIFF
--- a/hack/build/olm.sh
+++ b/hack/build/olm.sh
@@ -50,6 +50,11 @@ verify)
 
 push)
 
+    if  [[ $CSV_VERSION == "0.0.0" ]]; then
+        echo "ERROR: must not push to quay CSV_VERSION="$CSV_VERSION
+        exit 1
+    fi
+
     if [[ -z "$QUAY_USERNAME" ]] || [[ -z "$QUAY_USERNAME" ]]; then
         echo "please set QUAY_USERNAME, QUAY_PASSWORD"
         exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prevent pushing OLM bundle with CSV_VERSION = 0.0.0 to quay
CSV Version 0.0.0 is a default one and is used by travis 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Prevent pushing OLM bundle with CSV_VERSION = 0.0.0 to quay
CSV Version 0.0.0 is a default one and is used by travis 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
prevent CSV_VERSION=0.0.0 from being pushed to quay
```

