### PR TITLE
create aggregate cluster roles

### DIFF
--- a/manifests/templates/release/cdi-operator.yaml.in
+++ b/manifests/templates/release/cdi-operator.yaml.in
@@ -6,26 +6,5 @@ metadata:
   name: {{.Namespace}}
 {{index .GeneratedManifests "cdi-crd.yaml"}}
 {{index .GeneratedManifests "cdi-configmap-cr.yaml"}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cdi.kubevirt.io:operator
-  labels:
-    operator.cdi.kubevirt.io: ""
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-rules:
-- apiGroups:
-  - cdi.kubevirt.io
-  resources:
-  - cdis
-  verbs:
-  - create
-  - patch
-  - get
-  - list
-  - delete
-  - watch
-  - deletecollection
 {{index .GeneratedManifests "rbac-operator.authorization.k8s.yaml.in"}}
 {{index .GeneratedManifests "cdi-operator-deployment.yaml"}}

--- a/pkg/operator/resources/cluster/factory.go
+++ b/pkg/operator/resources/cluster/factory.go
@@ -26,33 +26,24 @@ import (
 
 // FactoryArgs contains the required parameters to generate all cluster-scoped resources
 type FactoryArgs struct {
-	DockerRepo             string `required:"true" split_words:"true"`
-	DockerTag              string `required:"true" split_words:"true"`
-	DeployClusterResources string `required:"true" split_words:"true"`
-	ControllerImage        string `required:"true" split_words:"true"`
-	ImporterImage          string `required:"true" split_words:"true"`
-	ClonerImage            string `required:"true" split_words:"true"`
-	APIServerImage         string `required:"true" envconfig:"apiserver_image"`
-	UploadProxyImage       string `required:"true" split_words:"true"`
-	UploadServerImage      string `required:"true" split_words:"true"`
-	Verbosity              string `required:"true"`
-	PullPolicy             string `required:"true" split_words:"true"`
-	Namespace              string
+	Namespace string
 }
 
 type factoryFunc func(*FactoryArgs) []runtime.Object
 
 const (
 	//CdiRBAC - groupCode to generate only operator rbac manifest
-	CdiRBAC string = "cdi-rbac"
+	CdiRBAC = "cdi-rbac"
 	//APIServerRBAC - groupCode to generate only apiserver rbac manifest
-	APIServerRBAC string = "apiserver-rbac"
+	APIServerRBAC = "apiserver-rbac"
 	//UploadProxyRBAC - groupCode to generate only apiserver rbac manifest
-	UploadProxyRBAC string = "uploadproxy-rbac"
+	UploadProxyRBAC = "uploadproxy-rbac"
 	//ControllerRBAC - groupCode to generate only controller rbac manifest
-	ControllerRBAC string = "controller-rbac"
+	ControllerRBAC = "controller-rbac"
 	//CRDResources - groupCode to generate only resources' manifest
-	CRDResources string = "crd-resources"
+	CRDResources = "crd-resources"
+	//AggregateRoles = groupCode to generate only aggregate roles
+	AggregateRoles = "aggregate-roles"
 )
 
 var factoryFunctions = map[string]factoryFunc{
@@ -61,6 +52,7 @@ var factoryFunctions = map[string]factoryFunc{
 	ControllerRBAC:  createControllerResources,
 	CRDResources:    createCRDResources,
 	UploadProxyRBAC: createUploadProxyResources,
+	AggregateRoles:  createAggregateClusterRoles,
 }
 
 //IsFactoryResource returns true id codeGroupo belolngs to factory functions

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -87,6 +87,8 @@ func createAggregateClusterRoles(args *FactoryArgs) []runtime.Object {
 		createAggregateClusterRole("cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
 		createAggregateClusterRole("cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
 		createAggregateClusterRole("cdi.kubevirt.io:view", "view", getViewPolicyRules()),
+		createConfigReaderClusterRole("cdi.kubevirt.io:config-reader"),
+		createConfigReaderClusterRoleBinding("cdi.kubevirt.io:config-reader"),
 	}
 }
 
@@ -197,6 +199,53 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 				"get",
 				"list",
 				"watch",
+			},
+		},
+	}
+}
+
+func createConfigReaderClusterRole(name string) *rbacv1.ClusterRole {
+	role := CreateClusterRole(name)
+
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+	}
+
+	return role
+}
+
+func createConfigReaderClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: utils.WithCommonLabels(nil),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     name,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				Name:     "system:authenticated",
+				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
 	}

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -226,6 +226,7 @@ func getOperatorClusterRules() *[]rbacv1.PolicyRule {
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
+				"upload.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -290,7 +290,9 @@ var _ = Describe("Aggregated role definition tests", func() {
 			}
 		}
 	},
-		Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
+		//causing an issue in CI so commenting out for now
+		//https://github.com/kubevirt/containerized-data-importer/pull/961#issuecomment-532757768
+		//Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
 		Entry("for edit", "edit", append(editRules, viewRules...)),
 		Entry("for view", "view", viewRules),
 	)

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -1,0 +1,284 @@
+package tests
+
+import (
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var _ = Describe("Aggregated role in-action tests", func() {
+	var createServiceAccount = func(client kubernetes.Interface, namespace, name string) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+
+		_, err := client.CoreV1().ServiceAccounts(namespace).Create(sa)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	var createRoleBinding = func(client kubernetes.Interface, clusterRoleName, namespace, serviceAccount string) {
+		rb := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceAccount,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     clusterRoleName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount,
+					Namespace: namespace,
+				},
+			},
+		}
+
+		_, err := client.RbacV1().RoleBindings(namespace).Create(rb)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	f := framework.NewFrameworkOrDie("aggregated-role-tests")
+
+	DescribeTable("admin/edit datavolume permission checks", func(user string) {
+		var client cdiClientset.Interface
+		var err error
+
+		createServiceAccount(f.K8sClient, f.Namespace.Name, user)
+		createRoleBinding(f.K8sClient, user, f.Namespace.Name, user)
+
+		Eventually(func() error {
+			client, err = f.GetCdiClientForServiceAccount(f.Namespace.Name, user)
+			return err
+		}, 60*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		dv := utils.NewDataVolumeWithHTTPImport("test-"+user, "1Gi", "http://nonexistant.url")
+		dv, err = client.Cdi().DataVolumes(f.Namespace.Name).Create(dv)
+		Expect(err).ToNot(HaveOccurred())
+
+		dvl, err := client.Cdi().DataVolumes(f.Namespace.Name).List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dvl.Items).To(HaveLen(1))
+
+		dv, err = client.Cdi().DataVolumes(f.Namespace.Name).Get(dv.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		err = client.Cdi().DataVolumes(f.Namespace.Name).Delete(dv.Name, &metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		dvl, err = client.Cdi().DataVolumes(f.Namespace.Name).List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dvl.Items).To(HaveLen(0))
+
+		cl, err := client.Cdi().CDIConfigs().List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cl.Items).To(HaveLen(1))
+
+		_, err = client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	},
+		Entry("can do everything with admin", "admin"),
+		Entry("can do everything with edit", "edit"),
+	)
+
+	It("view datavolume permission checks", func() {
+		const user = "view"
+		var client cdiClientset.Interface
+		var err error
+
+		createServiceAccount(f.K8sClient, f.Namespace.Name, user)
+		createRoleBinding(f.K8sClient, user, f.Namespace.Name, user)
+
+		Eventually(func() error {
+			client, err = f.GetCdiClientForServiceAccount(f.Namespace.Name, user)
+			return err
+		}, 60*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		dv := utils.NewDataVolumeWithHTTPImport("test-"+user, "1Gi", "http://nonexistant.url")
+		dv, err = client.Cdi().DataVolumes(f.Namespace.Name).Create(dv)
+		Expect(err).To(HaveOccurred())
+
+		dvl, err := client.Cdi().DataVolumes(f.Namespace.Name).List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dvl.Items).To(HaveLen(0))
+
+		_, err = client.Cdi().DataVolumes(f.Namespace.Name).Get("test-"+user, metav1.GetOptions{})
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+		cl, err := client.Cdi().CDIConfigs().List(metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cl.Items).To(HaveLen(1))
+
+		_, err = client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Aggregated role definition tests", func() {
+	var adminRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"datavolumes",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"datavolumes/source",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"patch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{
+				"upload.cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"uploadtokenrequests",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"create",
+			},
+		},
+	}
+
+	var editRules = adminRules
+
+	var viewRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"datavolumes",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"datavolumes/source",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+	}
+
+	var containsString = func(toCheck []string, values ...string) bool {
+		for _, value := range values {
+			for _, v := range toCheck {
+				if v == value {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	f := framework.NewFrameworkOrDie("aggregated-role-definition-tests")
+
+	DescribeTable("check all expected rules exist", func(role string, rules []rbacv1.PolicyRule) {
+		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(role, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		found := false
+		for _, expectedRule := range rules {
+			for _, r := range clusterRole.Rules {
+				if reflect.DeepEqual(expectedRule, r) {
+					found = true
+					break
+				}
+			}
+		}
+		Expect(found).To(BeTrue())
+	},
+		Entry("for admin", "admin", adminRules),
+		Entry("for edit", "edit", editRules),
+		Entry("for view", "view", viewRules),
+	)
+
+	DescribeTable("check no unexpected rules", func(role string, rules []rbacv1.PolicyRule) {
+		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(role, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, r := range clusterRole.Rules {
+			if containsString(r.APIGroups, "cdi.kubevirt.io", "api.kubevirt.io") {
+				found := false
+				for _, expectedRule := range rules {
+					if reflect.DeepEqual(expectedRule, r) {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			}
+		}
+	},
+		Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
+		Entry("for edit", "edit", append(editRules, viewRules...)),
+		Entry("for view", "view", viewRules),
+	)
+})

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"reflect"
 	"time"
 
@@ -87,11 +88,16 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(dvl.Items).To(HaveLen(0))
 
 		cl, err := client.Cdi().CDIConfigs().List(metav1.ListOptions{})
+		fmt.Printf("XXX %+v\n", err)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cl.Items).To(HaveLen(1))
 
-		_, err = client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
+		cfg, err := client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
+
+		cfg.Spec.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
+		cfg, err = client.Cdi().CDIConfigs().Update(cfg)
+		Expect(err).To(HaveOccurred())
 	},
 		Entry("can do everything with admin", "admin"),
 		Entry("can do everything with edit", "edit"),
@@ -126,8 +132,12 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cl.Items).To(HaveLen(1))
 
-		_, err = client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
+		cfg, err := client.Cdi().CDIConfigs().Get(cl.Items[0].Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
+
+		cfg.Spec.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
+		cfg, err = client.Cdi().CDIConfigs().Update(cfg)
+		Expect(err).To(HaveOccurred())
 	})
 })
 
@@ -272,6 +282,9 @@ var _ = Describe("Aggregated role definition tests", func() {
 						found = true
 						break
 					}
+				}
+				if !found {
+					fmt.Printf("PolicyRule %+v not found\n", r)
 				}
 				Expect(found).To(BeTrue())
 			}

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -290,9 +290,7 @@ var _ = Describe("Aggregated role definition tests", func() {
 			}
 		}
 	},
-		//causing an issue in CI so commenting out for now
-		//https://github.com/kubevirt/containerized-data-importer/pull/961#issuecomment-532757768
-		//Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
+		Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
 		Entry("for edit", "edit", append(editRules, viewRules...)),
 		Entry("for view", "view", viewRules),
 	)

--- a/tools/manifest-generator/manifest-generator.go
+++ b/tools/manifest-generator/manifest-generator.go
@@ -367,18 +367,7 @@ func getOperatorClusterResources(codeGroup string) ([]runtime.Object, error) {
 
 func getClusterResources(codeGroup string) ([]runtime.Object, error) {
 	args := &cdicluster.FactoryArgs{
-		Verbosity:              *verbosity,
-		DockerRepo:             *dockerRepo,
-		DockerTag:              *dockertag,
-		DeployClusterResources: *deployClusterResources,
-		ControllerImage:        *controllerImage,
-		ImporterImage:          *importerImage,
-		ClonerImage:            *clonerImage,
-		APIServerImage:         *apiServerImage,
-		UploadProxyImage:       *uploadProxyImage,
-		UploadServerImage:      *uploadServerImage,
-		PullPolicy:             *pullPolicy,
-		Namespace:              *namespace,
+		Namespace: *namespace,
 	}
 
 	if codeGroup == ClusterResourcesCodeGroupEverything {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen mhenriks@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Create cluster roles that aggregate to admin/edit/view cluster roles.  This allows users with say the "admin" cluster role in any namespace to do whatever they want with CDI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

CDI is not included in any of this.  Should it be?  Assumption is that we only want cluster admins messing with that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
admin/view/edit aggregate cluster roles
```

