### PR TITLE
Add note in docs that scratch space requires RWO mode on the PVs in o…

### DIFF
--- a/doc/scratch-space.md
+++ b/doc/scratch-space.md
@@ -9,7 +9,7 @@ CDI uses the following mechanism to determine which storage class to use:
 
 If none of those exist, then CDI will be unable to create scratch space. This means that none of the operations that require scratch space will work, however operations that do not require scratch space will continue to operate normally.
 
-**Important note:** CDI always requests scratch space with a `file` volume mode regardless of the volume mode of the related DataVolume.  Therefore, when using block mode DataVolumes you must ensure that a storage class capable of provisioning file mode PVCs is configured according to the instructions above. This limitation will be removed in a future release.
+**Important note:** CDI always requests scratch space with a `Filesystem` volume mode regardless of the volume mode of the related DataVolume. It also always requests it with a ReadWriteOnce accessMode. Therefore, when using block mode DataVolumes you must ensure that a storage class capable of provisioning Filesystem mode PVCs with ReadWriteOnce accessMode is configured according to the instructions above. This limitation will be removed in a future release.
 
 Operations that require scratch space are:
 


### PR DESCRIPTION
…rder to be matched.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Explain that scratch space PVC requests always use RWO accessMode, and thus scratch space storage will need to supply RWO PVs in order for it to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

