### PR TITLE
Update documentation that --extra-args=--enable-ceph is no longer nee…

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -133,7 +133,7 @@ Environment Variables and Supported Values
 | Env Variable       | Default       | Additional Values           |
 |--------------------|---------------|-----------------------------|
 |KUBEVIRT_PROVIDER   | k8s-1.15.1    | os-3.11.0-crio or okd-4.1   |
-|KUBEVIRT_PROVIDER_EXTRA_ARGS |      | --enable-ceph (for providers that support this argument like k8s-1.15.1 |
+|KUBEVIRT_PROVIDER_EXTRA_ARGS |      |                             |
 |NUM_NODES           | 1             | 2-5                         |
 
 To Run Standard *cluster-up/kubevirtci* Tests


### PR DESCRIPTION
…ded to enable ceph on k8s

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove documentation stating --enable-ceph is needed to get ceph running in k8s provider, it is now enabled by default when syncing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

