### PR TITLE
build: Add btrfs-progs-devel and device-mapper-devel to builder image

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -29,6 +29,8 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 	patch \
     unzip \
     java-1.8.0-openjdk \
+	btrfs-progs-devel \
+	device-mapper-devel \
 	&& microdnf clean all && \
 	mv /etc/yum.repos.d/old/* /etc/yum.repos.d/ && \
 	rmdir /etc/yum.repos.d/old


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR updates builder image with packages required to build images API. Images API is needed to replace/optimize skopeo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

