### PR TITLE
Sync with HCO definition of node placement values.

### DIFF
--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -315,6 +315,7 @@ type NodePlacement struct {
 	// the node must have each of the indicated key-value pairs as labels
 	// (it can have additional labels as well).
 	// See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+	// +kubebuilder:validation:Optional
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
@@ -322,12 +323,14 @@ type NodePlacement struct {
 	// that can be expressed with nodeSelector.
 	// affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector
 	// See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+	// +kubebuilder:validation:Optional
 	// +optional
-	Affinity corev1.Affinity `json:"affinity,omitempty"`
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
 	// tolerations is a list of tolerations applied to the relevant kind of pods
 	// See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info.
 	// These are additional tolerations other than default ones.
+	// +kubebuilder:validation:Optional
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -130,9 +130,9 @@ func (CDIStatus) SwaggerDoc() map[string]string {
 func (NodePlacement) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":             "NodePlacement describes CDI node scheduling configuration.",
-		"nodeSelector": "nodeSelector is the node selector applied to the relevant kind of pods\nIt specifies a map of key-value pairs: for the pod to be eligible to run on a node,\nthe node must have each of the indicated key-value pairs as labels\n(it can have additional labels as well).\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n+optional",
-		"affinity":     "affinity enables pod affinity/anti-affinity placement expanding the types of constraints\nthat can be expressed with nodeSelector.\naffinity is going to be applied to the relevant kind of pods in parallel with nodeSelector\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity\n+optional",
-		"tolerations":  "tolerations is a list of tolerations applied to the relevant kind of pods\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info.\nThese are additional tolerations other than default ones.\n+optional",
+		"nodeSelector": "nodeSelector is the node selector applied to the relevant kind of pods\nIt specifies a map of key-value pairs: for the pod to be eligible to run on a node,\nthe node must have each of the indicated key-value pairs as labels\n(it can have additional labels as well).\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n+kubebuilder:validation:Optional\n+optional",
+		"affinity":     "affinity enables pod affinity/anti-affinity placement expanding the types of constraints\nthat can be expressed with nodeSelector.\naffinity is going to be applied to the relevant kind of pods in parallel with nodeSelector\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity\n+kubebuilder:validation:Optional\n+optional",
+		"tolerations":  "tolerations is a list of tolerations applied to the relevant kind of pods\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info.\nThese are additional tolerations other than default ones.\n+kubebuilder:validation:Optional\n+optional",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -553,7 +553,11 @@ func (in *NodePlacement) DeepCopyInto(out *NodePlacement) {
 			(*out)[key] = val
 		}
 	}
-	in.Affinity.DeepCopyInto(&out.Affinity)
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -561,7 +561,7 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, sourcePvcNamespace
 			},
 			NodeSelector: workloadNodePlacement.NodeSelector,
 			Tolerations:  workloadNodePlacement.Tolerations,
-			Affinity:     &workloadNodePlacement.Affinity,
+			Affinity:     workloadNodePlacement.Affinity,
 		},
 	}
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -726,7 +726,7 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 			Volumes:       volumes,
 			NodeSelector:  workloadNodePlacement.NodeSelector,
 			Tolerations:   workloadNodePlacement.Tolerations,
-			Affinity:      &workloadNodePlacement.Affinity,
+			Affinity:      workloadNodePlacement.Affinity,
 		},
 	}
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -169,7 +169,7 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 
 		dummyNodeSelector := map[string]string{"kubernetes.io/arch": "amd64"}
 		dummyTolerations := []v1.Toleration{{Key: "test", Value: "123"}}
-		dummyAffinity := v1.Affinity{
+		dummyAffinity := &v1.Affinity{
 			NodeAffinity: &v1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 					NodeSelectorTerms: []v1.NodeSelectorTerm{
@@ -202,7 +202,7 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "importer-testPvc1", Namespace: "default"}, pod)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(*pod.Spec.Affinity).To(Equal(dummyAffinity))
+		Expect(pod.Spec.Affinity).To(Equal(dummyAffinity))
 		Expect(pod.Spec.NodeSelector).To(Equal(dummyNodeSelector))
 		Expect(pod.Spec.Tolerations).To(Equal(dummyTolerations))
 	})

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -714,7 +714,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			},
 			NodeSelector: workloadNodePlacement.NodeSelector,
 			Tolerations:  workloadNodePlacement.Tolerations,
-			Affinity:     &workloadNodePlacement.Affinity,
+			Affinity:     workloadNodePlacement.Affinity,
 		},
 	}
 

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -223,7 +223,7 @@ func CreateDeployment(name, matchKey, matchValue, serviceAccount string, numRepl
 	if infraNodePlacement != nil {
 		deployment.Spec.Template.Spec.NodeSelector = infraNodePlacement.NodeSelector
 		deployment.Spec.Template.Spec.Tolerations = infraNodePlacement.Tolerations
-		deployment.Spec.Template.Spec.Affinity = &infraNodePlacement.Affinity
+		deployment.Spec.Template.Spec.Affinity = infraNodePlacement.Affinity
 	}
 	if serviceAccount != "" {
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccount

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -31,7 +31,7 @@ var (
 	versionRegexGitVersion = regexp.MustCompile(`GitVersion:"v(\d+\.\d+\.\d+)\+?\S*"`)
 	nodeSelectorTestValue  = map[string]string{"kubernetes.io/arch": runtime.GOARCH}
 	tolerationsTestValue   = []v1.Toleration{{Key: "test", Value: "123"}}
-	affinityTestValue      = v1.Affinity{}
+	affinityTestValue      = &v1.Affinity{}
 )
 
 // CDIFailHandler call ginkgo.Fail with printing the additional information
@@ -125,7 +125,7 @@ func GetKubeVersion(f *framework.Framework) string {
 // The values chosen are valid, but the pod will likely not be schedulable.
 func TestNodePlacementValues(f *framework.Framework) cdiv1.NodePlacement {
 	nodes, _ := f.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-	affinityTestValue = v1.Affinity{
+	affinityTestValue = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 				NodeSelectorTerms: []v1.NodeSelectorTerm{
@@ -152,7 +152,7 @@ func PodSpecHasTestNodePlacementValues(f *framework.Framework, podSpec v1.PodSpe
 		fmt.Printf("mismatched nodeSelectors, podSpec:\n%v\nExpected:\n%v\n", podSpec.NodeSelector, nodeSelectorTestValue)
 		return false
 	}
-	if !reflect.DeepEqual(*podSpec.Affinity, affinityTestValue) {
+	if !reflect.DeepEqual(podSpec.Affinity, affinityTestValue) {
 		fmt.Printf("mismatched affinity, podSpec:\n%v\nExpected:\n%v\n", *podSpec.Affinity, affinityTestValue)
 		return false
 	}


### PR DESCRIPTION
But omitting +listType=set because it introduces errors.

Kubevirt wanted to make a small change.
We haven't made a release yet, so it's probably OK to make this change.
[HCO change](https://github.com/kubevirt/hyperconverged-cluster-operator/commit/8dd4177f1eeb906ad6e9e67b400ce5f5e5388aad)
[WIP kubevirt change](https://github.com/kubevirt/kubevirt/pull/4092/files#diff-4e3a0eed2e1047fddf0f53e6778e4daaR31)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

