### PR TITLE
Make it possible to import images needing conversion from servers that don't support range requests

### DIFF
--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -272,6 +272,12 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 		return nil, uint64(0), true, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
 	}
 
+	acceptRanges, ok := resp.Header["Accept-Ranges"]
+	if !ok || acceptRanges[0] != "bytes" {
+		klog.V(2).Infof("Accept-Ranges isn't bytes, avoiding qemu-img")
+		brokenForQemuImg = true
+	}
+
 	if total == 0 {
 		// The total seems bogus. Let's try the GET Content-Length header
 		total = parseHTTPHeader(resp)

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -273,7 +273,7 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 	}
 
 	acceptRanges, ok := resp.Header["Accept-Ranges"]
-	if !ok || acceptRanges[0] != "bytes" {
+	if !ok || acceptRanges[0] == "none" {
 		klog.V(2).Infof("Accept-Ranges isn't bytes, avoiding qemu-img")
 		brokenForQemuImg = true
 	}

--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Problematic server responses", func() {
 
 	DescribeTable("Importing from cdi bad web server", func(pathname string) {
 		cdiBadServer := fmt.Sprintf("http://cdi-bad-webserver.%s:9090", f.CdiInstallNs)
-		dataVolume = utils.NewDataVolumeWithHTTPImport("badserver-dv", "1Gi", cdiBadServer + pathname)
+		dataVolume = utils.NewDataVolumeWithHTTPImport("badserver-dv", "1Gi", cdiBadServer+pathname)
 		By("creating DataVolume")
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
@@ -32,6 +32,7 @@ var _ = Describe("Problematic server responses", func() {
 	},
 		Entry("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", "/forbidden-HEAD/cirros-qcow2.img"),
 		Entry("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", "/flaky/cirros-qcow2.img"),
+		Entry("Should succeed even if Accept-Ranges doesn't exist", "/no-accept-ranges/cirros-qcow2.img"),
 	)
 
 	AfterEach(func() {

--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -30,8 +30,8 @@ var _ = Describe("Problematic server responses", func() {
 		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 	},
-		Entry("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", "/forbidden-HEAD/tinyCore.iso"),
-		Entry("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", "/flaky/tinyCore.iso"),
+		Entry("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", "/forbidden-HEAD/cirros-qcow2.img"),
+		Entry("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", "/flaky/cirros-qcow2.img"),
 	)
 
 	AfterEach(func() {

--- a/tests/badserver_test.go
+++ b/tests/badserver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerized-data-importer/tests/framework"
@@ -18,11 +19,9 @@ var _ = Describe("Problematic server responses", func() {
 	const dvWaitTimeout = 500 * time.Second
 	var dataVolume *cdiv1.DataVolume
 
-	It("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", func() {
-		badServerTinyCoreIso := "http://cdi-bad-webserver.%s:9090/forbidden-HEAD/tinyCore.iso"
-		tinyCoreIsoURL := fmt.Sprintf(badServerTinyCoreIso, f.CdiInstallNs)
-
-		dataVolume = utils.NewDataVolumeWithHTTPImport("badserver-dv", "1Gi", tinyCoreIsoURL)
+	DescribeTable("Importing from cdi bad web server", func(pathname string) {
+		cdiBadServer := fmt.Sprintf("http://cdi-bad-webserver.%s:9090", f.CdiInstallNs)
+		dataVolume = utils.NewDataVolumeWithHTTPImport("badserver-dv", "1Gi", cdiBadServer + pathname)
 		By("creating DataVolume")
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
@@ -30,21 +29,10 @@ var _ = Describe("Problematic server responses", func() {
 
 		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", func() {
-		badServerTinyCoreIso := "http://cdi-bad-webserver.%s:9090/flaky/tinyCore.iso"
-		tinyCoreIsoURL := fmt.Sprintf(badServerTinyCoreIso, f.CdiInstallNs)
-
-		dataVolume := utils.NewDataVolumeWithHTTPImport("badserver-dv", "1Gi", tinyCoreIsoURL)
-		By("creating DataVolume")
-		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
-		Expect(err).ToNot(HaveOccurred())
-		f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
-
-		err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name, dvWaitTimeout)
-		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("[rfe_id:4109][test_id:4110][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even if HEAD forbidden", "/forbidden-HEAD/tinyCore.iso"),
+		Entry("[rfe_id:4191][test_id:4193][crit:low][vendor:cnv-qe@redhat.com][level:component] Should succeed even on a flaky server", "/flaky/tinyCore.iso"),
+	)
 
 	AfterEach(func() {
 		By("deleting DataVolume")


### PR DESCRIPTION
Some servers don't support range requests, and we have existing fallback for when qemu-img doesn't work, to fetch the file to scratch space and pass the pathname to qemu-img rather than URL. Let's use it.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1073

**Special notes for your reviewer**:
Wrote some tests. Could've probably combined some unit tests in a table, but I'd have to pass a function for every table entry, which seems a bit convoluted.

**Release note**:
```release-note
Support importing from web servers that don't support range requests (used to fail with non-raw images)
```

