### PR TITLE
Add upgrade from release version 1.10.4 to current master.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -42,6 +42,8 @@ elif [[ $TARGET =~ k8s-.* ]]; then
   export KUBEVIRT_PROVIDER_EXTRA_ARGS="--enable-ceph"
 fi
 
+export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+echo "Upgrading from verions: $UPGRADE_FROM"
 export KUBEVIRT_NUM_NODES=2
 
 kubectl() { cluster-up/kubectl.sh "$@"; }

--- a/cluster-sync/install.sh
+++ b/cluster-sync/install.sh
@@ -24,7 +24,15 @@ function install_cdi_olm {
 }
 
 function install_cdi_operator {
-  _kubectl apply -f "./_out/manifests/release/cdi-operator.yaml" 
+  if [ ! -z $UPGRADE_FROM ]; then
+    curl -L "https://github.com/kubevirt/containerized-data-importer/releases/download/$UPGRADE_FROM/cdi-operator.yaml" --output cdi-operator.yaml
+    sed -i "0,/name: cdi/{s/name: cdi/name: $CDI_NAMESPACE/}" cdi-operator.yaml
+    sed -i "s/namespace: cdi/namespace: $CDI_NAMESPACE/g" cdi-operator.yaml
+    echo $(cat cdi-operator.yaml)
+    _kubectl apply -f cdi-operator.yaml
+  else
+    _kubectl apply -f "./_out/manifests/release/cdi-operator.yaml"
+  fi
 }
 
 
@@ -54,6 +62,5 @@ function wait_cdi_crd_installed {
      echo "ERROR - CDI CRD is not defined after timeout"
      exit 1
   fi  
-
 }
 

--- a/cluster-sync/okd-4.1/install.sh
+++ b/cluster-sync/okd-4.1/install.sh
@@ -1,4 +1,1 @@
-CDI_INSTALL=${CDI_INSTALL_OLM}
-CDI_OLM_MANIFESTS_CATALOG_SRC="_out/manifests/release/olm/os/cdi-catalogsource-registry.yaml"
-CDI_OLM_MANIFESTS_SUBSCRIPTION="_out/manifests/release/olm/os/cdi-subscription.yaml"
-
+CDI_INSTALL=${CDI_INSTALL_OPERATOR}

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -171,13 +171,13 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 		reqLogger.Info("Reconciling to error state, no configmap")
 		// we are in a weird state
-		return r.reconcileError(reqLogger, cr)
+		return r.reconcileError(reqLogger, cr, "Reconciling to error state, no configmap")
 	}
 
 	// do we even care about this CR?
 	if !metav1.IsControlledBy(configMap, cr) {
 		reqLogger.Info("Reconciling to error state, unwanted CDI object")
-		return r.reconcileError(reqLogger, cr)
+		return r.reconcileError(reqLogger, cr, "Reconciling to error state, unwanted CDI object")
 	}
 
 	currentConditionValues := GetConditionValues(cr.Status.Conditions)
@@ -541,8 +541,8 @@ func (r *ReconcileCDI) reconcileDelete(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileCDI) reconcileError(logger logr.Logger, cr *cdiv1alpha1.CDI) (reconcile.Result, error) {
-	MarkCrFailed(cr, "ConfigError", "ConfigMap not owned by cr")
+func (r *ReconcileCDI) reconcileError(logger logr.Logger, cr *cdiv1alpha1.CDI, message string) (reconcile.Result, error) {
+	MarkCrFailed(cr, "ConfigError", message)
 	if err := r.crUpdate(cr.Status.Phase, cr); err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
Switch OKD-4.1 provider from olm install to operator install.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Automatically test upgrade during CI runs.
Switch OKD 4.1 provider install from olm to operator.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

