### PR TITLE
Update builder to v0.0.6 and include controller-gen install

### DIFF
--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,7 +26,7 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.5}
+BUILDER_TAG=${BUILDER_TAG:-0.0.6}
 BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:bed4f8c2451747f7f26eedce2b435b7538b9a0350b1dc4e928b005acc4c977a6}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER}"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install j2cli && pip3 install operator-courier && \
     ln -s /opt/gradle/gradle-4.3.1/bin/gradle /usr/local/bin/gradle && \
     rm gradle-4.3.1-bin.zip
 
-ENV GIMME_GO_VERSION=1.14.6 GOPATH="/go" KUBEBUILDER_VERSION="2.3.1" ARCH="amd64"
+ENV GIMME_GO_VERSION=1.14.6 GOPATH="/go" KUBEBUILDER_VERSION="2.3.1" ARCH="amd64" GO111MODULE="off"
 ENV BAZEL_PYTHON=/usr/bin/python3
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
@@ -67,20 +67,16 @@ RUN \
     go install ./... ) && \
     ( go get -u golang.org/x/lint/golint ) && \
     ( go get -u github.com/rmohr/go-swagger-utils/swagger-doc ) && \
-    ( go get -u -d k8s.io/klog ) && \
-    ( ln -s /go/src/k8s.io/klog /go/src/k8s.io/klog/v2 ) && \
-    ( go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
-    go get -u -d k8s.io/kube-openapi/cmd/openapi-gen ) && \
-    ( cd $GOPATH/src/k8s.io/code-generator/cmd/deepcopy-gen && \
-    git checkout v0.16.4 && \
-    go install ./... ) && \
-    ( cd $GOPATH/src/k8s.io/kube-openapi/cmd/openapi-gen && \
-    git checkout 30be4d16710ac61bce31eb28a01054596fe6a9f1 && \
-    go install ./... ) && \
+    (go get -u -d sigs.k8s.io/controller-tools/cmd/controller-gen && \
+    cd $GOPATH/src/sigs.k8s.io/controller-tools && \
+    #v0.3.0
+    git checkout 44656d3c15ecaef499d9157825afd843415cbfea && \
+    go install ./...) && \
     (curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz" && \
      tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz && \
      mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH} /usr/local/kubebuilder && \
      rm kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz )
+
 
 ADD entrypoint.sh /entrypoint.sh
 ADD entrypoint-bazel.sh /entrypoint-bazel.sh


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add controller-gen binary to builder image so we can use it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

