### PR TITLE
fix crd explain

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -146,6 +146,7 @@ if [[ ! -z "$UPGRADE_FROM" ]]; then
 	  exit 1
   fi
   wait_cdi_available
+  _kubectl patch crd cdis.cdi.kubevirt.io -p '{"spec": {"preserveUnknownFields":false}}'
 else
   _kubectl apply -f "./_out/manifests/release/cdi-cr.yaml"
   wait_cdi_available

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -87,6 +88,7 @@ func addReconcileCallbacks(r *ReconcileCDI) {
 	r.addCallback(&corev1.ServiceAccount{}, reconcileCreateSCC)
 	r.addCallback(&appsv1.Deployment{}, reconcileCreateRoute)
 	r.addCallback(&appsv1.Deployment{}, reconcileDeleteSecrets)
+	r.addCallback(&extv1.CustomResourceDefinition{}, reconcileInitializeCRD)
 }
 
 func isControllerDeployment(d *appsv1.Deployment) bool {

--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -25,6 +25,7 @@ import (
 	secv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,6 +168,18 @@ func reconcileServiceAccounts(args *ReconcileCallbackArgs) error {
 			}
 		}
 	}
+
+	return nil
+}
+
+// delete when we no longer support <= 1.21.0
+func reconcileInitializeCRD(args *ReconcileCallbackArgs) error {
+	if args.State != ReconcileStatePreUpdate {
+		return nil
+	}
+
+	crd := args.CurrentObject.(*extv1.CustomResourceDefinition)
+	crd.Spec.PreserveUnknownFields = false
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Explaining CRDs was broken when upgrading.  So, I diff'd a upgraded crd and a newly created crd.  The only meaningful difference was `spec. preserveUnknownFields`.  It was true for the upgraded resources.  Setting it to false (the default with CRD v1) fixed the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Unfortunately, this could only be fixed in a callback function.  This is because `preserveUnknownFields` is a bool with `omitempty` json tag.  Therefore, it doesn't get considered in our json merge algorithm.  Really wish it was a `*bool`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

