### PR TITLE
Update regex that matches version to accept +hash in version string

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -21,7 +21,7 @@ const (
 var (
 	versionRegex           = regexp.MustCompile(`ubernetes .*v(\d+\.\d+\.\d+)`)
 	versionRegexServer     = regexp.MustCompile(`Server Version: .*({.*})`)
-	versionRegexGitVersion = regexp.MustCompile(`GitVersion:"v(\d+\.\d+\.\d+)"`)
+	versionRegexGitVersion = regexp.MustCompile(`GitVersion:"v(\d+\.\d+\.\d+)\+?\S*"`)
 )
 
 // CDIFailHandler call ginkgo.Fail with printing the additional information


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The cdi config test checks the version of kubernetes, in newer versions the version can now have +<hash> in the version string. The existing regex failed to match, this PR fixes the regex.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

