### PR TITLE
Read timeout from environment variable instead of hard coding it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ cluster-clean:
 	./cluster-sync/clean.sh
 
 cluster-sync: cluster-clean
-	./cluster-sync/sync.sh DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
+	./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
 
 bazel-generate:
 	SYNC_VENDOR=true ${DO_BAZ} "./hack/build/bazel-generate.sh -- pkg/ tools/ tests/ cmd/ vendor/"

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -14,6 +14,7 @@ source ./cluster-sync/${KUBEVIRT_PROVIDER}/provider.sh
 CDI_INSTALL="install-operator"
 CDI_NAMESPACE=${CDI_NAMESPACE:-cdi}
 CDI_INSTALL_TIMEOUT=${CDI_INSTALL_TIMEOUT:-120}
+CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT:-480}
 
 # Set controller verbosity to 3 for functional tests.
 export VERBOSITY=3
@@ -57,8 +58,8 @@ install_cdi
 wait_cdi_crd_installed $CDI_INSTALL_TIMEOUT
 
 _kubectl apply -f "./_out/manifests/release/cdi-cr.yaml"
-echo "Waiting 480 seconds for CDI to become available"
-_kubectl wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=480s
+echo "Waiting $CDI_AVAILABLE_TIMEOUT seconds for CDI to become available"
+_kubectl wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=${CDI_AVAILABLE_TIMEOUT}s
 
 # If we are upgrading, verify our current value.
 if [[ ! -z "$UPGRADE_FROM" ]]; then
@@ -115,8 +116,8 @@ if [[ ! -z "$UPGRADE_FROM" ]]; then
 	echo $cdi_obj
 	exit 1
   fi
-  echo "Waiting 480 seconds for CDI to become available"
-  _kubectl wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=480s
+  echo "Waiting $CDI_AVAILABLE_TIMEOUT seconds for CDI to become available"
+  _kubectl wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=${CDI_AVAILABLE_TIMEOUT}s
 fi
 
 configure_storage


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The timeout to wait for cdi to be available is hard coded, the os-3.11-crio lane seems to take a lot longer in certain cases. This PR allows us to read the timeout from an environment variable which we can then set in the lane configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

