### PR TITLE
Add a field to DataVolume to track the number of retries/pod restarts

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3248,6 +3248,10 @@
      },
      "progress": {
       "type": "string"
+     },
+     "restartCount": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3241,6 +3241,9 @@
    },
    "v1alpha1.DataVolumeStatus": {
     "description": "DataVolumeStatus provides the parameters to store the phase of the Data Volume",
+    "required": [
+     "restartCount"
+    ],
     "properties": {
      "phase": {
       "description": "Phase is the current phase of the data volume",

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -766,6 +766,7 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeStatus(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"restartCount"},
 			},
 		},
 	}

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -759,6 +759,12 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeStatus(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"restartCount": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -126,8 +126,9 @@ type DataVolumeSourceImageIO struct {
 // DataVolumeStatus provides the parameters to store the phase of the Data Volume
 type DataVolumeStatus struct {
 	//Phase is the current phase of the data volume
-	Phase    DataVolumePhase    `json:"phase,omitempty"`
-	Progress DataVolumeProgress `json:"progress,omitempty"`
+	Phase        DataVolumePhase    `json:"phase,omitempty"`
+	Progress     DataVolumeProgress `json:"progress,omitempty"`
+	RestartCount int32              `json:"restartCount,omitempty"`
 }
 
 //DataVolumeList provides the needed parameters to do request a list of Data Volumes from the system

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -128,7 +128,7 @@ type DataVolumeStatus struct {
 	//Phase is the current phase of the data volume
 	Phase        DataVolumePhase    `json:"phase,omitempty"`
 	Progress     DataVolumeProgress `json:"progress,omitempty"`
-	RestartCount int32              `json:"restartCount,omitempty"`
+	RestartCount int32              `json:"restartCount"`
 }
 
 //DataVolumeList provides the needed parameters to do request a list of Data Volumes from the system

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -218,7 +218,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, "Clone Successful")
 	}
 	if sourcePod != nil && sourcePod.Status.ContainerStatuses != nil {
-		// update pvc annotation tracking pod restarts only if the source pod restarts are greater or equal
+		// update pvc annotation tracking pod restarts only if the source pod restart count is greater
 		// see the same in upload-controller
 		annPodRestarts, _ := strconv.Atoi(pvc.Annotations[AnnPodRestarts])
 		podRestarts := int(sourcePod.Status.ContainerStatuses[0].RestartCount)

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -217,7 +217,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		pvc.Annotations[AnnCloneOf] = "true"
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, "Clone Successful")
 	}
-	if sourcePod.Status.ContainerStatuses != nil {
+	if sourcePod != nil && sourcePod.Status.ContainerStatuses != nil {
 		// update pvc annotation tracking pod restarts only if the source pod restarts are greater or equal
 		// see the same in upload-controller
 		annPodRestarts, _ := strconv.Atoi(pvc.Annotations[AnnPodRestarts])

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -605,7 +605,7 @@ func (r *DatavolumeReconciler) reconcileDataVolumeStatus(dataVolume *cdiv1.DataV
 	}
 
 	if pvc != nil {
-		if i, err := strconv.Atoi(pvc.Annotations[AnnPodRestarts]); err == nil && i > 1 {
+		if i, err := strconv.Atoi(pvc.Annotations[AnnPodRestarts]); err == nil && i >= 0 {
 			dataVolumeCopy.Status.RestartCount = int32(i)
 		}
 	}

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -277,6 +277,7 @@ func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVol
 	if datavolume.Status.Progress == "" {
 		datavolume.Status.Progress = "N/A"
 	}
+
 	if datavolume.Spec.Source.HTTP != nil {
 		podNamespace = datavolume.Namespace
 	} else if datavolume.Spec.Source.PVC != nil {
@@ -754,6 +755,7 @@ func newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume) (*corev1.PersistentV
 		annotations[k] = v
 	}
 
+	annotations[AnnPodRestarts] = "0"
 	if dataVolume.Spec.Source.HTTP != nil {
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.HTTP.URL
 		annotations[AnnSource] = SourceHTTP

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -603,6 +603,11 @@ func (r *DatavolumeReconciler) reconcileDataVolumeStatus(dataVolume *cdiv1.DataV
 		}
 	}
 
+	if pvc != nil {
+		if i, err := strconv.Atoi(pvc.Annotations[AnnPodRestarts]); err == nil && i > 1 {
+			dataVolumeCopy.Status.RestartCount = int32(i)
+		}
+	}
 	result := reconcile.Result{}
 	var err error
 	if pvc != nil {

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -107,7 +107,6 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 	})
 
 	It("Should follow the phase of the created PVC", func() {
-		//todo
 		reconciler = createDatavolumeReconciler(newImportDataVolume("test-dv"))
 		_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
@@ -146,7 +145,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv := &cdiv1.DataVolume{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dv.Status.RestartCount).To(BeEquivalentTo(0))
+		Expect(dv.Status.RestartCount).To(Equal(0))
 
 		pvc.Annotations[AnnPodRestarts] = "2"
 		err = reconciler.Client.Update(context.TODO(), pvc)
@@ -158,7 +157,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv = &cdiv1.DataVolume{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dv.Status.RestartCount).To(BeEquivalentTo(2))
+		Expect(dv.Status.RestartCount).To(Equal(2))
 	})
 
 	It("Should error if a PVC with same name already exists that is not owned by us", func() {

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv := &cdiv1.DataVolume{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dv.Status.RestartCount).To(Equal(0))
+		Expect(dv.Status.RestartCount).To(Equal(int32(0)))
 
 		pvc.Annotations[AnnPodRestarts] = "2"
 		err = reconciler.Client.Update(context.TODO(), pvc)
@@ -157,7 +157,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv = &cdiv1.DataVolume{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dv.Status.RestartCount).To(Equal(2))
+		Expect(dv.Status.RestartCount).To(Equal(int32(2)))
 	})
 
 	It("Should error if a PVC with same name already exists that is not owned by us", func() {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -185,7 +185,6 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-
 	if pod == nil {
 		if isPVCComplete(pvc) {
 			// Don't create the POD if the PVC is completed already
@@ -234,12 +233,12 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 	}
 
 	if pod.Status.ContainerStatuses != nil {
-		log.V(1).Info(" ==**== PVC", "pod.Restarts", pod.Status.ContainerStatuses[0].RestartCount)
 		anno[AnnPodRestarts] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
 	}
 	anno[AnnImportPod] = string(pod.Name)
 	// Even if scratch space is needed, the pod state will still remain running, until the new pod is started.
 	anno[AnnPodPhase] = string(pod.Status.Phase)
+
 	// Check if the POD is waiting for scratch space, if so create some.
 	if pod.Status.Phase == corev1.PodPending && r.requiresScratchSpace(pvc) {
 		if err := r.createScratchPvcForPod(pvc, pod); err != nil {
@@ -277,7 +276,6 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 func (r *ImportReconciler) updatePVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
 	log.V(1).Info("Phase is now", "pvc.anno.Phase", pvc.GetAnnotations()[AnnPodPhase])
 	log.V(1).Info("Restarts is now", "pvc.anno.Restarts", pvc.GetAnnotations()[AnnPodRestarts])
-
 	if err := r.Client.Update(context.TODO(), pvc); err != nil {
 		return err
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -291,6 +291,7 @@ var _ = Describe("Update PVC from POD", func() {
 			Phase: corev1.PodFailed,
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
+					RestartCount: 2,
 					LastTerminationState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 1,
@@ -309,6 +310,7 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resPvc.GetAnnotations()[AnnPodPhase]).To(BeEquivalentTo(corev1.PodFailed))
 		Expect(resPvc.GetAnnotations()[AnnImportPod]).To(Equal(pod.Name))
+		Expect(resPvc.GetAnnotations()[AnnPodRestarts]).To(Equal("2"))
 		By("Checking error event recorded")
 		event := <-reconciler.recorder.(*record.FakeRecorder).Events
 		Expect(event).To(ContainSubstring("I went poof"))
@@ -340,6 +342,7 @@ var _ = Describe("Update PVC from POD", func() {
 		By("Verifying that the phase hasn't changed")
 		Expect(resPvc.GetAnnotations()[AnnPodPhase]).To(BeEquivalentTo(corev1.PodRunning))
 		Expect(resPvc.GetAnnotations()[AnnImportPod]).To(Equal(pod.Name))
+		Expect(resPvc.GetAnnotations()[AnnPodRestarts]).To(Equal("0"))
 		// No scratch space because the pod is not in pending.
 	})
 })

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -165,7 +165,7 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 	pvcCopy.Annotations[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
 
 	if pod.Status.ContainerStatuses != nil {
-		// update pvc annotation tracking pod restarts only if the upload pod restarts are greater or equal
+		// update pvc annotation tracking pod restarts only if the source pod restart count is greater
 		// see the same in clone-controller
 		pvcAnnPodRestarts, _ := strconv.Atoi(pvcCopy.Annotations[AnnPodRestarts])
 		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -164,6 +164,16 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 	pvcCopy.Annotations[AnnPodPhase] = string(podPhase)
 	pvcCopy.Annotations[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
 
+	if pod.Status.ContainerStatuses != nil {
+		// update pvc annotation tracking pod restarts only if the upload pod restarts are greater or equal
+		// see the same in clone-controller
+		pvcAnnPodRestarts, _ := strconv.Atoi(pvcCopy.Annotations[AnnPodRestarts])
+		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
+		if podRestarts > pvcAnnPodRestarts {
+			pvcCopy.Annotations[AnnPodRestarts] = strconv.Itoa(podRestarts)
+		}
+	}
+
 	if !reflect.DeepEqual(pvc, pvcCopy) {
 		if err := r.updatePVC(pvcCopy); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -63,6 +63,8 @@ const (
 	AnnPodReady = AnnAPIGroup + "/storage.pod.ready"
 	// AnnOwnerRef is used when owner is in a different namespace
 	AnnOwnerRef = AnnAPIGroup + "/storage.ownerRef"
+	// AnnPodRestarts is a PVC annotation that tells how many times a related pod was restarted
+	AnnPodRestarts = AnnAPIGroup + "/storage.pod.restarts"
 	// SourceImageio is the source type ovirt-imageio
 	SourceImageio = "imageio"
 )

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -168,7 +168,7 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 				{
 					Name:        "Restarts",
 					Type:        "integer",
-					Description: "The number of times the containers in this pod have been restarted.",
+					Description: "The number of times the transfer has been restarted.",
 					JSONPath:    ".status.restartCount",
 				},
 				{

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -166,6 +166,12 @@ func createDataVolumeCRD() *extv1beta1.CustomResourceDefinition {
 					JSONPath:    ".status.progress",
 				},
 				{
+					Name:        "Restarts",
+					Type:        "integer",
+					Description: "The number of times the containers in this pod have been restarted.",
+					JSONPath:    ".status.restartCount",
+				},
+				{
 					Name:     "Age",
 					Type:     "date",
 					JSONPath: ".metadata.creationTimestamp",

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -358,4 +358,37 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}, timeout, pollingInterval).Should(BeTrue())
 		})
 	})
+
+	Describe("Restarts reporting on import datavolume", func() {
+		It("Should report restarts on failed import", func() {
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", utils.NoImage404URL)
+			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			//Due to the rate limit, this will take a while, so we can expect the phase to be in progress.
+			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
+			utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dataVolume.Name)
+			if err != nil {
+				PrintControllerLog(f)
+				dv, dverr := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
+				if dverr != nil {
+					Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))
+				}
+			}
+
+			By("Verify dv")
+			println("aaaaaaaaaaaa")
+
+			Eventually(func() int32 {
+				dv, err := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				restarts := dv.Status.RestartCount
+				println("restarts", restarts)
+				return restarts
+			}, timeout, pollingInterval).Should(BeNumerically(">=", 1.0))
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -361,28 +361,16 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 	Describe("Restarts reporting on import datavolume", func() {
 		It("Should report restarts on failed import", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", utils.InvalidQcowImagesURL)
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", InvalidQcowImagesURL)
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
-
-			//Due to the rate limit, this will take a while, so we can expect the phase to be in progress.
-			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
-			utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dataVolume.Name)
-			if err != nil {
-				PrintControllerLog(f)
-				dv, dverr := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
-				if dverr != nil {
-					Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))
-				}
-			}
 
 			By("Verify dv")
 			Eventually(func() int32 {
 				dv, err := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				restarts := dv.Status.RestartCount
-				println("restarts", restarts)
 				return restarts
 			}, timeout, pollingInterval).Should(BeNumerically(">=", 1))
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -361,7 +361,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 	Describe("Restarts reporting on import datavolume", func() {
 		It("Should report restarts on failed import", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", utils.NoImage404URL)
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", utils.InvalidQcowImagesURL)
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -378,15 +378,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}
 
 			By("Verify dv")
-			println("aaaaaaaaaaaa")
-
 			Eventually(func() int32 {
 				dv, err := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				restarts := dv.Status.RestartCount
 				println("restarts", restarts)
 				return restarts
-			}, timeout, pollingInterval).Should(BeNumerically(">=", 1.0))
+			}, timeout, pollingInterval).Should(BeNumerically(">=", 1))
 
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -40,6 +40,8 @@ const (
 	CirrosURL = "http://cdi-file-host.%s/cirros-qcow2.img"
 	// ImageioURL provides URL of oVirt engine hosting imageio
 	ImageioURL = "https://imageio.%s:12346/ovirt-engine/api"
+	// a 404
+	NoImage404URL = "http://cdi-file-host:82/nonexistent.qcow2"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -40,7 +40,7 @@ const (
 	CirrosURL = "http://cdi-file-host.%s/cirros-qcow2.img"
 	// ImageioURL provides URL of oVirt engine hosting imageio
 	ImageioURL = "https://imageio.%s:12346/ovirt-engine/api"
-	// a 404
+	// NoImage404URL provides a fake broken url - a 404
 	NoImage404URL = "http://cdi-file-host:82/nonexistent.qcow2"
 )
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -40,8 +40,6 @@ const (
 	CirrosURL = "http://cdi-file-host.%s/cirros-qcow2.img"
 	// ImageioURL provides URL of oVirt engine hosting imageio
 	ImageioURL = "https://imageio.%s:12346/ovirt-engine/api"
-	// NoImage404URL provides a fake broken url - a 404
-	NoImage404URL = "http://cdi-file-host:82/nonexistent.qcow2"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a field to DataVolume to track the number of retries. 

Some background: A DataVolume will create a PVC with a specific annotation, that will trigger a CDI controller to create a pod (import/clone/upload) that will populate the PVC with a disk image. Things can potentially go wrong during the import (or upload/clone, I will talk only import from now on) causing the pod to fail and restart. Kubernetes when you get a pod will list the number or restarts:
```
$ k get pods
```
```
NAME                             READY   STATUS   RESTARTS   AGE
local-volume-provisioner-tgktc   1/1     Running  0          116m
local-volume-provisioner-w6dkt   1/1     Running  0          115m
```
This change adds RESTARTS column to DataVolume: 
```
k get dv
```
```
NAME                  PHASE             PROGRESS   RESTARTS   AGE
dv-test-1g-cloned     CloneInProgress   N/A        3          76s
dv-test-1g-qcow2-xz   Succeeded         100.0%                117s
```
DataVolumes abstract this whole process and unless you know that you need to look at the pods you can't tell if your data volume is progressing or not. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Work In Progress, needs tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a RESTARTS field to DataVolume that tracks a pod(import/clone/upload) retries. 
```

