### PR TITLE
Disable caching when converting qcow2 images

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -99,7 +99,7 @@ func NewQEMUOperations() QEMUOperations {
 }
 
 func convertToRaw(src, dest string) error {
-	_, err := qemuExecFunction(nil, nil, "qemu-img", "convert", "-p", "-O", "raw", "-o", "preallocation=falloc", src, dest)
+	_, err := qemuExecFunction(nil, nil, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", "-o", "preallocation=falloc", src, dest)
 	if err != nil {
 		os.Remove(dest)
 		return errors.Wrap(err, "could not convert image to raw")
@@ -115,7 +115,7 @@ func (o *qemuOperations) ConvertToRawStream(url *url.URL, dest string) error {
 	}
 	jsonArg := fmt.Sprintf("json: {\"file.driver\": \"%s\", \"file.url\": \"%s\", \"file.timeout\": %d}", url.Scheme, url, networkTimeoutSecs)
 
-	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", "convert", "-p", "-O", "raw", "-o", "preallocation=falloc", jsonArg, dest)
+	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", "-o", "preallocation=falloc", jsonArg, dest)
 	if err != nil {
 		// TODO: Determine what to do here, the conversion failed, and we need to clean up the mess, but we could be writing to a block device
 		os.Remove(dest)


### PR DESCRIPTION
When converting images the qemu-img command uses a writeback cache mode
by default.  This means that writes to a block device go through the
host page cache and are lazily flushed to the storage device.  When
using this cache mode, the process can exit before all writes have
reached storage and our DataVolume could appear ready to use before all
I/O has completed.  This becomes a problem with shared storage because a
second host does not have the benefit of the first host's page cache
when reading.  To prevent this problem we must perform I/O directly to
the storage device.  This behavior is selected by passing "-t" "none" to
qemu-img.

This problem will not arise with "create", "info", or "resize" qemu-img
commands because those are metadata operations.

The following document provides some good background on qemu cache modes:
https://documentation.suse.com/sles/11-SP4/html/SLES-kvm4zseries/cha-qemu-cachemodes.html

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

