### PR TITLE
Add DV restarts test for upload controller

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -770,7 +770,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		}
 	})
 
-	It("[test_id:3999] Create a data volume importing an image and then clone it and verify retry count", func() {
+	It("[test_id:3999] Create a data volume and then clone it and verify retry count", func() {
 		pvcDef := utils.NewPVCDefinition(sourcePVCName, "1G", nil, nil)
 		pvcDef.Namespace = f.Namespace.Name
 		sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, fillCommand+testFile)
@@ -796,7 +796,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(dv.Status.RestartCount).To(BeNumerically("==", 0))
 	})
 
-	It("[test_id:4000] Create a data volume importing an image and then clone it while killing the container and verify retry count", func() {
+	It("[test_id:4000] Create a data volume and then clone it while killing the container and verify retry count", func() {
 		By("Prepare source PVC")
 		pvcDef := utils.NewPVCDefinition(sourcePVCName, "1G", nil, nil)
 		pvcDef.Namespace = f.Namespace.Name

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -380,22 +380,4 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 	})
 
-	Describe("Restarts reporting on import datavolume", func() {
-		It("Should report restarts on failed import", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", InvalidQcowImagesURL)
-			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
-			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verify dv")
-			Eventually(func() int32 {
-				dv, err := f.CdiClient.CdiV1alpha1().DataVolumes(f.Namespace.Name).Get(dataVolume.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				restarts := dv.Status.RestartCount
-				return restarts
-			}, timeout, pollingInterval).Should(BeNumerically(">=", 1))
-
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
 })

--- a/tests/framework/exec_util.go
+++ b/tests/framework/exec_util.go
@@ -105,8 +105,8 @@ func (f *Framework) ExecCommandInContainer(namespace, podName, containerName str
 }
 
 // ExecShellInContainer provides a function to execute a shell cmd for the specified running container in a pod
-func (f *Framework) ExecShellInContainer(podName, containerName string, cmd string) (string, error) {
-	str, err := f.ExecCommandInContainer(podName, containerName, "/bin/sh", "-c", cmd)
+func (f *Framework) ExecShellInContainer(namespace, podName, containerName string, cmd string) (string, error) {
+	str, err := f.ExecCommandInContainer(namespace, podName, containerName, "/bin/sh", "-c", cmd)
 	if err != nil {
 		return "", err
 	}
@@ -127,7 +127,7 @@ func (f *Framework) ExecCommandInPod(podName, namespace string, cmd ...string) (
 
 // ExecCommandInPodWithFullOutput provides a function to execute a command in a running pod and to capture its output
 func (f *Framework) ExecCommandInPodWithFullOutput(namespace, podName string, cmd ...string) (string, string, error) {
-	pod, err := f.K8sClient.CoreV1().Pods(f.Namespace.GetName()).Get(podName, metav1.GetOptions{})
+	pod, err := f.K8sClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get pod")
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
 	return f.ExecCommandInContainerWithFullOutput(namespace, podName, pod.Spec.Containers[0].Name, cmd...)
@@ -143,8 +143,8 @@ func (f *Framework) ExecShellInPod(podName, namespace string, cmd string) (strin
 }
 
 // ExecShellInPodWithFullOutput provides a function to execute a shell cmd in a running pod and to capture its output
-func (f *Framework) ExecShellInPodWithFullOutput(podName string, cmd string) (string, string, error) {
-	return f.ExecCommandInPodWithFullOutput(podName, "/bin/sh", "-c", cmd)
+func (f *Framework) ExecShellInPodWithFullOutput(namespace, podName string, cmd string) (string, string, error) {
+	return f.ExecCommandInPodWithFullOutput(namespace, podName, "/bin/sh", "-c", cmd)
 }
 
 func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -527,10 +527,6 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		invalidQcowImagesURL = fmt.Sprintf(utils.InvalidQcowImagesURL, f.CdiInstallNs)
 	)
 
-	BeforeEach(func() {
-
-	})
-
 	AfterEach(func() {
 		By("Delete DV")
 		err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume.Name)

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -206,7 +206,7 @@ func podStatus(clientSet *kubernetes.Clientset, podName, namespace string, statu
 			}
 			return false, err
 		}
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Checking POD phase: %s\n", string(pod.Status.Phase))
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Checking POD %s phase: %s\n", podName, string(pod.Status.Phase))
 		switch pod.Status.Phase {
 		case status:
 			return true, nil


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
New functional tests for new RESTARTS column in DataVolume (done in PR
https://github.com/kubevirt/containerized-data-importer/pull/1155). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

