### PR TITLE
Update qe-tools dependency to avoid a cryptic Go module issue.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.18.6
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
-	kubevirt.io/qe-tools v0.1.3
+	kubevirt.io/qe-tools v0.1.6
 	sigs.k8s.io/controller-runtime v0.6.2
 	sigs.k8s.io/controller-tools v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -887,8 +887,8 @@ k8s.io/utils v0.0.0-20190712204705-3dccf664f023/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7MpmSnvtrOieolJKoE=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-kubevirt.io/qe-tools v0.1.3 h1:ZDDolkD2IsHuPW8PNyty5fWO6wpI2BXcQpC65en/9FU=
-kubevirt.io/qe-tools v0.1.3/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
+kubevirt.io/qe-tools v0.1.6 h1:S6z9CATmgV2/z9CWetij++Rhu7l/Z4ObZqerLdNMo0Y=
+kubevirt.io/qe-tools v0.1.6/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/controller-runtime v0.6.2 h1:jkAnfdTYBpFwlmBn3pS5HFO06SfxvnTZ1p5PeEF/zAA=

--- a/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/README.md
+++ b/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/README.md
@@ -10,10 +10,13 @@ This reporter fills in the xunit file the needed fields in order to upload it in
 - --polarion-execution=true to enable the reporter
 - --project-id="QE" will be set under 'properties'
 - --polarion-custom-plannedin="QE_1_0" will be set under 'properties'
-- --test-tier="tier1" will be set under 'properties'
 
 #### Optional parameters:
 - --polarion-report-file the output file will be generated under working directory, the default is polarion_results.xml
+- --test-suite-params="OS=EL8 Storage=NFS Arch=x86" will be set under 'properties' and the values will get concatenated to the test run name 
+- --test-id-prefix="PREFIX" will set "PREFIX" for each test ID in test properties, if this parameter is not passed, the project ID parameter is set to be that prefix by default
+- --test-run-template="Existing template name" will create the test run from an existing template
+- --test-run-title="Title" will set the test run title
 
 ### Usage
 
@@ -28,6 +31,6 @@ when executing the tests, in addition to your regular execution parameters,
 add the reporter parameters as specified above
 
 ``` bash
-go test YOUR_PARAMS --polarion-execution=true --project-id="QE" --polarion-custom-plannedin="QE_1_0" --test-tier="tier1" --polarion-report-file="polarion.xml"
+go test YOUR_PARAMS --polarion-execution=true --project-id="QE" --polarion-custom-plannedin="QE_1_0" --polarion-report-file="polarion.xml"
 ```
 Will generate `polarion.xml` file under the work directory that can be imported into polarion.

--- a/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/polarion_reporter.go
+++ b/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/polarion_reporter.go
@@ -39,7 +39,11 @@ func init() {
 	flag.StringVar(&Polarion.ProjectId, "polarion-project-id", "", "Set Polarion project ID")
 	flag.StringVar(&Polarion.Filename, "polarion-report-file", "polarion_results.xml", "Set Polarion report file path")
 	flag.StringVar(&Polarion.PlannedIn, "polarion-custom-plannedin", "", "Set Polarion planned-in ID")
-	flag.StringVar(&Polarion.Tier, "test-tier", "", "Set test tier number")
+	flag.StringVar(&Polarion.LookupMethod, "polarion-lookup-method", "id", "Set Polarion lookup method - id or name")
+	flag.StringVar(&Polarion.TestSuiteParams, "test-suite-params", "", "Set test suite params in space seperated name=value structure. Note that the values will be appended to the test run ID")
+	flag.StringVar(&Polarion.TestIDPrefix, "test-id-prefix", "", "Set Test ID prefix, in the case it is different than project ID")
+	flag.StringVar(&Polarion.TestRunTemplate, "test-run-template", "", "Set Test run template, if you wish to create your test run from an existing template")
+	flag.StringVar(&Polarion.TestRunTitle, "test-run-title", "", "Set Test run title, if you wish to nane your test run")
 }
 
 type PolarionTestSuite struct {
@@ -78,13 +82,17 @@ type PolarionProperty struct {
 }
 
 type PolarionReporter struct {
-	Suite         PolarionTestSuite
-	Run           bool
-	Filename      string
-	TestSuiteName string
-	ProjectId     string
-	PlannedIn     string
-	Tier          string
+	Suite           PolarionTestSuite
+	Run             bool
+	Filename        string
+	TestSuiteName   string
+	ProjectId       string
+	PlannedIn       string
+	LookupMethod    string
+	TestSuiteParams string
+	TestIDPrefix    string
+	TestRunTemplate string
+	TestRunTitle    string
 }
 
 func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
@@ -94,36 +102,38 @@ func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigT
 		TestCases:  []PolarionTestCase{},
 	}
 
-	properties := PolarionProperties{
-		Property: []PolarionProperty{
-			{
-				Name:  "polarion-project-id",
-				Value: reporter.ProjectId,
-			},
-			{
-				Name:  "polarion-lookup-method",
-				Value: "id",
-			},
-			{
-				Name:  "polarion-custom-plannedin",
-				Value: reporter.PlannedIn,
-			},
-			{
-				Name:  "polarion-testrun-id",
-				Value: reporter.PlannedIn + "_" + reporter.Tier,
-			},
-			{
-				Name:  "polarion-custom-isautomated",
-				Value: "True",
-			},
-			{
-				Name:  "polarion-testrun-status-id",
-				Value: "inprogress",
-			},
-		},
+	valuesString := ""
+	suiteParams := strings.Split(reporter.TestSuiteParams, " ")
+	for _, s := range suiteParams {
+		keyValue := strings.Split(s, "=")
+		if len(keyValue) > 1 {
+			valuesString = valuesString + "_" + keyValue[1]
+			reporter.Suite.Properties.Property = addProperty(
+				reporter.Suite.Properties.Property, "polarion-custom-"+keyValue[0], keyValue[1])
+		}
 	}
 
-	reporter.Suite.Properties = properties
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-project-id", reporter.ProjectId)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-lookup-method", reporter.LookupMethod)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-custom-plannedin", reporter.PlannedIn)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-testrun-id", reporter.PlannedIn + valuesString)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-custom-isautomated", "True")
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-testrun-status-id", "inprogress")
+	if reporter.TestRunTemplate != "" {
+		reporter.Suite.Properties.Property = addProperty(
+			reporter.Suite.Properties.Property, "polarion-testrun-template-id", reporter.TestRunTemplate)
+	}
+	if reporter.TestRunTitle != "" {
+		reporter.Suite.Properties.Property = addProperty(
+			reporter.Suite.Properties.Property, "polarion-testrun-title", reporter.TestRunTitle)
+	}
+		
 	reporter.TestSuiteName = summary.SuiteDescription
 }
 
@@ -147,7 +157,11 @@ func (reporter *PolarionReporter) handleSetupSummary(name string, setupSummary *
 			Properties: PolarionProperties{},
 		}
 
-		testCase.Properties = extractTestID(name, reporter.ProjectId)
+		if reporter.TestIDPrefix != "" {
+			testCase.Properties = extractTestID(name, reporter.TestIDPrefix)
+		} else {
+			testCase.Properties = extractTestID(name, reporter.ProjectId)
+		}
 
 		testCase.FailureMessage = &JUnitFailureMessage{
 			Type:    reporter.failureTypeForState(setupSummary.State),
@@ -168,7 +182,11 @@ func (reporter *PolarionReporter) SpecDidComplete(specSummary *types.SpecSummary
 		Name: testName,
 	}
 
-	testCase.Properties = extractTestID(testName, reporter.ProjectId)
+	if reporter.TestIDPrefix != "" {
+		testCase.Properties = extractTestID(testName, reporter.TestIDPrefix)
+	} else {
+		testCase.Properties = extractTestID(testName, reporter.ProjectId)
+	}
 
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		testCase.FailureMessage = &JUnitFailureMessage{
@@ -190,10 +208,6 @@ func (reporter *PolarionReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	}
 	if reporter.PlannedIn == "" {
 		fmt.Println("Can not create Polarion report without planned-in ID")
-		return
-	}
-	if reporter.Tier == "" {
-		fmt.Println("Can not create Polarion report without tier ID")
 		return
 	}
 
@@ -219,7 +233,7 @@ func (reporter *PolarionReporter) failureTypeForState(state types.SpecState) str
 	}
 }
 
-func extractTestID(testname string, ProjectID string) PolarionProperties {
+func extractTestID(testname string, testPrefix string) PolarionProperties {
 	var re = regexp.MustCompile(`test_id:\d+`)
 	properties := PolarionProperties{}
 	testID := re.FindString(testname)
@@ -229,10 +243,19 @@ func extractTestID(testname string, ProjectID string) PolarionProperties {
 			Property: []PolarionProperty{
 				{
 					Name:  "polarion-testcase-id",
-					Value: ProjectID + "-" + testID,
+					Value: testPrefix + "-" + testID,
 				},
 			},
 		}
 	}
+	return properties
+}
+
+func addProperty(properties []PolarionProperty, key string, value string) []PolarionProperty {
+	properties = append(
+		properties, PolarionProperty{
+			Name:  key,
+			Value: value,
+	})
 	return properties
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1167,7 +1167,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# kubevirt.io/qe-tools v0.1.3
+# kubevirt.io/qe-tools v0.1.6
 ## explicit
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml


### PR DESCRIPTION
We vendored the v0.1.3 version, but our vendoring code picked a
few commits before it, missing out on code we need.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

