### PR TITLE
Add nil check for ingress http rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-logr/logr v0.0.0-20190813230443-d63354a31b29
 	github.com/go-logr/zapr v0.0.0-20190813212058-2e515ec1daf7 // indirect
 	github.com/go-openapi/spec v0.19.2
+	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
@@ -43,6 +44,7 @@ require (
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -151,6 +151,10 @@ func (c *ConfigController) handleObject(obj interface{}) {
 
 	if ing, ok := obj.(*extensionsv1beta1.Ingress); ok {
 		for _, rule := range ing.Spec.Rules {
+			if rule.HTTP == nil {
+				continue
+			}
+
 			for _, path := range rule.HTTP.Paths {
 				if path.Backend.ServiceName == c.uploadProxyServiceName {
 					c.enqueueCDIConfig(config)


### PR DESCRIPTION
**What this PR does / why we need it**:
Ingress HTTP rule is optional field and can be nil. If we create a ingress with no http rule nil pointer exception is occur. Add nil check for ingress http rule.

**Which issue(s) this PR fixes**
Fixes #1048

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
NONE
```