### PR TITLE
Fail to import a containerDisk containing more than one file

### DIFF
--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -132,7 +132,12 @@ func getImageFileName(dir string) (string, error) {
 		return "", errors.New("image file does not exist in image directory - directory is empty")
 	}
 
-	fileinfo := entries[len(entries)-1]
+	if len(entries) > 1 {
+		klog.Errorf("image directory contains more than one file")
+		return "", errors.New("image directory contains more than one file")
+	}
+
+	fileinfo := entries[0]
 	if fileinfo.IsDir() {
 		klog.Errorf("image file does not exist in image directory contains another directory ")
 		return "", errors.New("image directory contains another directory")

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -146,6 +146,18 @@ var _ = Describe("Registry data source", func() {
 		Expect(err).To(HaveOccurred())
 		Expect("image file does has no name").To(Equal(err.Error()))
 	})
+
+	It("getImageFileName should return an error with multiple files in the image directory", func() {
+		err := os.Mkdir(filepath.Join(tmpDir, containerDiskImageDir), os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Create(filepath.Join(tmpDir, containerDiskImageDir, "extra-file"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Create(filepath.Join(tmpDir, containerDiskImageDir, "disk.img"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getImageFileName(filepath.Join(tmpDir, containerDiskImageDir))
+		Expect(err).To(HaveOccurred())
+		Expect("image directory contains more than one file").To(Equal(err.Error()))
+	})
 })
 
 type fakeSkopeoOperations struct {


### PR DESCRIPTION
The kubevirt containerDisk container format expects only a single file to exist
in the disk directory of the container.  Rather than assuming that this is the
case we should check explicitly and fail rather than guessing which file to
use.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

