### PR TITLE
Use right lane k8s-1.15.1, and verify that --enable-ceph is set.

### DIFF
--- a/cluster-sync/k8s-1.13.3/provider.sh
+++ b/cluster-sync/k8s-1.13.3/provider.sh
@@ -9,8 +9,3 @@ re='^-?[0-9]+$'
 if ! [[ $num_nodes =~ $re ]] || [[ $num_nodes -lt 1 ]] ; then
     num_nodes=1
 fi
-
-    #Set the default storage class.
-    _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-    _kubectl patch storageclass csi-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-

--- a/cluster-sync/k8s-1.15.1/provider.sh
+++ b/cluster-sync/k8s-1.15.1/provider.sh
@@ -10,4 +10,10 @@ if ! [[ $num_nodes =~ $re ]] || [[ $num_nodes -lt 1 ]] ; then
     num_nodes=1
 fi
 
+if [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS =~ "--enable-ceph" ]]; then
+  echo "Switching default storage class to ceph"
+  #Switch the default storage class to ceph
+  _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+  _kubectl patch storageclass csi-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+fi
 

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -146,14 +146,15 @@ func (f *Framework) VerifyBlankDisk(namespace *k8sv1.Namespace, pvc *k8sv1.Persi
 	err = utils.WaitTimeoutForPodReady(f.K8sClient, executorPod.Name, namespace.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	cmd := fmt.Sprintf("ls -lsh %s/disk.img | awk '{print $1}'", utils.DefaultPvcMountPath)
+	cmd := fmt.Sprintf("tr -d '\\000' <%s/disk.img | grep -q -m 1 ^ || echo \"All zeros\"", utils.DefaultPvcMountPath)
 
 	output, err := f.ExecShellInPod(executorPod.Name, namespace.Name, cmd)
 
 	if err != nil {
 		return false, err
 	}
-	return strings.Compare("0", string(output)) == 0, nil
+	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: empty file check %s\n", string(output))
+	return strings.Compare("All zeros", string(output)) == 0, nil
 }
 
 // VerifyTargetPVCArchiveContent provides a function to check if the number of files extracted from an archive matches the passed in value

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -110,9 +110,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(found).To(BeTrue())
 
 		By("Verify the image contents")
-		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, BlankImageMD5)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(same).To(BeTrue())
+		Expect(f.VerifyBlankDisk(f.Namespace, pvc)).To(BeTrue())
 	})
 })
 

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Transport Tests", func() {
 		}
 
 		By(fmt.Sprintf("Creating PVC with endpoint annotation %q", pvcAnn[controller.AnnEndpoint]))
-		pvc, err := utils.CreatePVCFromDefinition(c, ns, utils.NewPVCDefinition("transport-e2e", "40Mi", pvcAnn, nil))
+		pvc, err := utils.CreatePVCFromDefinition(c, ns, utils.NewPVCDefinition("transport-e2e", "400Mi", pvcAnn, nil))
 		Expect(err).NotTo(HaveOccurred(), "Error creating PVC")
 
 		if shouldSucceed {
@@ -113,7 +113,7 @@ var _ = Describe("Transport Tests", func() {
 			Expect(found).To(BeTrue())
 
 			By("Verifying PVC is empty")
-			Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeTrue(), fmt.Sprintf("Found 0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
+			Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeTrue(), fmt.Sprintf("Found >0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
 		}
 	}
 
@@ -128,9 +128,9 @@ var _ = Describe("Transport Tests", func() {
 		Entry("should not connect to http endpoint with invalid credentials", httpAuthEp, targetFile, "invalid", "invalid", controller.SourceHTTP, "", false, false),
 		Entry("should connect to QCOW http endpoint without credentials", httpNoAuthEp, targetQCOWFile, "", "", controller.SourceHTTP, "", false, true),
 		Entry("should connect to QCOW http endpoint with credentials", httpAuthEp, targetQCOWFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, "", false, true),
-		Entry("should succeed to import from registry when image contains valid qcow file", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "cdi-docker-registry-host-certs", false, true),
-		Entry("should succeed to import from registry when image contains valid qcow file", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
-		Entry("should succeed to import from registry when image contains valid qcow file", altRegistryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
+		Entry("should succeed to import from registry when image contains valid qcow file, custom cert", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "cdi-docker-registry-host-certs", false, true),
+		Entry("should succeed to import from registry when image contains valid qcow file, no auth", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
+		Entry("should succeed to import from registry when image contains valid qcow file, auth", altRegistryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", true, true),
 		Entry("should fail no certs", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "", false, false),
 		Entry("should fail bad certs", registryNoAuthEp, targetQCOWImage, "", "", controller.SourceRegistry, "cdi-file-host-certs", false, false),
 		Entry("should succeed to import from registry when image contains valid raw file", registryNoAuthEp, targetRawImage, "", "", controller.SourceRegistry, "cdi-docker-registry-host-certs", false, true),

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -99,12 +99,9 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(found).To(BeTrue())
 
 			By("Verify content")
-			same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5Extended)
+			same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5100kbytes, 100000)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
-			fileSize, err := f.RunCommandAndCaptureOutput(pvc, "stat -c \"%s\" /pvc/disk.img")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fileSize).To(Equal("1073741824")) // 1G
 		} else {
 			By("Verify PVC empty")
 			_, err = framework.VerifyPVCIsEmpty(f, pvc)

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -19,8 +19,8 @@ const (
 	// UploadFileMD5 is the expected MD5 of the uploaded file
 	UploadFileMD5 = "2a7a52285c846314d1dbd79e9818270d"
 
-	// UploadFileMD5Extended is the size of the image after being extended
-	UploadFileMD5Extended = "bbd634a97ffa672834717993b40e0ab7"
+	// UploadFileMD5100kbytes is the size of the image after being extended
+	UploadFileMD5100kbytes = "3710416a680523c7d07538cb1026c60c"
 
 	uploadTargetAnnotation = "cdi.kubevirt.io/storage.upload.target"
 	uploadStatusAnnotation = "cdi.kubevirt.io/storage.pod.phase"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previous PR was on wrong provider, k8s-1.13.3 while we use k8s-1.15.1 for CI.
Verify the flag is set before attempting to switch default classes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

