### PR TITLE
delete RBAC tests for unexpected aggregated PolicyRules

### DIFF
--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -237,17 +237,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 		},
 	}
 
-	var containsString = func(toCheck []string, values ...string) bool {
-		for _, value := range values {
-			for _, v := range toCheck {
-				if v == value {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
 	f := framework.NewFrameworkOrDie("aggregated-role-definition-tests")
 
 	DescribeTable("check all expected rules exist", func(role string, rules []rbacv1.PolicyRule) {
@@ -267,31 +256,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 	},
 		Entry("for admin", "admin", adminRules),
 		Entry("for edit", "edit", editRules),
-		Entry("for view", "view", viewRules),
-	)
-
-	DescribeTable("check no unexpected rules", func(role string, rules []rbacv1.PolicyRule) {
-		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(role, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		for _, r := range clusterRole.Rules {
-			if containsString(r.APIGroups, "cdi.kubevirt.io", "api.kubevirt.io") {
-				found := false
-				for _, expectedRule := range rules {
-					if reflect.DeepEqual(expectedRule, r) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					fmt.Printf("PolicyRule %+v not found\n", r)
-				}
-				Expect(found).To(BeTrue())
-			}
-		}
-	},
-		Entry("for admin", "admin", append(adminRules, append(editRules, viewRules...)...)),
-		Entry("for edit", "edit", append(editRules, viewRules...)),
 		Entry("for view", "view", viewRules),
 	)
 })


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

These tests are causing an issue with OLM based install.  I also think they are unnecessary.  Who cares if there are extra rules as long as the ones we install are there?  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

