### PR TITLE
set ceph to be default sc

### DIFF
--- a/cluster-sync/k8s-1.13.3/provider.sh
+++ b/cluster-sync/k8s-1.13.3/provider.sh
@@ -10,4 +10,7 @@ if ! [[ $num_nodes =~ $re ]] || [[ $num_nodes -lt 1 ]] ; then
     num_nodes=1
 fi
 
+    #Set the default storage class.
+    _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+    _kubectl patch storageclass csi-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -52,6 +52,7 @@ func VerifyPVCIsEmpty(f *Framework, pvc *k8sv1.PersistentVolumeClaim) (bool, err
 		if err != nil {
 			return false, err
 		}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: files found: %s\n", string(output))
 		found = strings.Compare("lost+found", output) == 0
 	}
 	return found, nil

--- a/tests/local_volume_test.go
+++ b/tests/local_volume_test.go
@@ -36,7 +36,7 @@ var _ = Describe("[rfe_id:1125][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		node = nodes.Items[0].Name
 
 		By("Creating PV with NodeAffinity and Binding label")
-		pv, err = f.CreatePVFromDefinition(utils.NewPVDefinition("local-volume", "1G", "test-sc", node, map[string]string{"node": node}))
+		pv, err = f.CreatePVFromDefinition(utils.NewPVDefinition("local-volume", "1G", storageClassName, node, map[string]string{"node": node}))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify that PV's phase is Available")
@@ -53,10 +53,10 @@ var _ = Describe("[rfe_id:1125][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 	It("[test_id:1367]Import to PVC should succeed with local PV allocated to specific node", func() {
 		By("Creating PVC with a selector field matches the PV's label")
-		httpEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPNoAuthPort)
+		httpEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPRateLimitPort)
 		_, err = f.CreatePVCFromDefinition(utils.NewPVCDefinitionWithSelector("local-volume-pvc",
 			"1G",
-			"test-sc",
+			storageClassName,
 			map[string]string{"node": node},
 			map[string]string{controller.AnnSource: controller.SourceHTTP,
 				controller.AnnContentType: string(cdiv1.DataVolumeKubeVirt), controller.AnnEndpoint: httpEp + "/tinyCore.iso"},


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For the k8s lane set ceph to be the default storage class.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

