### PR TITLE
Make CDI infra deployments as critical addons.

### DIFF
--- a/cluster-sync/nfs/nfs-server.yaml
+++ b/cluster-sync/nfs/nfs-server.yaml
@@ -10,42 +10,52 @@ spec:
     requests:
       storage: 30Gi
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: nfs-server
   labels:
     app: "nfs-server"
+    cdi.kubevirt.io/testing: ""
 spec:
-  containers:
-  - image: itsthenetwork/nfs-server-alpine:12
-    imagePullPolicy: IfNotPresent
-    name: nfs-server
-    env:
-    - name: SHARED_DIRECTORY
-      value: /data/nfs
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - mountPath: "/data/nfs"
-      name: nfsdata
-    command: ["/bin/bash", "-c"]
-    args:
-      - |
-        chmod 777 /data/nfs;
-        mkdir /data/nfs/disk1;
-        chmod 777 /data/nfs/disk1;
-        mkdir /data/nfs/disk2;
-        chmod 777 /data/nfs/disk2;
-        mkdir /data/nfs/disk3;
-        chmod 777 /data/nfs/disk3;
-        mkdir /data/nfs/disk4;
-        chmod 777 /data/nfs/disk4;
-        mkdir /data/nfs/disk5;
-        chmod 777 /data/nfs/disk5;
-        /usr/bin/nfsd.sh
-  volumes:
-  - name: nfsdata
-    persistentVolumeClaim:
-      claimName: nfs-data
-
+  selector:
+    matchLabels:
+      app: nfs-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nfs-server
+        cdi.kubevirt.io/testing: ""
+    spec:
+      containers:
+      - image: itsthenetwork/nfs-server-alpine:12
+        imagePullPolicy: IfNotPresent
+        name: nfs-server
+        env:
+        - name: SHARED_DIRECTORY
+          value: /data/nfs
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: "/data/nfs"
+          name: nfsdata
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            chmod 777 /data/nfs;
+            mkdir /data/nfs/disk1;
+            chmod 777 /data/nfs/disk1;
+            mkdir /data/nfs/disk2;
+            chmod 777 /data/nfs/disk2;
+            mkdir /data/nfs/disk3;
+            chmod 777 /data/nfs/disk3;
+            mkdir /data/nfs/disk4;
+            chmod 777 /data/nfs/disk4;
+            mkdir /data/nfs/disk5;
+            chmod 777 /data/nfs/disk5;
+            /usr/bin/nfsd.sh
+      volumes:
+      - name: nfsdata
+        persistentVolumeClaim:
+          claimName: nfs-data

--- a/manifests/templates/release/cdi-cr.yaml.in
+++ b/manifests/templates/release/cdi-cr.yaml.in
@@ -7,6 +7,9 @@ spec:
   infra:
     nodeSelector:
       kubernetes.io/os: linux
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
   workload:
     nodeSelector:
       kubernetes.io/os: linux

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -70,11 +70,11 @@ func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAcco
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
 		},
-		NodeSelector:map[string]string{"kubernetes.io/os":"linux"},
-		Tolerations:[]corev1.Toleration{
+		NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+		Tolerations: []corev1.Toleration{
 			{
-				Key:"CriticalAddonsOnly",
-				Operator:corev1.TolerationOpExists,
+				Key:      "CriticalAddonsOnly",
+				Operator: corev1.TolerationOpExists,
 			},
 		},
 	}

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -70,6 +70,13 @@ func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAcco
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsNonRoot: &[]bool{true}[0],
 		},
+		NodeSelector:map[string]string{"kubernetes.io/os":"linux"},
+		Tolerations:[]corev1.Toleration{
+			{
+				Key:"CriticalAddonsOnly",
+				Operator:corev1.TolerationOpExists,
+			},
+		},
 	}
 	deployment := ResourcesBuiler.CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount, numReplicas, podSpec)
 	return deployment

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -72,7 +72,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -157,6 +157,9 @@ var _ = Describe("Tests needing the restore of nodes", func() {
 	It("should deploy components that tolerate CriticalAddonsOnly taint", func() {
 		var err error
 		cr, err := f.CdiClient.CdiV1beta1().CDIs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			Skip("CDI CR 'cdi' does not exist.  Probably managed by another operator so skipping.")
+		}
 		Expect(err).ToNot(HaveOccurred())
 
 		criticalAddonsToleration := corev1.Toleration{

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Tests needing the restore of nodes", func() {
 		}
 
 		if !tolerationExists(cr.Spec.Infra.Tolerations, criticalAddonsToleration) {
-			Skip("Unexpected CDI CR (not from cdi-cr.yaml), doesn't tolerant CriticalAddonsOnly")
+			Skip("Unexpected CDI CR (not from cdi-cr.yaml), doesn't tolerate CriticalAddonsOnly")
 		}
 
 		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"cdi.kubevirt.io/testing": ""}}


### PR DESCRIPTION
While here, mark cdi-operator as linux-only, it doesn't take
its value from the CDI CR.

**What this PR does / why we need it**:

To cite Daniel Belenky that posted a pull request for this same feature,

> By toleratin the CriticalAddonsOnly taint, we ensure that our components
> will get a reserved spot for critical addons in case they are being
> evicted. This will reduce of chance of CDI component/s starving for a
> place on a node and permanently unavailable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1152

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the CriticalAddonsOnly toleration to CDI infrastructure deployments
```

