### PR TITLE
Eliminate the need for HEAD requests in the Go HTTP download client.

### DIFF
--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -271,7 +271,7 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 		return nil, uint64(0), true, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
 	}
 
-	if (total == 0) {
+	if total == 0 {
 		// The total seems bogus. Let's try the GET Content-Length header
 		total = parseHTTPHeader(resp)
 	}
@@ -342,7 +342,7 @@ func getContentLength(client *http.Client, ep *url.URL, accessKey, secKey string
 	return total, nil
 }
 
-func parseHTTPHeader(resp *http.Response) (uint64) {
+func parseHTTPHeader(resp *http.Response) uint64 {
 	var err error
 	total := uint64(0)
 	if val, ok := resp.Header["Content-Length"]; ok {

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -348,7 +348,7 @@ func parseHTTPHeader(resp *http.Response) (uint64) {
 	if val, ok := resp.Header["Content-Length"]; ok {
 		total, err = strconv.ParseUint(val[0], 10, 64)
 		if err != nil {
-			klog.Errorf("could not convert content length, got %d", err)
+			klog.Errorf("could not convert content length, got %v", err)
 		}
 		klog.V(3).Infof("Content length: %d\n", total)
 	}

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -341,7 +341,7 @@ var _ = Describe("Http reader", func() {
 
 	It("should continue even if HEAD is rejected, but mark broken for qemu-img", func() {
 		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if (r.Method == "HEAD") {
+			if r.Method == "HEAD" {
 				w.WriteHeader(http.StatusForbidden)
 			} else {
 				defer w.WriteHeader(http.StatusOK)

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -322,10 +322,8 @@ var _ = Describe("Http reader", func() {
 
 	It("should continue even if Content-Length is bogus", func() {
 		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _, ok := r.BasicAuth()
 			defer w.WriteHeader(http.StatusOK)
 			w.Header().Add("Content-Length", "intentional gibberish")
-			Expect(ok).To(BeFalse())
 		}))
 		defer redirTs.Close()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Http client", func() {
 
 var _ = Describe("Http reader", func() {
 	It("should fail when passed an invalid cert directory", func() {
-		_, total, err := createHTTPReader(context.Background(), nil, "", "", "/invalid")
+		_, total, _, err := createHTTPReader(context.Background(), nil, "", "", "/invalid")
 		Expect(err).To(HaveOccurred())
 		Expect(uint64(0)).To(Equal(total))
 	})
@@ -269,7 +269,7 @@ var _ = Describe("Http reader", func() {
 		defer ts.Close()
 		ep, err := url.Parse(ts.URL)
 		Expect(err).ToNot(HaveOccurred())
-		r, total, err := createHTTPReader(context.Background(), ep, "user", "password", "")
+		r, total, _, err := createHTTPReader(context.Background(), ep, "user", "password", "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uint64(25)).To(Equal(total))
 		err = r.Close()
@@ -292,7 +292,7 @@ var _ = Describe("Http reader", func() {
 		defer ts.Close()
 		ep, err := url.Parse(ts.URL)
 		Expect(err).ToNot(HaveOccurred())
-		r, total, err := createHTTPReader(context.Background(), ep, "user", "password", "")
+		r, total, _, err := createHTTPReader(context.Background(), ep, "user", "password", "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uint64(25)).To(Equal(total))
 		err = r.Close()
@@ -313,12 +313,34 @@ var _ = Describe("Http reader", func() {
 		defer ts.Close()
 		ep, err := url.Parse(ts.URL)
 		Expect(err).ToNot(HaveOccurred())
-		r, total, err := createHTTPReader(context.Background(), ep, "", "", "")
+		r, total, _, err := createHTTPReader(context.Background(), ep, "", "", "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uint64(25)).To(Equal(total))
 		err = r.Close()
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should continue even if Content-Length is bogus", func() {
+		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _, ok := r.BasicAuth()
+			defer w.WriteHeader(http.StatusOK)
+			w.Header().Add("Content-Length", "intentional gibberish")
+			Expect(ok).To(BeFalse())
+		}))
+		defer redirTs.Close()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirTs.URL, http.StatusFound)
+		}))
+		defer ts.Close()
+		ep, err := url.Parse(ts.URL)
+		Expect(err).ToNot(HaveOccurred())
+		r, total, _, err := createHTTPReader(context.Background(), ep, "", "", "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(uint64(0)).To(Equal(total))
+		err = r.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 
 	It("should fail if server returns error code", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -327,7 +349,7 @@ var _ = Describe("Http reader", func() {
 		defer ts.Close()
 		ep, err := url.Parse(ts.URL)
 		Expect(err).ToNot(HaveOccurred())
-		_, total, err := createHTTPReader(context.Background(), ep, "", "", "")
+		_, total, _, err := createHTTPReader(context.Background(), ep, "", "", "")
 		Expect(err).To(HaveOccurred())
 		Expect(uint64(0)).To(Equal(total))
 		Expect("expected status code 200, got 500. Status: 500 Internal Server Error").To(Equal(err.Error()))


### PR DESCRIPTION
Some servers reject such requests, and if Content-Length is available,
it's going to be sent in GET requests as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some servers reject HEAD requests but allow GET, this causes 403 Failed errors.
Example: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img fails (this is also listed as one of our examples).

This is one step towards a solution but doesn't actually solve the problem.
It's not complete because later we invoke qemu-img on the same URL and it suffers from the same limitation.

A complete solution will probably involve saving the file to disk and passing the saved file to qemu-img, but I don't want to block others until I finish writing that.

**Release note**:
```release-note
NONE
```

