### PR TITLE
Run make manfiest and make olm-verify before pushing to quay.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
     repo: kubevirt/containerized-data-importer
  # Release versioned images
 - provider: script
-  script: env CSV_VERSION=${TRAVIS_TAG#v} make olm-push publish
+  script: env CSV_VERSION=${TRAVIS_TAG#v} make manifests olm-verify olm-push publish
   branches:
       only: /v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+){0,1}/
   on:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The olm manifests weren't being generated when creating a new release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

