### PR TITLE
Copy kubevirt.io annotations to scratch space pvc

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -76,6 +76,11 @@ const (
 	// ClonerSourcePodNameSuffix (controller pkg only)
 	ClonerSourcePodNameSuffix = "-source-pod"
 
+	// KubeVirtAnnKey is part of a kubevirt.io key.
+	KubeVirtAnnKey = "kubevirt.io/"
+	// CDIAnnKey is part of a kubevirt.io key.
+	CDIAnnKey = "cdi.kubevirt.io/"
+
 	// SmartClonerCDILabel is the label applied to resources created by the smart-clone controller
 	SmartClonerCDILabel = "cdi-smart-clone"
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -235,7 +235,9 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 	// Check if the POD is waiting for scratch space, if so create some.
 	if pod.Status.Phase == corev1.PodPending && r.requiresScratchSpace(pvc) {
 		if err := r.createScratchPvcForPod(pvc, pod); err != nil {
-			return err
+			if !k8serrors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 	if !checkIfLabelExists(pvc, common.CDILabelKey, common.CDILabelValue) {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -929,12 +930,21 @@ func createScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassNa
 		"app":            "containerized-data-importer",
 		LabelImportPvc:   pvc.Name,
 	}
+	annotations := make(map[string]string)
+	if len(pvc.GetAnnotations()) > 0 {
+		for k, v := range pvc.GetAnnotations() {
+			if strings.Contains(k, common.KubeVirtAnnKey) && !strings.Contains(k, common.CDIAnnKey) {
+				annotations[k] = v
+			}
+		}
+	}
 
 	return &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvc.Name + "-scratch",
-			Namespace: pvc.Namespace,
-			Labels:    labels,
+			Name:        pvc.Name + "-scratch",
+			Namespace:   pvc.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         "v1",


### PR DESCRIPTION
but NOT cdi.kubevirt.io as those are what triggers import/upload/clone.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In general we do not want to copy over annotations from the original PVC to the scratch space PVC. For instance if provisioners use annotations do to special things to a PVC. However in certain situations we would like to copy them if the annotations are part of kubevirt.io. This PR copies kubevirt.io annotations from the PVC to the scratch space PVC, but not cdi.kubevirt.io because those are the annotations that trigger import/upload/clone and thus would cause the scratch space to be imported/uploaded/cloned to.

We want to copy the kubevirt.io/provisionOn annotation for the host path provisioner, so we can guarantee that the scratch space is on the same node if that annotation has been used. Otherwise there is a race condition between binding a PVC and scheduling a pod to determine which node the pod will run on. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

