### PR TITLE
Support form based uploads 

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -133,6 +133,12 @@ const (
 	// UploadPathAsync is the path to POST CDI uploads in async mode
 	UploadPathAsync = "/v1alpha1/upload-async"
 
+	// UploadFormSync is the path to POST CDI uploads as form data
+	UploadFormSync = "/v1alpha1/upload-form"
+
+	// UploadFormAsync is the path to POST CDI uploads as form data in async mode
+	UploadFormAsync = "/v1alpha1/upload-form-async"
+
 	// QemuSubGid is the gid used as the qemu group in fsGroup
 	QemuSubGid = int64(107)
 

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -82,6 +82,13 @@ type clientCreator struct {
 
 var authHeaderMatcher = regexp.MustCompile(`(?i)^Bearer\s+([A-Za-z0-9\-\._~\+\/]+)$`)
 
+var uploadPaths = []string{
+	common.UploadPathSync,
+	common.UploadPathAsync,
+	common.UploadFormSync,
+	common.UploadFormAsync,
+}
+
 // NewUploadProxy returns an initialized uploadProxyApp
 func NewUploadProxy(bindAddress string,
 	bindPort uint,
@@ -150,8 +157,9 @@ func (c *clientCreator) CreateClient() (*http.Client, error) {
 func (app *uploadProxyApp) initHandler() {
 	mux := http.NewServeMux()
 	mux.HandleFunc(healthzPath, app.handleHealthzRequest)
-	mux.HandleFunc(common.UploadPathSync, app.handleUploadRequest)
-	mux.HandleFunc(common.UploadPathAsync, app.handleUploadRequest)
+	for _, path := range uploadPaths {
+		mux.HandleFunc(path, app.handleUploadRequest)
+	}
 	app.handler = cors.AllowAll().Handler(mux)
 }
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The existing binary upload format does not work well for a browser.

Added `v1alpha1/upload-form` and `v1alpha1/upload-form-async` to support form data uploads

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New UploadProxy endpoints for form based uploads "v1alpha1/upload-form" and "vialpha1/upload-form-async"
```

