### PR TITLE
Remove references to extensions/v1beta1 in examples

### DIFF
--- a/doc/basic_pv_pvc_dv.md
+++ b/doc/basic_pv_pvc_dv.md
@@ -146,7 +146,7 @@ kind: ServiceAccount
 metadata:
   name: local-storage-admin
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-volume-provisioner

--- a/doc/exposing-upload-proxy.md
+++ b/doc/exposing-upload-proxy.md
@@ -18,7 +18,7 @@ Create Ingress for the upload proxy:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cdi-uploadproxy-ingress


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix examples that reference extension/v1beta1 API as its deprecated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1100 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

