### PR TITLE
Sparsify clone tarring

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -39,7 +39,7 @@ else
     UPLOAD_BYTES=$(du -sb . | cut -f1)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    tar cv . | /usr/bin/cdi-cloner -v=3 -alsologtostderr -content_type filesystem-clone -upload_bytes $UPLOAD_BYTES
+    tar Scv . | /usr/bin/cdi-cloner -v=3 -alsologtostderr -content_type filesystem-clone -upload_bytes $UPLOAD_BYTES
 
     popd
 fi


### PR DESCRIPTION
Make xfs default fs for ceph in k8s provider.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix issue when cloning in XFS the target would take more space than the source due to not being sparsified.
Update default FS on ceph to be xfs instead of ext4
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cloning using xfs file system to same size PVC
```

