### PR TITLE
Change +build ignore tag in tools.go to +build codegen

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,5 @@
 // VSCODE will say this is an error, but it's fine
-// +build ignore
+// +build codegen
 
 package tools
 


### PR DESCRIPTION
so that make deps-update will not ignore it and properly vendor in k8s.io/code-generator.
By using the +build tag will cause the build to not include this code
during a build unless the codegen tag is used.

// +build ignore is special apparently
https://github.com/golang/go/issues/29598

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix make deps-update to properly vendor in code-generator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

