### PR TITLE
Update comments on scratch space

### DIFF
--- a/doc/scratch-space.md
+++ b/doc/scratch-space.md
@@ -3,9 +3,8 @@ Containerized Data Importer(CDI) requires scratch space for certain operations t
 
 CDI uses the following mechanism to determine which storage class to use:
 
-1. Read the CDI config field _scratchSpaceStorageClass_ if that field exists, and the value matches one of the storage classes in the cluster, it will be used to create scratch space.
-2. If 1 is empty or didn't match a storage class, look up the _default_ storage class in the cluster, if that exists use that storage class.
-3. If there is no default storage class in the cluster, then use the storage class of the PersistentVolumeClaim(PVC) that is backing the DV that started the CDI operation.
+1. Read the CDI config status field _scratchSpaceStorageClass_ if that field exists, and the value matches one of the storage classes in the cluster, it will be used to create scratch space. (This field could be set manually or by fetching _default_ storage class in the cluster)
+2. If the CDI config field _scratchSpaceStorageClass_ is blank, then use the storage class of the PersistentVolumeClaim(PVC) that is backing the DV that started the CDI operation.
 
 If none of those exist, then CDI will be unable to create scratch space. This means that none of the operations that require scratch space will work, however operations that do not require scratch space will continue to operate normally.
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -296,10 +296,9 @@ func CreateScratchPersistentVolumeClaim(client kubernetes.Interface, pvc *v1.Per
 
 // GetScratchPvcStorageClass tries to determine which storage class to use for use with a scratch persistent
 // volume claim. The order of preference is the following:
-// 1. Defined value in CDI config map.
-// 2. If 1 is not available use the 'default' storage class.
-// 3. If 2 is not available use the storage class name of the original pvc that will own the scratch pvc.
-// 4. If none of those are available, return blank.
+// 1. Defined value in CDI Config field scratchSpaceStorageClass.
+// 2. If 1 is not available, use the storage class name of the original pvc that will own the scratch pvc.
+// 3. If none of those are available, return blank.
 func GetScratchPvcStorageClass(client kubernetes.Interface, cdiclient clientset.Interface, pvc *v1.PersistentVolumeClaim) string {
 	config, err := cdiclient.CdiV1alpha1().CDIConfigs().Get(common.ConfigName, metav1.GetOptions{})
 	if err != nil {
@@ -307,7 +306,7 @@ func GetScratchPvcStorageClass(client kubernetes.Interface, cdiclient clientset.
 	}
 	storageClassName := config.Status.ScratchSpaceStorageClass
 	if storageClassName == "" {
-		// Unable to determine default storage class, attempt to read the storage class from the pvc.
+		// Unable to determine scratch storage class, attempt to read the storage class from the pvc.
 		if pvc.Spec.StorageClassName != nil {
 			storageClassName = *pvc.Spec.StorageClassName
 			if storageClassName != "" {


### PR DESCRIPTION
- match comments on scratch space storage class with
 the source code

Signed-off-by: anencore94 <anencore94@kaist.ac.kr>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After this [commit](https://github.com/kubevirt/containerized-data-importer/commit/889f231300d8d4a0feb1dea9d64ca837c8cf150a), the field `scratchSpaceStorageClass` in `CDI config` checks the `default storage class` in config-controller's reconcile loop.

Thus the function `GetScratchPvcStorageClass` in `pkg/controller/util.go` no longer checks default storageclass, just uses the value in `scratchspacestorageclass`.

However, the comments says the old logic. Thus, update those to match with the source code.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

