### PR TITLE
Fix InsecureSkipVerify in imageio data source for http client. Use ht…

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -59,6 +59,7 @@ container_bundle(
         "$(container_prefix)/cdi-func-test-registry-init:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-init-image",
         "$(container_prefix)/cdi-func-test-registry-populate:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-populate-image",
         "$(container_prefix)/cdi-func-test-registry:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-image",
+        "$(container_prefix)/imageio-init:$(container_tag)": "//tools/imageio-init:imageio-init-image",
     },
 )
 

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -18,6 +18,14 @@ spec:
         cdi.kubevirt.io/testing: ""
     spec:
       serviceAccountName: cdi-sa
+      initContainers:
+      - name: init
+        image: {{ .DockerRepo }}/imageio-init:{{ .DockerTag }}
+        imagePullPolicy: {{ .PullPolicy }}
+        args: ["-certDir", "/tmp/certs"]
+        volumeMounts:
+        - name: "certs"
+          mountPath: "/tmp"
       containers:
       - name: imageiotest
         # Docker file: https://github.com/machacekondra/imageiotest
@@ -25,6 +33,11 @@ spec:
         imagePullPolicy: {{ .PullPolicy }}
         ports:
         - containerPort: 12345
+        volumeMounts:
+        - name: "certs"
+          mountPath: "/tmp"
+        command: ["/bin/bash"]
+        args: ["-c", "openssl ca x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/cert.pem; cp /tmp/certs/tls.key /ovirt-imageio/daemon/test/pki/key.pem; cd ovirt-imageio/daemon; ./ovirt-imageio -c test/conf& sleep 3; curl --unix-socket /ovirt-imageio/daemon/test/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: machacekondra/fakeovirt:v3
@@ -34,6 +47,15 @@ spec:
         env:
           - name: NAMESPACE
             value: {{ .Namespace }}
+        volumeMounts:
+        - name: "certs"
+          mountPath: "/tmp"
+        command: ["/bin/bash"]
+        args: ["-c", "cp /tmp/certs/tls.crt /app/server.crt; cp /tmp/certs/tls.key /app/server.key;/app/main"]      
+      volumes:
+      - name: "certs"
+        emptyDir: {}
+
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -18,7 +18,6 @@ package importer
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"io"
 	"io/ioutil"
@@ -176,23 +175,11 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 		return nil, uint64(0), err
 	}
 
-	ca, err := loadCA(certDir)
+	// Use the create client from http source.
+	client, err := createHTTPClient(certDir)
 	if err != nil {
 		return nil, uint64(0), err
 	}
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}
-	if len(ca.Subjects()) > 0 {
-		transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: ca,
-			},
-		}
-	}
-	client := &http.Client{Transport: transport}
 	transferURL, available := it.TransferUrl()
 	if !available {
 		return nil, uint64(0), errors.New("Error transfer url not available")

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -72,20 +72,14 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			var dataVolume *cdiv1.DataVolume
 			switch name {
 			case "imageio":
-				cmName := "imageiocm"
+				cm, err := utils.CopyImageIOCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
+				Expect(err).To(BeNil())
 				stringData := map[string]string{
 					common.KeyAccess: "YWRtaW5AaW50ZXJuYWw=",
 					common.KeySecret: "MTIzNDU2",
 				}
 				s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, "mysecret"))
-				cm := &v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: cmName,
-					},
-					Data: map[string]string{},
-				}
-				f.K8sClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(cm)
-				dataVolume = utils.NewDataVolumeWithImageioImport(dataVolumeName, "1Gi", imageioURL, s.Name, cmName, "123")
+				dataVolume = utils.NewDataVolumeWithImageioImport(dataVolumeName, "1Gi", imageioURL, s.Name, cm, "123")
 			case "import-http":
 				dataVolume = utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", url)
 			case "import-https":

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -34,6 +34,8 @@ const (
 	RegistryCertConfigMap = "cdi-docker-registry-host-certs"
 	// FileHostCertConfigMap is the ConfigMap where the cert fir the file host is stored
 	FileHostCertConfigMap = "cdi-file-host-certs"
+	// ImageIOCertConfigMap is the ConfigMap where the cert fir the file host is stored
+	ImageIOCertConfigMap = "imageio-certs"
 )
 
 var (

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -31,6 +31,15 @@ func CopyFileHostCertConfigMap(client kubernetes.Interface, destNamespace, cdiNa
 	return n, nil
 }
 
+// CopyImageIOCertConfigMap copies the test imageio configmap, it assumes the imageio server is in the CDI namespace
+func CopyImageIOCertConfigMap(client kubernetes.Interface, destNamespace, cdiNamespace string) (string, error) {
+	n, err := CopyConfigMap(client, cdiNamespace, ImageIOCertConfigMap, destNamespace, "")
+	if err != nil {
+		return "", err
+	}
+	return n, nil
+}
+
 // CopyConfigMap copies a ConfigMap
 func CopyConfigMap(client kubernetes.Interface, srcNamespace, srcName, destNamespace, destName string) (string, error) {
 	src, err := client.CoreV1().ConfigMaps(srcNamespace).Get(srcName, metav1.GetOptions{})

--- a/tools/imageio-init/BUILD.bazel
+++ b/tools/imageio-init/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_container_rpm//rpm:rpm.bzl", "rpm_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/containerized-data-importer/tools/imageio-init",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/util:go_default_library",
+        "//tests/utils:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "imageio-init",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "imageio-init-image",
+    base = "@fedora//image",
+    directory = "/usr/bin",
+    entrypoint = [
+        "imageio-init",
+        "-alsologtostderr",
+    ],
+    files = [":imageio-init"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/imageio-init/main.go
+++ b/tools/imageio-init/main.go
@@ -1,0 +1,42 @@
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package main
+
+import (
+	"flag"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+
+	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+const (
+	serviceName   = "imageio"
+	configMapName = serviceName + "-certs"
+	certFile      = "tls.crt"
+	keyFile       = "tls.key"
+)
+
+func main() {
+	certDir := flag.String("certDir", "", "")
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	if err := utils.CreateCertForTestService(util.GetNamespace(), serviceName, configMapName, *certDir, certFile, keyFile); err != nil {
+		klog.Fatal(errors.Wrapf(err, "populate certificate directory %s' errored: ", *certDir))
+	}
+
+	klog.Info("File initialization completed without error.")
+}


### PR DESCRIPTION
…tp data source client instead.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
ImageIO PR introduced a InsecureSkipVerify that is not needed. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

