### PR TITLE
Update the kubevirtci OKD image to fix cert issue.

### DIFF
--- a/cluster-up/cluster/okd-4.1/provider.sh
+++ b/cluster-up/cluster/okd-4.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1@sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
+image="okd-4.1@sha256:b26decaf0454cc1f99b39b9bc991f715a8d6d8e97499db5a2d40f778430972f7"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -49,7 +49,7 @@ ${CODEGEN_PKG}/generate-groups.sh "client,informer,lister" \
 ${SCRIPT_ROOT}/bin/openapi-spec-generator > ${SCRIPT_ROOT}/api/openapi-spec/swagger.json
 
 # the kubevirtci commit hash to vendor from
-kubevirtci_git_hash=dc4f3bb2d745377ede5dfbbc9f6fd127338a7cb4
+kubevirtci_git_hash=939594520a1ca5726b8aaeb2c1685d27e0b3687e
 
 # remove previous cluster-up dir entirely before vendoring
 rm -rf cluster-up


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update OKD lane to use image with working certs: https://github.com/kubevirt/kubevirtci/pull/172

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

