### PR TITLE
operator needs to use uncached client in certain places

### DIFF
--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 )
@@ -73,6 +74,7 @@ type ReconcileCallbackArgs struct {
 	Client    client.Client
 	Scheme    *runtime.Scheme
 	Namespace string
+	Resource  *cdiv1alpha1.CDI
 
 	State         ReconcileState
 	DesiredObject runtime.Object

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -93,8 +93,17 @@ func newReconciler(mgr manager.Manager) (*ReconcileCDI, error) {
 
 	log.Info("", "VARS", fmt.Sprintf("%+v", namespacedArgs))
 
+	uncachedClient, err := client.New(mgr.GetConfig(), client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	r := &ReconcileCDI{
 		client:         mgr.GetClient(),
+		uncachedClient: uncachedClient,
 		scheme:         mgr.GetScheme(),
 		namespace:      namespace,
 		clusterArgs:    clusterArgs,
@@ -113,9 +122,12 @@ var _ reconcile.Reconciler = &ReconcileCDI{}
 type ReconcileCDI struct {
 	// This Client, initialized using mgr.client() above, is a split Client
 	// that reads objects from the cache and writes to the apiserver
-	client     client.Client
-	scheme     *runtime.Scheme
-	controller controller.Controller
+	client client.Client
+
+	// use this for getting any resources not in the install namespace or cluster scope
+	uncachedClient client.Client
+	scheme         *runtime.Scheme
+	controller     controller.Controller
 
 	namespace      string
 	clusterArgs    *cdicluster.FactoryArgs
@@ -314,7 +326,7 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 			}
 
 			// PRE_CREATE callback
-			if err = r.invokeCallbacks(logger, ReconcileStatePreCreate, desiredRuntimeObj, nil); err != nil {
+			if err = r.invokeCallbacks(logger, cr, ReconcileStatePreCreate, desiredRuntimeObj, nil); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -325,7 +337,7 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 			}
 
 			// POST_CREATE callback
-			if err = r.invokeCallbacks(logger, ReconcileStatePostCreate, desiredRuntimeObj, nil); err != nil {
+			if err = r.invokeCallbacks(logger, cr, ReconcileStatePostCreate, desiredRuntimeObj, nil); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -335,7 +347,7 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 				"type", fmt.Sprintf("%T", desiredMetaObj))
 		} else {
 			// POST_READ callback
-			if err = r.invokeCallbacks(logger, ReconcileStatePostRead, desiredRuntimeObj, currentRuntimeObj); err != nil {
+			if err = r.invokeCallbacks(logger, cr, ReconcileStatePostRead, desiredRuntimeObj, currentRuntimeObj); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -362,7 +374,7 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 				setLabel(updateVersionLabel, r.namespacedArgs.OperatorVersion, currentMetaObj)
 
 				// PRE_UPDATE callback
-				if err = r.invokeCallbacks(logger, ReconcileStatePreUpdate, desiredRuntimeObj, currentRuntimeObj); err != nil {
+				if err = r.invokeCallbacks(logger, cr, ReconcileStatePreUpdate, desiredRuntimeObj, currentRuntimeObj); err != nil {
 					return reconcile.Result{}, err
 				}
 
@@ -371,7 +383,7 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1alpha1.CDI) 
 				}
 
 				// POST_UPDATE callback
-				if err = r.invokeCallbacks(logger, ReconcileStatePostUpdate, desiredRuntimeObj, nil); err != nil {
+				if err = r.invokeCallbacks(logger, cr, ReconcileStatePostUpdate, desiredRuntimeObj, nil); err != nil {
 					return reconcile.Result{}, err
 				}
 
@@ -488,7 +500,7 @@ func (r *ReconcileCDI) cleanupUnusedResources(logger logr.Logger, cr *cdiv1alpha
 
 			if !found && metav1.IsControlledBy(observedMetaObj, cr) {
 				//Invoke pre delete callback
-				if err = r.invokeCallbacks(logger, ReconcileStatePreDelete, nil, observedObj); err != nil {
+				if err = r.invokeCallbacks(logger, cr, ReconcileStatePreDelete, nil, observedObj); err != nil {
 					return err
 				}
 
@@ -501,7 +513,7 @@ func (r *ReconcileCDI) cleanupUnusedResources(logger logr.Logger, cr *cdiv1alpha
 				}
 
 				//invoke post delete callback
-				if err = r.invokeCallbacks(logger, ReconcileStatePostDelete, nil, observedObj); err != nil {
+				if err = r.invokeCallbacks(logger, cr, ReconcileStatePostDelete, nil, observedObj); err != nil {
 					return err
 				}
 			}
@@ -814,7 +826,7 @@ func (r *ReconcileCDI) invokeDeleteCDICallbacks(logger logr.Logger, cr *cdiv1alp
 	}
 
 	for _, desiredObj := range desiredResources {
-		if err = r.invokeCallbacks(logger, ReconcileStateCDIDelete, desiredObj, nil); err != nil {
+		if err = r.invokeCallbacks(logger, cr, ReconcileStateCDIDelete, desiredObj, nil); err != nil {
 			return err
 		}
 	}
@@ -822,7 +834,7 @@ func (r *ReconcileCDI) invokeDeleteCDICallbacks(logger logr.Logger, cr *cdiv1alp
 	return nil
 }
 
-func (r *ReconcileCDI) invokeCallbacks(l logr.Logger, s ReconcileState, desiredObj, currentObj runtime.Object) error {
+func (r *ReconcileCDI) invokeCallbacks(l logr.Logger, cr *cdiv1alpha1.CDI, s ReconcileState, desiredObj, currentObj runtime.Object) error {
 	var t reflect.Type
 
 	if desiredObj != nil {
@@ -853,12 +865,13 @@ func (r *ReconcileCDI) invokeCallbacks(l logr.Logger, s ReconcileState, desiredO
 
 		args := &ReconcileCallbackArgs{
 			Logger:        l,
-			Client:        r.client,
+			Client:        r.uncachedClient,
 			Scheme:        r.scheme,
 			Namespace:     r.namespace,
 			State:         s,
 			DesiredObject: desiredObj,
 			CurrentObject: currentObj,
+			Resource:      cr,
 		}
 
 		log.V(3).Info("Invoking callbacks for", "type", t)

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1366,6 +1366,7 @@ func createReconciler(client realClient.Client) *ReconcileCDI {
 
 	r := &ReconcileCDI{
 		client:         client,
+		uncachedClient: client,
 		scheme:         scheme.Scheme,
 		namespace:      namespace,
 		clusterArgs:    clusterArgs,


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The operator was no longer cleaning up orphaned import/upload/clone pods when CDI is deleted.  This is because #1091 switched controller runtime client config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1106 

**Special notes for your reviewer**:

Functional test here is pretty risky.  actually uninstalls/reinstalls CDI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

