### PR TITLE
Allow multiple previous versions to upgrade from

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -46,8 +46,14 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   exit 1
 fi
 
-export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-echo "Upgrading from verions: $UPGRADE_FROM"
+if [[ -z "$MULTI_UPGRADE" ]]; then
+  export UPGRADE_FROM="v1.10.7 v1.10.9 v1.11.0"
+fi
+
+if [[ -z "$UPGRADE_FROM" ]]; then
+  export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+  echo "Upgrading from verions: $UPGRADE_FROM"
+fi
 export KUBEVIRT_NUM_NODES=2
 
 kubectl() { cluster-up/kubectl.sh "$@"; }

--- a/cluster-sync/install.sh
+++ b/cluster-sync/install.sh
@@ -4,8 +4,9 @@ set -e
 source ./cluster-sync/install-config.sh
 
 function install_cdi {
-  if [ ! -z $UPGRADE_FROM ]; then
-    curl -L "https://github.com/kubevirt/containerized-data-importer/releases/download/$UPGRADE_FROM/cdi-operator.yaml" --output cdi-operator.yaml
+  if [[ ! -z "$UPGRADE_FROM" ]]; then
+    UPGRADE_FROM_LIST=( $UPGRADE_FROM )
+    curl -L "https://github.com/kubevirt/containerized-data-importer/releases/download/${UPGRADE_FROM_LIST[0]}/cdi-operator.yaml" --output cdi-operator.yaml
     sed -i "0,/name: cdi/{s/name: cdi/name: $CDI_NAMESPACE/}" cdi-operator.yaml
     sed -i "s/namespace: cdi/namespace: $CDI_NAMESPACE/g" cdi-operator.yaml
     echo $(cat cdi-operator.yaml)


### PR DESCRIPTION
Force kill operator during upgrade to test resilience

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow multiple previous release when upgrading, tests that they get upgraded in sequence specified.
Force delete operator pod during upgrade to test resilience.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

