### PR TITLE
For imageio data source, try content-length header if total 0

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -285,12 +285,10 @@ func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVol
 		datavolume.Status.Progress = "N/A"
 	}
 
-	if datavolume.Spec.Source.HTTP != nil {
-		podNamespace = datavolume.Namespace
-	} else if datavolume.Spec.Source.PVC != nil {
+	if datavolume.Spec.Source.PVC != nil {
 		podNamespace = datavolume.Spec.Source.PVC.Namespace
 	} else {
-		return reconcile.Result{}, nil
+		podNamespace = datavolume.Namespace
 	}
 
 	if datavolume.Status.Phase == cdiv1.Succeeded || datavolume.Status.Phase == cdiv1.Failed {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
No progress is being reported because the total is 0, if the total is 0 try the content-length header to find the total.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1190

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: imageio import was not reporting progress.
```

