### PR TITLE
Reverse the check for multi upgrade.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -46,7 +46,7 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   exit 1
 fi
 
-if [[ -z "$MULTI_UPGRADE" ]]; then
+if [[ -n "$MULTI_UPGRADE" ]]; then
   export UPGRADE_FROM="v1.10.7 v1.10.9 v1.11.0"
 fi
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The check was using -z instead of -n, so the condition was reverse of what it should be, this PR fixes it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

