### PR TITLE
Don't fail immediately when Local is not found when syncing.

### DIFF
--- a/cluster-sync/okd-4.1/provider.sh
+++ b/cluster-sync/okd-4.1/provider.sh
@@ -7,6 +7,7 @@ function seed_images(){
 }
 
 function configure_local_storage() {
+  set +e
   retry_counter=0
   sc=`_kubectl get sc local -o=jsonpath="{.metadata.name}"`
   all_sc=`_kubectl get sc`
@@ -24,5 +25,6 @@ function configure_local_storage() {
 
   #Set the default storage class. If the above timed out, this will fail and abort the sync
   _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  set -e
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
cluster sync would fail if the Local storage was not available fast enough due to set -e, this disables set -e while waiting for Local storage class to become available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

