### PR TITLE
Push builder image to dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_deploy:
 deploy:
   # Release :latest images
 - provider: script
-  script: make publish
+  script: make builder-push && make publish
   skip_cleanup: true
   on:
     branch: master

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,6 @@ bazel-push-images: bazel-cdi-generate bazel-build
 
 push: bazel-push-images
 
+builder-push:
+	./hack/build/bazel-build-builder.sh
+

--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+#Copyright 2019 The CDI Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+set -e
+script_dir="$(readlink -f $(dirname $0))"
+source "${script_dir}"/common.sh
+source "${script_dir}"/config.sh
+
+BUILDER_SPEC="${BUILD_DIR}/docker/builder"
+
+#TODO remove me and use the one from config.sh
+BUILDER_TAG="kubevirt/kubevirt-cdi-bazel-builder"
+
+# Build the encapsulated compile and test container
+(cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_TAG} .)
+echo "Image: ${BUILDER_TAG}"
+
+docker push ${BUILDER_TAG}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is the first step in using a prebuild builder images. This puts in the code to build and push the container image on merge. Then #997 can be modified the use the builder image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

