### PR TITLE
Wait for SC to be available before making it default

### DIFF
--- a/cluster-sync/okd-4.1/provider.sh
+++ b/cluster-sync/okd-4.1/provider.sh
@@ -7,7 +7,22 @@ function seed_images(){
 }
 
 function configure_local_storage() {
-  #Set the default storage class.
+  retry_counter=0
+  sc=`_kubectl get sc local -o=jsonpath="{.metadata.name}"`
+  all_sc=`_kubectl get sc`
+  echo "All storage classes:"
+  echo "${all_sc}"
+  while [[ $retry_counter -lt 60 ]] && [ "$sc" != "local" ]; do
+    sc=`_kubectl get sc local -o=jsonpath="{.metadata.name}"`
+    retry_counter=$((retry_counter + 1))
+    echo "Sleep 5s, waiting for local storage class, current sc=[$sc]"
+    sleep 5
+    all_sc=`_kubectl get sc`
+    echo "All storage classes:"
+    echo "${all_sc}"
+  done
+
+  #Set the default storage class. If the above timed out, this will fail and abort the sync
   _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 }
 

--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -129,10 +129,12 @@ var _ = Describe("[rfe_id:1250][crit:high][test_id:1889][vendor:cnv-qe@redhat.co
 		// The import is starting, and the transfer is about to happen. Now kill the leader
 		By("Killing leader, we should have a new leader elected")
 		err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).Delete(leaderPodName, &metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to kill leader: %v", err))
 
 		Eventually(func() bool {
 			log := getLog(f, newPodName)
+			fmt.Fprintf(GinkgoWriter, "INFO: Lookin for: %s\n", logIsLeaderRegex)
+			fmt.Fprintf(GinkgoWriter, "INFO: In: %s\n", log)
 			return checkLogForRegEx(logIsLeaderRegex, log)
 		}, timeout, pollingInterval).Should(BeTrue())
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The OKD sometimes take a bit to get the local storage class available, this PR adds a wait to make sure the local SC is available before setting it as default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

