### PR TITLE
Non-functional change cleanup: remove unused calls to UploadPodName

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -866,7 +866,6 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Kill upload pod to force error")
-		utils.UploadPodName(targetPvc)
 		_, errLog, err := f.ExecShellInPodWithFullOutput(targetNs.Name, "cdi-upload-target-dv", "kill 1")
 		Expect(err).To(BeNil())
 		Expect(errLog).To(BeEmpty())

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -862,11 +862,11 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, targetNs.Name, v1.ClaimBound, targetPvc.Name)
 
 		By("Wait for upload pod")
-		err = utils.WaitTimeoutForPodReady(f.K8sClient, "cdi-upload-target-dv", targetNs.Name, utils.PodWaitForTime)
+		err = utils.WaitTimeoutForPodReady(f.K8sClient, utils.UploadPodName(targetPvc), targetNs.Name, utils.PodWaitForTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Kill upload pod to force error")
-		_, errLog, err := f.ExecShellInPodWithFullOutput(targetNs.Name, "cdi-upload-target-dv", "kill 1")
+		_, errLog, err := f.ExecShellInPodWithFullOutput(targetNs.Name, utils.UploadPodName(targetPvc), "kill 1")
 		Expect(err).To(BeNil())
 		Expect(errLog).To(BeEmpty())
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -657,7 +657,6 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Kill upload container to force restart")
-		utils.UploadPodName(pvc)
 		_, errLog, err := f.ExecShellInPodWithFullOutput(f.Namespace.Name, utils.UploadPodName(pvc), "kill 1")
 		Expect(err).To(BeNil())
 		Expect(errLog).To(BeEmpty())


### PR DESCRIPTION
This function has no side effects and we ignore the return value.
While here, use the same function instead of hard-coding the name.
Might be a bit cleaner.

```release-note
NONE
```

