### PR TITLE
Strip 'v' from CSV_VERSION.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,14 @@ before_deploy:
 deploy:
   # Release :latest images
 - provider: script
-  script: env CSV_VERSION=$TRAVIS_TAG make publish
+  script: env CSV_VERSION=${TRAVIS_TAG#v} make publish
   skip_cleanup: true
   on:
     branch: master
     repo: kubevirt/containerized-data-importer
  # Release versioned images
 - provider: script
-  script: env CSV_VERSION=$TRAVIS_TAG make publish
+  script: env CSV_VERSION=${TRAVIS_TAG#v} make publish
   branches:
       only: /v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+){0,1}/
   on:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR strips the 'v' from the CSV_VERSION environment variable as the CSV parser doesn't like its numbers to start with v.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

