### PR TITLE
Increase test timeouts to account for slower CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-openapi/spec v0.19.2
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubernetes-csi/external-snapshotter v0.0.0-20190509204040-e49856eb417c
 	github.com/minio/minio-go v6.0.14+incompatible
@@ -37,9 +36,7 @@ require (
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ulikunitz/xz v0.5.6
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.uber.org/multierr v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -28,9 +28,9 @@ const (
 	fillCommand                      = "echo \"" + fillData + "\" >> " + testBaseDir
 	blockFillCommand                 = "dd if=/dev/urandom bs=4096 of=" + testBaseDir + " || echo this is fine"
 	assertionPollInterval            = 2 * time.Second
-	cloneCompleteTimeout             = 90 * time.Second
-	verifyPodDeletedTimeout          = 90 * time.Second
-	controllerSkipPVCCompleteTimeout = 90 * time.Second
+	cloneCompleteTimeout             = 270 * time.Second
+	verifyPodDeletedTimeout          = 270 * time.Second
+	controllerSkipPVCCompleteTimeout = 270 * time.Second
 )
 
 var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:component]Cloner Test Suite", func() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	pollingInterval = 2 * time.Second
-	timeout         = 90 * time.Second
+	timeout         = 270 * time.Second
 )
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	namespacePrefix                  = "importer"
 	assertionPollInterval            = 2 * time.Second
-	controllerSkipPVCCompleteTimeout = 90 * time.Second
+	controllerSkipPVCCompleteTimeout = 270 * time.Second
 	invalidEndpoint                  = "http://gopats.com/who-is-the-goat.iso"
 	CompletionTimeout                = 60 * time.Second
 	BlankImageMD5                    = "cd573cfaace07e7949bc0c46028904ff"

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultTimeout      = 90 * time.Second
+	defaultTimeout      = 270 * time.Second
 	testNamespacePrefix = "cdi-test-"
 )
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -18,9 +18,9 @@ import (
 
 const (
 	dataVolumePollInterval = 3 * time.Second
-	dataVolumeCreateTime   = 90 * time.Second
-	dataVolumeDeleteTime   = 90 * time.Second
-	dataVolumePhaseTime    = 90 * time.Second
+	dataVolumeCreateTime   = 270 * time.Second
+	dataVolumeDeleteTime   = 270 * time.Second
+	dataVolumePhaseTime    = 270 * time.Second
 )
 
 const (

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultPollInterval = 2 * time.Second
-	defaultPollPeriod   = 90 * time.Second
+	defaultPollPeriod   = 270 * time.Second
 
 	// DefaultPvcMountPath is the default mount path used
 	DefaultPvcMountPath = "/pvc"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CI has been failed a lot on pods that are getting ready but just take longer than the timeout. This PR increases the timeout to hopefully cut down on failures due to the CI being slow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

