### PR TITLE
Fix quota restore function by storing correct original value

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -664,7 +664,7 @@ var _ = Describe("Namespace with quota", func() {
 		By("Capturing original CDIConfig state")
 		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		orgConfig = config.Status.DefaultPodResourceRequirements.DeepCopy()
+		orgConfig = config.Spec.PodResourceRequirements.DeepCopy()
 	})
 
 	AfterEach(func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -445,7 +445,8 @@ var _ = Describe("Namespace with quota", func() {
 		By("Capturing original CDIConfig state")
 		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		orgConfig = config.Status.DefaultPodResourceRequirements
+		orgConfig = config.Spec.PodResourceRequirements
+		fmt.Fprintf(GinkgoWriter, "INFO: original config: %v\n", orgConfig)
 	})
 
 	AfterEach(func() {
@@ -459,6 +460,9 @@ var _ = Describe("Namespace with quota", func() {
 			Expect(err).ToNot(HaveOccurred())
 			return reflect.DeepEqual(config.Spec.PodResourceRequirements, orgConfig)
 		}, timeout, pollingInterval).Should(BeTrue(), "CDIConfig not properly restored to original value")
+		config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		fmt.Fprintf(GinkgoWriter, "INFO: new config: %v\n", config.Spec.PodResourceRequirements)
 	})
 
 	It("Should create import pod in namespace with quota", func() {


### PR DESCRIPTION
instead of status value. This was causing random CI failures.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
#1353 modified the logic that restores quota. However I missed that for import and clone I was saving from the status instead of the spec, causing random CI failures if the order of the tests was just right. This PR fixes that by saving the right original value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1354, #1358 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

