### PR TITLE
Block clone across namespace, delete populator/verifier pod

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -566,6 +566,17 @@ var _ = Describe("Block PV Cloner Test", func() {
 		sourceMD5, err := f.GetMD5(f.Namespace, sourcePvc, testBaseDir, 0)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Deleting verifier pod")
+		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(utils.VerifierPodName, &metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = utils.WaitPodDeleted(f.K8sClient, utils.VerifierPodName, f.Namespace.Name, verifyPodDeletedTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete("fill-source-block-pod", &metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = utils.WaitPodDeleted(f.K8sClient, "fill-source-block-pod", f.Namespace.Name, verifyPodDeletedTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
 		targetNs, err := f.CreateNamespace(f.NsPrefix, map[string]string{
 			framework.NsPrefixLabel: f.NsPrefix,
 		})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The populator and verifier pods where still there, which caused multi attach issues in the ceph lane. This PR makes sure the populator and verifier pod are deleted before cloning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

