### PR TITLE
Print additional information with kubectl get dv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/go-openapi/spec v0.19.2
-	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/martian v2.1.0+incompatible
@@ -44,7 +43,6 @@ require (
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -152,6 +152,25 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 					},
 				},
 			},
+			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+				{
+					Name:        "Phase",
+					Type:        "string",
+					Description: "The phase the data volume is in",
+					JSONPath:    ".status.phase",
+				},
+				{
+					Name:        "Progress",
+					Type:        "string",
+					Description: "Transfer progress in percentage if known, N/A otherwise",
+					JSONPath:    ".status.progress",
+				},
+				{
+					Name:     "Age",
+					Type:     "date",
+					JSONPath: ".metadata.creationTimestamp",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Print phase and progress with kubectl get in addition to the name and age.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1069 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Data volumes now print additional columns Phase/Progress with kubectl get
```

