### PR TITLE
Added missing cdiv1 scheme in import controller unit test.

### DIFF
--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -375,7 +375,7 @@ func createImportReconciler(objects ...runtime.Object) *ImportReconciler {
 
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
-	corev1.AddToScheme(s)
+	cdiv1.AddToScheme(s)
 
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
 	cdiConfig.Status = cdiv1.CDIConfigStatus{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Unit tests would sometimes fail with
```
•! Panic [0.000 seconds]
Create Importer Pod
/go/src/kubevirt.io/containerized-data-importer/pkg/controller/import-controller_test.go:311
  should
  /go/src/kubevirt.io/containerized-data-importer/vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
    should create pod with block volume mode and scratchspace [It]
    /go/src/kubevirt.io/containerized-data-importer/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:46

    Test Panicked
    failed to add object &{{ } {config      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[app:containerized-data-importer cdi.kubevirt.io:] map[] [] []  []} {<nil> <nil> nil} {<nil> test-sc nil}} to fake client: no kind is registered for the type v1alpha1.CDIConfig in scheme "k8s.io/client-go/kubernetes/scheme/register.go:67"
```
It was caused by a missing AddToScheme for the cdiv1 package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

