### PR TITLE
Add nbdkit-devel to builder image

### DIFF
--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,7 +26,7 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.7}
+BUILDER_TAG=${BUILDER_TAG:-0.0.8}
 BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:9d0f12fbaec87061fe570af16df64706410c401b7a87fb48a65d814e357c4d12}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER}"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -11,15 +11,15 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 	microdnf update -y && microdnf install -y \
 	bazel \
 	cpio \
-    diffutils \
+	diffutils \
 	git \
 	python3-pip \
 	python3-devel \
 	mercurial \
 	gcc \
-    gcc-c++ \
-    glibc-devel \
-    findutils \
+	gcc-c++ \
+	glibc-devel \
+	findutils \
 	autoconf \
 	automake \
 	libtool \
@@ -27,8 +27,9 @@ RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
 	rsync-daemon \
 	rsync \
 	patch \
-    unzip \
-    java-1.8.0-openjdk \
+	nbdkit-devel \
+	unzip \
+	java-1.8.0-openjdk \
 	btrfs-progs-devel \
 	device-mapper-devel \
 	&& microdnf clean all && \


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds nbdkit-devel to builder image for vddk-datasource. Also fix some tabbing issues with the Dockerfile

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

