### PR TITLE
Use an existing bazel-builder image instead of building it every time

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -21,9 +21,6 @@ source "${script_dir}"/config.sh
 
 BUILDER_SPEC="${BUILD_DIR}/docker/builder"
 
-#TODO remove me and use the one from config.sh
-BUILDER_TAG="kubevirt/kubevirt-cdi-bazel-builder"
-
 # Build the encapsulated compile and test container
 (cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_TAG} .)
 echo "Image: ${BUILDER_TAG}"

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -17,10 +17,10 @@
 set -e
 script_dir="$(readlink -f $(dirname $0))"
 source "${script_dir}"/common.sh
+source "${script_dir}"/config.sh
 
 WORK_DIR="/go/src/kubevirt.io/containerized-data-importer"
 BUILDER_SPEC="${BUILD_DIR}/docker/builder"
-BUILDER_TAG="kubevirt-cdi-bazel-builder"
 BUILDER_VOLUME="kubevirt-cdi-volume"
 BAZEL_BUILDER_SERVER="${BUILDER_VOLUME}-bazel-server"
 
@@ -30,9 +30,6 @@ if [ -n "${TRAVIS_JOB_ID}" ]; then
 common --noshow_progress --noshow_loading_progress
 EOF
 fi
-
-# Build the encapsulated compile and test container
-(cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_TAG} .)
 
 # Create the persistent docker volume
 if [ -z "$(docker volume list | grep ${BUILDER_VOLUME})" ]; then

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -24,6 +24,7 @@ FUNC_TEST_HTTP="cdi-func-test-file-host-http"
 FUNC_TEST_REGISTRY="cdi-func-test-registry"
 FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
+BUILDER_TAG=${BUILDER_TAG:-kubevirt/kubevirt-cdi-bazel-builder@sha256:38e449bb8f5e2e3dc8ae241323c69ce37e72bd98a109d2032955dd9bd0e0a545}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT}"
 CDI_PKGS="cmd/ pkg/ test/"

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -18,13 +18,9 @@ set -e
 
 script_dir="$(readlink -f $(dirname $0))"
 source "${script_dir}"/common.sh
+source "${script_dir}"/config.sh
 
 WORK_DIR="/go/src/kubevirt.io/containerized-data-importer"
-BUILDER_SPEC="${BUILD_DIR}/docker/builder"
-BUILDER_TAG="kubevirt-cdi-bazel-builder"
-
-# Build the encapsulated compile and test container
-(cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_TAG} .)
 
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"


### PR DESCRIPTION
Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

