### PR TITLE
Restore backwards compatible docker syntax

### DIFF
--- a/hack/build/docker/cdi-olm-catalog/Dockerfile
+++ b/hack/build/docker/cdi-olm-catalog/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/openshift/origin-operator-registry:4.2.0
 
 RUN mkdir -p /tmp/olm-catalog
-COPY --chown=1001 olm-catalog /tmp/olm-catalog
+COPY olm-catalog /tmp/olm-catalog
+RUN chown 1001 /tmp/olm-catalog
 
 # Initialize the database
 RUN initializer --manifests /tmp/olm-catalog --output bundles.db


### PR DESCRIPTION
The --chown option to the docker COPY command is only supported in
docker 17.09+.  This creates a dependency on docker-ce which is not
available in some distributions.  We can make our build work on more
environments if we use a separate chown command after the COPY.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

