### PR TITLE
ux: Clarify message when PVC is too small

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -190,7 +190,7 @@ func (o *qemuOperations) Validate(url *url.URL, availableSize int64) error {
 	}
 
 	if availableSize < info.VirtualSize {
-		return errors.Errorf("Virtual image size %d is larger than available size %d, shrink not yet supported.", info.VirtualSize, availableSize)
+		return errors.Errorf("Virtual image size %d is larger than available size %d. A larger PVC is required.", info.VirtualSize, availableSize)
 	}
 	return nil
 }

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Validate", func() {
 		table.Entry("should return error on bad json", mockExecFunction(badValidateJSON, "", expectedLimits), "unexpected end of JSON input", imageName),
 		table.Entry("should return error on bad format", mockExecFunction(badFormatValidateJSON, "", expectedLimits), fmt.Sprintf("Invalid format raw2 for image %s", imageName), imageName),
 		table.Entry("should return error on invalid backing file", mockExecFunction(backingFileValidateJSON, "", expectedLimits), fmt.Sprintf("Image %s is invalid because it has backing file backing-file.qcow2", imageName), imageName),
-		table.Entry("should return error on shrink", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("Virtual image size %d is larger than available size %d, shrink not yet supported.", 52949672960, 42949672960), imageName),
+		table.Entry("should return error when PVC is too small", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("Virtual image size %d is larger than available size %d. A larger PVC is required.", 52949672960, 42949672960), imageName),
 	)
 
 })


### PR DESCRIPTION
When a user imports into a PVC that is not large enough we print an
error stating that "shrink not supported".  When this situation happens
it is far more likely that the user simply used a PVC that is too small
to hold the image.  Let's make it easier for them to debug by suggesting
this.  The verbage about shrinking is simply confusing.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

