### PR TITLE
Requeue on failure like sample k8s controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-logr/logr v0.0.0-20190813230443-d63354a31b29
 	github.com/go-logr/zapr v0.0.0-20190813212058-2e515ec1daf7 // indirect
 	github.com/go-openapi/spec v0.19.2
-	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
@@ -31,7 +30,6 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190626212234-73c00f855607
 	github.com/operator-framework/operator-marketplace v0.0.0-20190617165322-1cbd32624349
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
@@ -45,9 +43,7 @@ require (
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -222,7 +222,10 @@ func (cc *CloneController) ProcessNextPvcItem() bool {
 	defer cc.queue.Done(key)
 
 	err := cc.syncPvc(key.(string))
-	if err != nil { // processPvcItem errors may not have been logged so log here
+	if err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		cc.queue.AddRateLimited(key.(string))
+		// processPvcItem errors may not have been logged so log here
 		klog.Errorf("error processing pvc %q: %v", key, err)
 		return true
 	}

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -200,6 +200,8 @@ func (c *ConfigController) processNextWorkItem() bool {
 		}
 
 		if err := c.syncHandler(key); err != nil {
+			// Put the item back on the workqueue to handle any transient errors.
+			c.queue.AddRateLimited(key)
 			return errors.Errorf("error syncing '%s': %s", key, err.Error())
 		}
 

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -304,6 +304,7 @@ func (c *DataVolumeController) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// DataVolume resource to be synced.
 		if err := c.syncHandler(key); err != nil {
+			c.workqueue.AddRateLimited(key)
 			return errors.Errorf("error syncing '%s': %s", key, err.Error())
 		}
 		// Finally, if no error occurs we Forget this item so it does not

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -293,7 +293,10 @@ func (ic *ImportController) ProcessNextPvcItem() bool {
 	defer ic.queue.Done(key)
 
 	err := ic.syncPvc(key.(string))
-	if err != nil { // processPvcItem errors may not have been logged so log here
+	if err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		ic.queue.AddRateLimited(key.(string))
+		// processPvcItem errors may not have been logged so log here
 		klog.Errorf("error processing pvc %q: %v", key, err)
 		return true
 	}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -332,6 +332,8 @@ func (c *UploadController) processNextWorkItem() bool {
 		}
 
 		if err := c.syncHandler(key); err != nil {
+			// Put the item back on the workqueue to handle any transient errors.
+			c.queue.AddRateLimited(key)
 			return err
 		}
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes requeuing of objects for processing on failure. The sample controller https://github.com/kubernetes/sample-controller/blob/master/controller.go#L219-L223 shows we should requeue on failure.

Note this doesn't include the smart clone controller
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Controllers now properly requeue objects on failures.
```

