### PR TITLE
Use blockdev instead of lsblk for getting block device size

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -30,7 +30,7 @@ echo "VOLUME_MODE=$VOLUME_MODE"
 echo "MOUNT_POINT=$MOUNT_POINT"
 
 if [ "$VOLUME_MODE" == "block" ]; then
-    UPLOAD_BYTES=$(lsblk -n -b -o SIZE $MOUNT_POINT)
+    UPLOAD_BYTES=$(blockdev --getsize64 $MOUNT_POINT)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
     /usr/bin/cdi-cloner -v=3 -alsologtostderr -content_type blockdevice-clone -upload_bytes $UPLOAD_BYTES < $MOUNT_POINT


### PR DESCRIPTION
**What this PR does / why we need it**:

lsblk does not work with raw block devices that are backed by
dm-multipath because the container does not populate the /dev/mapper
symlinks

blockdev comes from util-linux as well and already exists in the
cdi-cloner image so it should be a drop-in replacement

**Release note**:
```release-note
Use blockdev instead of lsblk for getting raw block device size
```

