### PR TITLE
skip CDI CR delete tests when expected name does not exist

### DIFF
--- a/manifests/templates/release/cdi-cr.yaml.in
+++ b/manifests/templates/release/cdi-cr.yaml.in
@@ -2,6 +2,5 @@ apiVersion: cdi.kubevirt.io/v1alpha1
 kind: CDI
 metadata:
   name: cdi
-  namespace: {{.Namespace}}
 spec:
   imagePullPolicy: {{.PullPolicy}}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -76,6 +76,9 @@ var _ = Describe("Operator delete CDI tests", func() {
 	BeforeEach(func() {
 		var err error
 		cr, err = f.CdiClient.CdiV1alpha1().CDIs().Get("cdi", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			Skip("CDI CR 'cdi' does not exist.  Probably managed by another operator so skipping.")
+		}
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When CDI is installed by HCO, skip CDI CR delete tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

