### PR TITLE
Fix os-3.11.0-crio comparison so it follow the right path on other provider.

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -59,7 +59,7 @@ wait_cdi_crd_installed $CDI_INSTALL_TIMEOUT
 
 _kubectl apply -f "./_out/manifests/release/cdi-cr.yaml"
 echo "Waiting $CDI_AVAILABLE_TIMEOUT seconds for CDI to become available"
-if [[ $KUBEVIRT_PROVIDER=="os-3.11.0-crio" ]]; then
+if [ "$KUBEVIRT_PROVIDER" == "os-3.11.0-crio" ]; then
   echo "Openshift 3.11 provider"
   available=$(_kubectl get cdi cdi -o jsonpath={.status.conditions[0].status})
   wait_time=0


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The newly added code to check for OS-3.11-crio provider had a bug where it would always follow that path. It doesn't actually cause issues, but it is not what we expected to happen.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

