### PR TITLE
uploadproxy should use pod ready annotation

### DIFF
--- a/pkg/operator/resources/cluster/uploadproxy.go
+++ b/pkg/operator/resources/cluster/uploadproxy.go
@@ -40,7 +40,7 @@ func GetUploadProxyRolePermissions() []rbacv1.PolicyRule {
 				"",
 			},
 			Resources: []string{
-				"pods",
+				"persistentvolumeclaims",
 			},
 			Verbs: []string{
 				"get",

--- a/pkg/uploadproxy/BUILD.bazel
+++ b/pkg/uploadproxy/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
@@ -23,7 +24,6 @@ go_test(
     srcs = ["uploadproxy_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/controller:go_default_library",
         "//pkg/token:go_default_library",
         "//pkg/util/cert/triple:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -27,16 +28,11 @@ import (
 )
 
 const (
-	// selfsigned cert secret name
-	apiCertSecretName = "cdi-api-certs"
-
-	apiServiceName = "cdi-api"
-
 	uploadPath  = "/v1alpha1/upload"
 	healthzPath = "/healthz"
 
-	connectTimeout = 2 * time.Second
-	connectTries   = 5
+	waitReadyTime     = 10 * time.Second
+	waitReadyImterval = time.Second
 
 	proxyRequestTimeout = time.Hour
 
@@ -178,7 +174,7 @@ func (app *uploadProxyApp) handleUploadRequest(w http.ResponseWriter, r *http.Re
 
 	klog.V(1).Infof("Received valid token: pvc: %s, namespace: %s", tokenData.Name, tokenData.Namespace)
 
-	err = app.uploadPossible(tokenData.Name, tokenData.Namespace)
+	err = app.uploadReady(tokenData.Name, tokenData.Namespace)
 	if err != nil {
 		klog.Error(err)
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -188,30 +184,29 @@ func (app *uploadProxyApp) handleUploadRequest(w http.ResponseWriter, r *http.Re
 	app.proxyUploadRequest(tokenData.Namespace, tokenData.Name, w, r)
 }
 
-func (app *uploadProxyApp) uploadPossible(pvcName, pvcNamespace string) error {
-	podName := controller.GetUploadResourceName(pvcName)
-	pod, err := app.client.CoreV1().Pods(pvcNamespace).Get(podName, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return fmt.Errorf("rejecting Upload Request for Pod %s that doesn't exist", podName)
+func (app *uploadProxyApp) uploadReady(pvcName, pvcNamespace string) error {
+	return wait.PollImmediate(waitReadyImterval, waitReadyTime, func() (bool, error) {
+		pvc, err := app.client.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(pvcName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, fmt.Errorf("rejecting Upload Request for PVC %s that doesn't exist", pvcName)
+			}
+
+			return false, err
 		}
-		return err
-	}
-	phase := pod.Status.Phase
-	if phase == v1.PodSucceeded {
-		return fmt.Errorf("rejecting Upload Request for Pod %s that already finished uploading", podName)
-	}
-	return nil
+
+		phase := v1.PodPhase(pvc.Annotations[controller.AnnPodPhase])
+		if phase == v1.PodSucceeded {
+			return false, fmt.Errorf("rejecting Upload Request for PVC %s that already finished uploading", pvcName)
+		}
+
+		ready, _ := strconv.ParseBool(pvc.Annotations[controller.AnnPodReady])
+		return ready, nil
+	})
 }
 
 func (app *uploadProxyApp) proxyUploadRequest(namespace, pvc string, w http.ResponseWriter, r *http.Request) {
 	url := app.urlResolver(namespace, pvc)
-
-	if err := app.testConnect(url); err != nil {
-		klog.Errorf("Error connecting to %s: %+v", url, err)
-		w.WriteHeader(http.StatusServiceUnavailable)
-		return
-	}
 
 	req, _ := http.NewRequest("POST", url, r.Body)
 	req.ContentLength = r.ContentLength
@@ -232,46 +227,6 @@ func (app *uploadProxyApp) proxyUploadRequest(namespace, pvc string, w http.Resp
 	if err != nil {
 		klog.Warningf("Error proxying response from url %s", url)
 	}
-}
-
-func (app *uploadProxyApp) testConnect(urlString string) error {
-	u, err := url.Parse(urlString)
-	if err != nil {
-		return errors.Wrapf(err, "error parsing URL %s", urlString)
-	}
-
-	port := u.Port()
-	if port == "" {
-		p, err := net.LookupPort("tcp", u.Scheme)
-		if err != nil {
-			return errors.Wrapf(err, "error looking up scheme %s", u.Scheme)
-		}
-		port = fmt.Sprintf("%d", p)
-	}
-	hostPort := net.JoinHostPort(u.Hostname(), port)
-
-	for i := 1; i <= connectTries; i++ {
-		d := net.Dialer{Timeout: connectTimeout}
-		conn, err := d.Dial("tcp", hostPort)
-		if err == nil {
-			klog.V(3).Infof("Successfully connected to %s on attempt %d", urlString, i)
-			conn.Close()
-			return nil
-		}
-
-		switch ne := err.(type) {
-		case net.Error:
-			if ne.Timeout() {
-				klog.V(3).Infof("Timeout connecting to %s on iteration %d", hostPort, i)
-				continue
-			}
-			klog.V(3).Infof("Unexpected net error connecting to %s on iteration %d %+v", hostPort, i, err)
-		default:
-			klog.V(3).Infof("Unexpected error connecting to %s on iteration %d %+v", hostPort, i, err)
-		}
-	}
-
-	return errors.Errorf("timed out %d times connecting to %s", connectTries, urlString)
 }
 
 func (app *uploadProxyApp) getSigningKey(publicKeyPEM string) error {

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -69,13 +69,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	})
 
 	DescribeTable("should", func(validToken bool, expectedStatus int) {
-
-		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*90)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Verify PVC status annotation says running")
-		found, err := utils.WaitPVCPodStatusRunning(f.K8sClient, pvc)
+		By("Verify PVC annotation says ready")
+		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
 
@@ -119,12 +114,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Entry("[posneg:negative][test_id:1369]fail given an invalid token", false, http.StatusUnauthorized),
 	)
 	It("Verify upload to the same pvc fails", func() {
-		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*90)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Verify PVC status annotation says running")
-		found, err := utils.WaitPVCPodStatusRunning(f.K8sClient, pvc)
+		By("Verify PVC annotation says ready")
+		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
 
@@ -250,12 +241,9 @@ var _ = Describe("Block PV upload Test", func() {
 		if !f.IsBlockVolumeStorageClassAvailable() {
 			Skip("Storage Class for block volume is not available")
 		}
-		By("Verify that upload server POD running")
-		err := f.WaitTimeoutForPodReady(utils.UploadPodName(pvc), time.Second*90)
-		Expect(err).ToNot(HaveOccurred())
 
-		By("Verify PVC status annotation says running")
-		found, err := utils.WaitPVCPodStatusRunning(f.K8sClient, pvc)
+		By("Verify PVC annotation says ready")
+		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
 

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strconv"
 	"time"
 
 	"fmt"
@@ -122,6 +123,11 @@ func WaitPVCPodStatusSucceeded(clientSet *kubernetes.Clientset, pvc *k8sv1.Persi
 // WaitPVCPodStatusFailed waits for the pod status annotation to be Failed
 func WaitPVCPodStatusFailed(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
 	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadStatusAnnotation, string(k8sv1.PodFailed))
+}
+
+// WaitPVCPodStatusReady waits for the pod ready annotation to be true
+func WaitPVCPodStatusReady(clientSet *kubernetes.Clientset, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
+	return WaitForPVCAnnotationWithValue(clientSet, pvc.Namespace, pvc, uploadReadyAnnotation, strconv.FormatBool(true))
 }
 
 type pollPVCAnnotationFunc = func(string) bool

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -24,6 +24,7 @@ const (
 
 	uploadTargetAnnotation = "cdi.kubevirt.io/storage.upload.target"
 	uploadStatusAnnotation = "cdi.kubevirt.io/storage.pod.phase"
+	uploadReadyAnnotation  = "cdi.kubevirt.io/storage.pod.ready"
 )
 
 // UploadPodName returns the name of the upload server pod associated with a PVC


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The upload controller sets "ready" annotation on a PVC when the Pod should be ready to accept uploads.  This is a better thing to check than whatever we were doing before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This may help with flaky upload tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

