### PR TITLE
Correct check in badserver_tests

### DIFF
--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,6 +15,7 @@ import (
 
 var _ = Describe("Problematic server responses", func() {
 	f := framework.NewFrameworkOrDie("badserver-func-test")
+	const dvWaitTimeout = 500 * time.Second
 	var dataVolume *cdiv1.DataVolume
 
 	It("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", func() {
@@ -38,7 +40,7 @@ var _ = Describe("Problematic server responses", func() {
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+		err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name, dvWaitTimeout)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -24,7 +24,9 @@ var _ = Describe("Problematic server responses", func() {
 		By("creating DataVolume")
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
-		utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", func() {
@@ -35,7 +37,9 @@ var _ = Describe("Problematic server responses", func() {
 		By("creating DataVolume")
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
-		utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/tools/cdi-func-test-bad-webserver/main.go
+++ b/tools/cdi-func-test-bad-webserver/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"encoding/binary"
+	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"math/big"
 	"net/http"
 	"os"
 	"regexp"
@@ -19,8 +19,12 @@ func failHEAD(w http.ResponseWriter, r *http.Request) {
 }
 
 func flaky(w http.ResponseWriter, r *http.Request) {
-	if getCounter()%4 == 3 {
-		// succeed after 10 attempts
+	random, err := rand.Int(rand.Reader, big.NewInt(3))
+	if err != nil {
+		panic(err)
+	}
+	if random.Cmp(big.NewInt(0)) == 0 {
+		// 1-in-3 odds of success
 		redirect(w, r)
 		return
 	}
@@ -36,33 +40,7 @@ func redirect(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectURL, 301)
 }
 
-func initCounter() {
-	newCounterBuf := make([]byte, binary.MaxVarintLen64)
-	_ = binary.PutUvarint(newCounterBuf, 0)
-
-	ioutil.WriteFile("state", newCounterBuf, 0644)
-}
-
-func getCounter() uint64 {
-	counterBuf, err := ioutil.ReadFile("state")
-	if err != nil {
-		panic(err)
-	}
-
-	counter, n := binary.Uvarint(counterBuf)
-	if n <= 0 {
-		counter = 0
-	}
-
-	newCounterBuf := make([]byte, binary.MaxVarintLen64)
-	_ = binary.PutUvarint(newCounterBuf, counter+1)
-	ioutil.WriteFile("state", newCounterBuf, 0644)
-
-	return counter
-}
-
 func main() {
-	initCounter()
 	http.HandleFunc("/forbidden-HEAD/", failHEAD)
 	http.HandleFunc("/flaky/", flaky)
 	err := http.ListenAndServe(":9090", nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a missing check at the end of the tests.

**Special notes for your reviewer**:
It's a duplicate of #1262 which uses random numbers.
It's probably better than switching to always succeeding on GET requests, and I happened to have the code lying around already.

**Release note**:
```release-note
NONE
```

