### PR TITLE
[Upgrade Operator] Make sure that ObservedVersion is updated

### DIFF
--- a/pkg/operator/controller/cr.go
+++ b/pkg/operator/controller/cr.go
@@ -26,7 +26,8 @@ import (
 )
 
 func (r *ReconcileCDI) isUpgrading(cr *cdiv1alpha1.CDI) bool {
-	return cr.Status.ObservedVersion != "" && cr.Status.ObservedVersion != cr.Status.TargetVersion
+	deploying := cr.Status.Phase == cdiv1alpha1.CDIPhaseDeploying
+	return (cr.Status.ObservedVersion != "" || !deploying) && cr.Status.ObservedVersion != cr.Status.TargetVersion
 }
 
 // this is used for testing.  wish this a helper function in test file instead of member


### PR DESCRIPTION
**What this PR does / why we need it**
Make sure that the `Status.ObservedVersion` field  on upgrade, even if it was not set in the previous version.

**Which issue(s) this PR fixes**
when PR gets merged)*:
Fixes #1212 

**Special notes for your reviewer**
Previous version `OPERATOR_VERSION` environment variable was not set by HCO. That was fixed in https://github.com/kubevirt/hyperconverged-cluster-operator/pull/588

**Release note**:
```release-note
Make sure that the `Status.ObservedVersion` field  on upgrade, even if it was not set in the previous version.
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>