### PR TITLE
[flaky test] datavolume should not say upload is ready until pod is running

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -519,11 +519,14 @@ func (r *DatavolumeReconciler) updateUploadStatusPhase(pvc *corev1.PersistentVol
 			event.reason = UploadScheduled
 			event.message = fmt.Sprintf(MessageUploadScheduled, pvc.Name)
 		case string(corev1.PodRunning):
-			// TODO: Use a more generic In Progess, like maybe TransferInProgress.
-			dataVolumeCopy.Status.Phase = cdiv1.UploadReady
-			event.eventType = corev1.EventTypeNormal
-			event.reason = UploadReady
-			event.message = fmt.Sprintf(MessageUploadReady, pvc.Name)
+			running := pvc.Annotations[AnnPodReady]
+			if running == "true" {
+				// TODO: Use a more generic In Progess, like maybe TransferInProgress.
+				dataVolumeCopy.Status.Phase = cdiv1.UploadReady
+				event.eventType = corev1.EventTypeNormal
+				event.reason = UploadReady
+				event.message = fmt.Sprintf(MessageUploadReady, pvc.Name)
+			}
 		case string(corev1.PodFailed):
 			dataVolumeCopy.Status.Phase = cdiv1.Failed
 			event.eventType = corev1.EventTypeWarning


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Hopefully help address upload flakiness.  Let's wait until pods are ready, not just running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

