### PR TITLE
Fix build and push of builder image

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -21,8 +21,15 @@ source "${script_dir}"/config.sh
 
 BUILDER_SPEC="${BUILD_DIR}/docker/builder"
 
-# Build the encapsulated compile and test container
-(cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_TAG} .)
-echo "Image: ${BUILDER_TAG}"
+# When building and pushing a new image we do not provide the sha hash
+# because docker assigns that for us.
+BUILD_TAG=$(expr match $BUILDER_TAG '\(.*\)@sha256')
 
-docker push ${BUILDER_TAG}
+# Build the encapsulated compile and test container
+(cd ${BUILDER_SPEC} && docker build --tag ${BUILD_TAG}:latest .)
+
+DIGEST=$(docker images --digests | grep $BUILD_TAG | grep latest | awk '{ print $3 }'
+echo "Image: ${BUILD_TAG}:latest"
+echo "Digest: ${DIGEST}"
+
+docker push ${BUILD_TAG}:latest


### PR DESCRIPTION
When building and pushing a new bazel builder image we do not want to use the
sha hash of the current builder image.  We should strip this off to get the
image name and just use :latest.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

