### PR TITLE
Update release message to include link to operator

### DIFF
--- a/hack/build/release-description.sh
+++ b/hack/build/release-description.sh
@@ -41,6 +41,7 @@ Pre-built CDI containers are published on Docker Hub and can be viewed at:
 <https://hub.docker.com/r/kubevirt/cdi-uploadproxy/>
 <https://hub.docker.com/r/kubevirt/cdi-apiserver/>
 <https://hub.docker.com/r/kubevirt/cdi-uploadserver/>
+<https://hub.docker.com/r/kubevirt/cdi-operator/>
 EOF
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add link to cdi operator in release description script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

