### PR TITLE
Add async endpoint for upload that closes connection immediately

### DIFF
--- a/doc/upload.md
+++ b/doc/upload.md
@@ -132,15 +132,30 @@ We will be using [curl](https://github.com/curl/curl) to upload `tests/images/ci
 Assuming that the environment variable `TOKEN` contains a valid UploadToken, execute the following to upload the image:
 
 ### Minikube
+#### Synchronous
 ```bash
 curl -v --insecure -H "Authorization: Bearer $TOKEN" --data-binary @tests/images/cirros-qcow2.img https://$(minikube ip):31001/v1alpha1/upload
 ```
+The connection will not be closed until the entire process is completed. If the conversion or resizing process takes a long time intermediate proxies might close the connection unexpectedly.
 
+#### Asynchronous
+```bash
+curl -v --insecure -H "Authorization: Bearer $TOKEN" --data-binary @tests/images/cirros-qcow2.img https://$(minikube ip):31001/v1alpha1/upload-async
+```
+As soon as the data has been transmitted, the connection will be closed. The caller should monitor the Datavolume status to see if the process is completed.
 ### Minishift
-
+#### Synchronous
 ```bash
 curl -v --insecure -H "Authorization: Bearer $TOKEN" --data-binary @tests/images/cirros-qcow2.img https://cdi-uploadproxy-cdi.$(minishift ip).nip.io/v1alpha1/upload
 ```
+The connection will not be closed until the entire process is completed. If the conversion or resizing process takes a long time intermediate proxies might close the connection unexpectedly.
+
+#### Asynchronous
+```bash
+curl -v --insecure -H "Authorization: Bearer $TOKEN" --data-binary @tests/images/cirros-qcow2.img https://cdi-uploadproxy-cdi.$(minishift ip).nip.io/v1alpha1/upload-async
+```
+As soon as the data has been transmitted, the connection will be closed. The caller should monitor the Datavolume status to see if the process is completed.
+
 
 Assuming you did not get an error, the Datavolume `upload-datavolume` should now contain a bootable VM image.
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -113,6 +113,9 @@ const (
 	// CloneTokenIssuer is the JWT issuer for clone tokens
 	CloneTokenIssuer = "cdi-apiserver"
 
-	// UploadPath is the path to POST CDI uploads
-	UploadPath = "/v1alpha1/upload"
+	// UploadPathSync is the path to POST CDI uploads
+	UploadPathSync = "/v1alpha1/upload"
+
+	// UploadPathAsync is the path to POST CDI uploads in async mode
+	UploadPathAsync = "/v1alpha1/upload-async"
 )

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/klog"
 
 	clientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
-	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/fetcher"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/generator"
 )
@@ -90,8 +89,8 @@ func UploadPossibleForPVC(pvc *v1.PersistentVolumeClaim) error {
 }
 
 // GetUploadServerURL returns the url the proxy should post to for a particular pvc
-func GetUploadServerURL(namespace, pvc string) string {
-	return fmt.Sprintf("https://%s.%s.svc%s", GetUploadResourceName(pvc), namespace, common.UploadPath)
+func GetUploadServerURL(namespace, pvc, path string) string {
+	return fmt.Sprintf("https://%s.%s.svc%s", GetUploadResourceName(pvc), namespace, path)
 }
 
 // NewUploadController returns a new UploadController

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -477,7 +477,7 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, ownerRefAnno strin
 	var ownerID string
 	podName := fmt.Sprintf("%s-%s-", common.ClonerSourcePodName, sourcePvcName)
 	id := string(pvc.GetUID())
-	url := GetUploadServerURL(pvc.Namespace, pvc.Name)
+	url := GetUploadServerURL(pvc.Namespace, pvc.Name, common.UploadPathSync)
 	pvcOwner := metav1.GetControllerOf(pvc)
 	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
 		ownerID = string(pvcOwner.UID)

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1085,7 +1085,7 @@ func createSourcePod(pvc *v1.PersistentVolumeClaim, pvcUID string) *v1.Pod {
 						},
 						{
 							Name:  "UPLOAD_URL",
-							Value: GetUploadServerURL(pvc.Namespace, pvc.Name),
+							Value: GetUploadServerURL(pvc.Namespace, pvc.Name, common.UploadPathSync),
 						},
 						{
 							Name:  common.OwnerUID,

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -90,3 +90,73 @@ func (ud *UploadDataSource) Close() error {
 	}
 	return nil
 }
+
+// AsyncUploadDataSource is an asynchronouse version of an upload data source, that returns finished phase instead
+// of going to post upload processing phases.
+type AsyncUploadDataSource struct {
+	uploadDataSource UploadDataSource
+	// Next Phase indicates what the next Processing Phase should be after the transfer completes.
+	ResumePhase ProcessingPhase
+}
+
+// NewAsyncUploadDataSource creates a new instance of an UploadDataSource
+func NewAsyncUploadDataSource(stream io.ReadCloser) *AsyncUploadDataSource {
+	return &AsyncUploadDataSource{
+		uploadDataSource: UploadDataSource{
+			stream: stream,
+		},
+		ResumePhase: ProcessingPhaseInfo,
+	}
+}
+
+// Info is called to get initial information about the data.
+func (aud *AsyncUploadDataSource) Info() (ProcessingPhase, error) {
+	return aud.uploadDataSource.Info()
+}
+
+// Transfer is called to transfer the data from the source to the passed in path.
+func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error) {
+	if util.GetAvailableSpace(path) <= int64(0) {
+		//Path provided is invalid.
+		return ProcessingPhaseError, ErrInvalidPath
+	}
+	file := filepath.Join(path, tempFile)
+	err := util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), file)
+	if err != nil {
+		return ProcessingPhaseError, err
+	}
+	// If we successfully wrote to the file, then the parse will succeed.
+	aud.uploadDataSource.url, _ = url.Parse(file)
+	aud.ResumePhase = ProcessingPhaseProcess
+	return ProcessingPhasePause, nil
+}
+
+// TransferFile is called to transfer the data from the source to the passed in file.
+func (aud *AsyncUploadDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	err := util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), fileName)
+	if err != nil {
+		return ProcessingPhaseError, err
+	}
+	aud.ResumePhase = ProcessingPhaseResize
+	return ProcessingPhasePause, nil
+}
+
+// Process is called to do any special processing before giving the url to the data back to the processor
+func (aud *AsyncUploadDataSource) Process() (ProcessingPhase, error) {
+	return ProcessingPhaseConvert, nil
+}
+
+// Close closes any readers or other open resources.
+func (aud *AsyncUploadDataSource) Close() error {
+	return aud.uploadDataSource.Close()
+}
+
+// GetURL returns the url that the data processor can use when converting the data.
+func (aud *AsyncUploadDataSource) GetURL() *url.URL {
+	return aud.uploadDataSource.GetURL()
+}
+
+// GetResumePhase returns the next phase to process when resuming
+func (aud *AsyncUploadDataSource) GetResumePhase() ProcessingPhase {
+	return aud.ResumePhase
+}

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -153,3 +153,138 @@ var _ = Describe("Upload data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("Async Upload data source", func() {
+	var (
+		aud    *AsyncUploadDataSource
+		tmpDir string
+		err    error
+	)
+
+	BeforeEach(func() {
+		tmpDir, err = ioutil.TempDir("", "scratch")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+	})
+
+	AfterEach(func() {
+		if aud != nil {
+			aud.Close()
+		}
+		os.RemoveAll(tmpDir)
+	})
+
+	It("Info should return Error, when passed in an image that cannot be read", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(filepath.Join(imageDir, "content.tar"))
+		Expect(err).NotTo(HaveOccurred())
+		err = file.Close()
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(file)
+		result, err := aud.Info()
+		Expect(err).To(HaveOccurred())
+		Expect(ProcessingPhaseError).To(Equal(result))
+	})
+
+	It("Info should return Transfer, when passed in a valid image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(file)
+		result, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
+	})
+
+	It("Info should return TransferData, when passed in a valid raw image", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(tinyCoreFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(file)
+		result, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+	})
+
+	table.DescribeTable("calling transfer should", func(fileName, scratchPath string, want []byte, wantErr bool) {
+		if scratchPath == "" {
+			scratchPath = tmpDir
+		}
+		sourceFile, err := os.Open(fileName)
+		Expect(err).NotTo(HaveOccurred())
+
+		aud = NewAsyncUploadDataSource(sourceFile)
+		nextPhase, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferScratch).To(Equal(nextPhase))
+		result, err := aud.Transfer(scratchPath)
+		if !wantErr {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ProcessingPhasePause).To(Equal(result))
+			Expect(ProcessingPhaseProcess).To(Equal(aud.GetResumePhase()))
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		table.Entry("return Error with missing scratch space", cirrosFilePath, "/imaninvalidpath", nil, true),
+		table.Entry("return Process with scratch space and valid qcow file", cirrosFilePath, "", cirrosData, false),
+	)
+
+	It("Transfer should fail on reader error", func() {
+		sourceFile, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+
+		aud = NewAsyncUploadDataSource(sourceFile)
+		nextPhase, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferScratch).To(Equal(nextPhase))
+		err = sourceFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+		result, err := aud.Transfer(tmpDir)
+		Expect(err).To(HaveOccurred())
+		Expect(ProcessingPhaseError).To(Equal(result))
+	})
+
+	It("TransferFile should succeed when writing to valid file", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		sourceFile, err := os.Open(tinyCoreFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(sourceFile)
+		result, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		result, err = aud.TransferFile(filepath.Join(tmpDir, "file"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ProcessingPhasePause).To(Equal(result))
+		Expect(ProcessingPhaseResize).To(Equal(aud.GetResumePhase()))
+	})
+
+	It("TransferFile should fail on streaming error", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		sourceFile, err := os.Open(tinyCoreFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(sourceFile)
+		result, err := aud.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		result, err = aud.TransferFile("/invalidpath/invalidfile")
+		Expect(err).To(HaveOccurred())
+		Expect(ProcessingPhaseError).To(Equal(result))
+	})
+
+	It("Process should return Convert", func() {
+		// Don't need to defer close, since ud.Close will close the reader
+		file, err := os.Open(cirrosFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		aud = NewAsyncUploadDataSource(file)
+		result, err := aud.Process()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ProcessingPhaseConvert).To(Equal(result))
+	})
+
+	It("Close with nil stream should not fail", func() {
+		aud = NewAsyncUploadDataSource(nil)
+		err := aud.Close()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/uploadproxy/BUILD.bazel
+++ b/pkg/uploadproxy/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     srcs = ["uploadproxy_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/common:go_default_library",
         "//pkg/token:go_default_library",
         "//pkg/util/cert:go_default_library",
         "//pkg/util/cert/fetcher:go_default_library",

--- a/pkg/uploadserver/BUILD.bazel
+++ b/pkg/uploadserver/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/importer:go_default_library",
         "//pkg/util/cert:go_default_library",
         "//pkg/util/cert/triple:go_default_library",
     ],


### PR DESCRIPTION
after transfer completes and then continues background processing.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds an async endpoint to the upload server and proxy. When an upload is called using this endpoint the connection is closed immediately as soon as the data has been received. But the uploadserver will continue to process until the entire process is complete.

This is backwards compatible with virtctl that doesn't handle this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CDI now has asynchronous upload endpoint.
```

