### PR TITLE
Restore sparse images as the default (revert #970)

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -99,7 +99,7 @@ func NewQEMUOperations() QEMUOperations {
 }
 
 func convertToRaw(src, dest string) error {
-	_, err := qemuExecFunction(nil, nil, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", "-o", "preallocation=falloc", src, dest)
+	_, err := qemuExecFunction(nil, nil, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", src, dest)
 	if err != nil {
 		os.Remove(dest)
 		return errors.Wrap(err, "could not convert image to raw")
@@ -115,7 +115,7 @@ func (o *qemuOperations) ConvertToRawStream(url *url.URL, dest string) error {
 	}
 	jsonArg := fmt.Sprintf("json: {\"file.driver\": \"%s\", \"file.url\": \"%s\", \"file.timeout\": %d}", url.Scheme, url, networkTimeoutSecs)
 
-	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", "-o", "preallocation=falloc", jsonArg, dest)
+	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", "convert", "-t", "none", "-p", "-O", "raw", jsonArg, dest)
 	if err != nil {
 		// TODO: Determine what to do here, the conversion failed, and we need to clean up the mess, but we could be writing to a block device
 		os.Remove(dest)
@@ -136,7 +136,7 @@ func convertQuantityToQemuSize(size resource.Quantity) string {
 }
 
 func (o *qemuOperations) Resize(image string, size resource.Quantity) error {
-	_, err := qemuExecFunction(nil, nil, "qemu-img", "resize", "-f", "raw", "--preallocation=falloc", image, convertQuantityToQemuSize(size))
+	_, err := qemuExecFunction(nil, nil, "qemu-img", "resize", "-f", "raw", image, convertQuantityToQemuSize(size))
 	if err != nil {
 		return errors.Wrapf(err, "Error resizing image %s", image)
 	}
@@ -223,13 +223,13 @@ func reportProgress(line string) {
 // CreateBlankImage creates empty raw image
 func CreateBlankImage(dest string, size resource.Quantity) error {
 	klog.V(1).Infof("creating raw image with size %s", size.String())
-	return util.RetryBackoffSize(dest, size, qemuIterface.CreateBlankImage)
+	return qemuIterface.CreateBlankImage(dest, size)
 }
 
 // CreateBlankImage creates a raw image with a given size
 func (o *qemuOperations) CreateBlankImage(dest string, size resource.Quantity) error {
 	klog.V(3).Infof("image size is %s", size.String())
-	_, err := qemuExecFunction(nil, nil, "qemu-img", "create", "-f", "raw", "-o", "preallocation=falloc", dest, convertQuantityToQemuSize(size))
+	_, err := qemuExecFunction(nil, nil, "qemu-img", "create", "-f", "raw", dest, convertQuantityToQemuSize(size))
 	if err != nil {
 		os.Remove(dest)
 		return errors.Wrap(err, fmt.Sprintf("could not create raw image with size %s in %s", size.String(), dest))

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Create blank image", func() {
 		quantity, err := resource.ParseQuantity("10Gi")
 		Expect(err).NotTo(HaveOccurred())
 		size := convertQuantityToQemuSize(quantity)
-		replaceExecFunction(mockExecFunction("", "", nil, "create", "-f", "raw", "-o", "preallocation=falloc", "image", size), func() {
+		replaceExecFunction(mockExecFunction("", "", nil, "create", "-f", "raw", "image", size), func() {
 			err = CreateBlankImage("image", quantity)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -299,27 +299,13 @@ var _ = Describe("Create blank image", func() {
 		quantity, err := resource.ParseQuantity("10Gi")
 		Expect(err).NotTo(HaveOccurred())
 		size := convertQuantityToQemuSize(quantity)
-		replaceExecFunction(mockExecFunctionIgnoreArgs("", "exit 1", nil, "create", "-f", "raw", "-o", "preallocation=falloc", "image", size), func() {
+		replaceExecFunction(mockExecFunction("", "exit 1", nil, "create", "-f", "raw", "image", size), func() {
 			err = CreateBlankImage("image", quantity)
 			Expect(err).To(HaveOccurred())
 			Expect(strings.Contains(err.Error(), "could not create raw image with size ")).To(BeTrue())
 		})
 	})
 })
-
-func mockExecFunctionIgnoreArgs(output, errString string, expectedLimits *system.ProcessLimitValues, checkArgs ...string) execFunctionType {
-	return func(limits *system.ProcessLimitValues, f func(string), cmd string, args ...string) (bytes []byte, err error) {
-		Expect(reflect.DeepEqual(expectedLimits, limits)).To(BeTrue())
-		if output != "" {
-			bytes = []byte(output)
-		}
-		if errString != "" {
-			err = errors.New(errString)
-		}
-
-		return
-	}
-}
 
 func mockExecFunction(output, errString string, expectedLimits *system.ProcessLimitValues, checkArgs ...string) execFunctionType {
 	return func(limits *system.ProcessLimitValues, f func(string), cmd string, args ...string) (bytes []byte, err error) {

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -266,7 +266,7 @@ func ResizeImage(dataFile, imageSize string, totalTargetSpace int64) error {
 			return nil
 		}
 		klog.V(1).Infof("Expanding image size to: %s\n", minSizeQuantity.String())
-		return util.RetryBackoffSize(dataFile, minSizeQuantity, qemuOperations.Resize)
+		return qemuOperations.Resize(dataFile, minSizeQuantity)
 	}
 	return errors.New("Image resize called with blank resize")
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -4,13 +4,11 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
-	"syscall"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -123,64 +121,6 @@ var _ = Describe("Copy files", func() {
 	It("Should not copy file from source to dest, with invalid target", func() {
 		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
 		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("RetryBackoffSize", func() {
-	var blockSize int64
-
-	BeforeEach(func() {
-		var stat syscall.Statfs_t
-		err := syscall.Statfs(".", &stat)
-		Expect(err).ToNot(HaveOccurred())
-		blockSize = int64(stat.Bsize)
-	})
-
-	It("Should succeed", func() {
-		callCount := 0
-		startQuantity := resource.NewScaledQuantity(int64(250*blockSize), 0)
-		err := RetryBackoffSize("", *startQuantity, func(dest string, size resource.Quantity) error {
-			callCount++
-			return nil
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(callCount).To(Equal(1))
-	})
-
-	It("Should succeed after 2 tries", func() {
-		callCount := 0
-		startQuantity := resource.NewScaledQuantity(int64(250*blockSize), 0)
-		err := RetryBackoffSize("", *startQuantity, func(dest string, size resource.Quantity) error {
-			callCount++
-			if resource.NewScaledQuantity(int64(200*blockSize), 0).Cmp(size) == 0 {
-				return nil
-			}
-			return fmt.Errorf("I am failing two tries, help me, %+v", size)
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(callCount).To(Equal(3))
-	})
-
-	It("Should fail after 10 tries", func() {
-		callCount := 0
-		startQuantity := resource.NewScaledQuantity(int64(250*blockSize), 0)
-		err := RetryBackoffSize("", *startQuantity, func(dest string, size resource.Quantity) error {
-			callCount++
-			return fmt.Errorf("I am failing, help me")
-		})
-		Expect(err).To(HaveOccurred())
-		Expect(callCount).To(Equal(11))
-	})
-
-	It("Should fail with invalid dest", func() {
-		callCount := 0
-		startQuantity := resource.NewScaledQuantity(int64(250*blockSize), 0)
-		err := RetryBackoffSize("/invalid/invalid", *startQuantity, func(dest string, size resource.Quantity) error {
-			callCount++
-			return fmt.Errorf("I should never get called")
-		})
-		Expect(err).To(HaveOccurred())
-		Expect(callCount).To(Equal(0))
 	})
 })
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -339,8 +339,8 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 		Expect(err).ToNot(HaveOccurred())
 		matchFile := filepath.Join(testBaseDir, "disk.img")
 		Expect(f.VerifyTargetPVCContentMD5(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(targetDv), matchFile, md5sum[:32])).To(BeTrue())
-		By("Verifying the image is not sparse")
-		Expect(f.VerifyNotSparse(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(targetDv))).To(BeTrue())
+		By("Verifying the image is sparse")
+		Expect(f.VerifySparse(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(targetDv))).To(BeTrue())
 
 	})
 

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -147,8 +147,8 @@ func (f *Framework) VerifyBlankDisk(namespace *k8sv1.Namespace, pvc *k8sv1.Persi
 	return strings.Compare("All zeros", string(output)) == 0, nil
 }
 
-// VerifyNotSparse checks a disk image not being sparse after creation/resize.
-func (f *Framework) VerifyNotSparse(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
+// VerifySparse checks a disk image being sparse after creation/resize.
+func (f *Framework) VerifySparse(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim) (bool, error) {
 	var executorPod *k8sv1.Pod
 	var err error
 
@@ -165,13 +165,13 @@ func (f *Framework) VerifyNotSparse(namespace *k8sv1.Namespace, pvc *k8sv1.Persi
 	if err != nil {
 		return false, err
 	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: not sparse output %s\n", string(output))
+	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: qemu-img info output %s\n", string(output))
 	var info image.ImgInfo
 	err = json.Unmarshal([]byte(output), &info)
 	if err != nil {
 		klog.Errorf("Invalid JSON:\n%s\n", string(output))
 	}
-	return info.ActualSize >= info.VirtualSize, nil
+	return info.VirtualSize >= info.ActualSize, nil
 }
 
 // VerifyTargetPVCArchiveContent provides a function to check if the number of files extracted from an archive matches the passed in value

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -111,8 +111,8 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		By("Verify the image contents")
 		Expect(f.VerifyBlankDisk(f.Namespace, pvc)).To(BeTrue())
-		By("Verifying the image is not sparse")
-		Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
+		By("Verifying the image is sparse")
+		Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 	})
 })
 

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -106,8 +106,8 @@ var _ = Describe("Transport Tests", func() {
 					Expect(same).To(BeTrue())
 				}
 			}
-			By("Verifying the image is not sparse")
-			Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
+			By("Verifying the image is sparse")
+			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 		} else {
 			By("Verify PVC status annotation says failed")
 			found, err := utils.WaitPVCPodStatusRunning(f.K8sClient, pvc)

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -99,8 +99,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5100kbytes, 100000)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
-			By("Verifying the image is not sparse")
-			Expect(f.VerifyNotSparse(f.Namespace, pvc)).To(BeTrue())
+			By("Verifying the image is sparse")
+			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 		} else {
 			uploader, err := utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, utils.UploadPodName(pvc), common.CDILabelSelector)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get uploader pod %q", f.Namespace.Name+"/"+utils.UploadPodName(pvc)))


### PR DESCRIPTION
(Leaving in some of the checks introduced in that change)

Having sparse disks works better with external storage being
monitored for low capacity. If we allocate the full size at
start, it shows up as a disk capacity alert immediately.

Another motivation to pre-allocate was that cloning would
sometimes fail for capacity reasons.
We now validate available size before cloning, so we don't
expect that problem to return.

```release-note
Images are again allocated sparsely.
This means that at first, the actual disk usage will be less than the full size of the image.
```