### PR TITLE
Set secondary GID of user on import and upload pods to be 107 (qemu) …

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -127,4 +127,7 @@ const (
 
 	// UploadPathAsync is the path to POST CDI uploads in async mode
 	UploadPathAsync = "/v1alpha1/upload-async"
+
+	// QemuSubGid is the gid used as the qemu group in fsGroup
+	QemuSubGid = int64(107)
 )

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	cdiclientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -500,6 +501,15 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
 		pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
+	}
+
+	if podEnvVar.contentType == string(cdiv1.DataVolumeKubeVirt) {
+		// Set the fsGroup on the security context to the QemuSubGid
+		if pod.Spec.SecurityContext == nil {
+			pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		}
+		fsGroup := common.QemuSubGid
+		pod.Spec.SecurityContext.FSGroup = &fsGroup
 	}
 	return pod
 }

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -503,6 +503,7 @@ func GetUploadServerURL(namespace, pvc, uploadPath string) string {
 
 func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequirements *v1.ResourceRequirements) *v1.Pod {
 	requestImageSize, _ := getRequestedImageSize(args.PVC)
+	fsGroup := common.QemuSubGid
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -583,6 +584,10 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 				},
 			},
 		},
+	}
+
+	if !checkPVC(args.PVC, AnnCloneRequest) {
+		pod.Spec.SecurityContext.FSGroup = &fsGroup
 	}
 
 	if resourceRequirements != nil {

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -223,6 +223,8 @@ var _ = Describe("Upload controller reconcile loop", func() {
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
+		By("Verifying the fsGroup of the pod is the qemu user")
+		Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 		uploadService = &corev1.Service{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)
@@ -255,6 +257,8 @@ var _ = Describe("reconcilePVC loop", func() {
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
+			By("Verifying the fsGroup of the pod is the qemu user")
+			Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)
@@ -291,6 +295,8 @@ var _ = Describe("reconcilePVC loop", func() {
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
+			By("Verifying the fsGroup of the pod is the qemu user")
+			Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -223,8 +223,6 @@ var _ = Describe("Upload controller reconcile loop", func() {
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
-		By("Verifying the fsGroup of the pod is the qemu user")
-		Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 		uploadService = &corev1.Service{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)
@@ -257,8 +255,6 @@ var _ = Describe("reconcilePVC loop", func() {
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
-			By("Verifying the fsGroup of the pod is the qemu user")
-			Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)
@@ -295,8 +291,6 @@ var _ = Describe("reconcilePVC loop", func() {
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadPod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadPod.Name).To(Equal(getUploadResourceName(testPvc.Name)))
-			By("Verifying the fsGroup of the pod is the qemu user")
-			Expect(*uploadPod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: getUploadResourceName("testPvc1"), Namespace: "default"}, uploadService)

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/ovirt/go-ovirt:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],

--- a/tests/framework/exec_util.go
+++ b/tests/framework/exec_util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -113,6 +113,11 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(f.VerifyBlankDisk(f.Namespace, pvc)).To(BeTrue())
 		By("Verifying the image is sparse")
 		Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
+		if utils.DefaultStorageCSI {
+			// CSI storage class, it should respect fsGroup
+			By("Checking that disk image group is qemu")
+			Expect(f.GetDiskGroup(f.Namespace, pvc)).To(Equal("107"))
+		}
 	})
 })
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -101,6 +101,11 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(same).To(BeTrue())
 			By("Verifying the image is sparse")
 			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
+			if utils.DefaultStorageCSI {
+				// CSI storage class, it should respect fsGroup
+				By("Checking that disk image group is qemu")
+				Expect(f.GetDiskGroup(f.Namespace, pvc)).To(Equal("107"))
+			}
 		} else {
 			uploader, err := utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, utils.UploadPodName(pvc), common.CDILabelSelector)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get uploader pod %q", f.Namespace.Name+"/"+utils.UploadPodName(pvc)))


### PR DESCRIPTION
…for kubevirt content type.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Attempt to set the group of the disk.img to be qemu (107) so that pods using the PVCs can run as qemu and still read the disk image. If a pod wants to override the group id of the file they can change the fsGroup of the POD consuming the PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Kubevirt content type disk.img files now have a group id of qemu (107) when imported/cloned/uploaded.
```

