### PR TITLE
Use long timeout for uploadproxy client

### DIFF
--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -31,7 +31,7 @@ const (
 	waitReadyTime     = 10 * time.Second
 	waitReadyImterval = time.Second
 
-	proxyRequestTimeout = time.Hour
+	proxyRequestTimeout = 24 * time.Hour
 
 	uploadTokenLeeway = 10 * time.Second
 )


### PR DESCRIPTION
The timeout value used by the uploadproxy client sets an upper limit on
the amount of time an upload can take.  After this limit is reached the
proxy will close the connection with the uploadserver resulting in a
failed upload.  We do want a reasonable timeout to prevent zombie upload
connections from persisting forever but we don't want to prevent
legitimate operations.  Increase the timeout value to 24 hours which
should be enough even for reasonably large images over relatively slow
connections.  Uploads that take longer than one day should probably be
done with an import process anyway.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Increased the maximum allowed time for an upload from one hour to 24 hours.
```

