### PR TITLE
apiserver not translating HTTP method

### DIFF
--- a/pkg/apiserver/authorizer.go
+++ b/pkg/apiserver/authorizer.go
@@ -77,6 +77,11 @@ func (a *authorizor) getUserExtras(headers http.Header, toMatch []string) map[st
 	return extras
 }
 
+// only supporting create for now
+var verbMap = map[string]string{
+	"POST": "create",
+}
+
 func (a *authorizor) generateAccessReview(req *restful.Request) (*authorization.SubjectAccessReview, error) {
 
 	httpRequest := req.Request
@@ -127,7 +132,12 @@ func (a *authorizor) generateAccessReview(req *restful.Request) (*authorization.
 	if err != nil {
 		return nil, err
 	}
-	verb := strings.ToLower(httpRequest.Method)
+
+	method := strings.ToUpper(httpRequest.Method)
+	verb, exists := verbMap[method]
+	if !exists {
+		return nil, fmt.Errorf("unsupported HTTP method %s", method)
+	}
 
 	r := &authorization.SubjectAccessReview{}
 	r.Spec = authorization.SubjectAccessReviewSpec{

--- a/pkg/apiserver/authorizer_test.go
+++ b/pkg/apiserver/authorizer_test.go
@@ -35,6 +35,7 @@ import (
 func fakeRequest() *restful.Request {
 	req := &restful.Request{}
 	req.Request = &http.Request{}
+	req.Request.Method = "POST"
 	req.Request.URL = &url.URL{}
 	req.Request.Header = make(map[string][]string)
 	req.Request.Header[userHeader] = []string{"user"}

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -148,9 +148,7 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 				"uploadtokenrequests",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"create",
+				"*",
 			},
 		},
 	}

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -188,9 +188,7 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"uploadtokenrequests",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"create",
+				"*",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

apiserver should translate POST requests to "create".

also allowing admin/edit to do everything with uploadtokenrequests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

