### PR TITLE
Run size validation before returning success on upload.

### DIFF
--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -74,6 +74,8 @@ func (ud *UploadDataSource) TransferFile(fileName string) (ProcessingPhase, erro
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
+	// If we successfully wrote to the file, then the parse will succeed.
+	ud.url, _ = url.Parse(fileName)
 	return ProcessingPhaseResize, nil
 }
 
@@ -136,7 +138,7 @@ func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error)
 	// If we successfully wrote to the file, then the parse will succeed.
 	aud.uploadDataSource.url, _ = url.Parse(file)
 	aud.ResumePhase = ProcessingPhaseProcess
-	return ProcessingPhasePause, nil
+	return ProcessingPhaseValidatePause, nil
 }
 
 // TransferFile is called to transfer the data from the source to the passed in file.
@@ -145,8 +147,10 @@ func (aud *AsyncUploadDataSource) TransferFile(fileName string) (ProcessingPhase
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
+	// If we successfully wrote to the file, then the parse will succeed.
+	aud.uploadDataSource.url, _ = url.Parse(fileName)
 	aud.ResumePhase = ProcessingPhaseResize
-	return ProcessingPhasePause, nil
+	return ProcessingPhaseValidatePause, nil
 }
 
 // Process is called to do any special processing before giving the url to the data back to the processor

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Async Upload data source", func() {
 		result, err := aud.Transfer(scratchPath)
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ProcessingPhasePause).To(Equal(result))
+			Expect(ProcessingPhaseValidatePause).To(Equal(result))
 			Expect(ProcessingPhaseProcess).To(Equal(aud.GetResumePhase()))
 		} else {
 			Expect(err).To(HaveOccurred())
@@ -255,7 +255,7 @@ var _ = Describe("Async Upload data source", func() {
 		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
 		result, err = aud.TransferFile(filepath.Join(tmpDir, "file"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ProcessingPhasePause).To(Equal(result))
+		Expect(ProcessingPhaseValidatePause).To(Equal(result))
 		Expect(ProcessingPhaseResize).To(Equal(aud.GetResumePhase()))
 	})
 

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -361,7 +361,12 @@ func (app *uploadServerApp) uploadHandlerAsync(irc imageReadCloser) http.Handler
 
 		if err != nil {
 			klog.Errorf("Saving stream failed: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			if _, ok := err.(importer.ValidationSizeError); ok {
+				w.WriteHeader(http.StatusBadRequest)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			w.Write([]byte(fmt.Sprintf("Saving stream failed: %s", err.Error())))
 			app.uploading = false
 			app.mutex.Unlock()
 			return

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -13,6 +13,8 @@ import (
 const (
 	// UploadFile is the file to upload
 	UploadFile = "./images/tinyCore.iso"
+	// UploadFileLargeVirtualDisk is the file to upload
+	UploadFileLargeVirtualDisk = "./images/cirros-large-vdisk.qcow2"
 
 	// UploadFileSize is the size of UploadFile
 	UploadFileSize = 18874368


### PR DESCRIPTION
 This is to give immediate feedback to the user when uploading.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Virtctl now supports asynchronous uploads, after the data has been transferred the connection is closed and post processing happens (convert/resize/etc) which may take a while. As part of that post processing we do a size validation. If the virtual disk image is > PVC size, the upload is considered failed. But with the async upload the connection is already closed and unless the user looks at the DataVolume, they will have a hard time understanding what happened.

This PR returns an 400 (BadRequest) and a message in the body based on the validation BEFORE we close the connection, so we can give more immediate feedback to the user. Currently virtctl doesn't print the contents of the response body, but this [PR](https://github.com/kubevirt/kubevirt/pull/3825) adds this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1219 (partially, virtctl needs update as well)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Return error code and message on upload when image validation fails on async upload.
```

