### PR TITLE
[flaky test] verifier pods hanging around keeps cloning from working

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -100,7 +100,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		fmt.Fprintf(GinkgoWriter, "INFO: wait for PVC claim phase: %s\n", targetPvc.Name)
 		utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
-		sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, pvc)
+		sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, pvc, true)
 		fmt.Fprintf(GinkgoWriter, "INFO: %s\n", sourcePvcDiskGroup)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -714,7 +714,7 @@ var _ = Describe("Namespace with quota", func() {
 		utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetDV.Name)
 		targetPvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
-		sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, sourcePvc)
+		sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, sourcePvc, true)
 		Expect(err).ToNot(HaveOccurred())
 		completeClone(f, f.Namespace, targetPvc, filepath.Join(testBaseDir, testFile), fillDataFSMD5sum, sourcePvcDiskGroup)
 	})
@@ -976,7 +976,7 @@ func doFileBasedCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolume
 
 	fmt.Fprintf(GinkgoWriter, "INFO: wait for PVC claim phase: %s\n", targetPvc.Name)
 	utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, targetNs.Name, v1.ClaimBound, targetPvc.Name)
-	sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, srcPVCDef)
+	sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, srcPVCDef, true)
 	fmt.Fprintf(GinkgoWriter, "INFO: %s\n", sourcePvcDiskGroup)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -1001,7 +1001,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 	if utils.DefaultStorageCSI && sourcePvcDiskGroup != "" {
 		// CSI storage class, it should respect fsGroup
 		By("Checking that disk image group is qemu")
-		Expect(f.GetDiskGroup(targetNs, targetPvc)).To(Equal(sourcePvcDiskGroup))
+		Expect(f.GetDiskGroup(targetNs, targetPvc, false)).To(Equal(sourcePvcDiskGroup))
 	}
 	By("Verifying permissions are 660")
 	Expect(f.VerifyPermissions(targetNs, targetPvc)).To(BeTrue(), "Permissions on disk image are not 660")

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -204,7 +204,7 @@ func (f *Framework) VerifyPermissions(namespace *k8sv1.Namespace, pvc *k8sv1.Per
 }
 
 // GetDiskGroup returns the group of a disk image.
-func (f *Framework) GetDiskGroup(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim) (string, error) {
+func (f *Framework) GetDiskGroup(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim, deletePod bool) (string, error) {
 	var executorPod *k8sv1.Pod
 	var err error
 
@@ -224,6 +224,11 @@ func (f *Framework) GetDiskGroup(namespace *k8sv1.Namespace, pvc *k8sv1.Persiste
 
 	output, err = f.ExecShellInPod(executorPod.Name, namespace.Name, cmd)
 	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: gid of disk.img: %s\n", string(output))
+
+	if deletePod {
+		err = f.K8sClient.CoreV1().Pods(namespace.Name).Delete(executorPod.Name, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
 
 	if err != nil {
 		return "", err

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -122,7 +122,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		if utils.DefaultStorageCSI {
 			// CSI storage class, it should respect fsGroup
 			By("Checking that disk image group is qemu")
-			Expect(f.GetDiskGroup(f.Namespace, pvc)).To(Equal("107"))
+			Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))
 		}
 	})
 })

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -108,7 +108,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			if utils.DefaultStorageCSI {
 				// CSI storage class, it should respect fsGroup
 				By("Checking that disk image group is qemu")
-				Expect(f.GetDiskGroup(f.Namespace, pvc)).To(Equal("107"))
+				Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))
 			}
 			By("Verifying permissions are 660")
 			Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:  Address flakes like this:

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1260/pull-containerized-data-importer-e2e-k8s-1.17-ceph/1275904563907399680

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

