### PR TITLE
Attempt to unstick the os-3.11-crio provider when an sdn pod is not r…

### DIFF
--- a/cluster-sync/os-3.11.0-crio/provider.sh
+++ b/cluster-sync/os-3.11.0-crio/provider.sh
@@ -10,5 +10,11 @@ if ! [[ $num_nodes =~ $re ]] || [[ $num_nodes -lt 1 ]] ; then
     num_nodes=1
 fi
 
-
+function fix_failed_sdn_pods() {
+   broken_pods=$(_kubectl get pods -n openshift-sdn -o jsonpath={.items[?\(@.status.containerStatuses[0].ready==false\)].metadata.name})
+   for pod in ${broken_pods[@]}; do
+     echo "Fixing broken pod $pod"
+     _kubectl delete pod $pod -n openshift-sdn
+   done
+}
 

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -68,6 +68,7 @@ if [ "$KUBEVIRT_PROVIDER" == "os-3.11.0-crio" ]; then
     wait_time=$((wait_time + 5))
     sleep 5
     available=$(_kubectl get cdi cdi -o jsonpath={.status.conditions[0].status})
+    fix_failed_sdn_pods
   done
 
 else


### PR DESCRIPTION
…eady.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The OS-3.11 provider sometimes gets stuck during cluster-sync because some of the sdn pods are crash looping, most likely due to memory issues. This PR attempts to allow the sync to continue by deleting the broken pod, and hoping they come back functional. In my testing this allowed the CDI operator to continue and deploy the rest of CDI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

