### PR TITLE
Split unit and functional test into own script,

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,11 @@ test: test-unit test-functional test-lint
 
 test-unit: WHAT = ./pkg/... ./cmd/...
 test-unit:
-	${DO} "./hack/build/run-tests.sh ${WHAT}"
+	${DO} "./hack/build/run-unit-tests.sh ${WHAT}"
 
 test-functional:  WHAT = ./tests/...
-test-functional:
+test-functional: build-functest
 	./hack/build/run-functional-tests.sh ${WHAT} "${TEST_ARGS}"
-
-test-functional-ci: build-functest test-functional
 
 # test-lint runs gofmt and golint tests against src files
 test-lint:

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -93,4 +93,4 @@ kubectl version
 ginko_params="--test-args=--ginkgo.noColor --junit-output=${ARTIFACTS_PATH}/junit.functest.xml"
 
 # Run functional tests
-TEST_ARGS=$ginko_params make test-functional-ci
+TEST_ARGS=$ginko_params make test-functional

--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -72,4 +72,6 @@ if [ $retry_counter -eq $MAX_CDI_WAIT_RETRY ]; then
     exit 1
 fi
 
-${script_dir}/run-tests.sh ${pkgs} --test-args="${test_args}"
+test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 180m ${test_args}"
+echo "${test_command}"
+(cd ${CDI_DIR}/tests; ${test_command})

--- a/hack/build/run-unit-tests.sh
+++ b/hack/build/run-unit-tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#Copyright 2019 The CDI Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+set -euo pipefail
+
+source hack/build/config.sh
+source hack/build/common.sh
+
+# parsetTestOpts sets 'pkgs' and test_args
+parseTestOpts "${@}"
+
+test_command="go test -v -coverprofile=.coverprofile -test.timeout 180m ${pkgs} ${test_args:+-args $test_args}"
+echo "${test_command}"
+${test_command}


### PR DESCRIPTION
The unit and functional tests were called the same script in the end, and we had an if statement determining which one to call. There really is no reason for it, and now we can combine test-functional and test-functional-ci into the same call, and run that to functional tests.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It combines functional-test and functional-test-ci into one call, and splits unit-test into its own script. This will help with making the unit tests be called from bazel as well as give immediate output during functional test runs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

