### PR TITLE
Fix builder build image.

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -64,6 +64,8 @@ RUN \
     go install ./... ) && \
     ( go get -u golang.org/x/lint/golint ) && \
     ( go get -u github.com/rmohr/go-swagger-utils/swagger-doc ) && \
+    ( go get -u -d k8s.io/klog ) && \
+    ( ln -s /go/src/k8s.io/klog /go/src/k8s.io/klog/v2 ) && \
     ( go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
     go get -u -d k8s.io/kube-openapi/cmd/openapi-gen ) && \
     ( cd $GOPATH/src/k8s.io/code-generator/cmd/deepcopy-gen && \


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
klog/v2 repo is no longer available due to klog releasing v2 a few days ago. Anything referencing v2 is breaking. This is a hack to symlink v2 to klog as they are now the same.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

