### PR TITLE
operator permissions still not right

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -175,6 +175,7 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"configmaps",
 				"events",
 				"secrets",
+				"services",
 			},
 			Verbs: []string{
 				"*",

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -50,8 +50,6 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 			Resources: []string{
 				"clusterrolebindings",
 				"clusterroles",
-				"rolebindings",
-				"roles",
 			},
 			Verbs: []string{
 				"*",
@@ -94,60 +92,18 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"customresourcedefinitions",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"create",
-				"update",
+				"*",
 			},
 		},
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
-				"upload.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",
 			},
 			Verbs: []string{
 				"*",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"serviceaccounts",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"apps",
-			},
-			Resources: []string{
-				"deployments",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"authorization.k8s.io",
-			},
-			Resources: []string{
-				"subjectaccessreviews",
-			},
-			Verbs: []string{
-				"create",
 			},
 		},
 		{
@@ -159,11 +115,7 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"mutatingwebhookconfigurations",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"create",
-				"update",
+				"*",
 			},
 		},
 		{
@@ -174,11 +126,7 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"apiservices",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"create",
-				"update",
+				"*",
 			},
 		},
 	}

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -98,6 +98,7 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
+				"upload.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Mostly removed permission but needed to add permission to delete some stuff, like CRDs, apiserver, and webhook configurations

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

