### PR TITLE
Added GetPodName function used to correctly generate pod names in con…

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -118,6 +118,9 @@ const (
 	// ScratchSpaceNeededExitCode is the exit code that indicates the importer pod requires scratch space to function properly.
 	ScratchSpaceNeededExitCode = 42
 
+	// ScratchNameSuffix (controller pkg only)
+	ScratchNameSuffix = "scratch"
+
 	// UploadTokenIssuer is the JWT issuer of upload tokens
 	UploadTokenIssuer = "cdi-apiserver"
 

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/cert:go_default_library",
         "//pkg/util/cert/fetcher:go_default_library",
         "//pkg/util/cert/generator:go_default_library",
+        "//pkg/util/naming:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1:go_default_library",
         "//vendor/github.com/openshift/api/route/v1:go_default_library",

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -18,6 +18,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/pkg/util/naming"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -535,11 +536,11 @@ func getDiskID(pvc *corev1.PersistentVolumeClaim) string {
 }
 
 func importPodNameFromPvc(pvc *corev1.PersistentVolumeClaim) string {
-	return fmt.Sprintf("%s-%s", common.ImporterPodName, pvc.Name)
+	return naming.GetResourceName(common.ImporterPodName, pvc.Name)
 }
 
 func scratchNameFromPvc(pvc *corev1.PersistentVolumeClaim) string {
-	return fmt.Sprintf("%s-scratch", pvc.Name)
+	return naming.GetResourceName(pvc.Name, common.ScratchNameSuffix)
 }
 
 // createImporterPod creates and returns a pointer to a pod which is created based on the passed-in endpoint, secret

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -43,6 +43,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/fetcher"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/generator"
+	"kubevirt.io/containerized-data-importer/pkg/util/naming"
 )
 
 const (
@@ -141,8 +142,7 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 	} else {
 		uploadClientName = uploadServerClientName
 
-		// TODO revisit naming, could overflow
-		scratchPVCName = pvc.Name + "-scratch"
+		scratchPVCName = getScratchPvcName(pvc.Name)
 	}
 
 	resourceName := getUploadResourceName(pvc.Name)
@@ -486,10 +486,14 @@ func addUploadControllerWatches(mgr manager.Manager, importController controller
 	return nil
 }
 
+// getScratchPvcName returns the name given to scratch pvc
+func getScratchPvcName(name string) string {
+	return naming.GetResourceName(name, common.ScratchNameSuffix)
+}
+
 // getUploadResourceName returns the name given to upload resources
 func getUploadResourceName(name string) string {
-	// TODO revisit naming, could overflow
-	return "cdi-upload-" + name
+	return naming.GetResourceName("cdi-upload", name)
 }
 
 // UploadPossibleForPVC is called by the api server to see whether to return an upload token

--- a/pkg/util/naming/BUILD.bazel
+++ b/pkg/util/naming/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["namer.go"],
+    importpath = "kubevirt.io/containerized-data-importer/pkg/util/naming",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/openshift/library-go/pkg/build/naming:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "namer_suite_test.go",
+        "namer_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/util:go_default_library",
+        "//tests/reporters:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
+    ],
+)

--- a/pkg/util/naming/namer.go
+++ b/pkg/util/naming/namer.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package naming
+
+import (
+	"github.com/openshift/library-go/pkg/build/naming"
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GetResourceName creates a name with provided suffix, and shortens if needed
+// with the length restriction for pods/resources
+func GetResourceName(base, suffix string) string {
+	return naming.GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// GetLabelName creates a name with the length restriction for labels, and shortens if needed
+func GetLabelName(base string) string {
+	if len(base) <= kvalidation.DNS1035LabelMaxLength {
+		return base
+	}
+
+	// TODO: GetName does not work correctly with empty suffix (leaves trailing '-'), check if we want to:
+	// - put our own small suffix - it has the advantage, that if some name is shortened we can see it was our shortener
+	// - put very long suffix so it will dropped by GetName
+	// - extend/fix GetName
+	// - write our own GetName
+	return naming.GetName(base, "cdi", kvalidation.DNS1035LabelMaxLength)
+}

--- a/pkg/util/naming/namer_suite_test.go
+++ b/pkg/util/naming/namer_suite_test.go
@@ -1,0 +1,15 @@
+package naming
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"kubevirt.io/containerized-data-importer/tests/reporters"
+)
+
+func TestClonerTarget(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Namer Test Suite", reporters.NewReporters())
+}

--- a/pkg/util/naming/namer_test.go
+++ b/pkg/util/naming/namer_test.go
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package naming
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+var _ = Describe("GetName", func() {
+	word63 := util.RandAlphaNum(63)
+	word260 := util.RandAlphaNum(260)
+	suffix250 := util.RandAlphaNum(250)
+
+	It("Should namer differentiates names if suffix is dropped", func() {
+		result := GetResourceName("base", util.RandAlphaNum(260))
+
+		anotherDifferentResult := GetResourceName("base", util.RandAlphaNum(260))
+		Expect(result).ToNot(Equal(anotherDifferentResult))
+	})
+
+	table.DescribeTable("getName", func(inputName, suffix string, resultMatcher types.GomegaMatcher) {
+		result := GetResourceName(inputName, suffix)
+		Expect(len(result)).To(BeNumerically("<=", 253))
+		Expect(result).To(resultMatcher)
+	},
+		table.Entry("Should not changed short name that fits under limits ", "abc", "suffix", Equal("abc-suffix")),
+		table.Entry("Should shorten name and join with -hash-suffix", word260, "suffix", HaveSuffix("-suffix")),
+		table.Entry("Should shorten too long name dropping too long suffix", "abc123", suffix250, And(HavePrefix("abc123"), HaveLen(15))),
+	)
+
+	It("Should not shorten label name if it fits", func() {
+		Expect(GetLabelName("name")).To(Equal("name"))
+		Expect(GetLabelName(word63)).To(Equal(word63))
+	})
+
+	It("Should shorten to long label correctly", func() {
+		word64 := util.RandAlphaNum(64)
+		result := GetLabelName(word64)
+		Expect(len(result)).To(BeNumerically("<=", 63))
+
+		shortenedWithoutHash := word64[0 : 63-13]
+		Expect(result).To(HavePrefix(shortenedWithoutHash))
+	})
+
+})

--- a/vendor/github.com/openshift/library-go/pkg/build/naming/BUILD.bazel
+++ b/vendor/github.com/openshift/library-go/pkg/build/naming/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["namer.go"],
+    importmap = "kubevirt.io/containerized-data-importer/vendor/github.com/openshift/library-go/pkg/build/naming",
+    importpath = "github.com/openshift/library-go/pkg/build/naming",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library"],
+)

--- a/vendor/github.com/openshift/library-go/pkg/build/naming/namer.go
+++ b/vendor/github.com/openshift/library-go/pkg/build/naming/namer.go
@@ -1,0 +1,73 @@
+package naming
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GetName returns a name given a base ("deployment-5") and a suffix ("deploy")
+// It will first attempt to join them with a dash. If the resulting name is longer
+// than maxLength: if the suffix is too long, it will truncate the base name and add
+// an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
+// it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
+func GetName(base, suffix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	name := fmt.Sprintf("%s-%s", base, suffix)
+	if len(name) <= maxLength {
+		return name
+	}
+
+	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
+
+	// if the suffix is too long, ignore it
+	if baseLength < 0 {
+		prefix := base[0:min(len(base), max(0, maxLength-9))]
+		// Calculate hash on initial base-suffix string
+		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
+		return shortName[:min(maxLength, len(shortName))]
+	}
+
+	prefix := base[0:baseLength]
+	// Calculate hash on initial base-suffix string
+	return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
+}
+
+// GetPodName calls GetName with the length restriction for pods
+func GetPodName(base, suffix string) string {
+	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// GetConfigMapName calls GetName with the length restriction for ConfigMaps
+func GetConfigMapName(base, suffix string) string {
+	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// min returns the lesser of its 2 inputs
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// hash calculates the hexadecimal representation (8-chars)
+// of the hash of the passed in string using the FNV-a algorithm
+func hash(s string) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(s))
+	intHash := hash.Sum32()
+	result := fmt.Sprintf("%08x", intHash)
+	return result
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,6 +226,7 @@ github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/operator/certrotation
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/v1helpers
+github.com/openshift/library-go/pkg/build/naming
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/operator/condition
 github.com/openshift/library-go/pkg/operator/resource/resourceapply


### PR DESCRIPTION
…trollers

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CDI creates resources with new names - like short term controllers and "scratch" resources (the name generation has to be deterministic because it is also used to find the resource). Previously the name generation could make too long names. The PR fixes this problem. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I am not yet 100% sure about the correct const to use as a length for Pod or Pvc in the  pkg/util/util.go: kvalidation.DNS1035LabelMaxLength or  kvalidation.DNS1123SubdomainMaxLength

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

