### PR TITLE
fix openapi-spec to generate available client

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1487,13 +1487,9 @@
    "big.Word": {},
    "inf.Dec": {
     "required": [
-     "unscaled",
-     "scale"
+     "unscaled"
     ],
     "properties": {
-     "scale": {
-      "$ref": "#/definitions/inf.Scale"
-     },
      "unscaled": {
       "$ref": "#/definitions/big.Int"
      }
@@ -1533,13 +1529,9 @@
    },
    "resource.int64Amount": {
     "required": [
-     "value",
-     "scale"
+     "value"
     ],
     "properties": {
-     "scale": {
-      "$ref": "#/definitions/resource.Scale"
-     },
      "value": {
       "type": "integer",
       "format": "int64"
@@ -2007,7 +1999,6 @@
    "v1.Patch": {
     "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
    },
-   "v1.PersistentVolumeAccessMode": {},
    "v1.PersistentVolumeClaimSpec": {
     "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
     "required": [
@@ -2018,7 +2009,7 @@
       "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.PersistentVolumeAccessMode"
+       "type": "string"
       }
      },
      "dataSource": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
api/openapi-spec/swagger.json file generate unavailable java client with swagger-codegen-cli-2.4.10.
It makes an unavailable java client since swagger.json file generates an abnormal java file (io.swagger.client.model.V1PersistentVolumeAccessMode) and does not make some java files necessary file to compile (io.swagger.client.model.ResourceScale, io.swagger.client.model.InfScale).

Thus, we modify to use just string rather than empty 'io.swagger.client.model.V1PersistentVolumeAccessMode'.
Also, we modify to do not use 'io.swagger.client.model.ResourceScale', 'io.swagger.client.model.InfScale' at some files such as 'io.swagger.client.model.InfDec' and 'io.swagger.client.model.ResourceInt64Amount'.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Please try generating java client with openapi-generator with this swagger.json file and original swagger.json file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

