### PR TITLE
Add NFS as KUBEVIRT_STORAGE to cluster-sync

### DIFF
--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -76,3 +76,11 @@ EOF
   _kubectl apply -f https://raw.githubusercontent.com/rook/rook/$ROOK_CEPH_VERSION/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
   set -e
 }
+
+function configure_nfs() {
+  #Configure static nfs service and storage class, so we can create NFS PVs during test run.
+  _kubectl apply -f ./cluster-sync/nfs/nfs-sc.yaml
+  _kubectl apply -f ./cluster-sync/nfs/nfs-service.yaml -n $CDI_NAMESPACE
+  _kubectl apply -f ./cluster-sync/nfs/nfs-server.yaml -n $CDI_NAMESPACE
+  _kubectl patch storageclass nfs -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+}

--- a/cluster-sync/k8s-1.16.2/provider.sh
+++ b/cluster-sync/k8s-1.16.2/provider.sh
@@ -19,6 +19,9 @@ function configure_storage() {
   elif [[ $KUBEVIRT_STORAGE == "hpp" ]] ; then
     echo "Installing hostpath provisioner storage"
     configure_hpp
+  elif [[ $KUBEVIRT_STORAGE == "nfs" ]] ; then
+    echo "Installing NFS static storage"
+    configure_nfs
   else
     echo "Using local volume storage"
     #Make sure local is not default

--- a/cluster-sync/nfs/nfs-sc.yaml
+++ b/cluster-sync/nfs/nfs-sc.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: nfs
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Delete

--- a/cluster-sync/nfs/nfs-server.yaml
+++ b/cluster-sync/nfs/nfs-server.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-data
+spec:
+  storageClassName: local
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nfs-server
+  labels:
+    app: "nfs-server"
+spec:
+  containers:
+  - image: itsthenetwork/nfs-server-alpine:12
+    imagePullPolicy: IfNotPresent
+    name: nfs-server
+    env:
+    - name: SHARED_DIRECTORY
+      value: /data/nfs
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: "/data/nfs"
+      name: nfsdata
+    command: ["/bin/bash", "-c"]
+    args:
+      - |
+        chmod 777 /data/nfs;
+        mkdir /data/nfs/disk1;
+        chmod 777 /data/nfs/disk1;
+        mkdir /data/nfs/disk2;
+        chmod 777 /data/nfs/disk2;
+        mkdir /data/nfs/disk3;
+        chmod 777 /data/nfs/disk3;
+        mkdir /data/nfs/disk4;
+        chmod 777 /data/nfs/disk4;
+        mkdir /data/nfs/disk5;
+        chmod 777 /data/nfs/disk5;
+        /usr/bin/nfsd.sh
+  volumes:
+  - name: nfsdata
+    persistentVolumeClaim:
+      claimName: nfs-data
+

--- a/cluster-sync/nfs/nfs-service.yaml
+++ b/cluster-sync/nfs/nfs-service.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-service
+spec:
+  selector:
+    app: nfs-server
+  ports:
+    # Open the ports required by the NFS server
+    # Port 2049 for TCP
+    - name: tcp-2049
+      port: 2049
+      protocol: TCP
+
+    # Port 111 for UDP
+    - name: udp-111
+      port: 111
+      protocol: UDP

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -50,8 +50,6 @@ function kill_running_operator {
 
 seed_images
 
-configure_storage
-
 # Install CDI
 install_cdi
 
@@ -120,6 +118,8 @@ if [[ ! -z "$UPGRADE_FROM" ]]; then
   echo "Waiting 480 seconds for CDI to become available"
   _kubectl wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=480s
 fi
+
+configure_storage
 
 # Start functional test HTTP server.
 # We skip the functional test additions for external provider for now, as they're specific

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-openapi/spec v0.19.2
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubernetes-csi/external-snapshotter v0.0.0-20190509204040-e49856eb417c
 	github.com/minio/minio-go v6.0.14+incompatible
@@ -36,9 +35,7 @@ require (
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ulikunitz/xz v0.5.6
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.uber.org/multierr v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect

--- a/tests/framework/BUILD.bazel
+++ b/tests/framework/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "exec_util.go",
         "framework.go",
+        "nfs-utils.go",
         "pod.go",
         "pv.go",
         "pvc.go",
@@ -22,6 +23,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",

--- a/tests/framework/nfs-utils.go
+++ b/tests/framework/nfs-utils.go
@@ -1,0 +1,61 @@
+package framework
+
+import (
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+const (
+	timeout         = time.Second * 90
+	pollingInterval = time.Second
+	pvCount         = 5
+)
+
+func createNFSPVs(client *kubernetes.Clientset, cdiNs string) error {
+	for i := 1; i <= 5; i++ {
+		if _, err := utils.CreatePVFromDefinition(client, nfsPVDef(strconv.Itoa(i), utils.NfsService.Spec.ClusterIP)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteNFSPVs(client *kubernetes.Clientset, cdiNs string) error {
+	for i := 1; i <= pvCount; i++ {
+		if err := utils.DeletePV(client, nfsPVDef(strconv.Itoa(i), utils.NfsService.Spec.ClusterIP)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nfsPVDef(index, serviceIP string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nfs-pv" + index,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			StorageClassName: "nfs",
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+				corev1.ReadWriteMany,
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("30Gi"),
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server: serviceIP,
+					Path:   "/disk" + index,
+				},
+			},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRecycle,
+		},
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds NFS storage to the CI test matrix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

