### PR TITLE
doc: Clarify supported kubevirt formats

### DIFF
--- a/doc/supported_operations.md
+++ b/doc/supported_operations.md
@@ -3,7 +3,7 @@ The Containerized Data Importer (CDI) supports importing data/disk images from a
 
 ## Supported matrix
 
-The first column represents the available content-types, Kubevirt and Archive. Kubevirt is broken down into QCOW2 vs RAW. QCOW2 needs to be converted before being written to the DV (and in a lot of cases requires scratch space for this conversion), where RAW doesn't need conversion and can be written directly to the DV.
+The first column represents the available content-types, Kubevirt and Archive. Kubevirt is broken down into QCOW2 vs RAW.  CDI can detect QCOW2 files (even when compressed.  Any file that is not identified as a QCOW2 disk image is assumed to be a RAW disk image.  This means that you can not encapsulate a disk image inside of a tar archive.  QCOW2 needs to be converted before being written to the DV (and in a lot of cases requires scratch space for this conversion), where RAW doesn't need conversion and can be written directly to the DV.
 
 | | http | https | http basic auth | Registry | S3 Bucket | Upload |
 |--------------|---------|-|--|-------|--------|------------|


### PR DESCRIPTION
Update the support matrix to clarify how files are handled when
content-type is kubevirt and to explicitly state that disk images should
not be encapsulated in a tar archive.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

