### PR TITLE
Wait for PVCs to be unused before initiating clone operations

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -223,7 +223,7 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 		if len(filtered) > 0 {
 			for _, pod := range filtered {
 				r.log.V(1).Info("can't create clone source pod, pvc in use by other pod",
-					"namespace", sourcePvc.Namespace, "name", sourcePvc.Name, "pods", pod.Name)
+					"namespace", sourcePvc.Namespace, "name", sourcePvc.Name, "pod", pod.Name)
 				r.recorder.Eventf(targetPvc, corev1.EventTypeWarning, CloneSourceInUse,
 					"pod %s/%s using PersistentVolumeClaim %s", pod.Namespace, pod.Name, sourcePvc.Name)
 			}

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +59,9 @@ const (
 
 	// CloneSucceededPVC provides a const to indicate a clone to the PVC succeeded
 	CloneSucceededPVC = "CloneSucceeded"
+
+	// CloneSourceInUse is reason for event created when clone source pvc is in use
+	CloneSourceInUse = "CloneSourceInUse"
 
 	cloneSourcePodFinalizer = "cdi.kubevirt.io/cloneSource"
 
@@ -183,8 +188,8 @@ func (r *CloneReconciler) Reconcile(req reconcile.Request) (reconcile.Result, er
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	if err := r.reconcileSourcePod(sourcePod, pvc, log); err != nil {
-		return reconcile.Result{}, err
+	if requeue, err := r.reconcileSourcePod(sourcePod, pvc, log); requeue || err != nil {
+		return reconcile.Result{Requeue: requeue}, err
 	}
 
 	if err := r.updatePvcFromPod(sourcePod, pvc, log); err != nil {
@@ -193,24 +198,46 @@ func (r *CloneReconciler) Reconcile(req reconcile.Request) (reconcile.Result, er
 	return reconcile.Result{}, nil
 }
 
-func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
+func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *corev1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
 	if sourcePod == nil {
-		if err := r.validateSourceAndTarget(pvc); err != nil {
-			return err
-		}
-
-		clientName, ok := pvc.Annotations[AnnUploadClientName]
-		if !ok {
-			return errors.Errorf("PVC %s/%s missing required %s annotation", pvc.Namespace, pvc.Name, AnnUploadClientName)
-		}
-
-		sourcePod, err := r.CreateCloneSourcePod(r.image, r.pullPolicy, clientName, pvc, log)
+		sourcePvc, err := r.getCloneRequestSourcePVC(targetPvc)
 		if err != nil {
-			return err
+			return false, err
+		}
+
+		if err := r.validateSourceAndTarget(sourcePvc, targetPvc); err != nil {
+			return false, err
+		}
+
+		clientName, ok := targetPvc.Annotations[AnnUploadClientName]
+		if !ok {
+			return false, errors.Errorf("PVC %s/%s missing required %s annotation", targetPvc.Namespace, targetPvc.Name, AnnUploadClientName)
+		}
+
+		pods, err := getPodsUsingPVCs(r.client, sourcePvc.Namespace, sets.NewString(sourcePvc.Name), true)
+		if err != nil {
+			return false, err
+		}
+
+		filtered := filterCloneSourcePods(pods)
+
+		if len(filtered) > 0 {
+			for _, pod := range filtered {
+				r.log.V(1).Info("can't create clone source pod, pvc in use by other pod",
+					"namespace", sourcePvc.Namespace, "name", sourcePvc.Name, "pods", pod.Name)
+				r.recorder.Eventf(targetPvc, corev1.EventTypeWarning, CloneSourceInUse,
+					"pod %s/%s using PersistentVolumeClaim %s", pod.Namespace, pod.Name, sourcePvc.Name)
+			}
+			return true, nil
+		}
+
+		sourcePod, err := r.CreateCloneSourcePod(r.image, r.pullPolicy, clientName, targetPvc, log)
+		if err != nil {
+			return false, err
 		}
 		log.V(3).Info("Created source pod ", "sourcePod.Namespace", sourcePod.Namespace, "sourcePod.Name", sourcePod.Name)
 	}
-	return nil
+	return false, nil
 }
 
 func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
@@ -306,17 +333,12 @@ func (r *CloneReconciler) findCloneSourcePod(pvc *corev1.PersistentVolumeClaim) 
 	return &podList.Items[0], nil
 }
 
-func (r *CloneReconciler) validateSourceAndTarget(targetPvc *corev1.PersistentVolumeClaim) error {
-	sourcePvc, err := r.getCloneRequestSourcePVC(targetPvc)
-	if err != nil {
+func (r *CloneReconciler) validateSourceAndTarget(sourcePvc, targetPvc *corev1.PersistentVolumeClaim) error {
+	if err := validateCloneToken(r.tokenValidator, sourcePvc, targetPvc); err != nil {
 		return err
 	}
 
-	if err = validateCloneToken(r.tokenValidator, sourcePvc, targetPvc); err != nil {
-		return err
-	}
-
-	err = ValidateCanCloneSourceAndTargetSpec(&sourcePvc.Spec, &targetPvc.Spec)
+	err := ValidateCanCloneSourceAndTargetSpec(&sourcePvc.Spec, &targetPvc.Spec)
 	if err == nil {
 		// Validation complete, put source PVC bound status in annotation
 		setBoundConditionFromPVC(targetPvc.GetAnnotations(), AnnBoundCondition, sourcePvc)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -84,6 +85,8 @@ const (
 	SnapshotForSmartCloneCreated = "SnapshotForSmartCloneCreated"
 	// SmartClonePVCInProgress provides a const to indicate snapshot creation for smart-clone is in progress
 	SmartClonePVCInProgress = "SmartClonePVCInProgress"
+	// SmartCloneSourceInUse proovides a const to indicate a smart clone is being delayed becasuse the source is in use
+	SmartCloneSourceInUse = "SmartCloneSourceInUse"
 	// CloneFailed provides a const to indicate clone has failed
 	CloneFailed = "CloneFailed"
 	// CloneSucceeded provides a const to indicate clone has succeeded
@@ -253,6 +256,9 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 		snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume)
 		if err == nil {
 			r.log.V(3).Info("Smart-Clone via Snapshot is available with Volume Snapshot Class", "snapshotClassName", snapshotClassName)
+			if requeue, err := r.sourceInUse(datavolume); requeue || err != nil {
+				return reconcile.Result{Requeue: requeue}, err
+			}
 			newSnapshot := newSnapshot(datavolume, snapshotClassName)
 			if err := r.client.Create(context.TODO(), newSnapshot); err != nil {
 				if k8serrors.IsAlreadyExists(err) {
@@ -276,6 +282,22 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 	// Finally, we update the status block of the DataVolume resource to reflect the
 	// current state of the world
 	return r.reconcileDataVolumeStatus(datavolume, pvc)
+}
+
+func (r *DatavolumeReconciler) sourceInUse(dv *cdiv1.DataVolume) (bool, error) {
+	pods, err := getPodsUsingPVCs(r.client, dv.Spec.Source.PVC.Namespace, sets.NewString(dv.Spec.Source.PVC.Name), false)
+	if err != nil {
+		return false, err
+	}
+
+	for _, pod := range pods {
+		r.log.V(1).Info("Cannot snapshot",
+			"namespace", dv.Namespace, "name", dv.Name, "pod namespace", pod.Namespace, "pod name", pod.Name)
+		r.recorder.Eventf(dv, corev1.EventTypeWarning, SmartCloneSourceInUse,
+			"pod %s/%s using PersistentVolumeClaim %s", pod.Namespace, pod.Name, dv.Spec.Source.PVC.Name)
+	}
+
+	return len(pods) > 0, nil
 }
 
 func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVolume, pvcUID types.UID) (reconcile.Result, error) {

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -85,7 +85,7 @@ const (
 	SnapshotForSmartCloneCreated = "SnapshotForSmartCloneCreated"
 	// SmartClonePVCInProgress provides a const to indicate snapshot creation for smart-clone is in progress
 	SmartClonePVCInProgress = "SmartClonePVCInProgress"
-	// SmartCloneSourceInUse proovides a const to indicate a smart clone is being delayed becasuse the source is in use
+	// SmartCloneSourceInUse provides a const to indicate a smart clone is being delayed becasuse the source is in use
 	SmartCloneSourceInUse = "SmartCloneSourceInUse"
 	// CloneFailed provides a const to indicate clone has failed
 	CloneFailed = "CloneFailed"

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -486,3 +486,24 @@ func createDefaultPodResourceRequirements(limitCPUValue int64, limitMemoryValue 
 			corev1.ResourceMemory: *resource.NewQuantity(requestMemoryValue, resource.DecimalSI)},
 	}
 }
+
+func podUsingPVC(pvc *corev1.PersistentVolumeClaim, readOnly bool) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      pvc.Name + "-pod",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc.Name,
+							ReadOnly:  readOnly,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -289,5 +289,7 @@ func (f *Framework) RunCommandAndCaptureOutput(pvc *k8sv1.PersistentVolumeClaim,
 		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: stderr: [%s]\n", stderr)
 		return "", err
 	}
+	err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(executorPod.Name, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return output, nil
 }

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -89,6 +89,8 @@ func (f *Framework) CreateAndPopulateSourcePVC(pvcDef *k8sv1.PersistentVolumeCla
 
 	err = f.WaitTimeoutForPodStatus(pod.Name, k8sv1.PodSucceeded, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(pod.Name, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return sourcePvc
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There is no way to 100% safely guard against data corruption when cloning in k8s.  But this improves our situation a bit by at least verifying that source PVCs are not being used in an unsafe way before the clone operation is started.  For smart clone (using snapshots) that means that the PVC cannot be mounted in any Pod.  Things are less strict with dumb cloning (copying over the network).  In that case, read only mounts are okay.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1845901

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Wait for PVCs to be unused before initiating clone operations
```

