### PR TITLE
Increase time we wait for operator upgrade to complete.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -47,7 +47,7 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
 fi
 
 if [[ -n "$MULTI_UPGRADE" ]]; then
-  export UPGRADE_FROM="v1.10.7 v1.10.9 v1.11.0"
+  export UPGRADE_FROM="v1.10.7 v1.11.0 v1.12.0 v1.13.2 v1.14.0 v1.15.0"
 fi
 
 if [[ -z "$UPGRADE_FROM" ]]; then


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are having frequent CI failures on the upgrade lane because we don't wait long enough for the upgrade to complete. Also made it an environment variable so we can change it from a lane perspective. Added more versions to upgrade to.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

