### PR TITLE
Explain better what is going on when trying to allocate maximum space…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-openapi/spec v0.19.2
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubernetes-csi/external-snapshotter v0.0.0-20190509204040-e49856eb417c
 	github.com/minio/minio-go v6.0.14+incompatible
@@ -36,9 +35,7 @@ require (
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ulikunitz/xz v0.5.6
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.uber.org/multierr v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -137,8 +137,8 @@ func RetryBackoffSize(dest string, size resource.Quantity, sizeFunc func(string,
 		retryCount++
 		// Reduce by 25 blocks, and try again. How did we end up with 25 blocks? Well we need to leave some blocks for the fs on the pvc.
 		// Then we need to leave some extra blocks so it can mount inside the container.
-		reduceSize.Sub(*resource.NewScaledQuantity(blockSize*int64(25), 0))
-		klog.V(3).Infof("Trying new size: %s\n", reduceSize.String())
+		reduceSize.Sub(*resource.NewScaledQuantity(blockSize*int64(25*retryCount*retryCount), 0))
+		klog.V(1).Infof("Trying reduced size: %s\n", reduceSize.String())
 		err = sizeFunc(dest, reduceSize)
 	}
 	return err

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -152,7 +152,7 @@ var _ = Describe("RetryBackoffSize", func() {
 		startQuantity := resource.NewScaledQuantity(int64(250*blockSize), 0)
 		err := RetryBackoffSize("", *startQuantity, func(dest string, size resource.Quantity) error {
 			callCount++
-			if resource.NewScaledQuantity(int64(200*blockSize), 0).Cmp(size) == 0 {
+			if resource.NewScaledQuantity(int64(125*blockSize), 0).Cmp(size) == 0 {
 				return nil
 			}
 			return fmt.Errorf("I am failing two tries, help me, %+v", size)


### PR DESCRIPTION
… available in PVC.

Increased number of retries for larger PVCs.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The information provided when fallocating resizing the disk image was not clear in what was going on. Also the number of retries was insufficient for most cases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

