### PR TITLE
Fix to create temporary pod with default resource quota

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -164,6 +164,7 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 	}
 
 	cloneController := controller.NewCloneController(client,
+		cdiClient,
 		pvcInformer,
 		podInformer,
 		clonerImage,

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/go-openapi/spec v0.19.2
+	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/martian v2.1.0+incompatible
@@ -43,6 +44,7 @@ require (
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4

--- a/pkg/apis/core/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/core/v1alpha1/deepcopy_generated.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "github.com/openshift/custom-resource-status/conditions/v1"
-	corev1 "k8s.io/api/core/v1"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -128,6 +128,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodResourceRequirements != nil {
+		in, out := &in.PodResourceRequirements, &out.PodResourceRequirements
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -148,6 +153,11 @@ func (in *CDIConfigStatus) DeepCopyInto(out *CDIConfigStatus) {
 		in, out := &in.UploadProxyURL, &out.UploadProxyURL
 		*out = new(string)
 		**out = **in
+	}
+	if in.DefaultPodResourceRequirements != nil {
+		in, out := &in.DefaultPodResourceRequirements, &out.DefaultPodResourceRequirements
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -216,7 +226,7 @@ func (in *CDIStatus) DeepCopyInto(out *CDIStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1.Condition, len(*in))
+		*out = make([]conditionsv1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -443,7 +453,7 @@ func (in *DataVolumeSpec) DeepCopyInto(out *DataVolumeSpec) {
 	in.Source.DeepCopyInto(&out.Source)
 	if in.PVC != nil {
 		in, out := &in.PVC, &out.PVC
-		*out = new(corev1.PersistentVolumeClaimSpec)
+		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -208,9 +208,16 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigSpec(ref common.ReferenceCallback) c
 							Format: "",
 						},
 					},
+					"podResourceRequirements": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
@@ -233,9 +240,16 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigStatus(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"defaultPodResourceRequirements": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -256,14 +256,16 @@ type CDIConfig struct {
 
 //CDIConfigSpec defines specification for user configuration
 type CDIConfigSpec struct {
-	UploadProxyURLOverride   *string `json:"uploadProxyURLOverride,omitempty"`
-	ScratchSpaceStorageClass *string `json:"scratchSpaceStorageClass,omitempty"`
+	UploadProxyURLOverride   *string                      `json:"uploadProxyURLOverride,omitempty"`
+	ScratchSpaceStorageClass *string                      `json:"scratchSpaceStorageClass,omitempty"`
+	PodResourceRequirements  *corev1.ResourceRequirements `json:"podResourceRequirements,omitempty"`
 }
 
 //CDIConfigStatus provides
 type CDIConfigStatus struct {
-	UploadProxyURL           *string `json:"uploadProxyURL,omitempty"`
-	ScratchSpaceStorageClass string  `json:"scratchSpaceStorageClass,omitempty"`
+	UploadProxyURL                 *string                      `json:"uploadProxyURL,omitempty"`
+	ScratchSpaceStorageClass       string                       `json:"scratchSpaceStorageClass,omitempty"`
+	DefaultPodResourceRequirements *corev1.ResourceRequirements `json:"defaultPodResourceRequirements,omitempty"`
 }
 
 //CDIConfigList provides the needed parameters to do request a list of CDIConfigs from the system

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	cdifake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
 	"reflect"
 	"strconv"
 
@@ -10,7 +12,6 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
-	cdifake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -317,7 +317,7 @@ var _ = Describe("Create Importer Pod", func() {
 			certConfigMap: "",
 			insecureTLS:   false,
 		}
-		pod, err := createImporterPod(reconciler.Log, reconciler.Client, testImage, "5", testPullPolicy, podEnvVar, pvc, scratchPvcName)
+		pod, err := createImporterPod(reconciler.Log, reconciler.Client, reconciler.CdiClient, testImage, "5", testPullPolicy, podEnvVar, pvc, scratchPvcName)
 		Expect(err).ToNot(HaveOccurred())
 		By("Verifying PVC owns pod")
 		Expect(len(pod.GetOwnerReferences())).To(Equal(1))

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -467,6 +467,7 @@ func (c *UploadController) getOrCreateUploadPod(pvc *v1.PersistentVolumeClaim, p
 
 		args := UploadPodArgs{
 			Client:         c.client,
+			CdiClient:      c.cdiClient,
 			Image:          c.uploadServiceImage,
 			Verbose:        c.verbose,
 			PullPolicy:     c.pullPolicy,

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1471,3 +1471,14 @@ func createVolumeSnapshotCrd() *apiextensionsv1beta1.CustomResourceDefinition {
 		},
 	}
 }
+
+func createDefaultPodResourceRequirements(limitCPUValue int64, limitMemoryValue int64, requestCPUValue int64, requestMemoryValue int64) *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    *resource.NewQuantity(limitCPUValue, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(limitMemoryValue, resource.DecimalSI)},
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    *resource.NewQuantity(requestCPUValue, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(requestMemoryValue, resource.DecimalSI)},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If we create a temporary pod in the namespace which has resource quota, `must specify quota` error occurs. Fix to create temporary pod with default resource quota.

**Which issue(s) this PR fixes**:
Fixes #1043

**Special notes for your reviewer**:
for now, I just added for the ImporterPod only. Could you please take a look? After the review, I will add for the CloneSourcePod and UploadPod.

**Release note**:
```release-note
- Fix to apply default quota if namespace does not have a quota
```