### PR TITLE
Increase DV state timeout for multiple clone tests

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Validate Data Volume should clone multiple clones in parallel"
 		dvs := []*cdiv1.DataVolume{targetDv1, targetDv2, targetDv3}
 		for _, dv := range dvs {
 			By("Waiting for clone to be completed")
-			err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+			err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 3*90*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			matchFile := filepath.Join(testBaseDir, "disk.img")
 			Expect(f.VerifyTargetPVCContentMD5(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(dv), matchFile, md5sum[:32])).To(BeTrue())
@@ -354,7 +354,7 @@ var _ = Describe("Validate Data Volume should clone multiple clones in parallel"
 		dvs := []*cdiv1.DataVolume{targetDv1, targetDv2, targetDv3}
 		for _, dv := range dvs {
 			By("Waiting for clone to be completed")
-			err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+			err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 3*90*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(f.VerifyTargetPVCContentMD5(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(dv), testBaseDir, md5sum[:32])).To(BeTrue())
 			_, err = utils.WaitPodDeleted(f.K8sClient, "verify-pvc-md5", f.Namespace.Name, verifyPodDeletedTimeout)


### PR DESCRIPTION
In case of a cluster with multiple nodes, the parallel cloning can take more time as the source pods can be scheduled on different nodes and the PVC cannot be attached on different nodes at the same time.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Co-authored-by: Daniel Erez <derez@redhat.com>
Signed-off-by: Fred Rolland <frolland@redhat.com>