### PR TITLE
Change gid check to use ls instead of stat

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -185,9 +185,10 @@ func (f *Framework) GetDiskGroup(namespace *k8sv1.Namespace, pvc *k8sv1.Persiste
 	err = utils.WaitTimeoutForPodReady(f.K8sClient, executorPod.Name, namespace.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	cmd := fmt.Sprintf("stat -c '%%g' %s/disk.img", utils.DefaultPvcMountPath)
+	cmd := fmt.Sprintf("x=$(ls -ln %s/disk.img); y=($x); echo ${y[3]}", utils.DefaultPvcMountPath)
 
 	output, err := f.ExecShellInPod(executorPod.Name, namespace.Name, cmd)
+	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: gid of disk.img: %s\n", string(output))
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Change the gid check in functional tests to use ln -ln instead of stat, as stat might not be available in the container that we use for the verifier pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

