### PR TITLE
Adding support to specify CA cert for push images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ bazel-build-images:	bazel-cdi-generate bazel-build
 	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build/bazel-build-images.sh"
 
 bazel-push-images: bazel-cdi-generate bazel-build
-	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build/bazel-push-images.sh"
+	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_CA_CERT_FILE=${DOCKER_CA_CERT_FILE} ./hack/build/bazel-push-images.sh"
 
 push: bazel-push-images
 

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -22,6 +22,8 @@ source "${script_dir}"/config.sh
 BUILDER_SPEC="${BUILD_DIR}/docker/builder"
 BUILDER_VOLUME="kubevirt-cdi-volume"
 BAZEL_BUILDER_SERVER="${BUILDER_VOLUME}-bazel-server"
+DOCKER_CA_CERT_FILE="${DOCKER_CA_CERT_FILE:-}"
+DOCKERIZED_CUSTOM_CA_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
 
 SYNC_OUT=${SYNC_OUT:-true}
 SYNC_VENDOR=${SYNC_VENDOR:-true}
@@ -117,6 +119,10 @@ if [ "${KUBEVIRTCI_RUNTIME}" != "podman" ]; then
     volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 else
     volumes="-v ${BUILDER_VOLUME}:/root:rw,z,exec"
+fi
+
+if [ -n "$DOCKER_CA_CERT_FILE" ] ; then
+    volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
 fi
 
 # Ensure that a bazel server is running

--- a/hack/build/bazel-push-images.sh
+++ b/hack/build/bazel-push-images.sh
@@ -24,6 +24,9 @@ source hack/build/config.sh
 
 docker_tag=$DOCKER_TAG
 docker_prefix=$DOCKER_PREFIX
+if [ -n "$DOCKER_CA_CERT_FILE" ] ; then
+    /usr/bin/update-ca-trust
+fi 
 
 echo "docker_prefix: $docker_prefix"
 for tag in ${docker_tag} ${docker_tag_alt}; do


### PR DESCRIPTION
Signed-off-by: Vishesh Ajay Tanksale <vtanksale@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`make push` fails for a docker registry created with private or self signed CA.
This PR provides user ability to specify the CA cert by pointing `DOCKER_CA_CERT_FILE` to the file containing the CA certs. The CA cert is placed at apporpriate location inside the container building and pushing docker images.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1344

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added ability to specify custom CA cert when pushing docker images
```

