### PR TITLE
Support custom authentication headers

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2401,6 +2401,10 @@
       "description": "CertConfigMap provides a reference to the Registry certs",
       "type": "string"
      },
+     "headerName": {
+      "description": "HeaderName provides custom header name",
+      "type": "string"
+     },
      "secretRef": {
       "description": "SecretRef provides the secret reference needed to access the HTTP source",
       "type": "string"

--- a/cluster-up/cluster/okd-4.3/provider.sh
+++ b/cluster-up/cluster/okd-4.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.3@sha256:dc31782e16020b9a10728d408b38cd78f56b3ee7261f99f0dc7a43e1365a537c"
+image="okd-4.3@sha256:63abc3884002a615712dfac5f42785be864ea62006892bf8a086ccdbca8b3d38"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -57,6 +57,7 @@ func main() {
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 	certDir, _ := util.ParseEnvVar(common.ImporterCertDirVar, false)
 	insecureTLS, _ := strconv.ParseBool(os.Getenv(common.InsecureTLSVar))
+	header, _ := util.ParseEnvVar(common.ImporterHeaderName, false)
 
 	//Registry import currently support kubevirt content type only
 	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
@@ -108,7 +109,8 @@ func main() {
 		var dp importer.DataSourceInterface
 		switch source {
 		case controller.SourceHTTP:
-			dp, err = importer.NewHTTPDataSource(ep, acc, sec, certDir, cdiv1.DataVolumeContentType(contentType))
+			size := resource.MustParse(imageSize)
+			dp, err = importer.NewHTTPDataSource(ep, acc, sec, certDir, header, size.Value(), cdiv1.DataVolumeContentType(contentType))
 			if err != nil {
 				klog.Errorf("%+v", err)
 				err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to http data source: %+v", err))

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -18,7 +18,8 @@ The following statuses are possible.
 * Unknown: Unknown status.
 
 ## HTTP/S3/Registry source
-DataVolumes are an abstraction on top of the annotations one can put on PVCs to trigger CDI. As such DVs have the notion of a 'source' that allows one to specify the source of the data. To import data from an external source, the source has to be either 'http' ,'S3' or 'registry'. If your source requires authentication, you can also pass in a `secretRef` to a Kubernetes [Secret](../manifest/example/endpoint-secret.yaml) containing the authentication information.  TLS certificates for https/registry sources may be specified in a [ConfigMap](../manifests/example/cert-configmap.yaml) and referenced by `certConfigMap`.  `secretRef` and `certConfigMap` must be in the same namespace as the DataVolume.
+DataVolumes are an abstraction on top of the annotations one can put on PVCs to trigger CDI. As such DVs have the notion of a 'source' that allows one to specify the source of the data. To import data from an external source, the source has to be either 'http' ,'S3' or 'registry'. If your source requires authentication, you can also pass in a `secretRef` to a Kubernetes [Secret](../manifest/example/endpoint-secret.yaml) containing the authentication information.  It is possible to define custom authentication header as `headerName` which uses `secretRef` as a token. TLS certificates for https/registry sources may be specified in a [ConfigMap](../manifests/example/cert-configmap.yaml) and referenced by `certConfigMap`.  `secretRef` and `certConfigMap` must be in the same namespace as the DataVolume. You can provide `diskSize` so importer won't
+get it from the source
 
 ```yaml
 apiVersion: cdi.kubevirt.io/v1alpha1
@@ -31,6 +32,7 @@ spec:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img" # Or S3
          secretRef: "" # Optional
          certConfigMap: "" # Optional
+         headerName: "" # Optional
   pvc:
     accessModes:
       - ReadWriteOnce

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -534,6 +534,13 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeSourceHTTP(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"headerName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HeaderName provides custom header name",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -108,6 +108,8 @@ type DataVolumeSourceHTTP struct {
 	SecretRef string `json:"secretRef,omitempty"`
 	//CertConfigMap provides a reference to the Registry certs
 	CertConfigMap string `json:"certConfigMap,omitempty"`
+	//HeaderName provides custom header name
+	HeaderName string `json:"headerName,omitempty"`
 }
 
 // DataVolumeStatus provides the parameters to store the phase of the Data Volume

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -64,6 +64,7 @@ func (DataVolumeSourceHTTP) SwaggerDoc() map[string]string {
 		"url":           "URL is the URL of the http source",
 		"secretRef":     "SecretRef provides the secret reference needed to access the HTTP source",
 		"certConfigMap": "CertConfigMap provides a reference to the Registry certs",
+		"headerName":    "HeaderName provides custom header name",
 	}
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -64,6 +64,8 @@ const (
 	ImporterCertDirVar = "IMPORTER_CERT_DIR"
 	// InsecureTLSVar provides a constant to capture our env variable "INSECURE_TLS"
 	InsecureTLSVar = "INSECURE_TLS"
+	// ImporterHeaderName provides a constant to capture out env variable "IMPORTER_HEADER_NAME"
+	ImporterHeaderName = "IMPORTER_HEADER_NAME"
 
 	// CloningLabelValue provides a constant to use as a label value for pod affinity (controller pkg only)
 	CloningLabelValue = "host-assisted-cloning"

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -973,6 +973,9 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 		if dataVolume.Spec.Source.HTTP.CertConfigMap != "" {
 			annotations[AnnCertConfigMap] = dataVolume.Spec.Source.HTTP.CertConfigMap
 		}
+		if dataVolume.Spec.Source.HTTP.HeaderName != "" {
+			annotations[AnnHeaderName] = dataVolume.Spec.Source.HTTP.HeaderName
+		}
 	} else if dataVolume.Spec.Source.S3 != nil {
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.S3.URL
 		if dataVolume.Spec.Source.S3.SecretRef != "" {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -43,6 +43,8 @@ const (
 	AnnImportPod = AnnAPIGroup + "/storage.import.importPodName"
 	// AnnRequiresScratch provides a const for our PVC requires scratch annotation
 	AnnRequiresScratch = AnnAPIGroup + "/storage.import.requiresScratch"
+	// AnnHeaderName provides is the name of a custom authentication header
+	AnnHeaderName = AnnAPIGroup + "/storage.import.headerName"
 
 	//LabelImportPvc is a pod label used to find the import pod that was created by the relevant PVC
 	LabelImportPvc = AnnAPIGroup + "/storage.import.importPvcName"
@@ -69,8 +71,8 @@ type ImportReconciler struct {
 }
 
 type importPodEnvVar struct {
-	ep, secretName, source, contentType, imageSize, certConfigMap string
-	insecureTLS                                                   bool
+	ep, secretName, source, contentType, imageSize, certConfigMap, headerName string
+	insecureTLS                                                               bool
 }
 
 // NewImportController creates a new instance of the import controller.
@@ -571,6 +573,12 @@ func makeImportEnv(podEnvVar *importPodEnvVar, uid types.UID) []v1.EnvVar {
 		env = append(env, v1.EnvVar{
 			Name:  common.ImporterCertDirVar,
 			Value: common.ImporterCertDir,
+		})
+	}
+	if podEnvVar.headerName != "" {
+		env = append(env, v1.EnvVar{
+			Name:  common.ImporterHeaderName,
+			Value: podEnvVar.headerName,
 		})
 	}
 	return env

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Import test env", func() {
 	const mockUID = "1111-1111-1111-1111"
 
 	It("Should create import env", func() {
-		testEnvVar := &importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", "", false}
+		testEnvVar := &importPodEnvVar{"myendpoint", "mysecret", SourceHTTP, string(cdiv1.DataVolumeKubeVirt), "1G", "", "", false}
 		Expect(reflect.DeepEqual(makeImportEnv(testEnvVar, mockUID), createImportTestEnv(testEnvVar, mockUID))).To(BeTrue())
 	})
 })

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -185,6 +185,14 @@ func getSecretName(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (
 	return name, nil
 }
 
+func getHeaderName(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) string {
+	headerName, found := pvc.Annotations[AnnHeaderName]
+	if !found {
+		headerName = ""
+	}
+	return headerName
+}
+
 // Update and return a copy of the passed-in pvc. Only one of the annotation or label maps is required though
 // both can be passed.
 // Note: the only pvc changes supported are annotations and labels.
@@ -985,6 +993,7 @@ func createImportEnvVar(client kubernetes.Interface, pvc *v1.PersistentVolumeCla
 		if err != nil {
 			return nil, err
 		}
+		podEnvVar.headerName = getHeaderName(client, pvc)
 	}
 	//get the requested image size.
 	podEnvVar.imageSize, err = getRequestedImageSize(pvc)

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -83,6 +83,9 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 												"secretRef": {
 													Type: "string",
 												},
+												"headerName": {
+													Type: "string",
+												},
 											},
 											Required: []string{
 												"url",

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -175,6 +175,7 @@ func NewPVCDefinitionWithSelector(pvcName, size, storageClassName string, select
 // You can use the following annotation keys to request an import or clone. The values are defined in the controller package
 // AnnEndpoint
 // AnnSecret
+// AnnHeaderName
 // AnnCloneRequest
 // You can also pass in any label you want.
 func NewPVCDefinition(pvcName string, size string, annotations, labels map[string]string) *k8sv1.PersistentVolumeClaim {


### PR DESCRIPTION
Till now http source supported only basic authentication with this PR
we can provide authentication header name. With this approach we enable
importing images from glance using `X-Auth-Token` header name.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>