### PR TITLE
Fixed race for block blank disks 

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -282,7 +282,8 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 		_, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
 		By("Waiting for import to be completed")
-		utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+		Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
 
 		By("Verifying a message was printed to indicate a request for a blank disk on a block device")
 		Eventually(func() bool {


### PR DESCRIPTION
Fixed test to check for error on phase detection.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix a bug where DataVolume phase was not being updated for a block blank disk. A block blank disk is a no-op for CDI, however we need to still to update the DataVolume phase to be successful. There was a race condition in the code that caused it to not update the DataVolume if the PVC was bound already.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed race condition in blank block disks.
```

