### PR TITLE
Minor fix to a manifest example, import-kubevirt-block-datavolume

### DIFF
--- a/manifests/example/import-kubevirt-block-datavolume.yaml
+++ b/manifests/example/import-kubevirt-block-datavolume.yaml
@@ -3,12 +3,12 @@ kind: DataVolume
 metadata:
   name: import-kubevirt-block-datavolume
 spec:
-  # Optional: Set the storage class or omit to accept the default
-  storageClassName: local
   source:
     http:
       url: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso"
   pvc:
+    # Optional: Set the storage class or omit to accept the default
+    storageClassName: local
     volumeMode: Block
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
Signed-off-by: isueyoon <sueyoon@protonmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It's a very tiny fix to an example yaml file, import-kubevirt-block-datavolume.yaml. Moved storageClassName key, value under the pvc.

I copy and pasted this example to create a data volume, and noticed why it didn't work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

It's a same request as #1173 which I closed few days ago by mistake. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

