### PR TITLE
Make sure input is not same as output directory when building olm-cat…

### DIFF
--- a/hack/build/docker/cdi-olm-catalog/Dockerfile
+++ b/hack/build/docker/cdi-olm-catalog/Dockerfile
@@ -1,9 +1,10 @@
-FROM quay.io/openshift/origin-operator-registry:4.1.0
+FROM quay.io/openshift/origin-operator-registry:4.2.0
 
-COPY olm-catalog /registry
+RUN mkdir -p /tmp/olm-catalog
+COPY --chown=1001 olm-catalog /tmp/olm-catalog
 
 # Initialize the database
-RUN initializer --manifests /registry --output bundles.db
+RUN initializer --manifests /tmp/olm-catalog --output bundles.db
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server


### PR DESCRIPTION
…alog.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The olm-catalog is randomly failing because the input and output are the same directories and sometimes its picking up the output as input which will fail. This PR separates the input and output so they won't mingle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

