### PR TITLE
Fix RBAC for CRDS to stop error message in deployment/operator log.

### DIFF
--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -106,6 +106,8 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			Verbs: []string{
 				"get",
 				"create",
+				"list",
+				"watch",
 			},
 		},
 		{
@@ -188,6 +190,8 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"get",
+				"list",
+				"watch",
 			},
 		},
 	}

--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -93,8 +93,8 @@ var _ = Describe("[rfe_id:1347][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 			secretsExpectedResult := make(map[string]string)
 			secretsExpectedResult["get"] = "yes"
-			secretsExpectedResult["list"] = "no"
-			secretsExpectedResult["watch"] = "no"
+			secretsExpectedResult["list"] = "yes"
+			secretsExpectedResult["watch"] = "yes"
 			secretsExpectedResult["delete"] = "no"
 			secretsExpectedResult["create"] = "yes"
 			secretsExpectedResult["update"] = "no"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PR #1012 was a little too aggressive on the CRD permissions. This resulted in the following message in the controller logs:
```
1120 20:47:45.837940       1 reflector.go:134] pkg/client/informers/externalversions/factory.go:117: Failed to list *v1beta1.CustomResourceDefinition: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:cdi:cdi-sa" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```
It didn't appear to actually affect the controller, but having it spam the log is annoying.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

