### PR TITLE
Unique client cert per clone source pod

### DIFF
--- a/cmd/cdi-uploadserver/uploadserver.go
+++ b/cmd/cdi-uploadserver/uploadserver.go
@@ -55,6 +55,7 @@ func main() {
 		os.Getenv("TLS_KEY"),
 		os.Getenv("TLS_CERT"),
 		os.Getenv("CLIENT_CERT"),
+		os.Getenv("CLIENT_NAME"),
 		os.Getenv(common.UploadImageSize),
 	)
 

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -44,7 +44,7 @@ const (
 	// APIServerPublicKeyPath is the path to the apiserver public key
 	APIServerPublicKeyPath = APIServerPublicKeyDir + "/id_rsa.pub"
 
-	cloneFinalizerName = "cdi.kubevirt.io/cloneSource"
+	cloneSourcePodFinalizer = "cdi.kubevirt.io/cloneSource"
 
 	cloneTokenLeeway = 10 * time.Second
 )
@@ -86,34 +86,34 @@ func newCloneTokenValidator(key *rsa.PublicKey) token.Validator {
 }
 
 func (cc *CloneController) findCloneSourcePodFromCache(pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
-	var sourcePod *v1.Pod
-	annCloneRequest := pvc.GetAnnotations()[AnnCloneRequest]
-	if annCloneRequest != "" {
-		sourcePvcNamespace, _ := ParseSourcePvcAnnotation(annCloneRequest, "/")
-		if sourcePvcNamespace == "" {
-			return nil, errors.Errorf("Bad CloneRequest Annotation")
-		}
-		//find the source pod
-		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				CloneUniqueID: string(pvc.GetUID()) + "-source-pod",
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		podList, err := cc.podLister.Pods(sourcePvcNamespace).List(selector)
-		if err != nil {
-			return nil, err
-		}
-		if len(podList) == 0 {
-			return nil, nil
-		} else if len(podList) > 1 {
-			return nil, errors.Errorf("multiple source pods found for clone PVC %s/%s", pvc.Namespace, pvc.Name)
-		}
-		sourcePod = podList[0]
+	isCloneRequest, sourceNamespace, _ := ParseCloneRequestAnnotation(pvc)
+	if !isCloneRequest {
+		return nil, nil
 	}
-	return sourcePod, nil
+
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			CloneUniqueID: string(pvc.GetUID()) + "-source-pod",
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating label selector")
+	}
+
+	podList, err := cc.podLister.Pods(sourceNamespace).List(selector)
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing pods")
+	}
+
+	if len(podList) > 1 {
+		return nil, errors.Errorf("multiple source pods found for clone PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+
+	if len(podList) == 0 {
+		return nil, nil
+	}
+
+	return podList[0], nil
 }
 
 // Create the cloning source and target pods based the pvc. The pvc is checked (again) to ensure that we are not already
@@ -125,6 +125,7 @@ func (cc *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 	}
 
 	if !ready {
+		klog.V(3).Infof("Upload pod not ready yet for PVC %s/%s", pvc.Namespace, pvc.Name)
 		return nil
 	}
 
@@ -135,37 +136,38 @@ func (cc *CloneController) processPvcItem(pvc *v1.PersistentVolumeClaim) error {
 
 	// source pod not seen yet
 	if !cc.podExpectations.SatisfiedExpectations(pvcKey) {
+		klog.V(3).Infof("Waiting on expectations for %s/%s", pvc.Namespace, pvc.Name)
 		return nil
 	}
 
 	sourcePod, err := cc.findCloneSourcePodFromCache(pvc)
 	if err != nil {
-		return errors.Wrap(err, "error getting clone source pod")
+		return err
 	}
 
 	if sourcePod == nil {
 		if err = cc.validateSourceAndTarget(pvc); err != nil {
-			return errors.Wrap(err, "error validating pvc before creating source")
+			return err
 		}
 
-		crann, err := getCloneRequestPVCAnnotation(pvc)
-		if err != nil {
-			return errors.Wrap(err, "error getting clone request annotation")
+		clientName, ok := pvc.Annotations[AnnUploadClientName]
+		if !ok {
+			return errors.Errorf("PVC %s/%s missing required %s annotation", pvc.Namespace, pvc.Name, AnnUploadClientName)
 		}
 
-		pvc, err = cc.addFinalizer(pvc)
+		pvc, err = addFinalizer(cc.clientset, pvc, cloneSourcePodFinalizer)
 		if err != nil {
-			return errors.Wrap(err, "error adding finalizer")
+			return err
 		}
 
 		cc.raisePodCreate(pvcKey)
-		pod, err := CreateCloneSourcePod(cc.clientset, cc.image, cc.pullPolicy, crann, pvc)
+		sourcePod, err = CreateCloneSourcePod(cc.clientset, cc.image, cc.pullPolicy, clientName, pvc)
 		if err != nil {
 			cc.observePodCreate(pvcKey)
-			return errors.Wrap(err, "error creating clone source pod")
+			return err
 		}
 
-		klog.V(3).Infof("Created pod %s/%s", pod.Namespace, pod.Name)
+		klog.V(3).Infof("Created pod %s/%s", sourcePod.Namespace, sourcePod.Name)
 	}
 
 	klog.V(3).Infof("Pod phase for PVC %s/%s is %s", pvc.Namespace, pvc.Name, pvc.Annotations[AnnPodPhase])
@@ -201,43 +203,6 @@ func (cc *CloneController) waitTargetPodRunningOrSucceeded(pvc *v1.PersistentVol
 	}
 
 	return true, nil
-}
-
-func (cc *CloneController) addFinalizer(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	if hasFinalizer(pvc, cloneFinalizerName) {
-		return pvc, nil
-	}
-
-	cpy := pvc.DeepCopy()
-	cpy.Finalizers = append(cpy.Finalizers, cloneFinalizerName)
-	cpy, err := cc.clientset.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(cpy)
-	if err != nil {
-		return pvc, errors.Wrap(err, "error updating PVC")
-	}
-
-	return cpy, nil
-}
-
-func (cc *CloneController) removeFinalizer(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	if !hasFinalizer(pvc, cloneFinalizerName) {
-		return pvc, nil
-	}
-
-	var finalizers []string
-	for _, f := range pvc.Finalizers {
-		if f != cloneFinalizerName {
-			finalizers = append(finalizers, f)
-		}
-	}
-
-	cpy := pvc.DeepCopy()
-	cpy.Finalizers = finalizers
-	cpy, err := cc.clientset.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(cpy)
-	if err != nil {
-		return pvc, errors.Wrap(err, "error updating PVC")
-	}
-
-	return cpy, nil
 }
 
 func (c *Controller) raisePodCreate(pvcKey string) {
@@ -286,7 +251,7 @@ func (cc *CloneController) cleanup(key string, pvc *v1.PersistentVolumeClaim) er
 
 	pod, err := cc.findCloneSourcePodFromCache(pvc)
 	if err != nil {
-		return errors.Wrap(err, "error getting clone source pod")
+		return err
 	}
 
 	if pod != nil && pod.DeletionTimestamp == nil {
@@ -302,9 +267,9 @@ func (cc *CloneController) cleanup(key string, pvc *v1.PersistentVolumeClaim) er
 		}
 	}
 
-	_, err = cc.removeFinalizer(pvc)
+	_, err = removeFinalizer(cc.clientset, pvc, cloneSourcePodFinalizer)
 	if err != nil {
-		return errors.Wrap(err, "error removing finalizer")
+		return err
 	}
 
 	cc.podExpectations.DeleteExpectations(key)

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -11,6 +11,9 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/cert"
+
+	"kubevirt.io/containerized-data-importer/pkg/util/cert/triple"
 )
 
 type CloneFixture struct {
@@ -21,24 +24,49 @@ var (
 	apiServerKey     *rsa.PrivateKey
 	apiServerKeyOnce sync.Once
 
-	testUploadServerClientKeySecret = &corev1.Secret{
+	testUploadServerCASecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cdi-upload-server-client-key",
+			Name:      "cdi-upload-server-ca-key",
 			Namespace: "cdi",
 		},
 		Data: map[string][]byte{
 			"tls.key": []byte("privatekey"),
 			"tls.crt": []byte("cert"),
-			"ca.crt":  []byte("cacert"),
 		},
 	}
+
+	testUploadServerClientCASecret     *corev1.Secret
+	testUploadServerClientCASecretOnce sync.Once
 )
+
+func testCreateClientKeyAndCert(ca *triple.KeyPair, commonName string, organizations []string) ([]byte, []byte, error) {
+	return []byte("foo"), []byte("bar"), nil
+}
 
 func getAPIServerKey() *rsa.PrivateKey {
 	apiServerKeyOnce.Do(func() {
 		apiServerKey, _ = rsa.GenerateKey(rand.Reader, 2048)
 	})
 	return apiServerKey
+}
+
+func getUploadServerClientCASecret() *corev1.Secret {
+	testUploadServerClientCASecretOnce.Do(func() {
+		keypair, _ := triple.NewCA("BAZ")
+		kb := cert.EncodePrivateKeyPEM(keypair.Key)
+		cb := cert.EncodeCertPEM(keypair.Cert)
+		testUploadServerClientCASecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cdi-upload-server-client-ca-key",
+				Namespace: "cdi",
+			},
+			Data: map[string][]byte{
+				"tls.key": kb,
+				"tls.crt": cb,
+			},
+		}
+	})
+	return testUploadServerClientCASecret
 }
 
 func newCloneFixture(t *testing.T) *CloneFixture {
@@ -129,20 +157,25 @@ func TestWaitsTargetRunningNoAnnotation(t *testing.T) {
 }
 
 func TestCreatesSourcePod(t *testing.T) {
+	createClientKeyAndCertFunc = testCreateClientKeyAndCert
+	defer func() {
+		createClientKeyAndCertFunc = createClientKeyAndCert
+	}()
 	f := newCloneFixture(t)
 	sourcePvc := createPvc("golden-pvc", "source-ns", nil, nil)
 	pvc := createClonePvc("source-ns", "golden-pvc", "target-ns", "target-pvc", nil, nil)
 	pvc.Annotations[AnnPodReady] = "true"
 
 	f.pvcLister = append(f.pvcLister, sourcePvc, pvc)
-	f.kubeobjects = append(f.kubeobjects, testUploadServerClientKeySecret, sourcePvc, pvc)
+	f.kubeobjects = append(f.kubeobjects, testUploadServerCASecret, getUploadServerClientCASecret(), sourcePvc, pvc)
 
 	id := string(pvc.GetUID())
 	expSourcePod := createSourcePod(pvc, id)
 	pvcUpdate := pvc.DeepCopy()
-	pvcUpdate.Finalizers = []string{cloneFinalizerName}
+	pvcUpdate.Finalizers = []string{cloneSourcePodFinalizer}
 	f.expectUpdatePvcAction(pvcUpdate)
-	f.expectSecretGetAction(testUploadServerClientKeySecret)
+	f.expectSecretGetAction(testUploadServerCASecret)
+	f.expectSecretGetAction(getUploadServerClientCASecret())
 	f.expectCreatePodAction(expSourcePod)
 
 	f.run(getPvcKey(pvc, t))
@@ -171,7 +204,7 @@ func TestDeletesSourcePodAndFinalizer(t *testing.T) {
 	f := newCloneFixture(t)
 	pvc := createClonePvc("source-ns", "golden-pvc", "target-ns", "target-pvc", nil, nil)
 	pvc.Annotations[AnnCloneOf] = "true"
-	pvc.Finalizers = []string{cloneFinalizerName}
+	pvc.Finalizers = []string{cloneSourcePodFinalizer}
 	id := string(pvc.GetUID())
 	pod := createSourcePod(pvc, id)
 	pod.Name = pod.GenerateName + "random"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -151,13 +151,13 @@ func (c *Controller) handlePodObject(obj interface{}, verb string) {
 	}
 
 	if pvc == nil {
-		ownerRefAnno, exists := object.GetAnnotations()[AnnOwnerRef]
+		ownerRefAnno, ok := object.GetAnnotations()[AnnOwnerRef]
 		if ok {
-			pvc, exists, err = c.pvcFromKey(ownerRefAnno)
+			pvc, ok, err = c.pvcFromKey(ownerRefAnno)
 			if err != nil {
 				runtime.HandleError(errors.Wrapf(err, "error getting PVC %s", ownerRefAnno))
 				return
-			} else if !exists {
+			} else if !ok {
 				runtime.HandleError(errors.Errorf("error getting PVC %s from ownerref", ownerRefAnno))
 				return
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -26,7 +26,6 @@ type ControllerFixture struct {
 
 	// Actions expected to happen on the client.
 	kubeactions []core.Action
-	actions     []core.Action
 
 	// Objects from here preloaded into NewSimpleFake.
 	kubeobjects []runtime.Object
@@ -144,11 +143,6 @@ func (f *ControllerFixture) expectCreatePodAction(d *corev1.Pod) {
 
 func (f *ControllerFixture) expectUpdatePvcAction(d *corev1.PersistentVolumeClaim) {
 	f.kubeactions = append(f.kubeactions, core.NewUpdateAction(schema.GroupVersionResource{Resource: "persistentvolumeclaims", Version: "v1"}, d.Namespace, d))
-}
-
-func (f *ControllerFixture) expectDeletePvcAction(pvc *corev1.PersistentVolumeClaim) {
-	f.kubeactions = append(f.kubeactions,
-		core.NewDeleteAction(schema.GroupVersionResource{Resource: "persistentvolumeclaims", Version: "v1"}, pvc.Namespace, pvc.Name))
 }
 
 func (f *ControllerFixture) expectDeletePodAction(p *corev1.Pod) {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -269,9 +269,10 @@ func (ic *ImportController) createScratchPvcForPod(pvc *v1.PersistentVolumeClaim
 		return err
 	}
 	if scratchPvc == nil {
+		scratchPVCName := pvc.Name + "-scratch"
 		storageClassName := GetScratchPvcStorageClass(ic.clientset, ic.cdiClient, pvc)
 		// Scratch PVC doesn't exist yet, create it. Determine which storage class to use.
-		_, err = CreateScratchPersistentVolumeClaim(ic.clientset, pvc, pod, storageClassName)
+		_, err = CreateScratchPersistentVolumeClaim(ic.clientset, pvc, pod, scratchPVCName, storageClassName)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -44,6 +45,9 @@ import (
 const (
 	// AnnUploadRequest marks that a PVC should be made available for upload
 	AnnUploadRequest = "cdi.kubevirt.io/storage.upload.target"
+
+	// AnnUploadClientName is the TLS name uploadserver will accept requests from
+	AnnUploadClientName = "cdi.kubevirt.io/uploadClientName"
 
 	annCreatedByUpload = "cdi.kubevirt.io/storage.createdByUploadController"
 
@@ -83,9 +87,10 @@ type UploadController struct {
 	uploadProxyServiceName                    string
 }
 
-// GetUploadResourceName returns the name given to upload services/pods
-func GetUploadResourceName(pvcName string) string {
-	return "cdi-upload-" + pvcName
+// GetUploadResourceName returns the name given to upload resources
+func GetUploadResourceName(name string) string {
+	// TODO revisit naming, could overflow
+	return "cdi-upload-" + name
 }
 
 // UploadPossibleForPVC is called by the api server to see whether to return an upload token
@@ -130,7 +135,6 @@ func NewUploadController(client kubernetes.Interface,
 		verbose:                verbose,
 	}
 
-	// Bind the pvc SharedIndexInformer to the pvc queue
 	c.pvcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.enqueueObject,
 		UpdateFunc: func(old, new interface{}) {
@@ -138,15 +142,12 @@ func NewUploadController(client kubernetes.Interface,
 		},
 	})
 
-	// Bind the pod SharedIndexInformer to the pvc queue
 	c.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.handleObject,
 		UpdateFunc: func(old, new interface{}) {
-			newDepl := new.(*v1.Pod)
-			oldDepl := old.(*v1.Pod)
-			if newDepl.ResourceVersion == oldDepl.ResourceVersion {
-				// Periodic resync will send update events for all known Pods.
-				// Two different versions of the same PVCs will always have different RVs.
+			newPod := new.(*v1.Pod)
+			oldPod := old.(*v1.Pod)
+			if newPod.ResourceVersion == oldPod.ResourceVersion {
 				return
 			}
 			c.handleObject(new)
@@ -154,15 +155,12 @@ func NewUploadController(client kubernetes.Interface,
 		DeleteFunc: c.handleObject,
 	})
 
-	// Bind the service SharedIndexInformer to the service queue
 	c.serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.handleObject,
 		UpdateFunc: func(old, new interface{}) {
-			newDepl := new.(*v1.Service)
-			oldDepl := old.(*v1.Service)
-			if newDepl.ResourceVersion == oldDepl.ResourceVersion {
-				// Periodic resync will send update events for all known Services.
-				// Two different versions of the same Servicess will always have different RVs.
+			newService := new.(*v1.Service)
+			oldService := old.(*v1.Service)
+			if newService.ResourceVersion == oldService.ResourceVersion {
 				return
 			}
 			c.handleObject(new)
@@ -179,7 +177,7 @@ func (c *UploadController) Init() error {
 
 	if err := c.initCerts(); err != nil {
 		runtime.HandleError(err)
-		return errors.Wrap(err, "error initializing certificates")
+		return err
 	}
 
 	return nil
@@ -272,20 +270,23 @@ func (c *UploadController) handleObject(obj interface{}) {
 	if object, ok = obj.(metav1.Object); !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			runtime.HandleError(errors.Errorf("error decoding object, invalid type"))
+			runtime.HandleError(errors.New("error decoding object, invalid type"))
 			return
 		}
+
 		object, ok = tombstone.Obj.(metav1.Object)
 		if !ok {
-			runtime.HandleError(errors.Errorf("error decoding object tombstone, invalid type"))
+			runtime.HandleError(errors.New("error decoding object tombstone, invalid type"))
 			return
 		}
+
 		klog.V(3).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
+
 	klog.V(3).Infof("Processing object: %s", object.GetName())
+
 	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
 		_, createdByUs := object.GetAnnotations()[annCreatedByUpload]
-
 		if ownerRef.Kind != "PersistentVolumeClaim" || !createdByUs {
 			return
 		}
@@ -297,9 +298,7 @@ func (c *UploadController) handleObject(obj interface{}) {
 		}
 
 		klog.V(3).Infof("queueing pvc %+v!!", pvc)
-
 		c.enqueueObject(pvc)
-		return
 	}
 }
 
@@ -332,12 +331,11 @@ func (c *UploadController) processNextWorkItem() bool {
 
 		if key, ok = obj.(string); !ok {
 			c.queue.Forget(obj)
-			runtime.HandleError(errors.Errorf("expected string in workqueue but got %#v", obj))
-			return nil
+			return errors.Errorf("expected string in workqueue but got %#v", obj)
 		}
 
 		if err := c.syncHandler(key); err != nil {
-			return errors.Errorf("error syncing '%s': %s", key, err.Error())
+			return err
 		}
 
 		c.queue.Forget(obj)
@@ -352,15 +350,6 @@ func (c *UploadController) processNextWorkItem() bool {
 	}
 
 	return true
-}
-
-func podPhaseFromPVC(pvc *v1.PersistentVolumeClaim) v1.PodPhase {
-	phase, _ := pvc.ObjectMeta.Annotations[AnnPodPhase]
-	return v1.PodPhase(phase)
-}
-
-func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
-	return (podPhaseFromPVC(pvc) == v1.PodSucceeded)
 }
 
 func (c *UploadController) syncHandler(key string) error {
@@ -379,64 +368,66 @@ func (c *UploadController) syncHandler(key string) error {
 		return errors.Wrapf(err, "error getting PVC %s", key)
 	}
 
-	_, isUploadPod := pvc.Annotations[AnnUploadRequest]
-	_, isCloneTargetPod := pvc.Annotations[AnnCloneRequest]
+	_, isUpload := pvc.Annotations[AnnUploadRequest]
+	_, isCloneTarget := pvc.Annotations[AnnCloneRequest]
 
-	if isUploadPod && isCloneTargetPod {
+	if isUpload && isCloneTarget {
 		runtime.HandleError(errors.Errorf("PVC has both clone and upload annotations"))
 		return nil
 	}
 
 	// force cleanup if PVC pending delete and pod running or the upload/clone annotation was removed
-	if (!isUploadPod && !isCloneTargetPod) || podSucceededFromPVC(pvc) || pvc.DeletionTimestamp != nil {
+	if (!isUpload && !isCloneTarget) || podSucceededFromPVC(pvc) || pvc.DeletionTimestamp != nil {
 		klog.V(3).Infof("%s/%s not doing anything with: upload=%t, clone=%t, succeeded=%t, deleted=%t",
-			pvc.Namespace, pvc.Name, isUploadPod, isCloneTargetPod, podSucceededFromPVC(pvc), pvc.DeletionTimestamp == nil)
+			pvc.Namespace, pvc.Name, isUpload, isCloneTarget, podSucceededFromPVC(pvc), pvc.DeletionTimestamp == nil)
 		if err = c.cleanup(pvc); err != nil {
-			return errors.Wrap(err, "error cleaning up resources")
+			return err
 		}
 		return nil
 	}
 
-	if isCloneTargetPod {
+	var uploadClientName, scratchPVCName string
+	pvcCopy := pvc.DeepCopy()
+
+	if isCloneTarget {
 		source, err := getCloneRequestSourcePVC(pvc, c.pvcLister)
 		if err != nil {
-			return errors.Wrap(err, "error getting clone source PVC")
+			return err
 		}
 
 		if err = ValidateCanCloneSourceAndTargetSpec(&source.Spec, &pvc.Spec); err != nil {
 			klog.Errorf("Error %s validating clone spec, ignoring", err)
 			return nil
 		}
+
+		uploadClientName = fmt.Sprintf("%s/%s-%s/%s", source.Namespace, source.Name, pvc.Namespace, pvc.Name)
+		pvcCopy.Annotations[AnnUploadClientName] = uploadClientName
+	} else {
+		uploadClientName = uploadServerClientName
+
+		// TODO revisit naming, could overflow
+		scratchPVCName = pvc.Name + "-scratch"
 	}
 
 	resourceName := GetUploadResourceName(pvc.Name)
 
-	if !podSucceededFromPVC(pvc) {
-		pod, err := c.getOrCreateUploadPod(pvc, resourceName, isUploadPod)
-		if err != nil {
-			return errors.Wrapf(err, "error creating upload pod for pvc: %s", key)
-		}
-
-		podPhase := pod.Status.Phase
-		var labels map[string]string
-		annotations := map[string]string{
-			AnnPodPhase: string(podPhase),
-			AnnPodReady: strconv.FormatBool(isPodReady(pod)),
-		}
-		pvc, err = updatePVC(c.client, pvc, annotations, labels)
-		if err != nil {
-			return errors.Wrapf(err, "error updating pvc %s, pod phase %s", key, podPhase)
-		}
+	pod, err := c.getOrCreateUploadPod(pvc, resourceName, scratchPVCName, uploadClientName)
+	if err != nil {
+		return err
 	}
 
-	if podSucceededFromPVC(pvc) {
-		if err = c.cleanup(pvc); err != nil {
-			return errors.Wrap(err, "error cleaning up resources on succeeded")
-		}
-	} else {
-		// make sure the service exists
-		if _, err = c.getOrCreateUploadService(pvc, resourceName); err != nil {
-			return errors.Wrapf(err, "error getting/creating service resource for PVC %s", key)
+	if _, err = c.getOrCreateUploadService(pvc, resourceName); err != nil {
+		return err
+	}
+
+	podPhase := pod.Status.Phase
+	pvcCopy.Annotations[AnnPodPhase] = string(podPhase)
+	pvcCopy.Annotations[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
+
+	if !reflect.DeepEqual(pvc, pvcCopy) {
+		pvc, err = c.client.CoreV1().PersistentVolumeClaims(pvcCopy.Namespace).Update(pvcCopy)
+		if err != nil {
+			return errors.Wrapf(err, "error updating pvc %s, pod phase %s", key, podPhase)
 		}
 	}
 
@@ -447,16 +438,13 @@ func (c *UploadController) cleanup(pvc *v1.PersistentVolumeClaim) error {
 	resourceName := GetUploadResourceName(pvc.Name)
 
 	// delete service
-	err := c.deleteService(pvc.Namespace, resourceName)
-	if err != nil {
-		return errors.Wrapf(err, "error deleting upload service for pvc: %s/%s", pvc.Namespace, pvc.Name)
+	if err := c.deleteService(pvc.Namespace, resourceName); err != nil {
+		return err
 	}
 
 	// delete pod
 	// we're using a req struct for now until we can normalize the controllers a bit more and share things like lister, client etc
 	// this way it's easy to stuff everything into an easy request struct, and can extend aditional behaviors if we want going forward
-	// NOTE this is a special case where the user updated annotations on the pvc to abort the upload requests, we'll add another call
-	// for this for the success case
 	dReq := podDeleteRequest{
 		namespace: pvc.Namespace,
 		podName:   resourceName,
@@ -464,86 +452,115 @@ func (c *UploadController) cleanup(pvc *v1.PersistentVolumeClaim) error {
 		k8sClient: c.client,
 	}
 
-	err = deletePod(dReq)
-	if err != nil {
-		return errors.Wrapf(err, "error deleting upload pod for pvc: %s/%s", pvc.Namespace, pvc.Name)
+	if err := deletePod(dReq); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func (c *UploadController) getOrCreateUploadPod(pvc *v1.PersistentVolumeClaim, name string, isUploadPod bool) (*v1.Pod, error) {
-	pod, err := c.podLister.Pods(pvc.Namespace).Get(name)
-
-	if k8serrors.IsNotFound(err) {
-		scratchPvcName := ""
-		if isUploadPod {
-			scratchPvcName = pvc.Name + "-scratch"
+func (c *UploadController) getOrCreateUploadPod(pvc *v1.PersistentVolumeClaim, podName, scratchPVCName, clientName string) (*v1.Pod, error) {
+	pod, err := c.podLister.Pods(pvc.Namespace).Get(podName)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "error getting upload pod %s/%s", pvc.Namespace, podName)
 		}
-		pod, err = CreateUploadPod(c.client, c.serverCAKeyPair, c.clientCAKeyPair.Cert, c.uploadServiceImage, c.verbose, c.pullPolicy, name, pvc, scratchPvcName)
+
+		args := UploadPodArgs{
+			Client:         c.client,
+			CAKeyPair:      c.serverCAKeyPair,
+			ClientCACert:   c.clientCAKeyPair.Cert,
+			Image:          c.uploadServiceImage,
+			Verbose:        c.verbose,
+			PullPolicy:     c.pullPolicy,
+			Name:           podName,
+			PVC:            pvc,
+			ScratchPVCName: scratchPVCName,
+			ClientName:     clientName,
+		}
+
+		pod, err = CreateUploadPod(args)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to create upload pod")
+			return nil, err
 		}
 	}
+
+	if !metav1.IsControlledBy(pod, pvc) {
+		return nil, errors.Errorf("%s pod not controlled by pvc %s", podName, pvc.Name)
+	}
+
 	// Always try to get or create the scratch PVC for a pod that is not successful yet, if it exists nothing happens otherwise attempt to create.
-	if isUploadPod {
-		_, err = c.getOrCreateScratchPvc(pvc, pod)
+	if scratchPVCName != "" {
+		_, err = c.getOrCreateScratchPvc(pvc, pod, scratchPVCName)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to create scratch space for upload")
+			return nil, err
 		}
 	}
 
-	if pod != nil && !metav1.IsControlledBy(pod, pvc) {
-		return nil, errors.Errorf("%s pod not controlled by pvc %s", name, pvc.Name)
-	}
-	return pod, err
+	return pod, nil
 }
 
-func (c *UploadController) getOrCreateScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod) (*v1.PersistentVolumeClaim, error) {
-	scratchPvc, _ := c.pvcLister.PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name + "-scratch")
-	if scratchPvc != nil {
-		// Scratch PVC already exists, maybe the pod crashed and the pvc didn't get cleaned up, verify this pvc is owned by the pod.
-		for _, ownerRef := range scratchPvc.OwnerReferences {
-			if ownerRef.UID == pod.UID {
-				return scratchPvc, nil
-			}
-		}
-		return nil, errors.New("scratch PVC exists, but is not owned by the right pod")
-	}
-	storageClassName := GetScratchPvcStorageClass(c.client, c.cdiClient, pvc)
-
-	// Scratch PVC doesn't exist yet, create it. Determine which storage class to use.
-	scratchPvc, err := CreateScratchPersistentVolumeClaim(c.client, pvc, pod, storageClassName)
+func (c *UploadController) getOrCreateScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, name string) (*v1.PersistentVolumeClaim, error) {
+	scratchPvc, err := c.pvcLister.PersistentVolumeClaims(pvc.Namespace).Get(name)
 	if err != nil {
-		return nil, err
+		if !k8serrors.IsNotFound(err) {
+			return nil, errors.Wrap(err, "error getting scratch PVC")
+		}
+
+		storageClassName := GetScratchPvcStorageClass(c.client, c.cdiClient, pvc)
+
+		// Scratch PVC doesn't exist yet, create it.
+		scratchPvc, err = CreateScratchPersistentVolumeClaim(c.client, pvc, pod, name, storageClassName)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	if !metav1.IsControlledBy(scratchPvc, pod) {
+		return nil, errors.Errorf("%s scratch PVC not controlled by pod %s", scratchPvc.Name, pod.Name)
+	}
+
 	return scratchPvc, nil
 }
 
 func (c *UploadController) getOrCreateUploadService(pvc *v1.PersistentVolumeClaim, name string) (*v1.Service, error) {
 	service, err := c.serviceLister.Services(pvc.Namespace).Get(name)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, errors.Wrap(err, "error getting upload service")
+		}
 
-	if k8serrors.IsNotFound(err) {
 		service, err = CreateUploadService(c.client, name, pvc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	if service != nil && !metav1.IsControlledBy(service, pvc) {
+	if !metav1.IsControlledBy(service, pvc) {
 		return nil, errors.Errorf("%s service not controlled by pvc %s", name, pvc.Name)
 	}
 
-	return service, err
+	return service, nil
 }
 
 func (c *UploadController) deleteService(namespace, name string) error {
 	service, err := c.serviceLister.Services(namespace).Get(name)
-	if k8serrors.IsNotFound(err) {
-		return nil
-	}
-	if err == nil && service.DeletionTimestamp == nil {
-		err = c.client.CoreV1().Services(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		return errors.Wrap(err, "error getting upload service")
 	}
-	return err
+
+	if service.DeletionTimestamp == nil {
+		err = c.client.CoreV1().Services(namespace).Delete(name, &metav1.DeleteOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return errors.Wrap(err, "error deleting upload service")
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -44,11 +44,11 @@ const (
 )
 
 var (
-	yyytestUploadServerCASecret     *corev1.Secret
-	yyytestUploadServerCASecretOnce sync.Once
+	testUploadServerCASecret     *corev1.Secret
+	testUploadServerCASecretOnce sync.Once
 
-	zzztestUploadServerClientCASecret     *corev1.Secret
-	zzztestUploadServerClientCASecretOnce sync.Once
+	testUploadServerClientCASecret     *corev1.Secret
+	testUploadServerClientCASecretOnce sync.Once
 )
 
 type uploadFixture struct {
@@ -73,21 +73,21 @@ type uploadFixture struct {
 }
 
 func getUploadServerClientCASecret() *corev1.Secret {
-	zzztestUploadServerClientCASecretOnce.Do(func() {
+	testUploadServerClientCASecretOnce.Do(func() {
 		keyPair, _ := triple.NewCA("client")
-		zzztestUploadServerClientCASecret = keystest.NewTLSSecret("cdi",
+		testUploadServerClientCASecret = keystest.NewTLSSecret("cdi",
 			"cdi-upload-server-client-ca-key", keyPair, nil, nil)
 	})
-	return zzztestUploadServerClientCASecret
+	return testUploadServerClientCASecret
 }
 
 func getUploadServerCASecret() *corev1.Secret {
-	yyytestUploadServerCASecretOnce.Do(func() {
+	testUploadServerCASecretOnce.Do(func() {
 		keyPair, _ := triple.NewCA("server")
-		yyytestUploadServerCASecret = keystest.NewTLSSecret("cdi",
+		testUploadServerCASecret = keystest.NewTLSSecret("cdi",
 			"cdi-upload-server-ca-key", keyPair, nil, nil)
 	})
-	return yyytestUploadServerCASecret
+	return testUploadServerCASecret
 }
 
 func newUploadFixture(t *testing.T) *uploadFixture {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -70,11 +70,18 @@ type podDeleteRequest struct {
 	k8sClient kubernetes.Interface
 }
 
-type pvcDeleteRequest struct {
-	namespace string
-	pvcName   string
-	pvcLister corelisters.PersistentVolumeClaimLister
-	k8sClient kubernetes.Interface
+var createClientKeyAndCertFunc = createClientKeyAndCert
+
+func createClientKeyAndCert(ca *triple.KeyPair, commonName string, organizations []string) ([]byte, []byte, error) {
+	clientKeyPair, err := triple.NewClientKeyPair(ca, commonName, organizations)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error creating client key pair")
+	}
+
+	clientKeyBytes := cert.EncodePrivateKeyPEM(clientKeyPair.Key)
+	clientCertBytes := cert.EncodeCertPEM(clientKeyPair.Cert)
+
+	return clientKeyBytes, clientCertBytes, nil
 }
 
 func checkPVC(pvc *v1.PersistentVolumeClaim, annotation string) bool {
@@ -261,7 +268,7 @@ func checkIfLabelExists(pvc *v1.PersistentVolumeClaim, lbl string, val string) b
 // newScratchPersistentVolumeClaimSpec creates a new PVC based on the size of the passed in PVC.
 // It also sets the appropriate OwnerReferences on the resource
 // which allows handleObject to discover the pod resource that 'owns' it, and clean up when needed.
-func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassName string) *v1.PersistentVolumeClaim {
+func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, name, storageClassName string) *v1.PersistentVolumeClaim {
 	labels := map[string]string{
 		"cdi-controller": pod.Name,
 		"app":            "containerized-data-importer",
@@ -270,16 +277,11 @@ func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.
 
 	pvcDef := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvc.Name + "-scratch",
+			Name:      name,
 			Namespace: pvc.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Name:       pod.Name,
-					UID:        pod.GetUID(),
-				},
+				MakePodOwnerReference(pod),
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
@@ -294,9 +296,9 @@ func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.
 }
 
 // CreateScratchPersistentVolumeClaim creates and returns a pointer to a scratch PVC which is created based on the passed-in pvc and storage class name.
-func CreateScratchPersistentVolumeClaim(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassName string) (*v1.PersistentVolumeClaim, error) {
+func CreateScratchPersistentVolumeClaim(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pod *v1.Pod, name, storageClassName string) (*v1.PersistentVolumeClaim, error) {
 	ns := pvc.Namespace
-	scratchPvcSpec := newScratchPersistentVolumeClaimSpec(pvc, pod, storageClassName)
+	scratchPvcSpec := newScratchPersistentVolumeClaimSpec(pvc, pod, name, storageClassName)
 	scratchPvc, err := client.CoreV1().PersistentVolumeClaims(ns).Create(scratchPvcSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "scratch PVC API create errored")
@@ -569,39 +571,35 @@ func addToMap(m1, m2 map[string]string) map[string]string {
 }
 
 // returns the CloneRequest string which contains the pvc name (and namespace) from which we want to clone the image.
-func getCloneRequestPVCAnnotation(pvc *v1.PersistentVolumeClaim) (string, error) {
-	cr, found := pvc.Annotations[AnnCloneRequest]
-	if !found || cr == "" {
-		verb := "empty"
-		if !found {
-			verb = "missing"
-		}
-		return cr, errors.Errorf("annotation %q in pvc \"%s/%s\" is %s\n", AnnCloneRequest, pvc.Namespace, pvc.Name, verb)
-	}
-	return cr, nil
-}
-
-// returns the CloneRequest string which contains the pvc name (and namespace) from which we want to clone the image.
 func getCloneRequestSourcePVC(pvc *v1.PersistentVolumeClaim, pvcLister corelisters.PersistentVolumeClaimLister) (*v1.PersistentVolumeClaim, error) {
-	ann, err := getCloneRequestPVCAnnotation(pvc)
+	exists, namespace, name := ParseCloneRequestAnnotation(pvc)
+	if !exists {
+		return nil, errors.New("error parsing clone request annotation")
+	}
+	pvc, err := pvcLister.PersistentVolumeClaims(namespace).Get(name)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error getting clone source PVC")
 	}
-	namespace, name := ParseSourcePvcAnnotation(ann, "/")
-	if namespace == "" || name == "" {
-		return nil, errors.New("Unable to parse to source PVC annotation")
-	}
-	return pvcLister.PersistentVolumeClaims(namespace).Get(name)
+	return pvc, nil
 }
 
-// ParseSourcePvcAnnotation parses out the annotations for a CDI PVC, splitting the string based on the delimiter argument
-func ParseSourcePvcAnnotation(sourcePvcAnno, del string) (namespace, name string) {
-	strArr := strings.Split(sourcePvcAnno, del)
-	if strArr == nil || len(strArr) < 2 {
-		klog.V(3).Infof("Bad CloneRequest Annotation")
-		return "", ""
+// ParseCloneRequestAnnotation parses the clone request annotation
+func ParseCloneRequestAnnotation(pvc *v1.PersistentVolumeClaim) (exists bool, namespace, name string) {
+	var ann string
+	ann, exists = pvc.Annotations[AnnCloneRequest]
+	if !exists {
+		return
 	}
-	return strArr[0], strArr[1]
+
+	sp := strings.Split(ann, "/")
+	if len(sp) != 2 {
+		klog.V(1).Infof("Bad CloneRequest Annotation %s", ann)
+		exists = false
+		return
+	}
+
+	namespace, name = sp[0], sp[1]
+	return
 }
 
 // ValidateCanCloneSourceAndTargetSpec validates the specs passed in are compatible for cloning.
@@ -610,7 +608,7 @@ func ValidateCanCloneSourceAndTargetSpec(sourceSpec, targetSpec *v1.PersistentVo
 	targetRequest := targetSpec.Resources.Requests[v1.ResourceStorage]
 	// Verify that the target PVC size is equal or larger than the source.
 	if sourceRequest.Value() > targetRequest.Value() {
-		return errors.New("Target resources requests storage size is smaller than the source")
+		return errors.New("target resources requests storage size is smaller than the source")
 	}
 	// Verify that the source and target volume modes are the same.
 	sourceVolumeMode := v1.PersistentVolumeFilesystem
@@ -622,7 +620,7 @@ func ValidateCanCloneSourceAndTargetSpec(sourceSpec, targetSpec *v1.PersistentVo
 		targetVolumeMode = v1.PersistentVolumeBlock
 	}
 	if sourceVolumeMode != targetVolumeMode {
-		return errors.New("Source and target volume modes do not match")
+		return errors.New("source and target volume modes do not match")
 	}
 	// Can clone.
 	return nil
@@ -671,10 +669,10 @@ func DecodePublicKey(keyBytes []byte) (*rsa.PublicKey, error) {
 }
 
 // CreateCloneSourcePod creates our cloning src pod which will be used for out of band cloning to read the contents of the src PVC
-func CreateCloneSourcePod(client kubernetes.Interface, image string, pullPolicy string, cr string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
-	sourcePvcNamespace, sourcePvcName := ParseSourcePvcAnnotation(cr, "/")
-	if sourcePvcNamespace == "" || sourcePvcName == "" {
-		return nil, errors.Errorf("Bad CloneRequest Annotation")
+func CreateCloneSourcePod(client kubernetes.Interface, image, pullPolicy, clientName string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
+	exists, sourcePvcNamespace, sourcePvcName := ParseCloneRequestAnnotation(pvc)
+	if !exists {
+		return nil, errors.Errorf("bad CloneRequest Annotation")
 	}
 
 	ownerKey, err := cache.MetaNamespaceKeyFunc(pvc)
@@ -682,12 +680,32 @@ func CreateCloneSourcePod(client kubernetes.Interface, image string, pullPolicy 
 		return nil, errors.Wrap(err, "error getting cache key")
 	}
 
-	keyCertBytes, err := keys.GetKeyPairAndCertBytes(client, util.GetNamespace(), uploadServerClientKeySecret)
+	serverCACertBytes, err := keys.GetKeyPairAndCertBytes(client, util.GetNamespace(), uploadServerCASecret)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting upload server client certs")
+		return nil, errors.Wrap(err, "error getting uploadserver server certs")
 	}
 
-	pod := MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerKey, keyCertBytes, pvc)
+	if serverCACertBytes == nil {
+		return nil, errors.Errorf("secret %s does not exist", uploadServerCASecret)
+	}
+
+	clientCAKeyPair, err := keys.GetKeyPairAndCert(client, util.GetNamespace(), uploadServerClientCASecret)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting uploadserver client CA certs")
+	}
+
+	if clientCAKeyPair == nil {
+		return nil, errors.Errorf("secret %s does not exist", uploadServerClientCASecret)
+	}
+
+	clientKeyBytes, clientCertBytes, err := createClientKeyAndCertFunc(&clientCAKeyPair.KeyPair, clientName, []string{})
+	if err != nil {
+		return nil, err
+	}
+
+	pod := MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerKey,
+		clientKeyBytes, clientCertBytes, serverCACertBytes.Cert, pvc)
+
 	pod, err = client.CoreV1().Pods(sourcePvcNamespace).Create(pod)
 	if err != nil {
 		return nil, errors.Wrap(err, "source pod API create errored")
@@ -700,7 +718,7 @@ func CreateCloneSourcePod(client kubernetes.Interface, image string, pullPolicy 
 
 // MakeCloneSourcePodSpec creates and returns the clone source pod spec based on the target pvc.
 func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerRefAnno string,
-	keyCertBytes *keys.KeyPairAndCertBytes, pvc *v1.PersistentVolumeClaim) *v1.Pod {
+	clientKey, clientCert, serverCACert []byte, pvc *v1.PersistentVolumeClaim) *v1.Pod {
 
 	var ownerID string
 	podName := fmt.Sprintf("%s-%s-", common.ClonerSourcePodName, sourcePvcName)
@@ -736,17 +754,21 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerRefAnno strin
 					Image:           image,
 					ImagePullPolicy: v1.PullPolicy(pullPolicy),
 					Env: []v1.EnvVar{
+						/*
+						 Easier to just stick key/certs in env vars directly no.
+						 Maybe revisit when we fix the "naming things" problem.
+						*/
 						{
 							Name:  "CLIENT_KEY",
-							Value: string(keyCertBytes.PrivateKey),
+							Value: string(clientKey),
 						},
 						{
 							Name:  "CLIENT_CERT",
-							Value: string(keyCertBytes.Cert),
+							Value: string(clientCert),
 						},
 						{
 							Name:  "SERVER_CA_CERT",
-							Value: string(keyCertBytes.CACert),
+							Value: string(serverCACert),
 						},
 						{
 							Name:  "UPLOAD_URL",
@@ -826,26 +848,33 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerRefAnno strin
 	return pod
 }
 
+// UploadPodArgs are the parameters required to create an upload pod
+type UploadPodArgs struct {
+	Client         kubernetes.Interface
+	CAKeyPair      *triple.KeyPair
+	ClientCACert   *x509.Certificate
+	Image          string
+	Verbose        string
+	PullPolicy     string
+	Name           string
+	PVC            *v1.PersistentVolumeClaim
+	ScratchPVCName string
+	ClientName     string
+}
+
 // CreateUploadPod creates upload service pod manifest and sends to server
-func CreateUploadPod(client kubernetes.Interface,
-	caKeyPair *triple.KeyPair,
-	clientCACert *x509.Certificate,
-	image string,
-	verbose string,
-	pullPolicy string,
-	name string,
-	pvc *v1.PersistentVolumeClaim,
-	scratchPvcName string) (*v1.Pod, error) {
-	ns := pvc.Namespace
-	commonName := name + "." + ns
-	secretName := name + "-server-tls"
+func CreateUploadPod(args UploadPodArgs) (*v1.Pod, error) {
+	ns := args.PVC.Namespace
+	commonName := args.Name + "." + ns
+	secretName := args.Name + "-server-tls"
 
-	pod := MakeUploadPodSpec(image, verbose, pullPolicy, name, pvc, scratchPvcName, secretName)
+	pod := makeUploadPodSpec(args.Image, args.Verbose, args.PullPolicy, args.Name,
+		args.PVC, args.ScratchPVCName, secretName, args.ClientName)
 
-	pod, err := client.CoreV1().Pods(ns).Create(pod)
+	pod, err := args.Client.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			pod, err = client.CoreV1().Pods(ns).Get(name, metav1.GetOptions{})
+			pod, err = args.Client.CoreV1().Pods(ns).Get(args.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, errors.Wrap(err, "upload pod should exist but couldn't retrieve it")
 			}
@@ -855,15 +884,16 @@ func CreateUploadPod(client kubernetes.Interface,
 	}
 
 	podOwner := MakePodOwnerReference(pod)
-	_, err = keys.GetOrCreateServerKeyPairAndCert(client, ns, secretName, caKeyPair, clientCACert, commonName, name, &podOwner)
+	_, err = keys.GetOrCreateServerKeyPairAndCert(args.Client, ns, secretName,
+		args.CAKeyPair, args.ClientCACert, commonName, args.Name, &podOwner)
 	if err != nil {
 		// try to clean up
-		client.CoreV1().Pods(ns).Delete(pod.Name, &metav1.DeleteOptions{})
+		args.Client.CoreV1().Pods(ns).Delete(pod.Name, &metav1.DeleteOptions{})
 
-		return nil, errors.Wrap(err, "Error creating server key pair")
+		return nil, errors.Wrap(err, "error creating server key pair")
 	}
 
-	klog.V(1).Infof("upload pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, image)
+	klog.V(1).Infof("upload pod \"%s/%s\" (image: %q) created\n", pod.Namespace, pod.Name, args.Image)
 	return pod, nil
 }
 
@@ -895,8 +925,8 @@ func MakePodOwnerReference(pod *v1.Pod) metav1.OwnerReference {
 	}
 }
 
-// MakeUploadPodSpec creates upload service pod manifest
-func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.PersistentVolumeClaim, scratchName, secretName string) *v1.Pod {
+func makeUploadPodSpec(image, verbose, pullPolicy, name string,
+	pvc *v1.PersistentVolumeClaim, scratchName, secretName, clientName string) *v1.Pod {
 	requestImageSize, _ := getRequestedImageSize(pvc)
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -963,6 +993,10 @@ func MakeUploadPodSpec(image, verbose, pullPolicy, name string, pvc *v1.Persiste
 						{
 							Name:  common.UploadImageSize,
 							Value: requestImageSize,
+						},
+						{
+							Name:  "CLIENT_NAME",
+							Value: clientName,
 						},
 					},
 					Args: []string{"-v=" + verbose},
@@ -1058,7 +1092,7 @@ func CreateUploadService(client kubernetes.Interface, name string, pvc *v1.Persi
 				return nil, errors.Wrap(err, "upload service should exist but couldn't retrieve it")
 			}
 		} else {
-			return nil, errors.Wrap(err, "upload pod API create errored")
+			return nil, errors.Wrap(err, "upload service API create errored")
 		}
 	}
 	klog.V(1).Infof("upload service \"%s/%s\" created\n", service.Namespace, service.Name)
@@ -1119,7 +1153,7 @@ func EnsureCDIConfigExists(client kubernetes.Interface, cdiClient clientset.Inte
 
 	err := operator.SetOwner(client, cfg)
 	if err != nil {
-		return errors.Wrap(err, "Error setting CDI config owner ref")
+		return errors.Wrap(err, "error setting CDI config owner ref")
 	}
 
 	config, err := cdiClient.CdiV1alpha1().CDIConfigs().Create(cfg)
@@ -1172,7 +1206,7 @@ func deletePod(req podDeleteRequest) error {
 	if err != nil {
 		klog.V(1).Infof("error encountered deleting pod (%s): %s", req.podName, err.Error())
 	}
-	return err
+	return errors.Wrapf(err, "error deleting pod %s/%s", req.namespace, req.podName)
 }
 
 func createImportEnvVar(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (*importPodEnvVar, error) {
@@ -1364,7 +1398,45 @@ func isPodReady(pod *v1.Pod) bool {
 			numReady++
 		}
 	}
+
 	return numReady == len(pod.Status.ContainerStatuses)
+}
+
+func addFinalizer(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, name string) (*v1.PersistentVolumeClaim, error) {
+	if hasFinalizer(pvc, name) {
+		return pvc, nil
+	}
+
+	cpy := pvc.DeepCopy()
+	cpy.Finalizers = append(cpy.Finalizers, name)
+	pvc, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(cpy)
+	if err != nil {
+		return nil, errors.Wrap(err, "error updating PVC")
+	}
+
+	return pvc, nil
+}
+
+func removeFinalizer(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim, name string) (*v1.PersistentVolumeClaim, error) {
+	if !hasFinalizer(pvc, name) {
+		return pvc, nil
+	}
+
+	var finalizers []string
+	for _, f := range pvc.Finalizers {
+		if f != name {
+			finalizers = append(finalizers, f)
+		}
+	}
+
+	cpy := pvc.DeepCopy()
+	cpy.Finalizers = finalizers
+	pvc, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(cpy)
+	if err != nil {
+		return nil, errors.Wrap(err, "error updating PVC")
+	}
+
+	return pvc, nil
 }
 
 func hasFinalizer(object metav1.Object, value string) bool {
@@ -1374,4 +1446,13 @@ func hasFinalizer(object metav1.Object, value string) bool {
 		}
 	}
 	return false
+}
+
+func podPhaseFromPVC(pvc *v1.PersistentVolumeClaim) v1.PodPhase {
+	phase := pvc.ObjectMeta.Annotations[AnnPodPhase]
+	return v1.PodPhase(phase)
+}
+
+func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
+	return (podPhaseFromPVC(pvc) == v1.PodSucceeded)
 }

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -467,61 +466,6 @@ func Test_getSecretName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_getCloneRequestPVCAnnotation(t *testing.T) {
-	tests := []struct {
-		name       string
-		wantOk     bool
-		annKey     string
-		annValue   string
-		annErrType string
-	}{
-		{
-			name:       "pvc without annotation should return error",
-			wantOk:     false,
-			annKey:     "",
-			annValue:   "",
-			annErrType: "missing",
-		},
-		{
-			name:       "pvc with blank annotation should return error",
-			wantOk:     false,
-			annKey:     AnnCloneRequest,
-			annValue:   "",
-			annErrType: "empty",
-		},
-		{
-			name:       "pvc with valid clone annotation",
-			wantOk:     true,
-			annKey:     AnnCloneRequest,
-			annValue:   "default/pvc-name",
-			annErrType: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pvc := createPvc("test", "default", map[string]string{tt.annKey: tt.annValue}, nil)
-			ann, err := getCloneRequestPVCAnnotation(pvc)
-			if !tt.wantOk && err == nil {
-				t.Error("Got no error when expecting one")
-			} else if tt.wantOk && err != nil {
-				t.Errorf("Got error %+v when not expecting one", err)
-			}
-			if !tt.wantOk && err != nil {
-				// Verify that the error contains what we are expecting.
-				if !strings.Contains(err.Error(), tt.annErrType) {
-					t.Errorf("Expecting error message to contain %s, but not found", tt.annErrType)
-				}
-			} else if tt.wantOk && err == nil {
-				if ann != tt.annValue {
-					t.Error("expected annotation did not match found annotation")
-				}
-			}
-		})
-	}
-
 }
 
 func Test_updatePVC(t *testing.T) {
@@ -1334,6 +1278,7 @@ func createPvcInStorageClass(name, ns string, storageClassName *string, annotati
 }
 
 func createScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassName string) *v1.PersistentVolumeClaim {
+	t := true
 	labels := map[string]string{
 		"cdi-controller": pod.Name,
 		"app":            "containerized-data-importer",
@@ -1347,10 +1292,12 @@ func createScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassNa
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Name:       pod.Name,
-					UID:        pod.GetUID(),
+					APIVersion:         "v1",
+					Kind:               "Pod",
+					Name:               pod.Name,
+					UID:                pod.GetUID(),
+					Controller:         &t,
+					BlockOwnerDeletion: &t,
 				},
 			},
 		},
@@ -1406,6 +1353,7 @@ func createClonePvcWithSize(sourceNamespace, sourceName, targetNamespace, target
 
 	annotations[AnnCloneRequest] = fmt.Sprintf("%s/%s", sourceNamespace, sourceName)
 	annotations[AnnCloneToken] = tokenString
+	annotations[AnnUploadClientName] = "FOOBAR"
 
 	return &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1543,54 +1491,8 @@ func createImportController(pvcSpec *v1.PersistentVolumeClaim, podSpec *v1.Pod, 
 	return c, pvc, pod, nil
 }
 
-func createCloneController(pvcSpec *v1.PersistentVolumeClaim, sourcePodSpec *v1.Pod, targetPodSpec *v1.Pod, targetNs, sourceNs string) (*CloneController, *v1.PersistentVolumeClaim, *v1.Pod, *v1.Pod, error) {
-	//Set up environment
-	myclient := k8sfake.NewSimpleClientset()
-
-	//create staging pvc and pods
-	pvc, err := myclient.CoreV1().PersistentVolumeClaims(targetNs).Create(pvcSpec)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("createImportController: failed to initialize and create pvc error = %v", err)
-	}
-
-	sourcePod, err := myclient.CoreV1().Pods(sourceNs).Create(sourcePodSpec)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("createCloneController: failed to initialize and create source pod error = %v", err)
-	}
-	targetPod, err := myclient.CoreV1().Pods(targetNs).Create(targetPodSpec)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("createCloneController: failed to initialize and create target pod error = %v", err)
-	}
-
-	// create informers and queue
-	k8sI := kubeinformers.NewSharedInformerFactory(myclient, noResyncPeriodFunc())
-
-	pvcInformer := k8sI.Core().V1().PersistentVolumeClaims()
-	podInformer := k8sI.Core().V1().Pods()
-
-	pvcQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	pvcQueue.Add(pvc)
-
-	k8sI.Core().V1().PersistentVolumeClaims().Informer().GetIndexer().Add(pvc)
-	k8sI.Core().V1().Pods().Informer().GetIndexer().Add(sourcePod)
-	k8sI.Core().V1().Pods().Informer().GetIndexer().Add(targetPod)
-
-	//run the informers
-	stop := make(chan struct{})
-	go pvcInformer.Informer().Run(stop)
-	go podInformer.Informer().Run(stop)
-	cache.WaitForCacheSync(stop, podInformer.Informer().HasSynced)
-	cache.WaitForCacheSync(stop, pvcInformer.Informer().HasSynced)
-	defer close(stop)
-
-	key := &getAPIServerKey().PublicKey
-
-	c := NewCloneController(myclient, pvcInformer, podInformer, "test/mycloneimage", "Always", "-v=5", key)
-	return c, pvc, sourcePod, targetPod, nil
-}
-
 func createSourcePod(pvc *v1.PersistentVolumeClaim, pvcUID string) *v1.Pod {
-	_, sourcePvcName := ParseSourcePvcAnnotation(pvc.GetAnnotations()[AnnCloneRequest], "/")
+	_, _, sourcePvcName := ParseCloneRequestAnnotation(pvc)
 	podName := fmt.Sprintf("%s-%s-", common.ClonerSourcePodName, sourcePvcName)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1619,15 +1521,15 @@ func createSourcePod(pvc *v1.PersistentVolumeClaim, pvcUID string) *v1.Pod {
 					Env: []v1.EnvVar{
 						{
 							Name:  "CLIENT_KEY",
-							Value: string(testUploadServerClientKeySecret.Data["tls.key"]),
+							Value: "foo",
 						},
 						{
 							Name:  "CLIENT_CERT",
-							Value: string(testUploadServerClientKeySecret.Data["tls.crt"]),
+							Value: "bar",
 						},
 						{
 							Name:  "SERVER_CA_CERT",
-							Value: string(testUploadServerClientKeySecret.Data["ca.crt"]),
+							Value: string(testUploadServerCASecret.Data["tls.crt"]),
 						},
 						{
 							Name:  "UPLOAD_URL",
@@ -1720,7 +1622,7 @@ func getPvcKey(pvc *corev1.PersistentVolumeClaim, t *testing.T) string {
 }
 
 func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
-	pod := createUploadClonePod(pvc)
+	pod := createUploadClonePod(pvc, "client.upload-server.cdi.kubevirt.io")
 	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
 		Name: ScratchVolName,
 		VolumeSource: v1.VolumeSource{
@@ -1737,7 +1639,7 @@ func createUploadPod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 	return pod
 }
 
-func createUploadClonePod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
+func createUploadClonePod(pvc *v1.PersistentVolumeClaim, clientName string) *v1.Pod {
 	name := "cdi-upload-" + pvc.Name
 	secretName := name + "-server-tls"
 	requestImageSize, _ := getRequestedImageSize(pvc)
@@ -1814,6 +1716,10 @@ func createUploadClonePod(pvc *v1.PersistentVolumeClaim) *v1.Pod {
 						{
 							Name:  common.UploadImageSize,
 							Value: requestImageSize,
+						},
+						{
+							Name:  "CLIENT_NAME",
+							Value: clientName,
 						},
 					},
 					Args: []string{"-v=" + "5"},

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1529,7 +1529,7 @@ func createSourcePod(pvc *v1.PersistentVolumeClaim, pvcUID string) *v1.Pod {
 						},
 						{
 							Name:  "SERVER_CA_CERT",
-							Value: string(testUploadServerCASecret.Data["tls.crt"]),
+							Value: string(getUploadServerCASecret().Data["tls.crt"]),
 						},
 						{
 							Name:  "UPLOAD_URL",

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -36,11 +36,11 @@ import (
 )
 
 func newServer() *uploadServerApp {
-	server := NewUploadServer("127.0.0.1", 0, "disk.img", "", "", "", "")
+	server := NewUploadServer("127.0.0.1", 0, "disk.img", "", "", "", "", "")
 	return server.(*uploadServerApp)
 }
 
-func newTLSServer(t *testing.T) (*uploadServerApp, *triple.KeyPair, *x509.Certificate) {
+func newTLSServer(t *testing.T, clientCertName, expectedName string) (*uploadServerApp, *triple.KeyPair, *x509.Certificate) {
 	serverCA, err := triple.NewCA("server")
 	if err != nil {
 		t.Error("Error creating CA")
@@ -60,9 +60,9 @@ func newTLSServer(t *testing.T) (*uploadServerApp, *triple.KeyPair, *x509.Certif
 	tlsCert := string(cert.EncodeCertPEM(serverKeyPair.Cert))
 	clientCert := string(cert.EncodeCertPEM(clientCA.Cert))
 
-	server := NewUploadServer("127.0.0.1", 0, "disk.img", tlsKey, tlsCert, clientCert, "").(*uploadServerApp)
+	server := NewUploadServer("127.0.0.1", 0, "disk.img", tlsKey, tlsCert, clientCert, expectedName, "").(*uploadServerApp)
 
-	clientKeyPair, err := triple.NewClientKeyPair(clientCA, "client", []string{})
+	clientKeyPair, err := triple.NewClientKeyPair(clientCA, clientCertName, []string{})
 	if err != nil {
 		t.Error("Error creating client cert")
 	}
@@ -227,44 +227,63 @@ func TestStreamFail(t *testing.T) {
 	})
 }
 
-func TestRealSuccess(t *testing.T) {
-	withProcessorSuccess(func() {
-		server, clientKeyPair, serverCACert := newTLSServer(t)
+func TestRealUploadWithClient(t *testing.T) {
+	type testData struct {
+		certName, expectedName string
+		expectedResponse       int
+	}
+	for _, data := range []testData{
+		{
+			certName:         "client",
+			expectedName:     "client",
+			expectedResponse: 200,
+		},
+		{
+			certName:         "foo",
+			expectedName:     "bar",
+			expectedResponse: 401,
+		},
+	} {
+		withProcessorSuccess(func() {
+			server, clientKeyPair, serverCACert := newTLSServer(t, data.certName, data.expectedName)
 
-		client := newHTTPClient(t, clientKeyPair, serverCACert)
+			client := newHTTPClient(t, clientKeyPair, serverCACert)
 
-		ch := make(chan struct{})
+			ch := make(chan struct{})
 
-		go func() {
-			server.Run()
-			close(ch)
-		}()
+			go func() {
+				server.Run()
+				close(ch)
+			}()
 
-		for i := 0; i < 10; i++ {
-			if server.bindPort != 0 {
-				break
+			for i := 0; i < 10; i++ {
+				if server.bindPort != 0 {
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
 			}
-			time.Sleep(500 * time.Millisecond)
-		}
 
-		if server.bindPort == 0 {
-			t.Error("Couldn't start http server")
-		}
+			if server.bindPort == 0 {
+				t.Error("Couldn't start http server")
+			}
 
-		url := fmt.Sprintf("https://localhost:%d%s", server.bindPort, common.UploadPath)
-		stringReader := strings.NewReader("nothing")
+			url := fmt.Sprintf("https://localhost:%d%s", server.bindPort, common.UploadPath)
+			stringReader := strings.NewReader("nothing")
 
-		resp, err := client.Post(url, "application/x-www-form-urlencoded", stringReader)
-		if err != nil {
-			close(server.doneChan)
-			t.Errorf("Request failed %+v", err)
-		}
+			resp, err := client.Post(url, "application/x-www-form-urlencoded", stringReader)
+			if err != nil {
+				t.Errorf("Request failed %+v", err)
+			}
 
-		if resp.StatusCode != http.StatusOK {
-			close(server.doneChan)
-			t.Errorf("Unexpected status code %d", resp.StatusCode)
-		}
+			if resp.StatusCode != data.expectedResponse {
+				t.Errorf("Unexpected status code %d wanted %d", resp.StatusCode, data.expectedResponse)
+			}
 
-		<-ch
-	})
+			if !server.done {
+				close(server.doneChan)
+			}
+
+			<-ch
+		})
+	}
 }

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 		targetDv = utils.NewDataVolumeForImageCloning("target-dv", "50Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
 		_, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 		Expect(err).To(HaveOccurred())
-		Expect(strings.Contains(err.Error(), "Target resources requests storage size is smaller than the source")).To(BeTrue())
+		Expect(strings.Contains(err.Error(), "target resources requests storage size is smaller than the source")).To(BeTrue())
 
 		By("Cloning from the source DataVolume to properly sized target")
 		targetDv = utils.NewDataVolumeForImageCloning("target-dv", "500Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
@@ -252,7 +252,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 		targetDv = utils.NewDataVolumeForImageCloning("target-dv", "50Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
 		_, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 		Expect(err).To(HaveOccurred())
-		Expect(strings.Contains(err.Error(), "Target resources requests storage size is smaller than the source")).To(BeTrue())
+		Expect(strings.Contains(err.Error(), "target resources requests storage size is smaller than the source")).To(BeTrue())
 
 		By("Cloning from the source DataVolume to properly sized target")
 		targetDv = utils.NewDataVolumeForImageCloning("target-dv", "500Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Clone source pods currently use the same TLS client key/cert as uploadproxy.  This is a potential security concern because an attacker could do the following:

1) Create clone in namespace they have admin/edit access to
2) Get TLS key/cert from clone source pod environment
3) Use key/cert to upload to any uploadserver pod in the cluster

Addressing this by: 

1) Assigning unique CN for each source/target pod combo
2) Uploadserver pod validates CN

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unique TLS key/cert per clone source pod
```

