### PR TITLE
Avoid failing reconciliation on new CR

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	// do we even care about this CR?
-	if !metav1.IsControlledBy(configMap, cr) {
+	if configMap.DeletionTimestamp == nil && !metav1.IsControlledBy(configMap, cr) {
 		reqLogger.Info("Reconciling to error state, unwanted CDI object")
 		return r.reconcileError(reqLogger, cr, "Reconciling to error state, unwanted CDI object")
 	}


### PR DESCRIPTION
Avoid failing reconciliation on new CR

If the user explicitly delete CDI cr,
HCO will quickly try to create a new one.
If HCO is quick enough, CDI operator can
enter the reconciliation loop when an older
cdi-config config-map is still there although
marked for deletion.
In that case CDI operator was not going to create
a new config-map but was then marking the new CDI CR
in error phase just because it's still not controlled
by the config map pending for deletion.
On the next run, CDI operator was not going to create a
new config map just because the new CR is already marked
with phase=Errror.
Skip the controlled-by check on config maps marked for
deletion to avoid this bad loop.

```release-note
Fixes: https://bugzilla.redhat.com/1809872
```

