### PR TITLE
Add ember csi lane

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -60,6 +60,7 @@ container_bundle(
         "$(container_prefix)/cdi-func-test-registry-populate:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-populate-image",
         "$(container_prefix)/cdi-func-test-registry:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-image",
         "$(container_prefix)/imageio-init:$(container_tag)": "//tools/imageio-init:imageio-init-image",
+        "$(container_prefix)/loop-back-lvm:$(container_tag)": "//tools/loop-back-lvm:loop-back-lvm-image",
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,10 +96,10 @@ container_pull(
 )
 
 container_pull(
-    name = "fedora-full",
+    name = "fedora-docker",
     digest = "sha256:d3d106e8f3affb1011b97c2b6ef388430dc1474bf7c7ad05963cff49961edb89",
     registry = "index.docker.io",
-    repository = "library/fedora",
+    repository = "fedora",
     tag = "31",
 )
 
@@ -309,5 +309,173 @@ http_file(
     sha256 = "ec22cf64138373b6f28dab0b824fbf9cdec8060bf7b8ce8216a361ab70f0849b",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/k/kmod-26-4.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "basesystem",
+    sha256 = "20ef955e5f735233a425725b9af41d960b5602dfb0ae812ae720e37c9bf8a292",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/b/basesystem-11-8.fc31.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "bash",
+    sha256 = "09f5522e833a03fd66e7ea9368331b7f316f494db26decda59cbacb6ea4185b3",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/b/bash-5.0.7-3.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "fedora-gpg-keys",
+    sha256 = "f2ae011207332ac90d0cf50b1f0b9eb0ce8be1d4d4c7186463dff38a90af0f3d",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-gpg-keys-31-1.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "fedora-release",
+    sha256 = "40eee4e4234c781277a202aa0e834c2be8afc28a3e4012b07d6c24058b0f4add",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-release-31-1.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "fedora-release-common",
+    sha256 = "e566c03caeeaa58db28c0b257f5d36ea92adfe2a18884208f03611c35397a6a1",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-release-common-31-1.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "fedora-repos",
+    sha256 = "9c9250ccd816e5d8c2bfdee14d16e9e71d2038707009e36e7642c136d7c62e4c",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-repos-31-1.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "filesystem",
+    sha256 = "ce05d442cca1de33cb9b4dfb72b94d8b97a072e2add394e075131d395ef463ff",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/filesystem-3.12-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "glibc",
+    sha256 = "33e0ad9b92d40c4e09d6407df1c8549b3d4d3d64fdd482439e66d12af6004f13",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-2.30-5.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "glibc-all-langpacks",
+    sha256 = "f67d5cc67029c6c38185f94b72aaa9034a49f5c4f166066c8268b41e1b18a202",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-all-langpacks-2.30-5.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "glibc-common",
+    sha256 = "1098c7738ca3b78a999074fbb93a268acac499ee8994c29757b1b858f59381bb",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-common-2.30-5.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "libgcc",
+    sha256 = "4106397648e9ef9ed7de9527f0da24c7e5698baa5bc1961b44707b55730ad5e1",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libgcc-9.2.1-1.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "libselinux",
+    sha256 = "b75fe6088e737720ea81a9377655874e6ac6919600a5652576f9ebb0d9232e5e",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libselinux-2.9-5.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "libsepol",
+    sha256 = "2ebd4efba62115da56ed54b7f0a5c2817f9acd29242a0334f62e8c645b81534f",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libsepol-2.9-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "ncurses-base",
+    sha256 = "cbd9d78da00aea6c1e98398fe883d5566971b3bc6764a07c5e945cd317013686",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/ncurses-base-6.1-12.20190803.fc31.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "ncurses-lib",
+    sha256 = "7b3ba4cdf8c0f1c4c807435d7b7a4a93ecb02737a95d064f3f20299e5bb3a106",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-12.20190803.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "pcre2",
+    sha256 = "017d8f5d4abb5f925c1b6d46467020c4fd5e8a8dcb4cc6650cab5627269e99d7",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/pcre2-10.33-14.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "setup",
+    sha256 = "4c859170bc4705a8ff4592f7376918fd2a97435c13cde79f24475c0a0866251d",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/s/setup-2.13.3-2.fc31.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "tzdata",
+    sha256 = "f0847b05feed5f47260e38b9ea40935644c061ccde2b82da5c68874190d59034",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/t/tzdata-2019c-1.fc31.noarch.rpm",
+    ],
+)
+
+http_file(
+    name = "iscsi-initiator-utils",
+    sha256 = "a3fab3da01bfcbeb3cfe223810f55ce6652976d51d07990f59cab2854498d90e",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "iscsi-initiator-utils-iscsiuio",
+    sha256 = "c557c2145799e5a5e45f8fdab25fd823c63babc36bb131e57c7c0e222ef6a911",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-iscsiuio-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "isns-utils-libs",
+    sha256 = "6805cf46806ab4b5975bccdb06bd33612bde50c0e09fbaafdc91d4498a45ea1b",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/isns-utils-libs-0.97-9.fc31.x86_64.rpm",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,6 +95,14 @@ container_pull(
     tag = "31",
 )
 
+container_pull(
+    name = "fedora-full",
+    digest = "sha256:d3d106e8f3affb1011b97c2b6ef388430dc1474bf7c7ad05963cff49961edb89",
+    registry = "index.docker.io",
+    repository = "library/fedora",
+    tag = "31",
+)
+
 # Pull base image container registry
 container_pull(
     name = "registry",
@@ -237,5 +245,69 @@ http_file(
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/o/ostree-libs-2019.4-3.fc31.x86_64.rpm",
         "https://storage.googleapis.com/builddeps/4011ad8b367db9d528d47202d07c287a958d4bd11a56b11618818dcb3be55bc6",
+    ],
+)
+
+http_file(
+    name = "lvm2",
+    sha256 = "790256fe3d3b39700a4345649fcaab1da8dc1d13104577480d1807a108c0273f",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/lvm2-2.03.05-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "lvm2-libs",
+    sha256 = "c8125a5f282f6022a2ca0c287c6804301262432646aba5a5b8ec06eeacb83102",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/lvm2-libs-2.03.05-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "device-mapper",
+    sha256 = "d8fa0b0947084bce50438b7eaf5a5085abd35e36c69cfb13d5f58e98a258e36f",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-1.02.163-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "device-mapper-event",
+    sha256 = "9dfb6c534d23d3058d83dfaf669544b58318c34351ae46e7341cdeee51be2ab8",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-event-1.02.163-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "device-mapper-event-libs",
+    sha256 = "3d9ed59c05d68649e255ab6961ce7b8b758ab82cbe74d6912d0f4395c7ebd4f3",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-event-libs-1.02.163-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "device-mapper-persistent-data",
+    sha256 = "4a3eef2bea1e3a1fe305b9c2acbf46d6bc6063d415fe0c33c25416ed42791cee",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-persistent-data-0.8.5-2.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "compat-readline5",
+    sha256 = "03179d5423784f6a61d18dcbb35fe986fb318ebac65330c0228bbef4e835c992",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/c/compat-readline5-5.2-34.fc31.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "kmod",
+    sha256 = "ec22cf64138373b6f28dab0b824fbf9cdec8060bf7b8ce8216a361ab70f0849b",
+    urls = [
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/k/kmod-26-4.fc31.x86_64.rpm",
     ],
 )

--- a/cluster-sync/ember/ember-csi-lvm.yaml
+++ b/cluster-sync/ember/ember-csi-lvm.yaml
@@ -67,8 +67,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
-  # volumeLifecycleModes: # added in Kubernetes 1.16, we use default
-  # - Persistent
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -162,8 +160,7 @@ spec:
               mountPath: /registration
         - name: csi-driver
           image: "embercsi/ember-csi:master"
-          #command: ["tail"]
-          #args: ["-f", "/dev/null"]
+          # Priviledged needed for access to lvm backend
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true

--- a/cluster-sync/ember/ember-csi-lvm.yaml
+++ b/cluster-sync/ember/ember-csi-lvm.yaml
@@ -1,0 +1,299 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-cr
+rules:
+  # Allow managing ember resources
+  - apiGroups: ['ember-csi.io']
+    resources: ['*']
+    verbs: ['*']
+  # Allow listing and creating CRDs
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ['list', 'create']
+  - apiGroups: ['']
+    resources: ['persistentvolumes']
+    verbs: ['create', 'delete', 'get', 'list', 'watch', 'update', 'patch']
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['get', 'list']
+  - apiGroups: ['']
+    resources: ['persistentvolumeclaims']
+    verbs: ['get', 'list', 'watch', 'update']
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ['']
+    resources: ['nodes']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['storage.k8s.io']
+    resources: ['volumeattachments']
+    verbs: ['get', 'list', 'watch', 'update', 'patch']
+  - apiGroups: ['storage.k8s.io']
+    resources: ['storageclasses']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['csi.storage.k8s.io']
+    resources: ['csidrivers']
+    verbs: ['get', 'list', 'watch', 'update', 'create']
+  - apiGroups: ['']
+    resources: ['events']
+    verbs: ['list', 'watch', 'create', 'update', 'patch']
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: ember-csi.io
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+  # volumeLifecycleModes: # added in Kubernetes 1.16, we use default
+  # - Persistent
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-rb
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: csi-controller-cr
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: ember-csi-lvm
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-cr
+rules:
+  # Allow managing ember resources
+  - apiGroups: ['ember-csi.io']
+    resources: ['*']
+    verbs: ['*']
+  # Allow listing and creating CRDs
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ['list', 'create']
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ['get', 'list', 'watch', 'update', 'patch']
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-rb
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: csi-node-cr
+subjects:
+- kind: ServiceAccount
+  name: csi-node-sa
+  namespace: ember-csi-lvm
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-node
+spec:
+  selector:
+    matchLabels:
+      app: csi-node
+  template:
+    metadata:
+      labels:
+        app: csi-node
+    spec:
+      serviceAccount: csi-node-sa
+      # Required by iSCSI
+      hostNetwork: true
+      # Required by multipath detach
+      hostIPC: true
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          args:
+          - --v=1
+          - --csi-address=/var/lib/ember-csi/csi.sock
+          - --kubelet-registration-path=/var/lib/ember-csi/ember-csi.io/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /var/lib/ember-csi
+              name: ember-csi-data
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-driver
+          image: "embercsi/ember-csi:master"
+          #command: ["tail"]
+          #args: ["-f", "/dev/null"]
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          imagePullPolicy: Always
+          env:
+            - name: PYTHONUNBUFFERED
+              value: '0'
+            - name: X_CSI_SPEC_VERSION
+              value: v1.1
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/ember-csi/csi.sock
+            - name: CSI_MODE
+              value: node
+            - name: X_CSI_PERSISTENCE_CONFIG
+              value: '{"storage":"crd"}'
+            - name: X_CSI_NODE_TOPOLOGY
+              value: '{"iscsi":"true"}'
+            - name: X_CSI_EMBER_CONFIG
+              value: '{"debug":false,"enable_probe":true}'
+            - name: X_CSI_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            exec:
+              command:
+              - ember-liveness
+            initialDelaySeconds: 120
+            periodSeconds: 90
+            timeoutSeconds: 60
+          volumeMounts:
+            # So we don't lose our private bindmounts on container reboot and
+            # this is also where our socket lives
+            - name: ember-csi-data
+              mountPath: /var/lib/ember-csi
+              mountPropagation: Bidirectional
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+            - name: iscsi-dir
+              mountPath: /etc/iscsi
+              mountPropagation: Bidirectional
+            - name: dev-dir
+              mountPath: /dev
+              mountPropagation: Bidirectional
+            - name: lvm-conf
+              mountPath: /etc/lvm/lvm.conf
+              mountPropagation: HostToContainer
+            - name: lvm-lock
+              mountPath: /var/lock/lvm
+              mountPropagation: Bidirectional
+            - name: multipath-dir
+              mountPath: /etc/multipath
+              mountPropagation: Bidirectional
+            - name: multipath-conf
+              mountPath: /etc/multipath.conf
+              mountPropagation: HostToContainer
+            - name: modules-dir
+              mountPath: /lib/modules
+              mountPropagation: HostToContainer
+            - name: localtime
+              mountPath: /etc/localtime
+              mountPropagation: HostToContainer
+            - name: udev-data
+              mountPath: /run/udev
+              mountPropagation: HostToContainer
+            # Required to preserve the node targets between restarts
+            - name: iscsi-info
+              mountPath: /var/lib/iscsi
+              mountPropagation: Bidirectional
+        - name: csc
+          image: embercsi/csc:v1.1.0
+          command: ["tail"]
+          args: ["-f", "/dev/null"]
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/ember-csi/csi.sock
+          volumeMounts:
+            - name: ember-csi-data
+              mountPath: /var/lib/ember-csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi
+            type: Directory
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: lvm-conf
+          hostPath:
+            path: /etc/lvm/lvm.conf
+        - name: lvm-lock
+          hostPath:
+            path: /var/lock/lvm
+        - name: multipath-dir
+          hostPath:
+            path: /etc/multipath
+        - name: multipath-conf
+          hostPath:
+            path: /etc/multipath.conf
+        - name: modules-dir
+          hostPath:
+            path: /lib/modules
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: udev-data
+          hostPath:
+            path: /run/udev
+        - name: iscsi-info
+          hostPath:
+            path: /var/lib/iscsi
+        - name: ember-csi-data
+          hostPath:
+            path: /var/lib/ember-csi/ember-csi.io
+            type: DirectoryOrCreate
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ember-csi-lvm
+provisioner: ember-csi.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/cluster-sync/ember/ember-csi-lvm.yaml
+++ b/cluster-sync/ember/ember-csi-lvm.yaml
@@ -159,7 +159,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: csi-driver
-          image: "embercsi/ember-csi:master"
+          image: "quay.io/awels/embercsi:1"
           # Priviledged needed for access to lvm backend
           securityContext:
             privileged: true

--- a/cluster-sync/ember/loop_back.yaml
+++ b/cluster-sync/ember/loop_back.yaml
@@ -35,19 +35,28 @@ spec:
       labels:
         app: loop-back-lvm
     spec:
+      # iSCSI only the very latest Open-iSCSI supports namespaces
+      hostNetwork: true
+      # Required by multipath detach (some drivers clone volumes dd-ing)
+      hostIPC: true
       containers:
       - name: loop-back-lvm
         image: registry:5000/loop-back-lvm:latest
+        # Priviledged needed for access to lvm backend
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
         env:
         - name: DEVICE_SIZE
           value: 25G
         - name: DATA_DIR
           value: /data
         volumeMounts:
-        - name: local-storage
-          mountPath: /data
-        securityContext:
-          privileged: true
+          - name: local-storage
+            mountPath: /host/data
+          - name: host-dir
+            mountPath: /host
+            mountPropagation: Bidirectional
         readinessProbe:
           exec:
             command:
@@ -59,4 +68,6 @@ spec:
         - name: local-storage
           persistentVolumeClaim:
             claimName: loop-back-pvc
-        
+        - name: host-dir
+          hostPath:
+            path: /

--- a/cluster-sync/ember/loop_back.yaml
+++ b/cluster-sync/ember/loop_back.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ember-csi-lvm
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loop-back-pvc
+  namespace: ember-csi-lvm
+  labels:
+    app: loop-back-lvm
+spec:
+  storageClassName: local
+  accessModes:
+     - ReadWriteOnce
+  resources:
+    requests:
+      storage: 25Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loopback-deployment
+  namespace: ember-csi-lvm
+  labels:
+    app: loop-back-lvm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loop-back-lvm
+  template:
+    metadata:
+      labels:
+        app: loop-back-lvm
+    spec:
+      containers:
+      - name: loop-back-lvm
+        image: registry:5000/loop-back-lvm:latest
+        env:
+        - name: DEVICE_SIZE
+          value: 25G
+        - name: DATA_DIR
+          value: /data
+        volumeMounts:
+        - name: local-storage
+          mountPath: /data
+        securityContext:
+          privileged: true
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /ready
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+        - name: local-storage
+          persistentVolumeClaim:
+            claimName: loop-back-pvc
+        

--- a/cluster-sync/ember/loop_back.yaml
+++ b/cluster-sync/ember/loop_back.yaml
@@ -29,6 +29,7 @@ spec:
   hostNetwork: true
   # Required by multipath detach (some drivers clone volumes dd-ing)
   hostIPC: true
+  restartPolicy: Never
   containers:
   - name: loop-back-lvm
     image: registry:5000/loop-back-lvm:latest
@@ -47,13 +48,6 @@ spec:
       - name: host-dir
         mountPath: /host
         mountPropagation: Bidirectional
-    readinessProbe:
-      exec:
-        command:
-        - cat
-        - /ready
-      initialDelaySeconds: 10
-      periodSeconds: 5
   volumes:
     - name: local-storage
       persistentVolumeClaim:

--- a/cluster-sync/ember/loop_back.yaml
+++ b/cluster-sync/ember/loop_back.yaml
@@ -18,56 +18,46 @@ spec:
     requests:
       storage: 25Gi
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
-  name: loopback-deployment
-  namespace: ember-csi-lvm
+  name: loop-back-lvm
   labels:
     app: loop-back-lvm
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: loop-back-lvm
-  template:
-    metadata:
-      labels:
-        app: loop-back-lvm
-    spec:
-      # iSCSI only the very latest Open-iSCSI supports namespaces
-      hostNetwork: true
-      # Required by multipath detach (some drivers clone volumes dd-ing)
-      hostIPC: true
-      containers:
-      - name: loop-back-lvm
-        image: registry:5000/loop-back-lvm:latest
-        # Priviledged needed for access to lvm backend
-        securityContext:
-          privileged: true
-          allowPrivilegeEscalation: true
-        env:
-        - name: DEVICE_SIZE
-          value: 25G
-        - name: DATA_DIR
-          value: /data
-        volumeMounts:
-          - name: local-storage
-            mountPath: /host/data
-          - name: host-dir
-            mountPath: /host
-            mountPropagation: Bidirectional
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /ready
-          initialDelaySeconds: 10
-          periodSeconds: 5
-      volumes:
-        - name: local-storage
-          persistentVolumeClaim:
-            claimName: loop-back-pvc
-        - name: host-dir
-          hostPath:
-            path: /
+  # iSCSI only the very latest Open-iSCSI supports namespaces
+  hostNetwork: true
+  # Required by multipath detach (some drivers clone volumes dd-ing)
+  hostIPC: true
+  containers:
+  - name: loop-back-lvm
+    image: registry:5000/loop-back-lvm:latest
+    # Priviledged needed for access to lvm backend
+    securityContext:
+      privileged: true
+      allowPrivilegeEscalation: true
+    env:
+    - name: DEVICE_SIZE
+      value: 25G
+    - name: DATA_DIR
+      value: /data
+    volumeMounts:
+      - name: local-storage
+        mountPath: /host/data
+      - name: host-dir
+        mountPath: /host
+        mountPropagation: Bidirectional
+    readinessProbe:
+      exec:
+        command:
+        - cat
+        - /ready
+      initialDelaySeconds: 10
+      periodSeconds: 5
+  volumes:
+    - name: local-storage
+      persistentVolumeClaim:
+        claimName: loop-back-pvc
+    - name: host-dir
+      hostPath:
+        path: /

--- a/cluster-sync/ember/snapshot-class.yaml
+++ b/cluster-sync/ember/snapshot-class.yaml
@@ -1,0 +1,5 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-snap
+snapshotter: ember-csi.io

--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -87,7 +87,7 @@ function configure_nfs() {
 }
 
 function configure_ember_lvm() {
-  _kubectl apply -f ./cluster-sync/ember/loop_back.yaml
+  _kubectl apply -f ./cluster-sync/ember/loop_back.yaml -n ember-csi-lvm
   set +e
 
   loopdeviceNode=$(_kubectl get pods -n ember-csi-lvm -l app=loop-back-lvm -o=jsonpath={.items[0].spec.nodeName})
@@ -181,7 +181,7 @@ spec:
         - mountPath: /csi-data
           name: socket-dir
       - name: csi-driver
-        image: "embercsi/ember-csi:master"
+        image: "quay.io/awels/embercsi:1"
         imagePullPolicy: Always
         # Priviledged needed for access to lvm backend
         securityContext:

--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -67,10 +67,11 @@ EOF
   set +e
   retry_counter=0
   _kubectl get VolumeSnapshotClass
-   while [[ $? -ne "0" ]] && [[ $retry_counter -lt 60 ]]; do
+  while [[ $? -ne "0" ]] && [[ $retry_counter -lt 60 ]]; do
+    retry_counter=$((retry_counter + 1))
     echo "Sleep 5s, waiting for VolumeSnapshotClass CRD"
-   sleep 5
-   _kubectl get VolumeSnapshotClass
+    sleep 5
+    _kubectl get VolumeSnapshotClass
   done
   echo "VolumeSnapshotClass CRD available, creating snapshot class"
   _kubectl apply -f https://raw.githubusercontent.com/rook/rook/$ROOK_CEPH_VERSION/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
@@ -83,4 +84,235 @@ function configure_nfs() {
   _kubectl apply -f ./cluster-sync/nfs/nfs-service.yaml -n $CDI_NAMESPACE
   _kubectl apply -f ./cluster-sync/nfs/nfs-server.yaml -n $CDI_NAMESPACE
   _kubectl patch storageclass nfs -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+}
+
+function configure_ember_lvm() {
+  _kubectl apply -f ./cluster-sync/ember/loop_back.yaml
+  set +e
+
+  loopdeviceNode=$(_kubectl get pods -n ember-csi-lvm -l app=loop-back-lvm -o=jsonpath={.items[0].spec.nodeName})
+  echo "loop back device node [$loopdeviceNode]"
+  retry_counter=0
+  while [[ $loopdeviceNode == "" ]] && [[ $retry_counter -lt 60 ]]; do
+    retry_counter=$((retry_counter + 1))
+    loopdeviceNode=$(_kubectl get pods -n ember-csi-lvm -l app=loop-back-lvm -o=jsonpath={.items[0].spec.nodeName})
+    echo "Sleep 1s, waiting for loopback device pod node to be found [$loopdeviceNode]"
+    sleep 1
+  done
+  echo "Loop back device pod is running on node $loopdeviceNode"
+  _kubectl wait --for=condition=ready pod -n ember-csi-lvm -l app=loop-back-lvm --timeout=600s
+#  echo "Loop back device available, creating PVs and VGs"
+#  ./cluster-up/ssh.sh $loopdeviceNode "sudo pvcreate /dev/loop0; sudo vgcreate ember-volumes /dev/loop0; sudo vgscan"
+  _kubectl apply -f ./cluster-sync/ember/ember-csi-lvm.yaml -n ember-csi-lvm
+
+  podIp=$(_kubectl get pods -n ember-csi-lvm -l app=loop-back-lvm -o=jsonpath={.items[0].status.podIP})
+  echo "LVM loopback device podIP: $podIp"
+  cat <<EOF | _kubectl apply -n ember-csi-lvm -f -
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-controller
+spec:
+  serviceName: csi-controller
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller
+  template:
+    metadata:
+      labels:
+        app: csi-controller
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - loop-back-lvm
+            topologyKey: kubernetes.io/hostname
+      serviceAccount: csi-controller-sa
+      # iSCSI only the very latest Open-iSCSI supports namespaces
+      hostNetwork: true
+      # Required by multipath detach (some drivers clone volumes dd-ing)
+      hostIPC: true
+      containers:
+      - name: external-provisioner
+        image: quay.io/k8scsi/csi-provisioner:v1.4.0
+        args:
+        - --v=1
+        - --provisioner=ember-csi.io
+        - --csi-address=/csi-data/csi.sock
+        - --feature-gates=Topology=true
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: external-attacher
+        image: quay.io/k8scsi/csi-attacher:v2.0.0
+        args:
+        - --v=1
+        - --csi-address=/csi-data/csi.sock
+        - --timeout=120s
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: external-snapshotter
+        image: quay.io/k8scsi/csi-snapshotter:v1.2.2
+        args:
+        - --v=1
+        - --csi-address=/csi-data/csi.sock
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: external-resizer
+        image: quay.io/k8scsi/csi-resizer:v0.3.0
+        args:
+        - --v=1
+        - --csi-address=/csi-data/csi.sock
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: csi-driver
+        image: "embercsi/ember-csi:master"
+        # command: ["tail"]
+        # args: ["-f", "/dev/null"]
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+        env:
+        - name: PYTHONUNBUFFERED
+          value: '0'
+        - name: CSI_ENDPOINT
+          value: unix:///csi-data/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: X_CSI_SPEC_VERSION
+          value: v1.1
+        - name: CSI_MODE
+          value: controller
+        - name: X_CSI_PERSISTENCE_CONFIG
+          value: '{"storage":"crd"}'
+        - name: X_CSI_EMBER_CONFIG
+          value: '{"debug":true,"enable_probe":true}'
+        - name: X_CSI_TOPOLOGIES
+          value: '[{"iscsi":"true"}]'
+        - name: X_CSI_BACKEND_CONFIG
+          value: '{"target_protocol":"iscsi","target_ip_address":"$podIp","name":"lvm","driver":"LVMVolume","volume_group":"ember-volumes","target_helper":"lioadm","multipath":false}'
+        livenessProbe:
+          exec:
+            command:
+            - ember-liveness
+          initialDelaySeconds: 120
+          periodSeconds: 90
+          timeoutSeconds: 60
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /csi-data
+        - name: iscsi-dir
+          mountPath: /etc/iscsi
+          mountPropagation: Bidirectional
+        - name: dev-dir
+          mountPath: /dev
+          mountPropagation: Bidirectional
+        - name: lvm-dir
+          mountPath: /etc/lvm
+          mountPropagation: Bidirectional
+        - name: lvm-lock
+          mountPath: /var/lock/lvm
+          mountPropagation: Bidirectional
+        - name: multipath-dir
+          mountPath: /etc/multipath
+          mountPropagation: Bidirectional
+        - name: multipath-conf
+          mountPath: /etc/multipath.conf
+          mountPropagation: HostToContainer
+        - name: modules-dir
+          mountPath: /lib/modules
+          mountPropagation: HostToContainer
+        - name: localtime
+          mountPath: /etc/localtime
+          mountPropagation: HostToContainer
+        - name: udev-data
+          mountPath: /run/udev
+          mountPropagation: HostToContainer
+        - name: lvm-run
+          mountPath: /run/lvm
+          mountPropagation: HostToContainer
+        # Required to preserve the node targets between restarts
+        - name: iscsi-info
+          mountPath: /var/lib/iscsi
+          mountPropagation: Bidirectional
+        # In a real deployment we should be mounting container's
+        # /var/lib-ember-csi on the host
+      - name: csc
+        image: embercsi/csc:v1.1.0
+        command: ["tail"]
+        args: ["-f", "/dev/null"]
+        env:
+          - name: CSI_ENDPOINT
+            value: unix:///csi-data/csi.sock
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /csi-data
+      volumes:
+      - name: socket-dir
+        emptyDir:
+      # Some backends do create volume from snapshot by attaching and dd-ing
+      - name: iscsi-dir
+        hostPath:
+          path: /etc/iscsi
+          type: Directory
+      - name: dev-dir
+        hostPath:
+          path: /dev
+      - name: lvm-dir
+        hostPath:
+          path: /etc/lvm
+          type: Directory
+      - name: lvm-lock
+        hostPath:
+          path: /var/lock/lvm
+      - name: multipath-dir
+        hostPath:
+          path: /etc/multipath
+      - name: multipath-conf
+        hostPath:
+          path: /etc/multipath.conf
+      - name: modules-dir
+        hostPath:
+          path: /lib/modules
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: udev-data
+        hostPath:
+          path: /run/udev
+      - name: lvm-run
+        hostPath:
+          path: /run/lvm
+      - name: iscsi-info
+        hostPath:
+          path: /var/lib/iscsi
+EOF
+
+  set +e
+  retry_counter=0
+  _kubectl get VolumeSnapshotClass
+  while [[ $? -ne "0" ]] && [[ $retry_counter -lt 60 ]]; do
+    retry_counter=$((retry_counter + 1))
+    echo "Sleep 5s, waiting for VolumeSnapshotClass CRD"
+   sleep 5
+   _kubectl get VolumeSnapshotClass
+  done
+  echo "VolumeSnapshotClass CRD available, creating snapshot class"
+  _kubectl apply -f ./cluster-sync/ember/snapshot-class.yaml
+  set -e
+
+  _kubectl patch storageclass ember-csi-lvm -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 }

--- a/cluster-sync/k8s-1.16.2/provider.sh
+++ b/cluster-sync/k8s-1.16.2/provider.sh
@@ -22,6 +22,9 @@ function configure_storage() {
   elif [[ $KUBEVIRT_STORAGE == "nfs" ]] ; then
     echo "Installing NFS static storage"
     configure_nfs
+  elif [[ $KUBEVIRT_STORAGE == "ember_lvm" ]] ; then
+    echo "Installing ember csi lvm storage"
+    configure_ember_lvm
   else
     echo "Using local volume storage"
     #Make sure local is not default

--- a/cluster-sync/k8s-1.17.0/provider.sh
+++ b/cluster-sync/k8s-1.17.0/provider.sh
@@ -22,6 +22,9 @@ function configure_storage() {
   elif [[ $KUBEVIRT_STORAGE == "nfs" ]] ; then
     echo "Installing NFS static storage"
     configure_nfs
+  elif [[ $KUBEVIRT_STORAGE == "ember_lvm" ]] ; then
+    echo "Installing ember csi lvm storage"
+    configure_ember_lvm
   else
     echo "Using local volume storage"
     #Make sure local is not default

--- a/hack/build/run-tests.sh
+++ b/hack/build/run-tests.sh
@@ -23,11 +23,11 @@ source hack/build/common.sh
 parseTestOpts "${@}"
 
 if [ -f "${TESTS_OUT_DIR}/tests.test" ]; then
-    test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 180m ${test_args}"
+    test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 270m ${test_args}"
 	echo "${test_command}"
 	(cd ${CDI_DIR}/tests; ${test_command})
 else
-	test_command="go test -v -coverprofile=.coverprofile -test.timeout 180m ${pkgs} ${test_args:+-args $test_args}"
+	test_command="go test -v -coverprofile=.coverprofile -test.timeout 270m ${pkgs} ${test_args:+-args $test_args}"
 	echo "${test_command}"
 	${test_command}
 fi

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 	})
 })
 
-var _ = Describe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.com][level:component]Importer Archive ContentType", func() {
+var _ = FDescribe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.com][level:component]Importer Archive ContentType", func() {
 	f := framework.NewFrameworkOrDie(namespacePrefix)
 
 	It("Should import archive content type tar file", func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 	})
 })
 
-var _ = FDescribe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.com][level:component]Importer Archive ContentType", func() {
+var _ = Describe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.com][level:component]Importer Archive ContentType", func() {
 	f := framework.NewFrameworkOrDie(namespacePrefix)
 
 	It("Should import archive content type tar file", func() {

--- a/tools/loop-back-lvm/BUILD.bazel
+++ b/tools/loop-back-lvm/BUILD.bazel
@@ -4,33 +4,54 @@ load("@io_bazel_rules_container_rpm//rpm:rpm.bzl", "rpm_image")
 
 rpm_image(
     name = "loop-back-lvm-base-image",
-    base = "@fedora//image",
+    base = "@fedora-docker//image",
     rpms = [
+        "@basesystem//file",
+        "@bash//file",
+        "@fedora-gpg-keys//file",
+        "@fedora-release//file",
+        "@fedora-release-common//file",
+        "@fedora-repos//file",
+        "@filesystem//file",
+        "@glibc//file",
+        "@glibc-common//file",
+        "@glibc-all-langpacks//file",
+        "@libgcc//file",
+        "@libselinux//file",
+        "@libsepol//file",
+        "@ncurses-base//file",
+        "@ncurses-lib//file",
+        "@pcre2//file",
+        "@setup//file",
+        "@tzdata//file",
         "@lvm2//file",
         "@lvm2-libs//file",
         "@device-mapper-event//file",
         "@device-mapper-persistent-data//file",
-        #"@compat-readline5//file",
+        "@compat-readline5//file",
         "@libaio//file",
         "@kmod//file",
         "@device-mapper-event-libs//file",
+        "@iscsi-initiator-utils//file",
+        "@iscsi-initiator-utils-iscsiuio//file",
+        "@isns-utils-libs//file",
     ],
 )
 
 container_image(
     name = "loop-back-lvm-image",
-    base = "@fedora-full//image",
+    base = ":loop-back-lvm-base-image",
     directory = "/",
     entrypoint = ["/entrypoint.sh"],
     tars = [":entrypoint-script-tar"],
     visibility = ["//visibility:public"],
-    port,
 )
 
 filegroup(
     name = "entrypoint-script",
     srcs = [
         ":entrypoint.sh",
+        ":create_lvm.sh",
     ],
 )
 

--- a/tools/loop-back-lvm/BUILD.bazel
+++ b/tools/loop-back-lvm/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_container_rpm//rpm:rpm.bzl", "rpm_image")
+
+rpm_image(
+    name = "loop-back-lvm-base-image",
+    base = "@fedora//image",
+    rpms = [
+        "@lvm2//file",
+        "@lvm2-libs//file",
+        "@device-mapper-event//file",
+        "@device-mapper-persistent-data//file",
+        #"@compat-readline5//file",
+        "@libaio//file",
+        "@kmod//file",
+        "@device-mapper-event-libs//file",
+    ],
+)
+
+container_image(
+    name = "loop-back-lvm-image",
+    base = "@fedora-full//image",
+    directory = "/",
+    entrypoint = ["/entrypoint.sh"],
+    tars = [":entrypoint-script-tar"],
+    visibility = ["//visibility:public"],
+    port,
+)
+
+filegroup(
+    name = "entrypoint-script",
+    srcs = [
+        ":entrypoint.sh",
+    ],
+)
+
+pkg_tar(
+    name = "entrypoint-script-tar",
+    srcs = [":entrypoint-script"],
+    mode = "755",
+    package_dir = "/",
+)

--- a/tools/loop-back-lvm/create_lvm.sh
+++ b/tools/loop-back-lvm/create_lvm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEVICE_SIZE=${DEVICE_SIZE:-30G}
+DATA_DIR=${DATA_DIR:-"/data"}
+
+echo $DEVICE_SIZE
+echo $DATA_DIR
+
+if [ -d $DATA_DIR ]; then
+  echo "Creating loop back device"
+  if [ -e "/dev/loop0" ]; then
+    losetup -d /dev/loop0
+  fi
+  rm -rf /dev/loop0
+  mknod -m 0660 /dev/loop0 b 7 0
+  truncate -s $DEVICE_SIZE $DATA_DIR/ember-volumes
+  loop_device=$(losetup --show -f $DATA_DIR/ember-volumes)
+  echo "Loop device: $loop_device"
+  pvcreate $loop_device -vv
+  vgcreate ember-volumes $loop_device -vv
+  vgscan
+else
+  echo "Data directory not found, exiting"
+  exit 1
+fi

--- a/tools/loop-back-lvm/entrypoint.sh
+++ b/tools/loop-back-lvm/entrypoint.sh
@@ -2,26 +2,9 @@
 
 set -euo pipefail
 
-DEVICE_SIZE=${DEVICE_SIZE:-30G}
-DATA_DIR=${DATA_DIR:-"/data"}
-
-#microdnf install compat-readline5 targetcli
-
-if [ -d $DATA_DIR ]; then
-  if [ -e "/dev/loop0" ]; then
-    losetup -d /dev/loop0
-  fi
-  rm -rf /dev/loop0
-  mknod -m 0660 /dev/loop0 b 7 0
-  truncate -s $DEVICE_SIZE $DATA_DIR/ember-volumes
-  loop_device=$(losetup --show -f $DATA_DIR/ember-volumes)
-  pvcreate $loop_device
-  vgcreate ember-volumes $loop_device
-  vgscan
-else
-  echo "Data directory not found, exiting"
-  exit 1
-fi
+cp ./create_lvm.sh /host/create_lvm.sh
+chroot /host ./create_lvm.sh
+rm /host/create_lvm.sh
 
 # let the monitoring script know we're done
 echo "done" >/ready

--- a/tools/loop-back-lvm/entrypoint.sh
+++ b/tools/loop-back-lvm/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEVICE_SIZE=${DEVICE_SIZE:-30G}
+DATA_DIR=${DATA_DIR:-"/data"}
+
+#microdnf install compat-readline5 targetcli
+
+if [ -d $DATA_DIR ]; then
+  if [ -e "/dev/loop0" ]; then
+    losetup -d /dev/loop0
+  fi
+  rm -rf /dev/loop0
+  mknod -m 0660 /dev/loop0 b 7 0
+  truncate -s $DEVICE_SIZE $DATA_DIR/ember-volumes
+  loop_device=$(losetup --show -f $DATA_DIR/ember-volumes)
+  pvcreate $loop_device
+  vgcreate ember-volumes $loop_device
+  vgscan
+else
+  echo "Data directory not found, exiting"
+  exit 1
+fi
+
+# let the monitoring script know we're done
+echo "done" >/ready
+echo "ready"
+while true; do
+  sleep 60
+done

--- a/tools/loop-back-lvm/entrypoint.sh
+++ b/tools/loop-back-lvm/entrypoint.sh
@@ -10,5 +10,5 @@ rm /host/create_lvm.sh
 echo "done" >/ready
 echo "ready"
 while true; do
-  sleep 60
+  sleep 1
 done

--- a/tools/loop-back-lvm/entrypoint.sh
+++ b/tools/loop-back-lvm/entrypoint.sh
@@ -5,10 +5,3 @@ set -euo pipefail
 cp ./create_lvm.sh /host/create_lvm.sh
 chroot /host ./create_lvm.sh
 rm /host/create_lvm.sh
-
-# let the monitoring script know we're done
-echo "done" >/ready
-echo "ready"
-while true; do
-  sleep 1
-done


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add ember csi as a storage provider for make cluster-sync, this involves:
- Adding a loopback device container that creates a new loopback device. The path and size are parameters that can be changed.
- Adding a new item to the list of storage providers, ember_lvm. It can be enabled by setting the KUBEVIRT_STORAGE environment variable to ember_lvm
- A script to identify the host the loopback container is running on and running some pvcreate and vgcreate commands to create the needed lvm objects.
- Yaml to create a new ember-csi-lvm namespace and creating the ember csi objects in that namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

