### PR TITLE
Provide a more verbose error.

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -619,7 +619,8 @@ func ValidateCanCloneSourceAndTargetSpec(sourceSpec, targetSpec *v1.PersistentVo
 		targetVolumeMode = v1.PersistentVolumeBlock
 	}
 	if sourceVolumeMode != targetVolumeMode {
-		return errors.New("source and target volume modes do not match")
+		return fmt.Errorf("source volumeMode (%s) and target volumeMode (%s) do not match",
+			sourceVolumeMode, targetVolumeMode)
 	}
 	// Can clone.
 	return nil


### PR DESCRIPTION
Use the term that appears in YAML files, volumeMode, and print
which one it is (may be an implicit value picked from the default)

```release-note
Improve volumeMode mismatch error reports
```