### PR TITLE
[release-v1.13] Don't annotate pvc/dvs with provisionOnNode

### DIFF
--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -38,41 +38,12 @@ const (
 )
 
 var (
-	// DefaultNodeName the default node to use in tests
-	DefaultNodeName string
 	// DefaultStorageClass the defauld storage class used in tests
 	DefaultStorageClass *storagev1.StorageClass
 	// NfsService is the service in the cdi namespace that will be created if KUBEVIRT_STORAGE=nfs
 	NfsService *corev1.Service
 	nfsChecked bool
 )
-
-func getDefaultNodeName(client *kubernetes.Clientset) string {
-	nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		ginkgo.Fail("Unable to list nodes")
-	}
-	for _, node := range nodes.Items {
-		scheduleable := true
-		if node.Spec.Taints != nil {
-			for _, taint := range node.Spec.Taints {
-				if taint.Effect == corev1.TaintEffectNoSchedule {
-					scheduleable = false
-				}
-			}
-		}
-		if node.GetLabels() != nil {
-			if val, ok := node.GetLabels()["node-role.kubernetes.io/master"]; ok && val == "true" {
-				scheduleable = false
-			}
-		}
-		if scheduleable {
-			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Using node %s as target node for hostpath provisioner if set.\n", node.Name)))
-			return node.Name
-		}
-	}
-	return ""
-}
 
 func getDefaultStorageClass(client *kubernetes.Clientset) *storagev1.StorageClass {
 	storageclasses, err := client.StorageV1().StorageClasses().List(metav1.ListOptions{})
@@ -97,19 +68,8 @@ func IsHostpathProvisioner() bool {
 	return DefaultStorageClass.Provisioner == "kubevirt.io/hostpath-provisioner"
 }
 
-// AddProvisionOnNodeToAnn adds 'kubevirt.io/provisionOnNode' annotaion
-func AddProvisionOnNodeToAnn(pvcAnn map[string]string) {
-	if DefaultNodeName == "" {
-		ginkgo.Skip("No scheduleable nodes available")
-	}
-	pvcAnn["kubevirt.io/provisionOnNode"] = DefaultNodeName
-}
-
 // CacheTestsData fetch and cache data required for tests
 func CacheTestsData(client *kubernetes.Clientset, cdiNs string) {
-	if DefaultNodeName == "" {
-		DefaultNodeName = getDefaultNodeName(client)
-	}
 	if DefaultStorageClass == nil {
 		DefaultStorageClass = getDefaultStorageClass(client)
 	}

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -42,12 +42,6 @@ const (
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume
 func CreateDataVolumeFromDefinition(clientSet *cdiclientset.Clientset, namespace string, def *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
-	if IsHostpathProvisioner() {
-		if def.ObjectMeta.Annotations == nil {
-			def.ObjectMeta.Annotations = map[string]string{}
-		}
-		AddProvisionOnNodeToAnn(def.ObjectMeta.Annotations)
-	}
 	var dataVolume *cdiv1.DataVolume
 	err := wait.PollImmediate(dataVolumePollInterval, dataVolumeCreateTime, func() (bool, error) {
 		var err error

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -178,12 +178,6 @@ func NewPVCDefinitionWithSelector(pvcName, size, storageClassName string, select
 // AnnCloneRequest
 // You can also pass in any label you want.
 func NewPVCDefinition(pvcName string, size string, annotations, labels map[string]string) *k8sv1.PersistentVolumeClaim {
-	if IsHostpathProvisioner() {
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		AddProvisionOnNodeToAnn(annotations)
-	}
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,


### PR DESCRIPTION
as it causes a race with the kubernetes scheduler. (#1157)

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #1157 to fix testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

