### PR TITLE
Return stderr from verifier pods

### DIFF
--- a/tests/framework/exec_util.go
+++ b/tests/framework/exec_util.go
@@ -95,34 +95,34 @@ func (f *Framework) ExecCommandInContainerWithFullOutput(namespace, podName, con
 }
 
 // ExecCommandInContainer executes a command in the specified container.
-func (f *Framework) ExecCommandInContainer(namespace, podName, containerName string, cmd ...string) (string, error) {
-	stdout, _, err := f.ExecCommandInContainerWithFullOutput(namespace, podName, containerName, cmd...)
+func (f *Framework) ExecCommandInContainer(namespace, podName, containerName string, cmd ...string) (string, string, error) {
+	stdout, stderr, err := f.ExecCommandInContainerWithFullOutput(namespace, podName, containerName, cmd...)
 	if err != nil {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "[WARN] error executing command %q, error: %s\n", cmd, err.Error())
-		return "", err
+		return "", stderr, err
 	}
-	return stdout, nil
+	return stdout, stderr, nil
 }
 
 // ExecShellInContainer provides a function to execute a shell cmd for the specified running container in a pod
-func (f *Framework) ExecShellInContainer(namespace, podName, containerName string, cmd string) (string, error) {
-	str, err := f.ExecCommandInContainer(namespace, podName, containerName, "/bin/sh", "-c", cmd)
+func (f *Framework) ExecShellInContainer(namespace, podName, containerName string, cmd string) (string, string, error) {
+	stdout, stderr, err := f.ExecCommandInContainer(namespace, podName, containerName, "/bin/sh", "-c", cmd)
 	if err != nil {
-		return "", err
+		return "", stderr, err
 	}
-	return str, nil
+	return stdout, stderr, nil
 }
 
 // ExecCommandInPod provides a function to execute a command on a running pod
-func (f *Framework) ExecCommandInPod(podName, namespace string, cmd ...string) (string, error) {
+func (f *Framework) ExecCommandInPod(podName, namespace string, cmd ...string) (string, string, error) {
 	pod, err := f.K8sClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get pod")
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
-	str, err := f.ExecCommandInContainer(namespace, podName, pod.Spec.Containers[0].Name, cmd...)
+	stdout, stderr, err := f.ExecCommandInContainer(namespace, podName, pod.Spec.Containers[0].Name, cmd...)
 	if err != nil {
-		return "", err
+		return "", stderr, err
 	}
-	return str, nil
+	return stdout, stderr, nil
 }
 
 // ExecCommandInPodWithFullOutput provides a function to execute a command in a running pod and to capture its output
@@ -134,12 +134,12 @@ func (f *Framework) ExecCommandInPodWithFullOutput(namespace, podName string, cm
 }
 
 // ExecShellInPod provides a function to execute a shell cmd in the specified pod
-func (f *Framework) ExecShellInPod(podName, namespace string, cmd string) (string, error) {
-	str, err := f.ExecCommandInPod(podName, namespace, "/bin/sh", "-c", cmd)
+func (f *Framework) ExecShellInPod(podName, namespace string, cmd string) (string, string, error) {
+	stdout, stderr, err := f.ExecCommandInPod(podName, namespace, "/bin/sh", "-c", cmd)
 	if err != nil {
-		return "", err
+		return "", stderr, err
 	}
-	return str, nil
+	return stdout, stderr, nil
 }
 
 // ExecShellInPodWithFullOutput provides a function to execute a shell cmd in a running pod and to capture its output


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It was hard to determine why verifier pods failed because they weren't printing stderr. This fixes that and should now print stderr on failure. This should allow us to debug the failures of the verifier pods more easily with more information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

