### PR TITLE
Strip status from objects in operator reconcile loop

### DIFF
--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -72,10 +72,12 @@ go_test(
         "certrotation_test.go",
         "controller_suite_test.go",
         "controller_test.go",
+        "util_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core/v1beta1:go_default_library",
+        "//pkg/apis/upload/v1beta1:go_default_library",
         "//pkg/common:go_default_library",
         "//pkg/operator/resources/cert:go_default_library",
         "//pkg/operator/resources/cluster:go_default_library",

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -410,12 +410,11 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1.CDI) (recon
 				return reconcile.Result{}, err
 			}
 
-			currentRuntimeObjCopy := currentRuntimeObj.DeepCopyObject()
-			currentRuntimeObjCopy, err = stripStatusFromObject(currentRuntimeObjCopy)
-
+			currentRuntimeObj, err = stripStatusFromObject(currentRuntimeObj)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
+			currentRuntimeObjCopy := currentRuntimeObj.DeepCopyObject()
 			currentMetaObj := currentRuntimeObj.(metav1.Object)
 
 			// allow users to add new annotations (but not change ours)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -411,6 +411,11 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1.CDI) (recon
 			}
 
 			currentRuntimeObjCopy := currentRuntimeObj.DeepCopyObject()
+			currentRuntimeObjCopy, err = stripStatusFromObject(currentRuntimeObjCopy)
+
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 			currentMetaObj := currentRuntimeObj.(metav1.Object)
 
 			// allow users to add new annotations (but not change ours)
@@ -429,7 +434,6 @@ func (r *ReconcileCDI) reconcileUpdate(logger logr.Logger, cr *cdiv1.CDI) (recon
 
 			if !reflect.DeepEqual(currentRuntimeObjCopy, currentRuntimeObj) {
 				logJSONDiff(logger, currentRuntimeObjCopy, currentRuntimeObj)
-
 				setLabel(updateVersionLabel, r.namespacedArgs.OperatorVersion, currentMetaObj)
 
 				// PRE_UPDATE callback

--- a/pkg/operator/controller/util.go
+++ b/pkg/operator/controller/util.go
@@ -71,16 +71,8 @@ func mergeObject(desiredObj, currentObj runtime.Object) (runtime.Object, error) 
 	if err != nil {
 		return nil, err
 	}
-	modified, err = stripStatusByte(modified)
-	if err != nil {
-		return nil, err
-	}
 
 	current, err := json.Marshal(currentObj)
-	if err != nil {
-		return nil, err
-	}
-	current, err = stripStatusByte(current)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/util.go
+++ b/pkg/operator/controller/util.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 )
 
+const statusKey = "status"
+
 func mergeLabelsAndAnnotations(src, dest metav1.Object) {
-	// allow users to add labels but not change ours
+	// allow users to add labels but not change ours. The operator supplies the src, so if someone altered dest it will get restored.
 	for k, v := range src.GetLabels() {
 		if dest.GetLabels() == nil {
 			dest.SetLabels(map[string]string{})
@@ -63,15 +65,22 @@ func mergeObject(desiredObj, currentObj runtime.Object) (runtime.Object, error) 
 	}
 
 	original := []byte(v)
-
 	// setting the timestamp saves unnecessary updates because creation timestamp is nulled
 	desiredMetaObj.SetCreationTimestamp(currentMetaObj.GetCreationTimestamp())
 	modified, err := json.Marshal(desiredObj)
 	if err != nil {
 		return nil, err
 	}
+	modified, err = stripStatusByte(modified)
+	if err != nil {
+		return nil, err
+	}
 
 	current, err := json.Marshal(currentObj)
+	if err != nil {
+		return nil, err
+	}
+	current, err = stripStatusByte(current)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +107,33 @@ func mergeObject(desiredObj, currentObj runtime.Object) (runtime.Object, error) 
 	}
 
 	return result, nil
+}
+
+func stripStatusFromObject(obj runtime.Object) (runtime.Object, error) {
+	modified, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	modified, err = stripStatusByte(modified)
+	if err != nil {
+		return nil, err
+	}
+	result := newDefaultInstance(obj)
+	if err = json.Unmarshal(modified, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func stripStatusByte(in []byte) ([]byte, error) {
+	var result map[string]interface{}
+	json.Unmarshal(in, &result)
+
+	if _, ok := result[statusKey]; ok {
+		delete(result, statusKey)
+	}
+	return json.Marshal(result)
 }
 
 func deployClusterResources() bool {

--- a/pkg/operator/controller/util_test.go
+++ b/pkg/operator/controller/util_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cdiuploadv1 "kubevirt.io/containerized-data-importer/pkg/apis/upload/v1beta1"
+)
+
+var _ = Describe("mergeLabelsAndAnnotations", func() {
+	It("Should properly merge labels and annotations, if no dest labels/anns", func() {
+		source := createPod("source", map[string]string{"l1": "test"}, map[string]string{"a1": "ann"})
+		dest := createPod("dest", nil, nil)
+		mergeLabelsAndAnnotations(&source.ObjectMeta, &dest.ObjectMeta)
+		Expect(dest.GetObjectMeta).ToNot(BeNil())
+		Expect(dest.GetLabels()["l1"]).To(Equal("test"))
+		Expect(dest.GetAnnotations()["a1"]).To(Equal("ann"))
+	})
+
+	It("Should properly merge labels and annotations, if no dest labels", func() {
+		source := createPod("source", map[string]string{"l1": "test"}, map[string]string{"a1": "ann"})
+		dest := createPod("dest", nil, map[string]string{"a1": "ann2"})
+		mergeLabelsAndAnnotations(&source.ObjectMeta, &dest.ObjectMeta)
+		Expect(dest.GetObjectMeta).ToNot(BeNil())
+		Expect(dest.GetLabels()["l1"]).To(Equal("test"))
+		// Check that dest is now equal to source
+		Expect(dest.GetAnnotations()["a1"]).To(Equal("ann"))
+	})
+
+	It("Should properly merge labels and annotations, if no dest labels, and different ann", func() {
+		source := createPod("source", map[string]string{"l1": "test"}, map[string]string{"a1": "ann"})
+		dest := createPod("dest", nil, map[string]string{"a2": "ann2"})
+		mergeLabelsAndAnnotations(&source.ObjectMeta, &dest.ObjectMeta)
+		Expect(dest.GetObjectMeta).ToNot(BeNil())
+		Expect(dest.GetLabels()["l1"]).To(Equal("test"))
+		Expect(dest.GetAnnotations()["a1"]).To(Equal("ann"))
+		Expect(dest.GetAnnotations()["a2"]).To(Equal("ann2"))
+	})
+
+	It("Should properly merge labels and annotations, if no dest ann", func() {
+		source := createPod("source", map[string]string{"l1": "test"}, map[string]string{"a1": "ann"})
+		dest := createPod("dest", map[string]string{"l1": "test2"}, nil)
+		mergeLabelsAndAnnotations(&source.ObjectMeta, &dest.ObjectMeta)
+		Expect(dest.GetObjectMeta).ToNot(BeNil())
+		// Check that dest is now equal to source
+		Expect(dest.GetLabels()["l1"]).To(Equal("test"))
+		Expect(dest.GetAnnotations()["a1"]).To(Equal("ann"))
+	})
+
+	It("Should properly merge labels and annotations, if no dest ann, and different label", func() {
+		source := createPod("source", map[string]string{"l1": "test"}, map[string]string{"a1": "ann"})
+		dest := createPod("dest", map[string]string{"l2": "test2"}, nil)
+		mergeLabelsAndAnnotations(&source.ObjectMeta, &dest.ObjectMeta)
+		Expect(dest.GetObjectMeta).ToNot(BeNil())
+		Expect(dest.GetLabels()["l1"]).To(Equal("test"))
+		Expect(dest.GetLabels()["l2"]).To(Equal("test2"))
+		Expect(dest.GetAnnotations()["a1"]).To(Equal("ann"))
+	})
+})
+
+var _ = Describe("StripStatusFromObject", func() {
+	It("Should not alter object without status", func() {
+		in := &cdiuploadv1.UploadTokenRequestList{}
+		out, err := stripStatusFromObject(in.DeepCopyObject())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reflect.DeepEqual(out, in)).To(BeTrue())
+	})
+
+	It("Should strip object status", func() {
+		in := &cdiuploadv1.UploadTokenRequest{
+			Status: cdiuploadv1.UploadTokenRequestStatus{
+				Token: "thisisatoken",
+			},
+		}
+		expected := &cdiuploadv1.UploadTokenRequest{
+			Status: cdiuploadv1.UploadTokenRequestStatus{},
+		}
+		out, err := stripStatusFromObject(in.DeepCopyObject())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reflect.DeepEqual(out, in)).To(BeFalse())
+		Expect(reflect.DeepEqual(out, expected)).To(BeTrue())
+	})
+
+})
+
+func createPod(name string, labels, annotations map[string]string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if len(labels) > 0 {
+		pod.ObjectMeta.Labels = labels
+	}
+	if len(annotations) > 0 {
+		pod.ObjectMeta.Annotations = annotations
+	}
+	return pod
+}

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -167,7 +167,11 @@ func createAPIService(version, namespace string, c client.Client, l logr.Logger)
 
 func createDataVolumeValidatingWebhook(namespace string, c client.Client, l logr.Logger) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
 	path := "/datavolume-validate"
+	defaultServicePort := int32(443)
+	allScopes := admissionregistrationv1beta1.AllScopes
+	exactPolicy := admissionregistrationv1beta1.Exact
 	failurePolicy := admissionregistrationv1beta1.Fail
+	defaultTimeoutSeconds := int32(30)
 	sideEffect := admissionregistrationv1beta1.SideEffectClassNone
 	whc := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -192,6 +196,7 @@ func createDataVolumeValidatingWebhook(namespace string, c client.Client, l logr
 						APIGroups:   []string{cdicorev1.SchemeGroupVersion.Group},
 						APIVersions: []string{cdicorev1.SchemeGroupVersion.Version},
 						Resources:   []string{"datavolumes"},
+						Scope:       &allScopes,
 					},
 				}},
 				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
@@ -199,10 +204,18 @@ func createDataVolumeValidatingWebhook(namespace string, c client.Client, l logr
 						Namespace: namespace,
 						Name:      apiServerServiceName,
 						Path:      &path,
+						Port:      &defaultServicePort,
 					},
 				},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffect,
+				FailurePolicy:     &failurePolicy,
+				SideEffects:       &sideEffect,
+				MatchPolicy:       &exactPolicy,
+				NamespaceSelector: &metav1.LabelSelector{},
+				TimeoutSeconds:    &defaultTimeoutSeconds,
+				AdmissionReviewVersions: []string{
+					"v1beta1",
+				},
+				ObjectSelector: &metav1.LabelSelector{},
 			},
 		},
 	}
@@ -221,8 +234,12 @@ func createDataVolumeValidatingWebhook(namespace string, c client.Client, l logr
 
 func createCDIValidatingWebhook(namespace string, c client.Client, l logr.Logger) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
 	path := "/cdi-validate"
-	failurePolicy := admissionregistrationv1beta1.Fail
 	sideEffect := admissionregistrationv1beta1.SideEffectClassNone
+	defaultServicePort := int32(443)
+	allScopes := admissionregistrationv1beta1.AllScopes
+	exactPolicy := admissionregistrationv1beta1.Exact
+	failurePolicy := admissionregistrationv1beta1.Fail
+	defaultTimeoutSeconds := int32(30)
 	whc := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissionregistration.k8s.io/v1beta1",
@@ -245,6 +262,7 @@ func createCDIValidatingWebhook(namespace string, c client.Client, l logr.Logger
 						APIGroups:   []string{cdicorev1.SchemeGroupVersion.Group},
 						APIVersions: []string{cdicorev1.SchemeGroupVersion.Version},
 						Resources:   []string{"cdis"},
+						Scope:       &allScopes,
 					},
 				}},
 				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
@@ -252,9 +270,18 @@ func createCDIValidatingWebhook(namespace string, c client.Client, l logr.Logger
 						Namespace: namespace,
 						Name:      apiServerServiceName,
 						Path:      &path,
+						Port:      &defaultServicePort,
 					},
 				},
-				SideEffects: &sideEffect,
+				SideEffects:       &sideEffect,
+				FailurePolicy:     &failurePolicy,
+				MatchPolicy:       &exactPolicy,
+				NamespaceSelector: &metav1.LabelSelector{},
+				TimeoutSeconds:    &defaultTimeoutSeconds,
+				AdmissionReviewVersions: []string{
+					"v1beta1",
+				},
+				ObjectSelector: &metav1.LabelSelector{},
 			},
 		},
 	}
@@ -276,7 +303,12 @@ func createCDIValidatingWebhook(namespace string, c client.Client, l logr.Logger
 
 func createDataVolumeMutatingWebhook(namespace string, c client.Client, l logr.Logger) *admissionregistrationv1beta1.MutatingWebhookConfiguration {
 	path := "/datavolume-mutate"
+	defaultServicePort := int32(443)
+	allScopes := admissionregistrationv1beta1.AllScopes
+	exactPolicy := admissionregistrationv1beta1.Exact
 	failurePolicy := admissionregistrationv1beta1.Fail
+	defaultTimeoutSeconds := int32(30)
+	reinvocationNever := admissionregistrationv1beta1.NeverReinvocationPolicy
 	sideEffect := admissionregistrationv1beta1.SideEffectClassNone
 	whc := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -301,6 +333,7 @@ func createDataVolumeMutatingWebhook(namespace string, c client.Client, l logr.L
 						APIGroups:   []string{cdicorev1.SchemeGroupVersion.Group},
 						APIVersions: []string{cdicorev1.SchemeGroupVersion.Version},
 						Resources:   []string{"datavolumes"},
+						Scope:       &allScopes,
 					},
 				}},
 				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
@@ -308,10 +341,19 @@ func createDataVolumeMutatingWebhook(namespace string, c client.Client, l logr.L
 						Namespace: namespace,
 						Name:      apiServerServiceName,
 						Path:      &path,
+						Port:      &defaultServicePort,
 					},
 				},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffect,
+				FailurePolicy:     &failurePolicy,
+				SideEffects:       &sideEffect,
+				MatchPolicy:       &exactPolicy,
+				NamespaceSelector: &metav1.LabelSelector{},
+				TimeoutSeconds:    &defaultTimeoutSeconds,
+				AdmissionReviewVersions: []string{
+					"v1beta1",
+				},
+				ObjectSelector:     &metav1.LabelSelector{},
+				ReinvocationPolicy: &reinvocationNever,
 			},
 		},
 	}

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -87,6 +87,7 @@ func createAPIServerService() *corev1.Service {
 }
 
 func createAPIServerDeployment(image, verbosity, pullPolicy string) *appsv1.Deployment {
+	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(apiServerRessouceName, cdiLabel, apiServerRessouceName, apiServerRessouceName, 1)
 	container := utils.CreateContainer(apiServerRessouceName, image, verbosity, corev1.PullPolicy(pullPolicy))
 	container.ReadinessProbe = &corev1.Probe{
@@ -102,6 +103,9 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string) *appsv1.Depl
 		},
 		InitialDelaySeconds: 2,
 		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		TimeoutSeconds:      1,
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
@@ -130,6 +134,7 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string) *appsv1.Depl
 							Path: "ca-bundle.crt",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -148,6 +153,7 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string) *appsv1.Depl
 							Path: "tls.key",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -92,6 +92,7 @@ func createControllerServiceAccount() *corev1.ServiceAccount {
 }
 
 func createControllerDeployment(controllerImage, importerImage, clonerImage, uploadServerImage, verbosity, pullPolicy string) *appsv1.Deployment {
+	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(controllerResourceName, "app", "containerized-data-importer", common.ControllerServiceAccountName, int32(1))
 	container := utils.CreateContainer("cdi-controller", controllerImage, verbosity, corev1.PullPolicy(pullPolicy))
 	container.Env = []corev1.EnvVar{
@@ -124,6 +125,9 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 		},
 		InitialDelaySeconds: 2,
 		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		TimeoutSeconds:      1,
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
@@ -160,6 +164,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 							Path: "id_rsa.pub",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -178,6 +183,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 							Path: "tls.key",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -196,6 +202,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 							Path: "tls.key",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -212,6 +219,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 							Path: "ca-bundle.crt",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -228,6 +236,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 							Path: "ca-bundle.crt",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -82,6 +82,7 @@ func createUploadProxyRole() *rbacv1.Role {
 }
 
 func createUploadProxyDeployment(image, verbosity, pullPolicy string) *appsv1.Deployment {
+	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, uploadProxyResourceName, int32(1))
 	container := utils.CreateContainer(uploadProxyResourceName, image, verbosity, corev1.PullPolicy(pullPolicy))
 	container.Env = []corev1.EnvVar{
@@ -110,6 +111,9 @@ func createUploadProxyDeployment(image, verbosity, pullPolicy string) *appsv1.De
 		},
 		InitialDelaySeconds: 2,
 		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		TimeoutSeconds:      1,
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
@@ -140,6 +144,7 @@ func createUploadProxyDeployment(image, verbosity, pullPolicy string) *appsv1.De
 							Path: "tls.key",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},
@@ -158,6 +163,7 @@ func createUploadProxyDeployment(image, verbosity, pullPolicy string) *appsv1.De
 							Path: "tls.key",
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -236,10 +236,12 @@ func CreatePortsContainer(name, image, verbosity string, pullPolicy corev1.PullP
 // CreateContainer creates container
 func CreateContainer(name, image, verbosity string, pullPolicy corev1.PullPolicy) corev1.Container {
 	return corev1.Container{
-		Name:            name,
-		Image:           image,
-		ImagePullPolicy: pullPolicy,
-		Args:            []string{"-v=" + verbosity},
+		Name:                     name,
+		Image:                    image,
+		ImagePullPolicy:          pullPolicy,
+		Args:                     []string{"-v=" + verbosity},
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 	}
 }
 


### PR DESCRIPTION
This stops the operator controller from trying to modify the CRDs in each reconcile loop.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The operator tries to update the CRDs in each reconcile loop because the desired object status is empty and k8s will have populated some status. Then the operator removes the status because it expects there to be none, which in turn will cause k8s to set the status again. On each reconcile loop this ping pong happened. This PR changes the code to strip the status value from the current object so the comparison will cause not fail due to a minor status change.

Also added default values for deployments that would be filled in by k8s as well as defaults for the webhooks

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

