### PR TITLE
Stop smart clone controller being registered twice

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -153,8 +153,6 @@ func start(cfg *rest.Config, stopCh <-chan struct{}) {
 		os.Exit(1)
 	}
 
-	startSmartController(extClient, mgr, log)
-
 	if _, err := controller.NewUploadController(mgr, log, uploadServerImage, pullPolicy, verbose, uploadServerCertGenerator, uploadClientBundleFetcher); err != nil {
 		klog.Errorf("Unable to setup upload controller: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
Stop smart clone controller being registered twice and causing error messages about duplicate metrics.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If smart clone controller is registered, it would get registered twice and cause duplicate metrics errors in the log from prometheus. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Duplicate metrics message in controller log when smart clone is available
```

