### PR TITLE
remove permission to get secrets at cluster scope

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -156,16 +156,6 @@ func getSecretName(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (
 		klog.V(2).Infof(msg+"\n", AnnSecret, ns, pvc.Name)
 		return "", nil // importer pod will not contain secret credentials
 	}
-	klog.V(3).Infof("getEndpointSecret: retrieving Secret \"%s/%s\"\n", ns, name)
-	_, err := client.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
-		klog.V(1).Infof("secret %q defined in pvc \"%s/%s\" is missing. Importer pod will run once this secret is created\n", name, ns, pvc.Name)
-		return name, nil
-	}
-	if err != nil {
-		return "", errors.Wrapf(err, "error getting secret %q defined in pvc \"%s/%s\"", name, ns, pvc.Name)
-	}
-	klog.V(1).Infof("retrieved secret %q defined in pvc \"%s/%s\"\n", name, ns, pvc.Name)
 	return name, nil
 }
 

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -99,20 +99,6 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"secrets",
-			},
-			Verbs: []string{
-				"get",
-				"create",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
 				"extensions",
 			},
 			Resources: []string{

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -67,6 +67,19 @@ func createControllerRole() *rbacv1.Role {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"secrets",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
 	return role
 }

--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -92,11 +92,11 @@ var _ = Describe("[rfe_id:1347][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			ValidateRBACForResource(f, podExpectedResult, "pods/finalizers", sa)
 
 			secretsExpectedResult := make(map[string]string)
-			secretsExpectedResult["get"] = "yes"
-			secretsExpectedResult["list"] = "yes"
-			secretsExpectedResult["watch"] = "yes"
+			secretsExpectedResult["get"] = "no"
+			secretsExpectedResult["list"] = "no"
+			secretsExpectedResult["watch"] = "no"
 			secretsExpectedResult["delete"] = "no"
-			secretsExpectedResult["create"] = "yes"
+			secretsExpectedResult["create"] = "no"
 			secretsExpectedResult["update"] = "no"
 			secretsExpectedResult["patch"] = "no"
 			secretsExpectedResult["deletecollection"] = "no"


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently CDI has permission to get secrets in any namespace.  This is obviously a security concern.  It is also not necessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Related issue in Kubevirt

https://github.com/kubevirt/kubevirt/issues/2967

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

