### PR TITLE
Don't hard code CDI CR object name to be cdi in tests.

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -53,8 +53,10 @@ var _ = Describe("Operator tests", func() {
 
 	// Condition flags can be found here with their meaning https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md
 	It("Condition flags on CR should be healthy and operating", func() {
-		cdiObject, err := f.CdiClient.CdiV1alpha1().CDIs().Get("cdi", metav1.GetOptions{})
+		cdiObjects, err := f.CdiClient.CdiV1alpha1().CDIs().List(metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
+		Expect(len(cdiObjects.Items)).To(Equal(1))
+		cdiObject := cdiObjects.Items[0]
 		conditionMap := operatorcontroller.GetConditionValues(cdiObject.Status.Conditions)
 		// Application should be fully operational and healthy.
 		Expect(conditionMap[conditions.ConditionAvailable]).To(Equal(corev1.ConditionTrue))


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Functional test hard coded the name of the operator operand to be 'cdi' which is not always true. This PR improves the test by not assuming the name is 'cdi' but instead assuming there is only one operand and using that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

