### PR TITLE
Enable the use of podman

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/go-openapi/spec v0.19.2
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 	github.com/minio/minio-go v6.0.14+incompatible
@@ -36,9 +35,7 @@ require (
 	github.com/prometheus/common v0.4.0 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
-	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ulikunitz/xz v0.5.6
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.uber.org/multierr v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
 	golang.org/x/sys v0.0.0-20191220220014-0732a990476f

--- a/hack/build/build-manifests.sh
+++ b/hack/build/build-manifests.sh
@@ -30,7 +30,6 @@ echo "NAMESPACE=${NAMESPACE}"
 
 source "${script_dir}"/resource-generator.sh
 
-
 mkdir -p "${MANIFEST_GENERATED_DIR}/"
 
 #generate operator related manifests used to deploy cdi with operator-framework
@@ -40,4 +39,3 @@ generateResourceManifest $generator $MANIFEST_GENERATED_DIR "operator" "everythi
 tempDir=${MANIFEST_TEMPLATE_DIR}
 processDirTemplates ${tempDir} ${OUT_DIR}/manifests ${OUT_DIR}/manifests/templates ${generator} ${MANIFEST_GENERATED_DIR} 
 processDirTemplates ${tempDir}/release ${OUT_DIR}/manifests/release ${OUT_DIR}/manifests/templates/release ${generator} ${MANIFEST_GENERATED_DIR}
-

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,7 +26,7 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.2}
+BUILDER_TAG=${BUILDER_TAG:-0.0.3}
 BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:c0af85e45a74a04822119d58085b85f6635f92929e90b0751f30976c567f7ba8}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER}"

--- a/hack/build/docker/builder/entrypoint.sh
+++ b/hack/build/docker/builder/entrypoint.sh
@@ -24,6 +24,6 @@ export PATH=${GOPATH}/bin:/opt/gradle/gradle-4.3.1/bin:$PATH
 
 eval "$@"
 
-if [ -n ${RUN_UID} ] && [ -n ${RUN_GID} ]; then
+if [ "$KUBEVIRTCI_RUNTIME" != "podman" ] && [ -n ${RUN_UID} ] && [ -n ${RUN_GID} ]; then
     find . -user root -exec chown -h ${RUN_UID}:${RUN_GID} {} \;
 fi

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -30,6 +30,7 @@ docker run ${USE_TTY} \
     -v ${CACHE_DIR}:/gocache:rw,Z \
     -e RUN_UID=$(id -u) \
     -e RUN_GID=$(id -g) \
+    -e KUBEVIRTCI_RUNTIME=${KUBEVIRTCI_RUNTIME} \
     -e GOCACHE=/gocache \
     -w ${WORK_DIR} \
     ${BUILDER_IMAGE} "$1"


### PR DESCRIPTION
Enable the use of podman to start the kubevirtci cluster, and make cluster-sync

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently kubevirtci uses docker everywhere, and gocli is also tied to docker. For newer fedora (31+) docker no longer works out of the box (it doesn't support cgroupsv2 yet) and we don't know when docker will work. In order for our developers to use a newer fedora we have to support podman which does support cgroupsv2.

Luckily for us, some work has already happened to get a drop in replacement for gocli called [pack8s](https://github.com/kubevirt/kubevirtci/tree/master/pack8s) that can be enabled by setting the KUBEVIRTCI_RUNTIME to podman
```bash
$ export KUBEVIRTCI_RUNTIME=podman
```

This PR enables the rest of our tool chain (bazel, make cluster-sync) to use podman as well. Most of the changes are minor and involve fixing how volumes are mounted (permissions) in podman vs docker.

To enabled podman follow the [instructions](https://github.com/kubevirt/kubevirtci/tree/master/pack8s) for pack8s after disabling and removing docker. Also install the podman-docker package to create an alias between podman and docker.

**known issue**
It only works with a single node, the cluster doesn't come up with multipe nodes


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Note when testing this, we don't have a new bazel-builder yet, so you have to manually do a buildah bud in hack/build/docker/builder to build the new image, and update hack/build/config.sh to use the local image instead of the BUILDER_IMAGE in there now. Once we have this merged, we have to do a follow up PR to update the hash. If you don't then make generate will mess up the owner of your entire containerized-data-importer directory. With docker it is required to fix the owner from root to the user, but podman doesn't touch the owner.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Devel: podman now works with kubevirtci cluster-up and cluster-sync
```

