### PR TITLE
Allow tokens for PVCs that do not exist. (#1233)

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -24,12 +24,13 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	"github.com/appscode/jsonpatch"
 	restful "github.com/emicklei/go-restful"
@@ -316,9 +317,8 @@ var _ = Describe("API server tests", func() {
 	})
 
 	type args struct {
-		authorizer     CdiAPIAuthorizer
-		pvc            *v1.PersistentVolumeClaim
-		uploadPossible uploadPossibleFunc
+		authorizer CdiAPIAuthorizer
+		pvc        *v1.PersistentVolumeClaim
 	}
 
 	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -360,7 +360,6 @@ var _ = Describe("API server tests", func() {
 		app := &cdiAPIApp{client: client,
 			privateSigningKey: signingKey,
 			authorizer:        args.authorizer,
-			uploadPossible:    args.uploadPossible,
 			tokenGenerator:    newUploadTokenGenerator(signingKey)}
 		app.composeUploadTokenAPI()
 
@@ -401,23 +400,13 @@ var _ = Describe("API server tests", func() {
 			args{
 				authorizer: authorizeSuccess,
 			},
-			http.StatusBadRequest,
-			false),
-
-		table.Entry("upload not possible",
-			args{
-				authorizer:     authorizeSuccess,
-				pvc:            pvc,
-				uploadPossible: func(*v1.PersistentVolumeClaim) error { return fmt.Errorf("NOPE") },
-			},
-			http.StatusServiceUnavailable,
+			http.StatusOK,
 			false),
 
 		table.Entry("upload possible",
 			args{
-				authorizer:     authorizeSuccess,
-				pvc:            pvc,
-				uploadPossible: func(*v1.PersistentVolumeClaim) error { return nil },
+				authorizer: authorizeSuccess,
+				pvc:        pvc,
 			},
 			http.StatusOK,
 			true),

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -53,6 +53,7 @@ type ClientCreator interface {
 }
 
 type urlLookupFunc func(string, string, string) string
+type uploadPossibleFunc func(*v1.PersistentVolumeClaim) error
 
 type uploadProxyApp struct {
 	bindAddress string
@@ -68,8 +69,9 @@ type uploadProxyApp struct {
 
 	mux *http.ServeMux
 
-	// test hook
-	urlResolver urlLookupFunc
+	// test hooks
+	urlResolver    urlLookupFunc
+	uploadPossible uploadPossibleFunc
 }
 
 type clientCreator struct {
@@ -89,12 +91,13 @@ func NewUploadProxy(bindAddress string,
 	client kubernetes.Interface) (Server, error) {
 	var err error
 	app := &uploadProxyApp{
-		bindAddress:   bindAddress,
-		bindPort:      bindPort,
-		certWatcher:   certWatcher,
-		clientCreator: &clientCreator{certFetcher: clientCertFetcher, bundleFetcher: serverCAFetcher},
-		client:        client,
-		urlResolver:   controller.GetUploadServerURL,
+		bindAddress:    bindAddress,
+		bindPort:       bindPort,
+		certWatcher:    certWatcher,
+		clientCreator:  &clientCreator{certFetcher: clientCertFetcher, bundleFetcher: serverCAFetcher},
+		client:         client,
+		urlResolver:    controller.GetUploadServerURL,
+		uploadPossible: controller.UploadPossibleForPVC,
 	}
 	// retrieve RSA key used by apiserver to sign tokens
 	err = app.getSigningKey(apiServerPublicKey)
@@ -192,6 +195,8 @@ func (app *uploadProxyApp) handleUploadRequest(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		klog.Error(err)
 		w.WriteHeader(http.StatusServiceUnavailable)
+		// Return the error to the caller in the body.
+		w.Write([]byte(err.Error()))
 		return
 	}
 
@@ -209,6 +214,10 @@ func (app *uploadProxyApp) uploadReady(pvcName, pvcNamespace string) error {
 			return false, err
 		}
 
+		err = app.uploadPossible(pvc)
+		if err != nil {
+			return false, err
+		}
 		phase := v1.PodPhase(pvc.Annotations[controller.AnnPodPhase])
 		if phase == v1.PodSucceeded {
 			return false, fmt.Errorf("rejecting Upload Request for PVC %s that already finished uploading", pvcName)


### PR DESCRIPTION
* Allow tokens for PVCs that do not exist, the proxy will reject upload requests.
Put error in body returned by proxy.

Signed-off-by: Alexander Wels <awels@redhat.com>

* Addressed comments on PR.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
backport of #1233 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

