### PR TITLE
Handle service name generation correctly

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -324,6 +324,7 @@ func (app *cdiAPIApp) uploadHandler(request *restful.Request, response *restful.
 
 	tokenData := &token.Payload{
 		Operation: token.OperationUpload,
+		// this is service or pod but not pvc?
 		Name:      pvcName,
 		Namespace: namespace,
 		Resource: metav1.GroupVersionResource{

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -152,7 +152,8 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 		return reconcile.Result{}, err
 	}
 
-	if _, err = r.getOrCreateUploadService(pvc, resourceName); err != nil {
+	svcName := naming.GetServiceName(resourceName)
+	if _, err = r.getOrCreateUploadService(pvc, svcName); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -217,9 +218,10 @@ func (r *UploadReconciler) getCloneRequestSourcePVC(targetPvc *corev1.Persistent
 
 func (r *UploadReconciler) cleanup(pvc *v1.PersistentVolumeClaim) error {
 	resourceName := getUploadResourceName(pvc.Name)
+	svcName := naming.GetServiceName(resourceName)
 
 	// delete service
-	if err := r.deleteService(pvc.Namespace, resourceName); err != nil {
+	if err := r.deleteService(pvc.Namespace, svcName); err != nil {
 		return err
 	}
 
@@ -246,7 +248,9 @@ func (r *UploadReconciler) getOrCreateUploadPod(pvc *v1.PersistentVolumeClaim, p
 			return nil, errors.Wrapf(err, "error getting upload pod %s/%s", pvc.Namespace, podName)
 		}
 
-		serverCert, serverKey, err := r.serverCertGenerator.MakeServerCert(pvc.Namespace, podName, uploadServerCertDuration)
+		// TODO: discuss, certificate needs to apply for a service! now implicitly it works, because service name is the same as podname,
+		// if we limit the upload pod name to 63 chars, then we can still keep our 1 to 1 mapping of pod - service
+		serverCert, serverKey, err := r.serverCertGenerator.MakeServerCert(pvc.Namespace, naming.GetServiceName(podName), uploadServerCertDuration)
 		if err != nil {
 			return nil, err
 		}
@@ -506,11 +510,13 @@ func UploadPossibleForPVC(pvc *v1.PersistentVolumeClaim) error {
 
 // GetUploadServerURL returns the url the proxy should post to for a particular pvc
 func GetUploadServerURL(namespace, pvc, uploadPath string) string {
-	return fmt.Sprintf("https://%s.%s.svc%s", getUploadResourceName(pvc), namespace, uploadPath)
+	serviceName := naming.GetServiceName(getUploadResourceName(pvc))
+	return fmt.Sprintf("https://%s.%s.svc%s", serviceName, namespace, uploadPath)
 }
 
 func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequirements *v1.ResourceRequirements) *v1.Pod {
 	requestImageSize, _ := getRequestedImageSize(args.PVC)
+	serviceName := naming.GetServiceName(args.Name)
 	fsGroup := common.QemuSubGid
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -526,7 +532,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			Labels: map[string]string{
 				common.CDILabelKey:              common.CDILabelValue,
 				common.CDIComponentLabel:        common.UploadServerCDILabel,
-				common.UploadServerServiceLabel: args.Name,
+				common.UploadServerServiceLabel: serviceName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				MakePVCOwnerReference(args.PVC),

--- a/pkg/util/naming/namer.go
+++ b/pkg/util/naming/namer.go
@@ -43,3 +43,9 @@ func GetLabelName(base string) string {
 	// - write our own GetName
 	return naming.GetName(base, "cdi", kvalidation.DNS1035LabelMaxLength)
 }
+
+// GetServiceName creates a name with the length restriction for service (label), and shortens if needed
+func GetServiceName(name string) string {
+	// The name of a Service object must be a valid DNS label name.
+	return GetLabelName(name)
+}

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/common:go_default_library",
         "//pkg/image:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/naming:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/ulikunitz/xz:go_default_library",

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -7,6 +7,7 @@ import (
 
 	cdiuploadv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/upload/v1alpha1"
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
+	"kubevirt.io/containerized-data-importer/pkg/util/naming"
 )
 
 const (
@@ -29,7 +30,7 @@ const (
 
 // UploadPodName returns the name of the upload server pod associated with a PVC
 func UploadPodName(pvc *k8sv1.PersistentVolumeClaim) string {
-	return "cdi-upload-" + pvc.Name
+	return naming.GetResourceName("cdi-upload", pvc.Name)
 }
 
 // UploadPVCDefinition creates a PVC with the upload target annotation


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Generates service name according to Service naming rules. So the DNS label standard as defined in RFC 1123: (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). Previously it was just an upload pod name. If/When upload pod name is ever changed to be longer then service can not be created.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
We might actually discuss if this is the right approach, or if better is to limit the upload pod name and just keep the old logic that ties service name to upload pod name 1:1.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

