### PR TITLE
Increase timeout waiting for ceph to be ready

### DIFF
--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -59,7 +59,10 @@ function configure_ceph() {
 
   # wait for ceph
   until _kubectl get cephblockpools -n rook-ceph replicapool -o jsonpath='{.status.phase}' | grep Ready; do
-      ((count++)) && ((count == 60)) && echo "Ceph not ready in time" && exit 1
+      ((count++)) && ((count == 120)) && echo "Ceph not ready in time" && exit 1
+      if ! ((count % 6 )); then
+        _kubectl get pods -n rook-ceph
+      fi
       echo "Waiting for Ceph to be Ready, sleeping 5s and rechecking"
       sleep 5
   done


### PR DESCRIPTION
Increase timeout waiting for ceph to be ready, also print ceph namespace pods every 30 seconds

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The ceph lane fails to start due to ceph not being ready in the allotted time, however it due to ci being busy, so just waiting longer should allow the test to run.

Also print the ceph namespace pod every 30 seconds so we can look at the progress on failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

