### PR TITLE
Add oVirt imageIO documentation

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -60,8 +60,8 @@ func main() {
 	diskID, _ := util.ParseEnvVar(common.ImporterDiskID, false)
 
 	//Registry import currently support kubevirt content type only
-	if contentType != string(cdiv1.DataVolumeKubeVirt) && source == controller.SourceRegistry {
-		klog.Errorf("Unsupported content type %s when importing from registry", contentType)
+	if contentType != string(cdiv1.DataVolumeKubeVirt) && (source == controller.SourceRegistry || source == controller.SourceImageio) {
+		klog.Errorf("Unsupported content type %s when importing from %s", contentType, source)
 		os.Exit(1)
 	}
 

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -132,6 +132,30 @@ spec:
         storage: 1Gi
 ```
 
+## Image IO Data Volume
+Image IO sources are sources from oVirt imageio endpoints. In order to use these endpoints you will need an oVirt installation with imageIO enabled. You will then be able to import disk images from oVirt into KubeVirt. The diskId can be obtained from the oVirt webadmin UI or REST api.
+```yaml
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: "test-dv"
+spec:
+  source:
+      imageio:
+         url: "http://<ovirt engine url>/ovirt-engine/api"
+         secretRef: "endpoint-secret"
+         certConfigMap: "tls-certs"
+         diskId: "1"
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: "500Mi"
+```
+[Get secret example](../manifests/example/endpoint-secret.yaml)
+[Get certificate example](../manifests/example/cert-configmap.yaml)
+
 ## Block Volume Mode
 You can import, clone and upload a disk image to a raw block persistent volume.
 This is done by assigning the value 'Block' to the PVC volumeMode field in the DataVolume yaml.


### PR DESCRIPTION
Make sure you can only do kubevirt content type for image IO

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add documentation for image IO sources.
Make sure kubevirt content type is used with image IO sources in importer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

