### PR TITLE
Update cdi-builder to use go version 1.14.6 (current latest)

### DIFF
--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,7 +26,7 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.4}
+BUILDER_TAG=${BUILDER_TAG:-0.0.5}
 BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:6fb922950f5c1e7b9fad4411ac447e212a6975eab617a4fd34ed5cf5ee1df11b}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER}"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install j2cli && pip3 install operator-courier && \
     ln -s /opt/gradle/gradle-4.3.1/bin/gradle /usr/local/bin/gradle && \
     rm gradle-4.3.1-bin.zip
 
-ENV GIMME_GO_VERSION=1.12.14 GOPATH="/go" KUBEBUILDER_VERSION="2.2.0" ARCH="amd64"
+ENV GIMME_GO_VERSION=1.14.6 GOPATH="/go" KUBEBUILDER_VERSION="2.3.1" ARCH="amd64"
 ENV BAZEL_PYTHON=/usr/bin/python3
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh

--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -72,6 +72,5 @@ if [ $retry_counter -eq $MAX_CDI_WAIT_RETRY ]; then
     exit 1
 fi
 
-test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 180m ${test_args}"
-echo "${test_command}"
+test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 360m ${test_args}"
 (cd ${CDI_DIR}/tests; ${test_command})

--- a/tests/alpha_test.go
+++ b/tests/alpha_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("Alpha API tests", func() {
-	f := framework.NewFrameworkOrDie("alpha-api-test")
+	f := framework.NewFramework("alpha-api-test")
 
 	Context("with v1alpha1 api", func() {
 

--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -27,7 +27,7 @@ const (
 )
 
 var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redhat.com][level:component]Validation tests", func() {
-	f := framework.NewFrameworkOrDie("api-validation-func-test")
+	f := framework.NewFramework("api-validation-func-test")
 
 	Describe("Verify DataVolume validation", func() {
 		Context("when creating Datavolume", func() {

--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var _ = Describe("Problematic server responses", func() {
-	f := framework.NewFrameworkOrDie("badserver-func-test")
+	f := framework.NewFramework("badserver-func-test")
 	const dvWaitTimeout = 500 * time.Second
 	var dataVolume *cdiv1.DataVolume
 

--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:1347][crit:high][vendor:cnv-qe@redhat.com][level:component]Basic Sanity", func() {
-	f := framework.NewFrameworkOrDie("sanity", framework.Config{
+	f := framework.NewFramework("sanity", framework.Config{
 		SkipNamespaceCreation: true,
 	})
 

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -35,7 +35,7 @@ var (
 
 var _ = Describe("CDI storage class config tests", func() {
 	var (
-		f                   = framework.NewFrameworkOrDie("cdiconfig-test")
+		f                   = framework.NewFramework("cdiconfig-test")
 		defaultSc, secondSc *storagev1.StorageClass
 	)
 
@@ -201,7 +201,7 @@ var _ = Describe("CDI storage class config tests", func() {
 
 var _ = Describe("CDI ingress config tests, using manifests", func() {
 	var (
-		f            = framework.NewFrameworkOrDie("cdiconfig-test")
+		f            = framework.NewFramework("cdiconfig-test")
 		manifestFile string
 	)
 
@@ -272,7 +272,7 @@ var _ = Describe("CDI ingress config tests, using manifests", func() {
 
 var _ = Describe("CDI ingress config tests", func() {
 	var (
-		f          = framework.NewFrameworkOrDie("cdiconfig-test")
+		f          = framework.NewFramework("cdiconfig-test")
 		routeStart = fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs)
 		ingress    *extensionsv1beta1.Ingress
 	)
@@ -374,7 +374,7 @@ var _ = Describe("CDI ingress config tests", func() {
 
 var _ = Describe("CDI route config tests", func() {
 	var (
-		f               = framework.NewFrameworkOrDie("cdiconfig-test")
+		f               = framework.NewFramework("cdiconfig-test")
 		routeStart      = fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs)
 		openshiftClient *route1client.Clientset
 	)
@@ -430,7 +430,7 @@ var _ = Describe("CDI route config tests", func() {
 })
 
 var _ = Describe("CDIConfig instance management", func() {
-	f := framework.NewFrameworkOrDie("cdiconfig-test")
+	f := framework.NewFramework("cdiconfig-test")
 
 	It("Should re-create the object if deleted", func() {
 		By("Verifying the object exists")

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -273,7 +273,7 @@ var _ = Describe("CDI ingress config tests, using manifests", func() {
 var _ = Describe("CDI ingress config tests", func() {
 	var (
 		f          = framework.NewFramework("cdiconfig-test")
-		routeStart = fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs)
+		routeStart = func() string { return fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs) }
 		ingress    *extensionsv1beta1.Ingress
 	)
 
@@ -292,7 +292,7 @@ var _ = Describe("CDI ingress config tests", func() {
 				if config.Status.UploadProxyURL == nil {
 					return false
 				}
-				return strings.HasPrefix(*config.Status.UploadProxyURL, routeStart)
+				return strings.HasPrefix(*config.Status.UploadProxyURL, routeStart())
 			}, time.Second*30, time.Second).Should(BeTrue())
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -375,7 +375,7 @@ var _ = Describe("CDI ingress config tests", func() {
 var _ = Describe("CDI route config tests", func() {
 	var (
 		f               = framework.NewFramework("cdiconfig-test")
-		routeStart      = fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs)
+		routeStart      = func() string { return fmt.Sprintf("%s-%s.", routeName, f.CdiInstallNs) }
 		openshiftClient *route1client.Clientset
 	)
 
@@ -395,7 +395,7 @@ var _ = Describe("CDI route config tests", func() {
 			if config.Status.UploadProxyURL == nil {
 				return false
 			}
-			return strings.HasPrefix(*config.Status.UploadProxyURL, routeStart)
+			return strings.HasPrefix(*config.Status.UploadProxyURL, routeStart())
 		}, time.Second*30, time.Second).Should(BeTrue())
 	})
 

--- a/tests/certrotation_test.go
+++ b/tests/certrotation_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 var _ = Describe("Cert rotation tests", func() {
-	f := framework.NewFrameworkOrDie("certrotation-test")
+	f := framework.NewFramework("certrotation-test")
 
 	Context("with port forward", func() {
 		DescribeTable("check secrets re read", func(serviceName, secretName string) {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:component]Cloner Test Suite", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	var sourcePvc *v1.PersistentVolumeClaim
 	var targetPvc *v1.PersistentVolumeClaim
@@ -259,7 +259,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 })
 
 var _ = Describe("Validate creating multiple clones of same source Data Volume", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
 
 	var (
@@ -372,7 +372,7 @@ var _ = Describe("Validate creating multiple clones of same source Data Volume",
 })
 
 var _ = Describe("Validate Data Volume clone to smaller size", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
 
 	var (
@@ -474,7 +474,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 })
 
 var _ = Describe("Validate Data Volume should clone multiple clones in parallel", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
 
 	var (
@@ -605,7 +605,7 @@ var _ = Describe("Validate Data Volume should clone multiple clones in parallel"
 })
 
 var _ = Describe("Block PV Cloner Test", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	It("Should clone data across namespaces", func() {
 		if !f.IsBlockVolumeStorageClassAvailable() {
@@ -645,7 +645,7 @@ var _ = Describe("Block PV Cloner Test", func() {
 })
 
 var _ = Describe("Namespace with quota", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	var (
 		orgConfig *v1.ResourceRequirements
 		sourcePvc *v1.PersistentVolumeClaim
@@ -826,7 +826,7 @@ var _ = Describe("Namespace with quota", func() {
 })
 
 var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:component]Cloner Test Suite", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	var sourcePvc *v1.PersistentVolumeClaim
 	var targetPvc *v1.PersistentVolumeClaim

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -41,6 +41,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 	var sourcePvc *v1.PersistentVolumeClaim
 	var targetPvc *v1.PersistentVolumeClaim
+
 	AfterEach(func() {
 		if sourcePvc != nil {
 			By("[AfterEach] Clean up source PVC")
@@ -260,7 +261,7 @@ var _ = Describe("[rfe_id:1277][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 var _ = Describe("Validate creating multiple clones of same source Data Volume", func() {
 	f := framework.NewFramework(namespacePrefix)
-	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
+	tinyCoreIsoURL := func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
 
 	var (
 		sourceDv, targetDv1, targetDv2, targetDv3 *cdiv1.DataVolume
@@ -276,7 +277,7 @@ var _ = Describe("Validate creating multiple clones of same source Data Volume",
 
 	It("[rfe_id:1277][test_id:1891][crit:High][vendor:cnv-qe@redhat.com][level:component]Should allow multiple clones from a single source datavolume", func() {
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL)
+		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -324,7 +325,7 @@ var _ = Describe("Validate creating multiple clones of same source Data Volume",
 			Skip("Storage Class for block volume is not available")
 		}
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL, f.BlockSCName)
+		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL(), f.BlockSCName)
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -373,7 +374,7 @@ var _ = Describe("Validate creating multiple clones of same source Data Volume",
 
 var _ = Describe("Validate Data Volume clone to smaller size", func() {
 	f := framework.NewFramework(namespacePrefix)
-	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
+	tinyCoreIsoURL := func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
 
 	var (
 		sourceDv, targetDv *cdiv1.DataVolume
@@ -395,7 +396,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 
 	It("[rfe_id:1126][test_id:1896][crit:High][vendor:cnv-qe@redhat.com][level:component] Should not allow cloning into a smaller sized data volume", func() {
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL)
+		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -440,7 +441,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 			Skip("Storage Class for block volume is not available")
 		}
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL, f.BlockSCName)
+		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL(), f.BlockSCName)
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -475,7 +476,7 @@ var _ = Describe("Validate Data Volume clone to smaller size", func() {
 
 var _ = Describe("Validate Data Volume should clone multiple clones in parallel", func() {
 	f := framework.NewFramework(namespacePrefix)
-	tinyCoreIsoURL := fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs)
+	tinyCoreIsoURL := func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
 
 	var (
 		sourceDv, targetDv1, targetDv2, targetDv3 *cdiv1.DataVolume
@@ -491,7 +492,7 @@ var _ = Describe("Validate Data Volume should clone multiple clones in parallel"
 
 	It("[rfe_id:1277][test_id:1899][crit:High][vendor:cnv-qe@redhat.com][level:component] Should allow multiple cloning operations in parallel", func() {
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL)
+		sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -552,7 +553,7 @@ var _ = Describe("Validate Data Volume should clone multiple clones in parallel"
 			Skip("Storage Class for block volume is not available")
 		}
 		By("Creating a source from a real image")
-		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL, f.BlockSCName)
+		sourceDv = utils.NewDataVolumeWithHTTPImportToBlockPV("source-dv", "200Mi", tinyCoreIsoURL(), f.BlockSCName)
 		sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2,10 +2,11 @@ package tests
 
 import (
 	"fmt"
-	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"regexp"
 	"strings"
 	"time"
+
+	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -905,7 +906,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		table.DescribeTable("Feature Gate - disabled", func(
 			dvName string,
-			url string,
+			url func() string,
 			dvFunc func(string, string, string) *cdiv1.DataVolume,
 			phase cdiv1.DataVolumePhase) {
 			if !utils.IsHostpathProvisioner() {
@@ -917,7 +918,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.Spec.FeatureGates).To(BeNil())
 
-			dataVolume := dvFunc(dvName, size, url)
+			dataVolume := dvFunc(dvName, size, url())
 
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -953,32 +954,32 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		},
 			table.Entry("[test_id:4459] Import Positive flow",
 				"dv-wffc-http-import",
-				fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs),
+				func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) },
 				utils.NewDataVolumeWithHTTPImport,
 				cdiv1.Succeeded),
 			table.Entry("[test_id:4460] Import invalid url",
 				"dv-wffc-http-url-not-valid-import",
-				fmt.Sprintf(noSuchFileFileURL, f.CdiInstallNs),
+				func() string { return fmt.Sprintf(noSuchFileFileURL, f.CdiInstallNs) },
 				utils.NewDataVolumeWithHTTPImport,
 				cdiv1.ImportInProgress),
 			table.Entry("[test_id:4461] Import qcow2 scratch space",
 				"dv-wffc-qcow2-import",
-				fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs),
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
 				createHTTPSDataVolume,
 				cdiv1.Succeeded),
 			table.Entry("[test_id:4462] Import blank image",
 				"dv-wffc-blank-import",
-				fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs),
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
 				createBlankRawDataVolume,
 				cdiv1.Succeeded),
 			table.Entry("[test_id:4463] Upload - positive flow",
 				"dv-wffc-upload",
-				fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs),
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
 				createUploadDataVolume,
 				cdiv1.UploadReady),
 			table.Entry("[test_id:4464] Clone - positive flow",
 				"dv-wffc-clone",
-				fillCommand, // its not URL, but command, but the parameter lines up.
+				func() string { return fillCommand }, // its not URL, but command, but the parameter lines up.
 				createCloneDataVolume,
 				cdiv1.Succeeded),
 		)

--- a/tests/framework/BUILD.bazel
+++ b/tests/framework/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-        "//vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	storagev1 "k8s.io/api/storage/v1"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -14,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -40,7 +38,6 @@ import (
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/tests/utils"
-	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
 const (
@@ -53,14 +50,8 @@ const (
 
 // run-time flags
 var (
-	kubectlPath    *string
-	ocPath         *string
-	cdiInstallNs   *string
-	kubeConfig     *string
-	master         *string
-	goCLIPath      *string
-	snapshotSCName *string
-	blockSCName    *string
+	ClientsInstance = &Clients{}
+	reporter        = NewKubernetesReporter()
 )
 
 // Config provides some basic test config options
@@ -68,17 +59,19 @@ type Config struct {
 	// SkipNamespaceCreation sets whether to skip creating a namespace. Use this ONLY for tests that do not require
 	// a namespace at all, like basic sanity or other global tests.
 	SkipNamespaceCreation bool
-	// SkipControllerPodLookup sets whether to skip looking up the name of the cdi controller pod.
-	SkipControllerPodLookup bool
 }
 
-// Framework supports common operations used by functional/e2e tests. It holds the k8s and cdi clients,
-// a generated unique namespace, run-time flags, and more fields will be added over time as cdi e2e
-// evolves. Global BeforeEach and AfterEach are called in the Framework constructor.
-type Framework struct {
-	Config
-	// NsPrefix is a prefix for generated namespace
-	NsPrefix string
+// Clients is the struct containing the client-go kubernetes clients
+type Clients struct {
+	KubectlPath    string
+	OcPath         string
+	CdiInstallNs   string
+	KubeConfig     string
+	Master         string
+	GoCLIPath      string
+	SnapshotSCName string
+	BlockSCName    string
+
 	//  k8sClient provides our k8s client pointer
 	K8sClient *kubernetes.Clientset
 	// CdiClient provides our CDI client pointer
@@ -89,6 +82,15 @@ type Framework struct {
 	CrClient crclient.Client
 	// RestConfig provides a pointer to our REST client config.
 	RestConfig *rest.Config
+}
+
+// Framework supports common operations used by functional/e2e tests. It holds the k8s and cdi clients,
+// a generated unique namespace, run-time flags, and more fields will be added over time as cdi e2e
+// evolves. Global BeforeEach and AfterEach are called in the Framework constructor.
+type Framework struct {
+	Config
+	// NsPrefix is a prefix for generated namespace
+	NsPrefix string
 	// Namespace provides a namespace for each test generated/unique ns per test
 	Namespace *v1.Namespace
 	// Namespace2 provides an additional generated/unique secondary ns for testing across namespaces (eg. clone tests)
@@ -98,152 +100,34 @@ type Framework struct {
 	// ControllerPod provides a pointer to our test controller pod
 	ControllerPod *v1.Pod
 
-	// KubectlPath is a test run-time flag so we can find kubectl
-	KubectlPath string
-	// OcPath is a test run-time flag so we can find OpenShift Client
-	OcPath string
-	// CdiInstallNs is a test run-time flag to store the Namespace we installed CDI in
-	CdiInstallNs string
-	// KubeConfig is a test run-time flag to store the location of our test setup kubeconfig
-	KubeConfig string
-	// Master is a test run-time flag to store the id of our master node
-	Master string
-	// GoCliPath is a test run-time flag to store the location of gocli
-	GoCLIPath string
-	// SnapshotSCName is the Storage Class name that supports Snapshots
-	SnapshotSCName string
-	// BlockSCName is the Storage Class name that supports block mode
-	BlockSCName string
-
+	*Clients
 	reporter *KubernetesReporter
-
-	mux sync.Mutex
 }
 
-// TODO: look into k8s' SynchronizedBeforeSuite() and SynchronizedAfterSuite() code and their general
-//       purpose test/e2e/framework/cleanup.go function support.
-
-// initialize run-time flags
-func init() {
-	// By accessing something in the ginkgo_reporters package, we are ensuring that the init() is called
-	// That init calls flag.StringVar, and makes sure the --junit-output flag is added before we call
-	// flag.Parse in NewFramework. Without this, the flag is NOT added.
-	fmt.Fprintf(ginkgo.GinkgoWriter, "Making sure junit flag is available %v\n", ginkgo_reporters.JunitOutput)
-	kubectlPath = flag.String("kubectl-path", "kubectl", "The path to the kubectl binary")
-	ocPath = flag.String("oc-path", "oc", "The path to the oc binary")
-	cdiInstallNs = flag.String("cdi-namespace", "cdi", "The namespace of the CDI controller")
-	kubeConfig = flag.String("kubeconfig", "/var/run/kubernetes/admin.kubeconfig", "The absolute path to the kubeconfig file")
-	master = flag.String("master", "", "master url:port")
-	goCLIPath = flag.String("gocli-path", "cli.sh", "The path to cli script")
-	snapshotSCName = flag.String("snapshot-sc", "", "The Storage Class supporting snapshots")
-	blockSCName = flag.String("block-sc", "", "The Storage Class supporting block mode volumes")
-}
-
-// NewFrameworkOrDie calls NewFramework and handles errors by calling Fail. Config is optional, but
+// NewFramework calls NewFramework and handles errors by calling Fail. Config is optional, but
 // if passed there can only be one.
-func NewFrameworkOrDie(prefix string, config ...Config) *Framework {
+// To understand the order in which things are run, read http://onsi.github.io/ginkgo/#understanding-ginkgos-lifecycle
+// flag parsing happens AFTER ginkgo has constructed the entire testing tree. So anything that uses information from flags
+// cannot work when called during test tree construction.
+func NewFramework(prefix string, config ...Config) *Framework {
 	cfg := Config{}
 	if len(config) > 0 {
 		cfg = config[0]
 	}
-	f, err := NewFramework(prefix, cfg)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("failed to create test framework with config %+v: %v", cfg, err))
-	}
-	return f
-}
-
-// NewFramework makes a new framework and sets up the global BeforeEach/AfterEach's.
-// Test run-time flags are parsed and added to the Framework struct.
-func NewFramework(prefix string, config Config) (*Framework, error) {
 	f := &Framework{
-		Config:   config,
+		Config:   cfg,
 		NsPrefix: prefix,
+		Clients:  ClientsInstance,
+		reporter: reporter,
 	}
-
-	// handle run-time flags
-	if !flag.Parsed() {
-		flag.Parse()
-		klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-		klog.InitFlags(klogFlags)
-		flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-			f2 := klogFlags.Lookup(f1.Name)
-			if f2 != nil {
-				value := f1.Value.String()
-				f2.Value.Set(value)
-			}
-		})
-
-		fmt.Fprintf(ginkgo.GinkgoWriter, "** Test flags:\n")
-		flag.Visit(func(f *flag.Flag) {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "   %s = %q\n", f.Name, f.Value.String())
-		})
-		fmt.Fprintf(ginkgo.GinkgoWriter, "**\n")
-	}
-
-	f.KubectlPath = *kubectlPath
-	f.OcPath = *ocPath
-	f.CdiInstallNs = *cdiInstallNs
-	f.KubeConfig = *kubeConfig
-	f.Master = *master
-	f.GoCLIPath = *goCLIPath
-	f.SnapshotSCName = *snapshotSCName
-	f.BlockSCName = *blockSCName
-
-	restConfig, err := f.LoadConfig()
-	if err != nil {
-		// Can't use Expect here due this being called outside of an It block, and Expect
-		// requires any calls to it to be inside an It block.
-		return nil, errors.Wrap(err, "ERROR, unable to load RestConfig")
-	}
-	f.RestConfig = restConfig
-	// clients
-	kcs, err := f.GetKubeClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "ERROR, unable to create K8SClient")
-	}
-	f.K8sClient = kcs
-
-	cs, err := f.GetCdiClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "ERROR, unable to create CdiClient")
-	}
-	f.CdiClient = cs
-
-	extcs, err := f.GetExtClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "ERROR, unable to create CsiClient")
-	}
-	f.ExtClient = extcs
-
-	crClient, err := f.GetCrClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "ERROR, unable to create CrClient")
-	}
-	f.CrClient = crClient
 
 	ginkgo.BeforeEach(f.BeforeEach)
 	ginkgo.AfterEach(f.AfterEach)
-	f.reporter = NewKubernetesReporter()
-
-	f.mux.Lock()
-	utils.CacheTestsData(f.K8sClient, f.CdiInstallNs)
-	f.mux.Unlock()
-
-	return f, err
+	return f
 }
 
 // BeforeEach provides a set of operations to run before each test
 func (f *Framework) BeforeEach() {
-	if !f.SkipControllerPodLookup {
-		if f.ControllerPod == nil {
-			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiPodPrefix, common.CDILabelSelector)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Located cdi-controller-pod: %q\n", pod.Name)
-			f.ControllerPod = pod
-		}
-	}
-
 	if !f.SkipNamespaceCreation {
 		// generate unique primary ns (ns2 not created here)
 		ginkgo.By(fmt.Sprintf("Building a %q namespace api object", f.NsPrefix))
@@ -349,8 +233,8 @@ func DeleteNS(c *kubernetes.Clientset, ns string) error {
 }
 
 // GetCdiClient gets an instance of a kubernetes client that includes all the CDI extensions.
-func (f *Framework) GetCdiClient() (*cdiClientset.Clientset, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags(f.Master, f.KubeConfig)
+func (c *Clients) GetCdiClient() (*cdiClientset.Clientset, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags(c.Master, c.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +246,8 @@ func (f *Framework) GetCdiClient() (*cdiClientset.Clientset, error) {
 }
 
 // GetExtClient gets an instance of a kubernetes client that includes all the api extensions.
-func (f *Framework) GetExtClient() (*extclientset.Clientset, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags(f.Master, f.KubeConfig)
+func (c *Clients) GetExtClient() (*extclientset.Clientset, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags(c.Master, c.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -375,12 +259,12 @@ func (f *Framework) GetExtClient() (*extclientset.Clientset, error) {
 }
 
 // GetCrClient returns a controller runtime client
-func (f *Framework) GetCrClient() (crclient.Client, error) {
+func (c *Clients) GetCrClient() (crclient.Client, error) {
 	if err := snapshotv1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}
 
-	client, err := crclient.New(f.RestConfig, crclient.Options{Scheme: scheme.Scheme})
+	client, err := crclient.New(c.RestConfig, crclient.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, err
 	}
@@ -439,13 +323,13 @@ func (f *Framework) GetCdiClientForServiceAccount(namespace, name string) (*cdiC
 }
 
 // GetKubeClient returns a Kubernetes rest client
-func (f *Framework) GetKubeClient() (*kubernetes.Clientset, error) {
-	return GetKubeClientFromRESTConfig(f.RestConfig)
+func (c *Clients) GetKubeClient() (*kubernetes.Clientset, error) {
+	return GetKubeClientFromRESTConfig(c.RestConfig)
 }
 
 // LoadConfig loads our specified kubeconfig
-func (f *Framework) LoadConfig() (*rest.Config, error) {
-	return clientcmd.BuildConfigFromFlags(f.Master, f.KubeConfig)
+func (c *Clients) LoadConfig() (*rest.Config, error) {
+	return clientcmd.BuildConfigFromFlags(c.Master, c.KubeConfig)
 }
 
 // GetKubeClientFromRESTConfig provides a function to get a K8s client using hte REST config

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -40,7 +40,7 @@ const (
 var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:component]Importer Test Suite", func() {
 	var (
 		ns string
-		f  = framework.NewFrameworkOrDie(namespacePrefix)
+		f  = framework.NewFramework(namespacePrefix)
 		c  = f.K8sClient
 	)
 
@@ -138,7 +138,7 @@ var _ = Describe("[rfe_id:1118][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	BeforeEach(func() {
 		_, err := f.CreatePrometheusServiceInNs(f.Namespace.Name)
@@ -235,7 +235,7 @@ func startPrometheusPortForward(f *framework.Framework) (string, *exec.Cmd, erro
 }
 
 var _ = Describe("Importer Test Suite-Block_device", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	var pvc *v1.PersistentVolumeClaim
 	var err error
 
@@ -308,7 +308,7 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 })
 
 var _ = Describe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.com][level:component]Importer Archive ContentType", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	It("Should import archive content type tar file", func() {
 		c := f.K8sClient
@@ -337,7 +337,7 @@ var _ = Describe("[rfe_id:1947][crit:high][test_id:2145][vendor:cnv-qe@redhat.co
 })
 
 var _ = Describe("PVC import phase matches pod phase", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	It("Should never go to failed even if import fails", func() {
 		c := f.K8sClient
@@ -370,7 +370,7 @@ var _ = Describe("PVC import phase matches pod phase", func() {
 })
 
 var _ = Describe("Namespace with quota", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	var (
 		orgConfig *v1.ResourceRequirements
 	)
@@ -542,7 +542,7 @@ var _ = Describe("Namespace with quota", func() {
 })
 
 var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:component] Add a field to DataVolume to track the number of retries", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	var (
 		dataVolume           *cdiv1.DataVolume
@@ -645,7 +645,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 })
 
 var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:component] CDI Label Naming - Import", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	var (
 		// pvc            *v1.PersistentVolumeClaim

--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -49,7 +49,7 @@ func checkLogForRegEx(regEx *regexp.Regexp, log string) bool {
 }
 
 var _ = Describe("[rfe_id:1250][crit:high][vendor:cnv-qe@redhat.com][level:component]Leader election tests", func() {
-	f := framework.NewFrameworkOrDie("leaderelection-test")
+	f := framework.NewFramework("leaderelection-test")
 	var (
 		leaderPodName string
 		newDeployment *appsv1.Deployment
@@ -85,7 +85,7 @@ var _ = Describe("[rfe_id:1250][crit:high][vendor:cnv-qe@redhat.com][level:compo
 })
 
 var _ = Describe("[rfe_id:1250][crit:high][test_id:1889][vendor:cnv-qe@redhat.com][level:component]Leader election tests during import", func() {
-	f := framework.NewFrameworkOrDie("leaderelection-test")
+	f := framework.NewFramework("leaderelection-test")
 	var (
 		leaderPodName string
 		newDeployment *appsv1.Deployment

--- a/tests/local_volume_test.go
+++ b/tests/local_volume_test.go
@@ -29,7 +29,7 @@ var _ = Describe("[rfe_id:1125][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		node string
 	)
 
-	f := framework.NewFrameworkOrDie("local-volume-func-test")
+	f := framework.NewFramework("local-volume-func-test")
 
 	BeforeEach(func() {
 		nodes, err := f.K8sClient.CoreV1().Nodes().List(metav1.ListOptions{})

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = Describe("Operator tests", func() {
-	f := framework.NewFrameworkOrDie("operator-test")
+	f := framework.NewFramework("operator-test")
 
 	It("[test_id:3951]should create a route in OpenShift", func() {
 		if !isOpenshift(f.K8sClient) {
@@ -95,7 +95,7 @@ var _ = Describe("Operator tests", func() {
 
 var _ = Describe("Operator delete CDI tests", func() {
 	var cr *cdiv1.CDI
-	f := framework.NewFrameworkOrDie("operator-delete-cdi-test")
+	f := framework.NewFramework("operator-delete-cdi-test")
 
 	BeforeEach(func() {
 		var err error

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	f := framework.NewFrameworkOrDie("aggregated-role-tests")
+	f := framework.NewFramework("aggregated-role-tests")
 
 	DescribeTable("admin/edit datavolume permission checks", func(user string) {
 		var client *cdiClientset.Clientset
@@ -255,7 +255,7 @@ var _ = Describe("Aggregated role definition tests", func() {
 		},
 	}
 
-	f := framework.NewFrameworkOrDie("aggregated-role-definition-tests")
+	f := framework.NewFramework("aggregated-role-definition-tests")
 
 	DescribeTable("check all expected rules exist", func(role string, rules []rbacv1.PolicyRule) {
 		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(role, metav1.GetOptions{})

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -26,7 +26,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 	fillCommandFilesystem := "echo -n \"" + fillData + "\" >> " + testFile
 	fillCommandBlock := "echo -n \"" + fillData + "\" | dd of=" + utils.DefaultPvcMountPath
 
-	f := framework.NewFrameworkOrDie("dv-func-test")
+	f := framework.NewFramework("dv-func-test")
 
 	It("[rfe_id:1106][test_id:3494][crit:high][vendor:cnv-qe@redhat.com][level:component] Verify DataVolume Smart Cloning - volumeMode filesystem - Positive flow", func() {
 		if !f.IsSnapshotStorageClassAvailable() {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -1,17 +1,84 @@
 package tests_test
 
 import (
+	"flag"
 	"testing"
 
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerized-data-importer/tests"
+	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/reporters"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var (
+	kubectlPath    = flag.String("kubectl-path", "kubectl", "The path to the kubectl binary")
+	ocPath         = flag.String("oc-path", "oc", "The path to the oc binary")
+	cdiInstallNs   = flag.String("cdi-namespace", "cdi", "The namespace of the CDI controller")
+	kubeConfig     = flag.String("kubeconfig", "/var/run/kubernetes/admin.kubeconfig", "The absolute path to the kubeconfig file")
+	master         = flag.String("master", "", "master url:port")
+	goCLIPath      = flag.String("gocli-path", "cli.sh", "The path to cli script")
+	snapshotSCName = flag.String("snapshot-sc", "", "The Storage Class supporting snapshots")
+	blockSCName    = flag.String("block-sc", "", "The Storage Class supporting block mode volumes")
 )
 
 func TestTests(t *testing.T) {
 	defer GinkgoRecover()
 	RegisterFailHandler(tests.CDIFailHandler)
+	BuildTestSuite()
 	RunSpecsWithDefaultAndCustomReporters(t, "Tests Suite", reporters.NewReporters())
+}
+
+// To understand the order in which things are run, read http://onsi.github.io/ginkgo/#understanding-ginkgos-lifecycle
+// flag parsing happens AFTER ginkgo has constructed the entire testing tree. So anything that uses information from flags
+// cannot work when called during test tree construction.
+func BuildTestSuite() {
+	BeforeSuite(func() {
+		// Read flags, and configure client instances
+		framework.ClientsInstance.KubectlPath = *kubectlPath
+		framework.ClientsInstance.OcPath = *ocPath
+		framework.ClientsInstance.CdiInstallNs = *cdiInstallNs
+		framework.ClientsInstance.KubeConfig = *kubeConfig
+		framework.ClientsInstance.Master = *master
+		framework.ClientsInstance.GoCLIPath = *goCLIPath
+		framework.ClientsInstance.SnapshotSCName = *snapshotSCName
+		framework.ClientsInstance.BlockSCName = *blockSCName
+
+		restConfig, err := framework.ClientsInstance.LoadConfig()
+		if err != nil {
+			// Can't use Expect here due this being called outside of an It block, and Expect
+			// requires any calls to it to be inside an It block.
+			ginkgo.Fail("ERROR, unable to load RestConfig")
+		}
+		framework.ClientsInstance.RestConfig = restConfig
+		// clients
+		kcs, err := framework.ClientsInstance.GetKubeClient()
+		if err != nil {
+			ginkgo.Fail("ERROR, unable to create K8SClient")
+		}
+		framework.ClientsInstance.K8sClient = kcs
+
+		cs, err := framework.ClientsInstance.GetCdiClient()
+		if err != nil {
+			ginkgo.Fail("ERROR, unable to create CdiClient")
+		}
+		framework.ClientsInstance.CdiClient = cs
+
+		extcs, err := framework.ClientsInstance.GetExtClient()
+		if err != nil {
+			ginkgo.Fail("ERROR, unable to create CsiClient")
+		}
+		framework.ClientsInstance.ExtClient = extcs
+
+		crClient, err := framework.ClientsInstance.GetCrClient()
+		if err != nil {
+			ginkgo.Fail("ERROR, unable to create CrClient")
+		}
+		framework.ClientsInstance.CrClient = crClient
+
+		utils.CacheTestsData(framework.ClientsInstance.K8sClient, framework.ClientsInstance.CdiInstallNs)
+	})
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Transport Tests", func() {
 
 	var (
 		ns  string
-		f   = framework.NewFrameworkOrDie("transport", framework.Config{SkipNamespaceCreation: false})
+		f   = framework.NewFramework("transport", framework.Config{SkipNamespaceCreation: false})
 		c   = f.K8sClient
 		sec *v1.Secret
 	)

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -30,32 +30,31 @@ var _ = Describe("Transport Tests", func() {
 	var (
 		ns  string
 		f   = framework.NewFramework("transport", framework.Config{SkipNamespaceCreation: false})
-		c   = f.K8sClient
 		sec *v1.Secret
 	)
 
 	BeforeEach(func() {
 		ns = f.Namespace.Name
 		By(fmt.Sprintf("Waiting for all \"%s/%s\" deployment replicas to be Ready", f.CdiInstallNs, utils.FileHostName))
-		utils.WaitForDeploymentReplicasReadyOrDie(c, f.CdiInstallNs, utils.FileHostName)
+		utils.WaitForDeploymentReplicasReadyOrDie(f.K8sClient, f.CdiInstallNs, utils.FileHostName)
 	})
 
 	// it() is the body of the test and is executed once per Entry() by DescribeTable()
 	// closes over c and ns
-	it := func(ep, file, accessKey, secretKey, source, certConfigMap string, insecureRegistry, shouldSucceed bool) {
+	it := func(ep func() string, file, accessKey, secretKey, source, certConfigMap string, insecureRegistry, shouldSucceed bool) {
 
 		var (
 			err error // prevent shadowing
 		)
 
 		pvcAnn := map[string]string{
-			controller.AnnEndpoint: ep + "/" + file,
+			controller.AnnEndpoint: ep() + "/" + file,
 			controller.AnnSecret:   "",
 			controller.AnnSource:   source,
 		}
 
 		if accessKey != "" || secretKey != "" {
-			By(fmt.Sprintf("Creating secret for endpoint %s", ep))
+			By(fmt.Sprintf("Creating secret for endpoint %s", ep()))
 			if accessKey == "" {
 				accessKey = utils.AccessKeyValue
 			}
@@ -66,25 +65,25 @@ var _ = Describe("Transport Tests", func() {
 			stringData[common.KeyAccess] = accessKey
 			stringData[common.KeySecret] = secretKey
 
-			sec, err = utils.CreateSecretFromDefinition(c, utils.NewSecretDefinition(nil, stringData, nil, ns, secretPrefix))
+			sec, err = utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, ns, secretPrefix))
 			Expect(err).NotTo(HaveOccurred(), "Error creating test secret")
 			pvcAnn[controller.AnnSecret] = sec.Name
 		}
 
 		if certConfigMap != "" {
-			n, err := utils.CopyConfigMap(c, f.CdiInstallNs, certConfigMap, ns, "")
+			n, err := utils.CopyConfigMap(f.K8sClient, f.CdiInstallNs, certConfigMap, ns, "")
 			Expect(err).To(BeNil())
 			pvcAnn[controller.AnnCertConfigMap] = n
 		}
 
 		if insecureRegistry {
-			err = utils.SetInsecureRegistry(c, f.CdiInstallNs, ep)
+			err = utils.SetInsecureRegistry(f.K8sClient, f.CdiInstallNs, ep())
 			Expect(err).To(BeNil())
-			defer utils.ClearInsecureRegistry(c, f.CdiInstallNs)
+			defer utils.ClearInsecureRegistry(f.K8sClient, f.CdiInstallNs)
 		}
 
 		By(fmt.Sprintf("Creating PVC with endpoint annotation %q", pvcAnn[controller.AnnEndpoint]))
-		pvc, err := utils.CreatePVCFromDefinition(c, ns, utils.NewPVCDefinition("transport-e2e", "400Mi", pvcAnn, nil))
+		pvc, err := utils.CreatePVCFromDefinition(f.K8sClient, ns, utils.NewPVCDefinition("transport-e2e", "400Mi", pvcAnn, nil))
 		Expect(err).NotTo(HaveOccurred(), "Error creating PVC")
 
 		By("Verifying pvc was created")
@@ -119,19 +118,25 @@ var _ = Describe("Transport Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 			Eventually(func() bool {
-				importer, err := utils.FindPodByPrefix(c, ns, common.ImporterPodName, common.CDILabelSelector)
+				importer, err := utils.FindPodByPrefix(f.K8sClient, ns, common.ImporterPodName, common.CDILabelSelector)
 				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", ns+"/"+common.ImporterPodName))
 				return importer.Status.ContainerStatuses[0].RestartCount > 0
 			}, timeout, pollingInterval).Should(BeTrue())
 		}
 	}
 
-	httpNoAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPNoAuthPort)
-	httpsNoAuthEp := fmt.Sprintf("https://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPSNoAuthPort)
-	httpAuthEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPAuthPort)
-	registryNoAuthEp := fmt.Sprintf("docker://%s", utils.RegistryHostName+"."+f.CdiInstallNs)
-	registryAuthEp := fmt.Sprintf("docker://%s.%s:%d", utils.RegistryHostName, f.CdiInstallNs, 1443)
-	altRegistryNoAuthEp := fmt.Sprintf("docker://%s.%s:%d", utils.RegistryHostName, f.CdiInstallNs, 5000)
+	httpNoAuthEp := func() string {
+		return fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPNoAuthPort)
+	}
+	httpsNoAuthEp := func() string {
+		return fmt.Sprintf("https://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPSNoAuthPort)
+	}
+	httpAuthEp := func() string {
+		return fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPAuthPort)
+	}
+	registryNoAuthEp := func() string { return fmt.Sprintf("docker://%s", utils.RegistryHostName+"."+f.CdiInstallNs) }
+	registryAuthEp := func() string { return fmt.Sprintf("docker://%s.%s:%d", utils.RegistryHostName, f.CdiInstallNs, 1443) }
+	altRegistryNoAuthEp := func() string { return fmt.Sprintf("docker://%s.%s:%d", utils.RegistryHostName, f.CdiInstallNs, 5000) }
 	DescribeTable("Transport Test Table", it,
 		Entry("should connect to http endpoint without credentials", httpNoAuthEp, targetFile, "", "", controller.SourceHTTP, "", false, true),
 		Entry("should connect to http endpoint with credentials", httpAuthEp, targetFile, utils.AccessKeyValue, utils.SecretKeyValue, controller.SourceHTTP, "", false, true),

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -52,7 +52,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		portForwardCmd *exec.Cmd
 	)
 
-	f := framework.NewFrameworkOrDie("upload-func-test")
+	f := framework.NewFramework("upload-func-test")
 
 	BeforeEach(func() {
 		if pvc != nil {
@@ -340,7 +340,7 @@ var _ = Describe("Block PV upload Test", func() {
 		portForwardCmd *exec.Cmd
 	)
 
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 
 	BeforeEach(func() {
 		if pvc != nil {
@@ -424,7 +424,7 @@ var _ = Describe("Block PV upload Test", func() {
 })
 
 var _ = Describe("Namespace with quota", func() {
-	f := framework.NewFrameworkOrDie(namespacePrefix)
+	f := framework.NewFramework(namespacePrefix)
 	var (
 		orgConfig      *v1.ResourceRequirements
 		pvc            *v1.PersistentVolumeClaim
@@ -561,7 +561,7 @@ var _ = Describe("Namespace with quota", func() {
 })
 
 var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:component] Upload tests", func() {
-	f := framework.NewFrameworkOrDie("upload-func-test")
+	f := framework.NewFramework("upload-func-test")
 
 	var (
 		pvc        *v1.PersistentVolumeClaim

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	f := framework.NewFrameworkOrDie("clone-auth-webhook-test")
+	f := framework.NewFramework("clone-auth-webhook-test")
 
 	Describe("Verify DataVolume validation", func() {
 		Context("Authorization checks", func() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix functional test framework to work with go >= 1.13. We were not
using the ginkgo ordering correctly, and our framework would call
flag.Parse() too soon, and mess with the go testing flag parsing.
As a result we had to alter some of the variables that we use to build
urls to be functions so that when called the required information is
available.
Fixed several tests not checking for errors.
Fixed dumping code being initialized several times messing with the
order in which failures were reported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: CDI now uses golang 1.14.6
```

