### PR TITLE
update builder to k8s 1.16.4 and use tags for builder image

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -23,13 +23,13 @@ BUILDER_SPEC="${BUILD_DIR}/docker/builder"
 
 # When building and pushing a new image we do not provide the sha hash
 # because docker assigns that for us.
-BUILD_TAG=$(expr match $BUILDER_TAG '\(.*\)@sha256')
+UNTAGGED_BUILDER_IMAGE=$(expr match $BUILDER_IMAGE '\(.*\)@sha256')
 
 # Build the encapsulated compile and test container
-(cd ${BUILDER_SPEC} && docker build --tag ${BUILD_TAG}:latest .)
+(cd ${BUILDER_SPEC} && docker build --tag ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG} .)
 
-DIGEST=$(docker images --digests | grep $BUILD_TAG | grep latest | awk '{ print $3 }')
-echo "Image: ${BUILD_TAG}:latest"
+DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
+echo "Image: ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG}"
 echo "Digest: ${DIGEST}"
 
-docker push ${BUILD_TAG}:latest
+docker push ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG}

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -38,11 +38,11 @@ fi
 
 # Make sure that the output directory exists
 echo "Making sure output directory exists..."
-docker run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label:disable --rm --entrypoint "/entrypoint-bazel.sh" ${BUILDER_TAG} mkdir -p /root/go/src/kubevirt.io/containerized-data-importer/_out
+docker run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label:disable --rm --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} mkdir -p /root/go/src/kubevirt.io/containerized-data-importer/_out
 
 echo "Starting rsyncd"
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID_CDI=$(docker run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label:disable --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_TAG} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID_CDI=$(docker run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label:disable --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
     docker stop ${RSYNC_CID_CDI} >/dev/null 2>&1 &
@@ -102,7 +102,7 @@ volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 # Ensure that a bazel server is running
 
 if [ -z "$(docker ps --format '{{.Names}}' | grep ${BAZEL_BUILDER_SERVER})" ]; then
-    docker run --network host -d ${volumes} --security-opt label:disable --name ${BAZEL_BUILDER_SERVER} -w "/root/go/src/kubevirt.io/containerized-data-importer" --rm ${BUILDER_TAG} hack/build/bazel-server.sh
+    docker run --network host -d ${volumes} --security-opt label:disable --name ${BAZEL_BUILDER_SERVER} -w "/root/go/src/kubevirt.io/containerized-data-importer" --rm ${BUILDER_IMAGE} hack/build/bazel-server.sh
 fi
 
 echo "Starting bazel server"

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -24,7 +24,9 @@ FUNC_TEST_HTTP="cdi-func-test-file-host-http"
 FUNC_TEST_REGISTRY="cdi-func-test-registry"
 FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
-BUILDER_TAG=${BUILDER_TAG:-kubevirt/kubevirt-cdi-bazel-builder@sha256:38e449bb8f5e2e3dc8ae241323c69ce37e72bd98a109d2032955dd9bd0e0a545}
+# update this whenever builder Dockerfile is updated
+BUILDER_TAG=${BUILDER_TAG:-0.0.1}
+BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:38e449bb8f5e2e3dc8ae241323c69ce37e72bd98a109d2032955dd9bd0e0a545}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT}"
 CDI_PKGS="cmd/ pkg/ test/"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -33,7 +33,7 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 
 RUN pip3 install j2cli && pip3 install operator-courier
 
-ENV GIMME_GO_VERSION=1.11.5 GOPATH="/go" KUBEBUILDER_VERSION="1.0.8" ARCH="amd64"
+ENV GIMME_GO_VERSION=1.12.14 GOPATH="/go" KUBEBUILDER_VERSION="2.2.0" ARCH="amd64"
 ENV BAZEL_PYTHON=/usr/bin/python3
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
@@ -61,10 +61,10 @@ RUN \
     ( go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
     go get -u -d k8s.io/kube-openapi/cmd/openapi-gen ) && \
     ( cd $GOPATH/src/k8s.io/code-generator/cmd/deepcopy-gen && \
-    git checkout kubernetes-1.13.4 && \
+    git checkout v0.16.4 && \
     go install ./... ) && \
     ( cd $GOPATH/src/k8s.io/kube-openapi/cmd/openapi-gen && \
-    git checkout a01b7d5d6c2258c80a4a10070f3dee9cd575d9c7 && \
+    git checkout 30be4d16710ac61bce31eb28a01054596fe6a9f1 && \
     go install ./... ) && \
     (curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz" && \
      tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz && \

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -32,4 +32,4 @@ docker run ${USE_TTY} \
     -e RUN_GID=$(id -g) \
     -e GOCACHE=/gocache \
     -w ${WORK_DIR} \
-    ${BUILDER_TAG} "$1"
+    ${BUILDER_IMAGE} "$1"


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

update builder to k8s 1.16.4  and refactor image building to use tags for easier management

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

