### PR TITLE
Replace current ceph install with operator based rook-ceph.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -37,7 +37,8 @@ export KUBEVIRT_PROVIDER=$TARGET
 if [[ $TARGET =~ openshift-.* ]]; then
   export KUBEVIRT_PROVIDER="os-3.11.0-crio"
 elif [[ $TARGET =~ k8s-.* ]]; then
-  export KUBEVIRT_PROVIDER_EXTRA_ARGS="--enable-ceph"
+  export KUBEVIRT_NUM_NODES=2
+  export KUBEVIRT_MEMORY_SIZE=8192
 fi
 
 if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then

--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -30,6 +30,6 @@ function verify() {
   echo "cluster node are ready!"
 }
 
-function configure_local_storage() {
-  echo "Local storage already configured ..."
+function configure_storage() {
+  echo "Storage already configured ..."
 }

--- a/cluster-sync/external/provider.sh
+++ b/cluster-sync/external/provider.sh
@@ -19,7 +19,7 @@ function up() {
   echo "using external provider"
 }
 
-function configure_local_storage() {
+function configure_storage() {
   echo "Local storage not needed for external provider..."
 }
 

--- a/cluster-sync/k8s-1.15.1/ceph_sc.yaml
+++ b/cluster-sync/k8s-1.15.1/ceph_sc.yaml
@@ -1,0 +1,33 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: rook-ceph-block
+   annotations:
+     storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+    # clusterID is the namespace where the rook cluster is running
+    # If you change this namespace, also change the namespace below where the secret namespaces are defined
+    clusterID: rook-ceph
+
+    # Ceph pool into which the RBD image shall be created
+    pool: replicapool
+
+    # RBD image format. Defaults to "2".
+    imageFormat: "2"
+
+    # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
+    imageFeatures: layering
+
+    # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+    # in the same namespace as the cluster.
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    # Specify the filesystem type of the volume. If not specified, csi-provisioner
+    # will set default as `ext4`.
+    csi.storage.k8s.io/fstype: xfs
+# uncomment the following to use rbd-nbd as mounter on supported nodes
+#mounter: rbd-nbd
+reclaimPolicy: Delete

--- a/cluster-sync/k8s-1.15.1/rook_ceph.yaml
+++ b/cluster-sync/k8s-1.15.1/rook_ceph.yaml
@@ -1,0 +1,48 @@
+#################################################################################################################
+# Define the settings for the rook-ceph cluster with settings that should only be used in a test environment.
+# A single filestore OSD will be created in the dataDirHostPath.
+# For example, to create the cluster:
+#   kubectl create -f common.yaml
+#   kubectl create -f operator.yaml
+#   kubectl create -f cluster-test.yaml
+#################################################################################################################
+
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  cephVersion:
+    image: ceph/ceph:v14.2.4-20190917
+    allowUnsupported: true
+  dataDirHostPath: /var/lib/rook
+  skipUpgradeChecks: false
+  mon:
+    count: 1
+    allowMultiplePerNode: true
+  dashboard:
+    enabled: true
+    ssl: true
+  monitoring:
+    enabled: false  # requires Prometheus to be pre-installed
+    rulesNamespace: rook-ceph
+  network:
+    hostNetwork: false
+  rbdMirroring:
+    workers: 0
+  mgr:
+    modules:
+    # the pg_autoscaler is only available on nautilus or newer. remove this if testing mimic.
+    - name: pg_autoscaler
+      enabled: true
+  storage:
+    useAllNodes: true
+    useAllDevices: false
+    deviceFilter:
+    config:
+      databaseSizeMB: "1024" # this value can be removed for environments with normal sized disks (100 GB or larger)
+      journalSizeMB: "1024"  # this value can be removed for environments with normal sized disks (20 GB or larger)
+      osdsPerDevice: "1" # this value can be overridden at the node or device level
+    directories:
+    - path: /var/lib/rook

--- a/cluster-sync/okd-4.1/provider.sh
+++ b/cluster-sync/okd-4.1/provider.sh
@@ -6,7 +6,7 @@ function seed_images(){
   echo "seed_images is a noop for okd4.1"
 }
 
-function configure_local_storage() {
+function configure_storage() {
   set +e
   retry_counter=0
   sc=`_kubectl get sc local -o=jsonpath="{.metadata.name}"`

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -38,7 +38,7 @@ DOCKER_PREFIX=$DOCKER_PREFIX make push
 
 seed_images
 
-configure_local_storage
+configure_storage
 
 # Install CDI
 install_cdi

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-logr/logr v0.0.0-20190813230443-d63354a31b29
 	github.com/go-logr/zapr v0.0.0-20190813212058-2e515ec1daf7 // indirect
 	github.com/go-openapi/spec v0.19.2
-	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
@@ -31,7 +30,6 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190626212234-73c00f855607
 	github.com/operator-framework/operator-marketplace v0.0.0-20190617165322-1cbd32624349
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
@@ -45,9 +43,7 @@ require (
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4

--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -35,8 +35,8 @@ KUBECTL=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 GOCLI=${GOCLI:-${CDI_DIR}/cluster-up/cli.sh}
 KUBE_MASTER_URL=${KUBE_MASTER_URL:-""}
 CDI_NAMESPACE=${CDI_NAMESPACE:-cdi}
-SNAPSHOT_SC=${SNAPSHOT_SC:-csi-rbd}
-BLOCK_SC=${BLOCK_SC:-csi-rbd}
+SNAPSHOT_SC=${SNAPSHOT_SC:-rook-ceph-block}
+BLOCK_SC=${BLOCK_SC:-rook-ceph-block}
 
 # parsetTestOpts sets 'pkgs' and test_args
 parseTestOpts "${@}"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replace the kubevirtci ceph installation with a ceph rook based one that we can debug and we know is the latest.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

