### PR TITLE
Remove potential failed state from DV

### DIFF
--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -19,14 +19,15 @@ package controller
 import (
 	"context"
 	"fmt"
-	storagev1 "k8s.io/api/storage/v1"
-	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
+	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -287,7 +288,7 @@ var _ = Describe("Reconcile Datavolume status", func() {
 		Entry("should remain unset", cdiv1.PhaseUnset, cdiv1.PhaseUnset),
 		Entry("should remain pending", cdiv1.Pending, cdiv1.Pending),
 		Entry("should remain snapshotforsmartcloninginprogress", cdiv1.SnapshotForSmartCloneInProgress, cdiv1.SnapshotForSmartCloneInProgress),
-		Entry("should switch to failed from inprogress", cdiv1.ImportInProgress, cdiv1.Failed),
+		Entry("should remain inprogress", cdiv1.ImportInProgress, cdiv1.ImportInProgress),
 	)
 
 	It("Should switch to pending if PVC phase is pending", func() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove last remaining location where we could set a DV to failed during normal operations. We can still get in failed state due to the PVC claim being lost, but that is the only possibility at this point.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

