### PR TITLE
Fix race in prlimit ExecWithLimits

### DIFF
--- a/pkg/system/prlimit.go
+++ b/pkg/system/prlimit.go
@@ -152,10 +152,11 @@ func ExecWithLimits(limits *ProcessLimitValues, callback func(string), command s
 			return nil, errors.Wrap(err, "Couldn't set address space limit")
 		}
 	}
-
-	err = cmd.Wait()
 	<-stdoutDone
 	<-stderrDone
+	// The wait has to be after the reading channels are finished otherwise there is a race where the wait completes and closes stdout/err before anything
+	// is read from it.
+	err = cmd.Wait()
 
 	output := buf.Bytes()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Because cmd.wait blocked first, it was possible for it to close stdout/err before anything was read by the reader. This caused intermittent JSON parsing errors in the validation function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed race between cmd.Wait and stdout/err readers.
```

