### PR TITLE
Looks like gradle is no longer available in fedora 31, and the build …

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -15,7 +15,6 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 	python3-pip \
 	python3-devel \
 	mercurial \
-	gradle \
 	gcc \
     gcc-c++ \
     glibc-devel \
@@ -27,11 +26,18 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 	rsync-daemon \
 	rsync \
 	patch \
+    unzip \
+    java-1.8.0-openjdk \
 	&& microdnf clean all && \
 	mv /etc/yum.repos.d/old/* /etc/yum.repos.d/ && \
 	rmdir /etc/yum.repos.d/old
 
-RUN pip3 install j2cli && pip3 install operator-courier
+RUN pip3 install j2cli && pip3 install operator-courier && \
+    curl -sL https://services.gradle.org/distributions/gradle-4.3.1-bin.zip -o gradle-4.3.1-bin.zip && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle gradle-4.3.1-bin.zip && \
+    ln -s /opt/gradle/gradle-4.3.1/bin/gradle /usr/local/bin/gradle && \
+    rm gradle-4.3.1-bin.zip
 
 ENV GIMME_GO_VERSION=1.12.14 GOPATH="/go" KUBEBUILDER_VERSION="2.2.0" ARCH="amd64"
 ENV BAZEL_PYTHON=/usr/bin/python3

--- a/hack/build/docker/builder/entrypoint-bazel.sh
+++ b/hack/build/docker/builder/entrypoint-bazel.sh
@@ -19,6 +19,7 @@ set -eo pipefail
 
 source /etc/profile.d/gimme.sh
 
-export PATH=${GOPATH}/bin:$PATH
+export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+export PATH=${GOPATH}/bin:/opt/gradle/gradle-4.3.1/bin:$PATH
 
 eval "$@"

--- a/hack/build/docker/builder/entrypoint.sh
+++ b/hack/build/docker/builder/entrypoint.sh
@@ -19,7 +19,8 @@ set -eo pipefail
 
 source /etc/profile.d/gimme.sh
 
-export PATH=${GOPATH}/bin:$PATH
+export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+export PATH=${GOPATH}/bin:/opt/gradle/gradle-4.3.1/bin:$PATH
 
 eval "$@"
 

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -38,7 +38,7 @@ WORKDIR="hack/gen-swagger-doc"
 GRADLE_BUILD_FILE="$WORKDIR/build.gradle"
 
 # Generate *.adoc files from swagger.json
-gradle -b $GRADLE_BUILD_FILE $GRADLE_EXTRA_PARAMS convertSwagger2markup --info
+gradle -b $GRADLE_BUILD_FILE $GRADLE_EXTRA_PARAMS convertSwagger2markup --info --stacktrace
 
 #insert a TOC for top level API objects
 buf="${HEADER}${HEADER} Top Level API Objects\n\n"


### PR DESCRIPTION
…image build is failing due to it.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Builder is not completing and releases are failing due to it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

