### PR TITLE
Fix `GetAvailableSpaceBlock` always return -1 in LXC

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -102,7 +102,7 @@ func GetAvailableSpace(path string) int64 {
 
 // GetAvailableSpaceBlock gets the amount of available space at the block device path specified.
 func GetAvailableSpaceBlock(deviceName string) int64 {
-	cmd := exec.Command("/usr/bin/lsblk", "-n", "-b", "-o", "SIZE", deviceName)
+	cmd := exec.Command("/usr/sbin/blockdev", "--getsize64", deviceName)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
In a normal Linux container, /sys/class/block/ is inherited from the host, and the result presented by lsblk is the metadata of the host, which does not effectively capture the size of the block device transmitted to the container

Signed-off-by: clarklee92 <clarklee1992@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1064

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

