### PR TITLE
Add import network support for importer pod

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -649,6 +649,8 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, sourcePvcNamespace
 		}
 	}
 
+	util.SetPodNetwork(pvc, pod)
+
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
 
 	return pod

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv.GetAnnotations()["test-ann-1"] = "test-value-1"
 		dv.GetAnnotations()["test-ann-2"] = "test-value-2"
 		dv.GetAnnotations()[AnnSource] = "invalid phase should not copy"
+		dv.GetAnnotations()[AnnPodNetwork] = "data-network"
 		reconciler = createDatavolumeReconciler(dv)
 		_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
@@ -107,6 +108,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Expect(pvc.GetAnnotations()["test-ann-1"]).To(Equal("test-value-1"))
 		Expect(pvc.GetAnnotations()["test-ann-2"]).To(Equal("test-value-2"))
 		Expect(pvc.GetAnnotations()[AnnSource]).To(Equal(SourceHTTP))
+		Expect(pvc.GetAnnotations()[AnnPodNetwork]).To(Equal("data-network"))
 	})
 
 	It("Should pass annotation from DV with S3 source to created a PVC on a DV", func() {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -872,8 +872,8 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 		})
 	}
 
-	if pvc.Annotations[AnnImportNetwork] != nil {
-		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = pvc.Annotations[AnnImportNetwork]
+	if net, ok := pvc.Annotations[AnnImportNetwork]; ok {
+		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = net
 	}
 
 	pod.Spec.Containers[0].Env = makeImportEnv(podEnvVar, ownerUID)

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -67,17 +67,14 @@ const (
 	AnnRequiresScratch = AnnAPIGroup + "/storage.import.requiresScratch"
 	// AnnDiskID provides a const for our PVC diskId annotation
 	AnnDiskID = AnnAPIGroup + "/storage.import.diskId"
-<<<<<<< HEAD
 	// AnnUUID provides a const for our PVC uuid annotation
 	AnnUUID = AnnAPIGroup + "/storage.import.uuid"
 	// AnnBackingFile provides a const for our PVC backing file annotation
 	AnnBackingFile = AnnAPIGroup + "/storage.import.backingFile"
 	// AnnThumbprint provides a const for our PVC backing thumbprint annotation
 	AnnThumbprint = AnnAPIGroup + "/storage.import.vddk.thumbprint"
-=======
 	// AnnImportNetwork provides a const for our importNetwork annotation
 	AnnImportNetwork = AnnAPIGroup + "/storage.import.network"
->>>>>>> Add import network support for importer pod
 
 	//LabelImportPvc is a pod label used to find the import pod that was created by the relevant PVC
 	LabelImportPvc = AnnAPIGroup + "/storage.import.importPvcName"

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -872,9 +872,7 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 		})
 	}
 
-	if net, ok := pvc.Annotations[AnnImportNetwork]; ok {
-		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = net
-	}
+	util.SetPodNetwork(pvc, pod)
 
 	pod.Spec.Containers[0].Env = makeImportEnv(podEnvVar, ownerUID)
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -67,12 +67,17 @@ const (
 	AnnRequiresScratch = AnnAPIGroup + "/storage.import.requiresScratch"
 	// AnnDiskID provides a const for our PVC diskId annotation
 	AnnDiskID = AnnAPIGroup + "/storage.import.diskId"
+<<<<<<< HEAD
 	// AnnUUID provides a const for our PVC uuid annotation
 	AnnUUID = AnnAPIGroup + "/storage.import.uuid"
 	// AnnBackingFile provides a const for our PVC backing file annotation
 	AnnBackingFile = AnnAPIGroup + "/storage.import.backingFile"
 	// AnnThumbprint provides a const for our PVC backing thumbprint annotation
 	AnnThumbprint = AnnAPIGroup + "/storage.import.vddk.thumbprint"
+=======
+	// AnnImportNetwork provides a const for our importNetwork annotation
+	AnnImportNetwork = AnnAPIGroup + "/storage.import.network"
+>>>>>>> Add import network support for importer pod
 
 	//LabelImportPvc is a pod label used to find the import pod that was created by the relevant PVC
 	LabelImportPvc = AnnAPIGroup + "/storage.import.importPvcName"
@@ -865,6 +870,10 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 			Name:      "vddk-vol-mount",
 			MountPath: "/opt",
 		})
+	}
+
+	if pvc.Annotations[AnnImportNetwork] != nil {
+		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = pvc.Annotations[AnnImportNetwork]
 	}
 
 	pod.Spec.Containers[0].Env = makeImportEnv(podEnvVar, ownerUID)

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -771,5 +771,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 		})
 	}
 
+	util.SetPodNetwork(pvc, pod)
+
 	return pod
 }

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -81,6 +81,9 @@ const (
 
 	// PodRunningReason is const that defines the pod was started as a reason
 	podRunningReason = "Pod is running"
+
+	// AnnPodNetwork provides a const for our Pod Network annotation
+￼	AnnPodNetwork = AnnAPIGroup + "/storage.pod.network"
 )
 
 func checkPVC(pvc *v1.PersistentVolumeClaim, annotation string, log logr.Logger) bool {
@@ -560,4 +563,11 @@ func IsPopulated(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
 		err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dv)
 		return dv, err
 	})
+}
+
+// SetPodNetwork applies the Pod Network annotation on the pod
+func SetPodNetwork(pvc *v1.PersistentVolumeClaim, pod *v1.Pod) error {
+        if net, ok := pvc.Annotations[AnnPodNetwork]; ok {
+￼		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = net
+￼	}
 }


### PR DESCRIPTION
In an environment where multus is configured, the user should be able to specify the network to use for data import. It could be part of the DataVolume spec and used to generate the ImporterPod spec. This pull request adds support for a new annotation on the PVC that will be used to set the network annotation on the pod.

Fixes #1364 

```release-note
Add support to specify import network in multus environment
```

