### PR TITLE
falloc on resize and blank disk.

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -244,7 +244,7 @@ func ResizeImage(dataFile, imageSize string, totalTargetSpace int64) error {
 			return nil
 		}
 		klog.V(1).Infof("Expanding image size to: %s\n", minSizeQuantity.String())
-		return qemuOperations.Resize(dataFile, minSizeQuantity)
+		return util.RetryBackoffSize(dataFile, minSizeQuantity, qemuOperations.Resize)
 	}
 	return errors.New("Image resize called with blank resize")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -118,6 +118,32 @@ func GetAvailableSpaceBlock(deviceName string) int64 {
 	return i
 }
 
+// RetryBackoffSize Calls the passed in function to size/resize and if it fails lowers the size and tries again up to 10 times.
+func RetryBackoffSize(dest string, size resource.Quantity, sizeFunc func(string, resource.Quantity) error) error {
+	var stat syscall.Statfs_t
+	klog.V(3).Infof("Checking block size on path: %s\n", filepath.Dir(dest))
+	err := syscall.Statfs(filepath.Dir(dest), &stat)
+	if err != nil {
+		// Unable to stat, won't be able to size.
+		return err
+	}
+	blockSize := int64(stat.Bsize)
+	klog.V(3).Infof("Block size: %d\n", blockSize)
+
+	err = sizeFunc(dest, size)
+	retryCount := 0
+	reduceSize := *size.Copy()
+	for err != nil && retryCount < 10 {
+		retryCount++
+		// Reduce by 25 blocks, and try again. How did we end up with 25 blocks? Well we need to leave some blocks for the fs on the pvc.
+		// Then we need to leave some extra blocks so it can mount inside the container.
+		reduceSize.Sub(*resource.NewScaledQuantity(blockSize*int64(25), 0))
+		klog.V(3).Infof("Trying new size: %s\n", reduceSize.String())
+		err = sizeFunc(dest, reduceSize)
+	}
+	return err
+}
+
 // MinQuantity calculates the minimum of two quantities.
 func MinQuantity(availableSpace, imageSize *resource.Quantity) resource.Quantity {
 	if imageSize.Cmp(*availableSpace) == 1 {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -227,6 +227,9 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 		Expect(err).ToNot(HaveOccurred())
 		matchFile := filepath.Join(testBaseDir, "disk.img")
 		Expect(f.VerifyTargetPVCContentMD5(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(targetDv), matchFile, md5sum[:32])).To(BeTrue())
+		By("Verifying the image is not sparse")
+		Expect(f.VerifyNotSparse(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(targetDv))).To(BeTrue())
+
 	})
 
 	It("[rfe_id:CNV-1126][case_id:CNV-1896][crit:High][vendor:cnv-qe@redhat.com][level:component] Should not allow cloning into a smaller sized data volume in block volume mode", func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -111,6 +111,8 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		By("Verify the image contents")
 		Expect(f.VerifyBlankDisk(f.Namespace, pvc)).To(BeTrue())
+		By("Verifying the image is not sparse")
+		Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
 	})
 })
 

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -106,6 +106,8 @@ var _ = Describe("Transport Tests", func() {
 					Expect(same).To(BeTrue())
 				}
 			}
+			By("Verifying the image is not sparse")
+			Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
 		} else {
 			By("Verify PVC status annotation says failed")
 			found, err := utils.WaitPVCPodStatusFailed(f.K8sClient, pvc)

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -102,6 +102,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5100kbytes, 100000)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
+			By("Verifying the image is not sparse")
+			Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
 		} else {
 			By("Verify PVC empty")
 			_, err = framework.VerifyPVCIsEmpty(f, pvc)

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -67,7 +67,7 @@ func NewPodWithPVC(podName, cmd string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1
 			Containers: []k8sv1.Container{
 				{
 					Name:    "runner",
-					Image:   "registry.fedoraproject.org/fedora-minimal:29",
+					Image:   "kubevirt/cdi-importer:latest",
 					Command: []string{"/bin/sh", "-c", cmd},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use falloc when resizing/creating blank to make sure we can guarantee the space reported is available for VMs.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resize/Blank disk now use falloc instead of being sparse to guarantee available space.
```

