### PR TITLE
Add node selector for VerifyPvcEmpty pod

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -30,14 +30,25 @@ func (f *Framework) CreateExecutorPodWithPVC(podName string, pvc *k8sv1.Persiste
 	return utils.CreateExecutorPodWithPVC(f.K8sClient, podName, f.Namespace.Name, pvc)
 }
 
+// CreateExecutorPodWithPVCSpecificNode is a wrapper around utils.CreateExecutorPodWithPVCSpecificNode
+func (f *Framework) CreateExecutorPodWithPVCSpecificNode(podName string, pvc *k8sv1.PersistentVolumeClaim, node string) (*k8sv1.Pod, error) {
+	return utils.CreateExecutorPodWithPVCSpecificNode(f.K8sClient, podName, f.Namespace.Name, pvc, node)
+}
+
 // FindPVC is a wrapper around utils.FindPVC
 func (f *Framework) FindPVC(pvcName string) (*k8sv1.PersistentVolumeClaim, error) {
 	return utils.FindPVC(f.K8sClient, f.Namespace.Name, pvcName)
 }
 
-// VerifyPVCIsEmpty verifies a passed in PVC is empty, returns true if the PVC is empty, false if it is not.
-func VerifyPVCIsEmpty(f *Framework, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
-	executorPod, err := f.CreateExecutorPodWithPVC("verify-pvc-empty", pvc)
+// VerifyPVCIsEmpty verifies a passed in PVC is empty, returns true if the PVC is empty, false if it is not. Optionaly, specify node for the pod.
+func VerifyPVCIsEmpty(f *Framework, pvc *k8sv1.PersistentVolumeClaim, node string) (bool, error) {
+	var err error
+	var executorPod *k8sv1.Pod
+	if node != "" {
+		executorPod, err = f.CreateExecutorPodWithPVCSpecificNode("verify-pvc-empty", pvc, node)
+	} else {
+		executorPod, err = f.CreateExecutorPodWithPVC("verify-pvc-empty", pvc)
+	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	err = f.WaitTimeoutForPodReady(executorPod.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -58,7 +58,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 		// Wait a while to see if CDI puts anything in the PVC.
-		isEmpty, err := framework.VerifyPVCIsEmpty(f, pvc)
+		isEmpty, err := framework.VerifyPVCIsEmpty(f, pvc, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(isEmpty).To(BeTrue())
 		// Not deleting PVC as it will be removed with the NS removal.

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Transport Tests", func() {
 			Expect(found).To(BeTrue())
 
 			By("Verifying PVC is not empty")
-			Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeFalse(), fmt.Sprintf("Found 0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
+			Expect(framework.VerifyPVCIsEmpty(f, pvc, "")).To(BeFalse(), fmt.Sprintf("Found 0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
 
 			switch pvcAnn[controller.AnnSource] {
 			case controller.SourceHTTP, controller.SourceRegistry:
@@ -111,9 +111,11 @@ var _ = Describe("Transport Tests", func() {
 			found, err := utils.WaitPVCPodStatusFailed(f.K8sClient, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-
+			importer, err := utils.FindPodByPrefix(c, ns, common.ImporterPodName, common.CDILabelSelector)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
 			By("Verifying PVC is empty")
-			Expect(framework.VerifyPVCIsEmpty(f, pvc)).To(BeTrue(), fmt.Sprintf("Found >0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
+			By(fmt.Sprintf("importer.Spec.NodeName %q", importer.Spec.NodeName))
+			Expect(framework.VerifyPVCIsEmpty(f, pvc, importer.Spec.NodeName)).To(BeTrue(), fmt.Sprintf("Found >0 imported files on PVC %q", pvc.Namespace+"/"+pvc.Name))
 		}
 	}
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/tests"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -103,8 +104,12 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
 		} else {
+			uploader, err := utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, utils.UploadPodName(pvc), common.CDILabelSelector)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get uploader pod %q", f.Namespace.Name+"/"+utils.UploadPodName(pvc)))
+			By("Verifying PVC is empty")
+			By(fmt.Sprintf("uploader.Spec.NodeName %q", uploader.Spec.NodeName))
 			By("Verify PVC empty")
-			_, err = framework.VerifyPVCIsEmpty(f, pvc)
+			_, err = framework.VerifyPVCIsEmpty(f, pvc, uploader.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 		}
 	},

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -28,6 +28,16 @@ func CreateExecutorPodWithPVC(clientSet *kubernetes.Clientset, podName, namespac
 	return CreatePod(clientSet, namespace, newExecutorPodWithPVC(podName, pvc))
 }
 
+// CreateExecutorPodWithPVCSpecificNode creates a Pod on a specific node with the passed in PVC mounted under /pvc. You can then use the executor utilities to
+// run commands against the PVC through this Pod.
+func CreateExecutorPodWithPVCSpecificNode(clientSet *kubernetes.Clientset, podName, namespace string, pvc *k8sv1.PersistentVolumeClaim, node string) (*k8sv1.Pod, error) {
+	var pod = newExecutorPodWithPVC(podName, pvc)
+	pod.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": node,
+	}
+	return CreatePod(clientSet, namespace, pod)
+}
+
 // CreatePod calls the Kubernetes API to create a Pod
 func CreatePod(clientSet *kubernetes.Clientset, namespace string, podDef *k8sv1.Pod) (*k8sv1.Pod, error) {
 	var pod *k8sv1.Pod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In case of cluster with multiple nodes, the VerifyPvcEmpty pod could be scheduled on a different node than the importer, then it will fail to attach the PVC. (At least on CEPH/RBD/File).
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Co-authored-by: Daniel Erez <derez@redhat.com>
Signed-off-by: Fred Rolland <frolland@redhat.com>