### PR TITLE
Resize disk image after cloning if we cloned a virtual disk.

### DIFF
--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -24,8 +24,11 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -267,4 +270,36 @@ func TestRealSuccess(t *testing.T) {
 
 		<-ch
 	})
+}
+
+func TestContainsDiskImg(t *testing.T) {
+	destDir, err := ioutil.TempDir("", "destdir")
+	defer os.RemoveAll(destDir)
+	if err != nil {
+		t.Errorf("Unable to create tempdestdir %+v", err)
+	}
+	result := containsDiskImg(destDir)
+	if result {
+		t.Error("Empty directory return true")
+	}
+
+	diskImgFile, err := os.Create(filepath.Join(destDir, common.DiskImageName))
+	defer diskImgFile.Close()
+	if err != nil {
+		t.Errorf("Unable to create disk.img %+v", err)
+	}
+	result = containsDiskImg(destDir)
+	if !result {
+		t.Error("Directory with disk.img file returned false")
+	}
+	anotherFile, err := os.Create(filepath.Join(destDir, "anotherfile.txt"))
+	defer anotherFile.Close()
+	if err != nil {
+		t.Errorf("Unable to create another file %+v", err)
+	}
+	result = containsDiskImg(destDir)
+	if result {
+		t.Error("Directory with multiple files returned true")
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add the ability to resize a clone after the clone finishes and we have cloned a virtual disk image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #930 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resize cloned virtual disk images.
```

