### PR TITLE
Make sure the storage class annotations are not nil.

### DIFF
--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -485,6 +485,9 @@ func setStorageClassDefault(f *framework.Framework, scName string, isDefault boo
 		return err
 	}
 	ann := sc.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string)
+	}
 	ann[controller.AnnDefaultStorageClass] = strconv.FormatBool(isDefault)
 	sc.SetAnnotations(ann)
 	_, err = f.K8sClient.StorageV1().StorageClasses().Update(sc)


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If we have a storage class without annotations, then running the cdi config tests will generate a nil pointer error because I forget to check for a nil. This PR fixes that.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

