### PR TITLE
Use semantic DeepEqual check on DV update

### DIFF
--- a/hack/build/build-manifests.sh
+++ b/hack/build/build-manifests.sh
@@ -39,3 +39,6 @@ generateResourceManifest $generator $MANIFEST_GENERATED_DIR "operator" "everythi
 tempDir=${MANIFEST_TEMPLATE_DIR}
 processDirTemplates ${tempDir} ${OUT_DIR}/manifests ${OUT_DIR}/manifests/templates ${generator} ${MANIFEST_GENERATED_DIR}
 processDirTemplates ${tempDir}/release ${OUT_DIR}/manifests/release ${OUT_DIR}/manifests/templates/release ${generator} ${MANIFEST_GENERATED_DIR}
+
+testsManifestsDir=${CDI_DIR}/tests/manifests
+processDirTemplates ${testsManifestsDir}/templates ${testsManifestsDir}/out ${testsManifestsDir}/out/templates ${generator} ${MANIFEST_GENERATED_DIR}

--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -285,7 +286,7 @@ func (wh *dataVolumeValidatingWebhook) Admit(ar v1beta1.AdmissionReview) *v1beta
 			return toAdmissionResponseError(err)
 		}
 
-		if !reflect.DeepEqual(dv.Spec, oldDV.Spec) {
+		if !apiequality.Semantic.DeepEqual(dv.Spec, oldDV.Spec) {
 			klog.Errorf("Cannot update spec for DataVolume %s/%s", dv.GetNamespace(), dv.GetName())
 			var causes []metav1.StatusCause
 			causes = append(causes, metav1.StatusCause{

--- a/tests/manifests/templates/dv1024MiPVC.yaml.in
+++ b/tests/manifests/templates/dv1024MiPVC.yaml.in
@@ -1,0 +1,14 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: test-dv
+spec:
+  source:
+      http:
+         url: "http://cdi-file-host.{{ .Namespace }}:82/tinyCore.qcow2"
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1024Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in #1341 datavolume-controller mistakenly used reflect.DeepEqual() to check DV spec is not updated, however it rejected even a no-change (of size 4096Mi to 4Gi). This fix uses semantic.DeepEqual() instead so it won't be rejected.

**Which issue(s) this PR fixes**
Fixes #1341

**Special notes for your reviewer**:

**Release note**:
```release-note
Fixed a bug that prevented adding DataVolumes of sizes which are a multiple of 1024 (e.g 5120Mi).
```