### PR TITLE
keep go.mod and vendor up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ cluster-sync: cluster-clean
 	./cluster-sync/sync.sh DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
 
 bazel-generate:
-	SYNC_VENDOR=true ${DO_BAZ} "./hack/build/bazel-generate.sh"
+	SYNC_VENDOR=true ${DO_BAZ} "./hack/build/bazel-generate.sh -- pkg/ tools/ tests/ cmd/ vendor/"
 
 bazel-cdi-generate:
 	${DO_BAZ} "./hack/build/bazel-generate.sh -- pkg/ tools/ tests/ cmd/"
@@ -113,7 +113,7 @@ bazel-cdi-generate:
 bazel-build:
 	${DO_BAZ} "./hack/build/bazel-build.sh"
 
-bazel-build-images:	bazel-cdi-generate bazel-build
+bazel-build-images:	gomod-update bazel-generate bazel-build
 	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build/bazel-build-images.sh"
 
 bazel-push-images: bazel-cdi-generate bazel-build

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -102,7 +102,11 @@ volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 # Ensure that a bazel server is running
 
 if [ -z "$(docker ps --format '{{.Names}}' | grep ${BAZEL_BUILDER_SERVER})" ]; then
-    docker run --network host -d ${volumes} --security-opt label:disable --name ${BAZEL_BUILDER_SERVER} -w "/root/go/src/kubevirt.io/containerized-data-importer" --rm ${BUILDER_IMAGE} hack/build/bazel-server.sh
+    docker run --network host -d ${volumes} --security-opt label:disable \
+        --name ${BAZEL_BUILDER_SERVER} \
+        -w "/root/go/src/kubevirt.io/containerized-data-importer" \
+        -e GOPATH=/root/go \
+        --rm ${BUILDER_IMAGE} hack/build/bazel-server.sh
 fi
 
 echo "Starting bazel server"


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We are using `go mod` for dependency management but not using straight `go build` for building.  If we were, `go.mod` would be updated whenever we build.  So simulating that with this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

If `kubevirt-cdi-volume-bazel-server` container is running it, kill it.  The first build will take awhile as all deps are downloaded.  But future builds will be fast.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

