### PR TITLE
Fix CDI apiserver authentication on AKS

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -197,15 +197,6 @@ func (app *cdiAPIApp) getKeysAndCerts() error {
 func (app *cdiAPIApp) getTLSConfig() (*tls.Config, error) {
 	authConfig := app.authConfigWatcher.GetAuthConfig()
 
-	validName := func(name string) bool {
-		for _, n := range authConfig.AllowedNames {
-			if n == name {
-				return true
-			}
-		}
-		return false
-	}
-
 	cert, err := app.certWarcher.GetCertificate(nil)
 	if err != nil {
 		return nil, err
@@ -220,7 +211,7 @@ func (app *cdiAPIApp) getTLSConfig() (*tls.Config, error) {
 				return nil
 			}
 			for i := range verifiedChains {
-				if validName(verifiedChains[i][0].Subject.CommonName) {
+				if authConfig.ValidateName(verifiedChains[i][0].Subject.CommonName) {
 					return nil
 				}
 			}

--- a/pkg/apiserver/auth-config.go
+++ b/pkg/apiserver/auth-config.go
@@ -64,6 +64,19 @@ type authConfigWatcher struct {
 	mutex  sync.RWMutex
 }
 
+// ValidateName checks if name is allowed
+func (ac *AuthConfig) ValidateName(name string) bool {
+	klog.V(3).Infof("Validating CN: %s", name)
+	for _, n := range ac.AllowedNames {
+		if n == name {
+			return true
+		}
+	}
+	// no allowed names means anyone is allowed
+	// https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#kubernetes-apiserver-client-authentication
+	return len(ac.AllowedNames) == 0
+}
+
 // NewAuthConfigWatcher crates a new authConfigWatcher
 func NewAuthConfigWatcher(client kubernetes.Interface, stopCh <-chan struct{}) AuthConfigWatcher {
 	informerFactory := informers.NewFilteredSharedInformerFactory(client,


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`kube-apiserver` was not able to communicate with `cdi-apiserver` on Azure.  Was determined that the root cause was the lack of any value for `requestheader-allowed-names` in `extension-apiserver-authentication` configmap.  Although probably not ideal, that is a valid configuration per this:  https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#kubernetes-apiserver-client-authentication

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1295 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

