### PR TITLE
Enable IPv6 on cdi http file host.

### DIFF
--- a/tools/cdi-func-test-file-host-init/nginx.conf
+++ b/tools/cdi-func-test-file-host-init/nginx.conf
@@ -20,6 +20,7 @@ http {
         server_name localhost;
 
         listen 80;
+        listen [::]:80;
 
         root /tmp/shared/images;
 
@@ -34,6 +35,7 @@ http {
         server_name localhost;
 
         listen 81;
+        listen [::]:81;
 
         root /tmp/shared/images;
 
@@ -51,6 +53,7 @@ http {
         server_name localhost;
 
         listen 82;
+        listen [::]:82;
 
         root /tmp/shared/images;
 
@@ -66,6 +69,7 @@ http {
         server_name localhost;
 
         listen 443 ssl;
+        listen [::]:443 ssl;
 
         ssl_certificate /tmp/shared/certs/tls.crt;
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enable ipv6 for the cdi file hosts in case of an ipv6 only cluster for testing. The registry file host is already ipv6 enabled from what I could tell.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

