### PR TITLE
Add missing content types to clone source flag

### DIFF
--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -24,7 +24,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&contentType, "content_type", "", "archive|kubevirt")
+	flag.StringVar(&contentType, "content_type", "", "archive|kubevirt|filesystem-clone|blockdevice-clone")
 	flag.Uint64Var(&uploadBytes, "upload_bytes", 0, "approx number of bytes in input")
 	klog.InitFlags(nil)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
  cdi-cloner support filesystem-clone/blockdevice-clone content types, but they don't appear on the flags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

