### PR TITLE
Rename PVC.

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -613,7 +613,11 @@ func validateCloneToken(validator token.Validator, source, target *corev1.Persis
 		tokenData.Namespace != source.Namespace ||
 		tokenData.Resource.Resource != "persistentvolumeclaims" ||
 		tokenData.Params["targetNamespace"] != target.Namespace ||
-		tokenData.Params["targetName"] != target.Name {
+		// Either target.Name (PVC name) is token["targetName"] (DV Name) + 5 random chars
+		//     OR token["targetName"] (DV Name) is very long and the PVC name is made of
+		//        DV name cut to size + 5 random chars
+		!(strings.HasPrefix(target.Name, tokenData.Params["targetName"]) ||
+			strings.HasPrefix(tokenData.Params["targetName"], target.Name[:len(target.Name)-5])) {
 		return errors.New("invalid token")
 	}
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -556,7 +556,8 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		dv := utils.NewDataVolumeWithHTTPImport(dvName, "100Mi", tinyCoreIsoURL)
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.Succeeded
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -587,7 +588,8 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		dv := utils.NewDataVolumeWithHTTPImport(dvName, "100Mi", invalidQcowImagesURL)
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.ImportInProgress
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -186,7 +186,11 @@ var _ = Describe("Operator delete CDI tests", func() {
 
 		By("Waiting for pod to be running")
 		Eventually(func() bool {
-			pod, err := f.K8sClient.CoreV1().Pods(dv.Namespace).Get("cdi-upload-"+dv.Name, metav1.GetOptions{})
+			pvc, err := utils.FindPVCForDV(f.K8sClient, dv)
+			if err != nil {
+				return false
+			}
+			pod, err := f.K8sClient.CoreV1().Pods(dv.Namespace).Get("cdi-upload-"+pvc.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				return false
 			}

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 
 		var pvc *corev1.PersistentVolumeClaim
 		Eventually(func() error {
-			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(dv.Name, metav1.GetOptions{})
+			pvc, err = utils.FindPVCByLabel(f.K8sClient, f.Namespace.Name, dv.Name)
 			if err != nil {
 				return err
 			}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -495,7 +495,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))
 		dv := utils.NewDataVolumeForUpload(dvName, "100Mi")
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.UploadReady
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -553,7 +554,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))
 		dv := utils.NewDataVolumeForUpload(dvName, "100Mi")
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.UploadReady
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -599,7 +601,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		dv := utils.NewDataVolumeForUpload(shortDvName, "1Gi")
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.UploadReady
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -643,7 +646,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		dv := utils.NewDataVolumeForUpload(dvName160Characters, "1Gi")
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.UploadReady
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -687,7 +691,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		dv := utils.NewDataVolumeForUpload(dvName160Characters, "1Gi")
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
-		pvc = utils.PersistentVolumeClaimFromDataVolume(dataVolume)
+		pvc, err = utils.WaitForPVCForDV(f.K8sClient, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
 
 		phase := cdiv1.UploadReady
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))


### PR DESCRIPTION
In order to make DVs and PVCs more user-friendly and to help users
confuse one with the other, we're changing the name of PVC created for
DV.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR changes generated PVC spec"s `Name` to `GenerateName` to let k8s to create the actual name. This will make PVC name different from its parent DV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
User's config/code could have made an assumption that the names of PVCs are equal to the names of the DVs. This is no longer true and this might cause some confusion after the update.
```

