### PR TITLE
Exclude master and tainted nodes from being used as node for hostpath…

### DIFF
--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -47,7 +49,26 @@ func getDefaultNodeName(client *kubernetes.Clientset) string {
 	if err != nil {
 		ginkgo.Fail("Unable to list nodes")
 	}
-	return nodes.Items[0].Name
+	for _, node := range nodes.Items {
+		scheduleable := true
+		if node.Spec.Taints != nil {
+			for _, taint := range node.Spec.Taints {
+				if taint.Effect == corev1.TaintEffectNoSchedule {
+					scheduleable = false
+				}
+			}
+		}
+		if node.GetLabels() != nil {
+			if val, ok := node.GetLabels()["node-role.kubernetes.io/master"]; ok && val == "true" {
+				scheduleable = false
+			}
+		}
+		if scheduleable {
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Using node %s as target node for hostpath provisioner if set.\n", node.Name)))
+			return node.Name
+		}
+	}
+	return ""
 }
 
 func getDefaultStorageClass(client *kubernetes.Clientset) *storagev1.StorageClass {
@@ -75,6 +96,9 @@ func IsHostpathProvisioner() bool {
 
 // AddProvisionOnNodeToAnn adds 'kubevirt.io/provisionOnNode' annotaion
 func AddProvisionOnNodeToAnn(pvcAnn map[string]string) {
+	if DefaultNodeName == "" {
+		ginkgo.Skip("No scheduleable nodes available")
+	}
 	pvcAnn["kubevirt.io/provisionOnNode"] = DefaultNodeName
 }
 


### PR DESCRIPTION
… provisioner

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Exclude master and tainted nodes from the nodes that we can use for annotations used by the hostpath provisioner.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

