### PR TITLE
Fix, crash when total size is 0 from endpoint. If total was 0 no prog…

### DIFF
--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -262,5 +262,7 @@ func (fr *FormatReaders) Close() (rtnerr error) {
 
 // StartProgressUpdate starts the go routine to automatically update the progress on a set interval.
 func (fr *FormatReaders) StartProgressUpdate() {
-	fr.progressReader.StartTimedUpdate()
+	if fr.progressReader != nil {
+		fr.progressReader.StartTimedUpdate()
+	}
 }

--- a/pkg/importer/format-readers_test.go
+++ b/pkg/importer/format-readers_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,4 +90,14 @@ var _ = Describe("Format Readers", func() {
 		table.Entry("should append io.reader", rdrGz, stringRdr, 3, false),
 		table.Entry("should append io.Multireader", rdrMulti, stringRdr, 3, false),
 	)
+
+	It("should not crash on no progress reader", func() {
+		stringReader := ioutil.NopCloser(strings.NewReader("This is a test string"))
+		testReader, err := NewFormatReaders(stringReader, uint64(0))
+		// Not passing a real string, so the header checking will fail.
+		Expect(err).To(HaveOccurred())
+		Expect(testReader.progressReader).To(BeNil())
+		// This should not crash
+		testReader.StartProgressUpdate()
+	})
 })


### PR DESCRIPTION
…ress reader is constructed and a call to updateProgress would crash.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the content length returned by the end point was 0, we are not constructing a progress reader, but still called StartUpdateProgress, which would cause a npe. This PR fixes that.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1187

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix crash when total discovered was 0.
```

