### PR TITLE
Fix code schema to match what is generated by types.go

### DIFF
--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -210,23 +210,23 @@ func createDataVolumeCRD() *extv1.CustomResourceDefinition {
 													Type:        "object",
 													Properties: map[string]extv1.JSONSchemaProps{
 														"backingFile": {
-															Description: "BackingFile is the path to the disk's backing file in the datastore",
+															Description: "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
 															Type:        "string",
 														},
 														"secretRef": {
-															Description: "SecretRef provides the secret reference needed to access the vcenter or esxi host",
+															Description: "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
 															Type:        "string",
 														},
 														"thumbprint": {
-															Description: "Thumbprint is the certificate thumbprint of the vcenter or esxi host",
+															Description: "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
 															Type:        "string",
 														},
 														"url": {
-															Description: "URL is the URL of the vcenter or esxi host",
+															Description: "URL is the URL of the vCenter or ESXi host with the VM to migrate",
 															Type:        "string",
 														},
 														"uuid": {
-															Description: "UUID is the UUID of the virtual machine the disk is attached to",
+															Description: "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
 															Type:        "string",
 														},
 													},
@@ -624,23 +624,23 @@ func createDataVolumeCRD() *extv1.CustomResourceDefinition {
 													Type:        "object",
 													Properties: map[string]extv1.JSONSchemaProps{
 														"backingFile": {
-															Description: "BackingFile is the path to the disk's backing file in the datastore",
+															Description: "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
 															Type:        "string",
 														},
 														"secretRef": {
-															Description: "SecretRef provides the secret reference needed to access the vcenter or esxi host",
+															Description: "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
 															Type:        "string",
 														},
 														"thumbprint": {
-															Description: "Thumbprint is the certificate thumbprint of the vcenter or esxi host",
+															Description: "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
 															Type:        "string",
 														},
 														"url": {
-															Description: "URL is the URL of the vcenter or esxi host",
+															Description: "URL is the URL of the vCenter or ESXi host with the VM to migrate",
 															Type:        "string",
 														},
 														"uuid": {
-															Description: "UUID is the UUID of the virtual machine the disk is attached to",
+															Description: "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
 															Type:        "string",
 														},
 													},

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -22,10 +22,6 @@ import (
 	"github.com/blang/semver"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version"
-	"golang.org/x/tools/go/packages"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-tools/pkg/loader"
-	"sigs.k8s.io/controller-tools/pkg/markers"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,9 +33,6 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cluster "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
 	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
-
-	crdgen "sigs.k8s.io/controller-tools/pkg/crd"
-	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 )
 
 const (
@@ -284,66 +277,2629 @@ func createCRD(args *FactoryArgs) []runtime.Object {
 	}
 }
 
-func packageErrors(pkg *loader.Package, filterKinds ...packages.ErrorKind) error {
-	toSkip := make(map[packages.ErrorKind]struct{})
-	for _, errKind := range filterKinds {
-		toSkip[errKind] = struct{}{}
-	}
-	var outErr error
-	packages.Visit([]*packages.Package{pkg.Package}, nil, func(pkgRaw *packages.Package) {
-		for _, err := range pkgRaw.Errors {
-			if _, skip := toSkip[err.Kind]; skip {
-				continue
-			}
-			outErr = err
-		}
-	})
-	return outErr
-}
-
 func createCDIListCRD() *extv1.CustomResourceDefinition {
-	pkgs, err := loader.LoadRoots(utils.GetCdiToplevel() + "/...")
-	if err != nil {
-		panic(err)
-	}
-	reg := &markers.Registry{}
-	crdmarkers.Register(reg)
-
-	parser := &crdgen.Parser{
-		Collector: &markers.Collector{Registry: reg},
-		Checker:   &loader.TypeChecker{},
-	}
-	crdgen.AddKnownTypes(parser)
-	if len(pkgs) == 0 {
-		panic("Failed identifying packages")
-	}
-	for _, p := range pkgs {
-		parser.NeedPackage(p)
-	}
-	groupKind := schema.GroupKind{Kind: "CDI", Group: "cdi.kubevirt.io"}
-	parser.NeedCRDFor(groupKind, nil)
-	for _, p := range pkgs {
-		err = packageErrors(p, packages.TypeError)
-		if err != nil {
-			panic(err)
-		}
-	}
-	c := parser.CustomResourceDefinitions[groupKind]
-	// enforce validation of CR name to prevent multiple CRs
-
-	for _, v := range c.Spec.Versions {
-		v.Schema.OpenAPIV3Schema.Properties["metadata"] = extv1.JSONSchemaProps{
-			Type: "object",
-			Properties: map[string]extv1.JSONSchemaProps{
-				"name": {
-					Type:    "string",
-					Pattern: "cdi",
+	return &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cdis.cdi.kubevirt.io",
+			Labels: map[string]string{
+				"operator.cdi.kubevirt.io": "",
+			},
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "cdi.kubevirt.io",
+			Scope: "Cluster",
+			Versions: []extv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: false,
+					Schema: &extv1.CustomResourceValidation{
+						OpenAPIV3Schema: &extv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "CDI is the CDI Operator CRD",
+							Properties: map[string]extv1.JSONSchemaProps{
+								// We are aware apiVersion, kind, and metadata are technically not needed, but to make comparision with
+								// kubebuilder easier, we add it here.
+								"apiVersion": {
+									Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+									Type:        "string",
+								},
+								"kind": {
+									Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+									Type:        "string",
+								},
+								"metadata": {
+									Type: "object",
+								},
+								"spec": {
+									Properties: map[string]extv1.JSONSchemaProps{
+										"imagePullPolicy": {
+											Description: "PullPolicy describes a policy for if/when to pull a container image",
+											Type:        "string",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"Always"`),
+												},
+												{
+													Raw: []byte(`"IfNotPresent"`),
+												},
+												{
+													Raw: []byte(`"Never"`),
+												},
+											},
+										},
+										"infra": {
+											Description: "Rules on which nodes CDI infrastructure pods will be scheduled",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"affinity": {
+													Description: "affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"nodeAffinity": {
+															Description: "Describes node affinity scheduling rules for the pod.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"preference": {
+																					Description: "A node selector term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"weight": {
+																					Description: "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+																					Format:      "int32",
+																					Type:        "integer",
+																				},
+																			},
+																			Required: []string{
+																				"preference",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+																	Type:        "object",
+																	Properties: map[string]extv1.JSONSchemaProps{
+																		"nodeSelectorTerms": {
+																			Description: "Required. A list of node selector terms. The terms are ORed.",
+																			Type:        "array",
+																			Items: &extv1.JSONSchemaPropsOrArray{
+																				Schema: &extv1.JSONSchemaProps{
+																					Description: "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"nodeSelectorTerms",
+																	},
+																},
+															},
+														},
+														"podAffinity": {
+															Description: "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+														"podAntiAffinity": {
+															Description: "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"nodeSelector": {
+													Description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector",
+													Type:        "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "string",
+														},
+													},
+												},
+												"tolerations": {
+													Description: "tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.",
+													Type:        "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"effect": {
+																	Description: "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+																	Type:        "string",
+																},
+																"key": {
+																	Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+																	Type:        "string",
+																},
+																"operator": {
+																	Description: "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+																	Type:        "string",
+																},
+																"tolerationSeconds": {
+																	Description: "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+																	Type:        "integer",
+																	Format:      "int64",
+																},
+																"value": {
+																	Description: "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+																	Type:        "string",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"workload": {
+											Description: "Restrict on which nodes CDI workload pods will be scheduled",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"affinity": {
+													Description: "affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"nodeAffinity": {
+															Description: "Describes node affinity scheduling rules for the pod.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"preference": {
+																					Description: "A node selector term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"weight": {
+																					Description: "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+																					Format:      "int32",
+																					Type:        "integer",
+																				},
+																			},
+																			Required: []string{
+																				"preference",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+																	Type:        "object",
+																	Properties: map[string]extv1.JSONSchemaProps{
+																		"nodeSelectorTerms": {
+																			Description: "Required. A list of node selector terms. The terms are ORed.",
+																			Type:        "array",
+																			Items: &extv1.JSONSchemaPropsOrArray{
+																				Schema: &extv1.JSONSchemaProps{
+																					Description: "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"nodeSelectorTerms",
+																	},
+																},
+															},
+														},
+														"podAffinity": {
+															Description: "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+														"podAntiAffinity": {
+															Description: "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"nodeSelector": {
+													Description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector",
+													Type:        "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "string",
+														},
+													},
+												},
+												"tolerations": {
+													Description: "tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.",
+													Type:        "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"effect": {
+																	Description: "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+																	Type:        "string",
+																},
+																"key": {
+																	Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+																	Type:        "string",
+																},
+																"operator": {
+																	Description: "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+																	Type:        "string",
+																},
+																"tolerationSeconds": {
+																	Description: "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+																	Type:        "integer",
+																	Format:      "int64",
+																},
+																"value": {
+																	Description: "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+																	Type:        "string",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"uninstallStrategy": {
+											Type:        "string",
+											Description: "CDIUninstallStrategy defines the state to leave CDI on uninstall",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"RemoveWorkloads"`),
+												},
+												{
+													Raw: []byte(`"BlockUninstallIfWorkloadsExist"`),
+												},
+											},
+										},
+									},
+									Type:        "object",
+									Description: "CDISpec defines our specification for the CDI installation",
+								},
+								"status": {
+									Type:        "object",
+									Description: "CDIStatus defines the status of the CDI installation",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"targetVersion": {
+											Description: "The desired version of the CDI resource",
+											Type:        "string",
+										},
+										"observedVersion": {
+											Description: "The observed version of the CDI resource",
+											Type:        "string",
+										},
+										"operatorVersion": {
+											Description: "The version of the CDI resource as defined by the operator",
+											Type:        "string",
+										},
+										"phase": {
+											Description: "CDIPhase is the current phase of the CDI deployment",
+											Type:        "string",
+										},
+										"conditions": {
+											Description: "A list of current conditions of the CDI resource",
+											Type:        "array",
+											Items: &extv1.JSONSchemaPropsOrArray{
+												Schema: &extv1.JSONSchemaProps{
+													Type:        "object",
+													Description: "Condition represents the state of the operator's reconciliation functionality.",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastHeartbeatTime": {
+															Type:   "string",
+															Format: "date-time",
+														},
+														"lastTransitionTime": {
+															Type:   "string",
+															Format: "date-time",
+														},
+														"message": {
+															Type: "string",
+														},
+														"reason": {
+															Type: "string",
+														},
+														"status": {
+															Type: "string",
+														},
+														"type": {
+															Description: "ConditionType is the state of the operator's reconciliation functionality.",
+															Type:        "string",
+														},
+													},
+													Required: []string{
+														"status",
+														"type",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Required: []string{
+								"spec",
+							},
+						},
+					},
+					AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+						{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+						{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+					},
+					Subresources: &extv1.CustomResourceSubresources{},
+				},
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: true,
+					Schema: &extv1.CustomResourceValidation{
+						OpenAPIV3Schema: &extv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "CDI is the CDI Operator CRD",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"apiVersion": {
+									Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+									Type:        "string",
+								},
+								"kind": {
+									Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+									Type:        "string",
+								},
+								"metadata": {
+									Type: "object",
+								},
+								"spec": {
+									Properties: map[string]extv1.JSONSchemaProps{
+										"imagePullPolicy": {
+											Description: "PullPolicy describes a policy for if/when to pull a container image",
+											Type:        "string",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"Always"`),
+												},
+												{
+													Raw: []byte(`"IfNotPresent"`),
+												},
+												{
+													Raw: []byte(`"Never"`),
+												},
+											},
+										},
+										"infra": {
+											Description: "Rules on which nodes CDI infrastructure pods will be scheduled",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"affinity": {
+													Description: "affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"nodeAffinity": {
+															Description: "Describes node affinity scheduling rules for the pod.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"preference": {
+																					Description: "A node selector term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"weight": {
+																					Description: "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+																					Format:      "int32",
+																					Type:        "integer",
+																				},
+																			},
+																			Required: []string{
+																				"preference",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+																	Type:        "object",
+																	Properties: map[string]extv1.JSONSchemaProps{
+																		"nodeSelectorTerms": {
+																			Description: "Required. A list of node selector terms. The terms are ORed.",
+																			Type:        "array",
+																			Items: &extv1.JSONSchemaPropsOrArray{
+																				Schema: &extv1.JSONSchemaProps{
+																					Description: "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"nodeSelectorTerms",
+																	},
+																},
+															},
+														},
+														"podAffinity": {
+															Description: "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+														"podAntiAffinity": {
+															Description: "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"nodeSelector": {
+													Description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector",
+													Type:        "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "string",
+														},
+													},
+												},
+												"tolerations": {
+													Description: "tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.",
+													Type:        "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"effect": {
+																	Description: "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+																	Type:        "string",
+																},
+																"key": {
+																	Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+																	Type:        "string",
+																},
+																"operator": {
+																	Description: "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+																	Type:        "string",
+																},
+																"tolerationSeconds": {
+																	Description: "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+																	Type:        "integer",
+																	Format:      "int64",
+																},
+																"value": {
+																	Description: "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+																	Type:        "string",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"workload": {
+											Description: "Restrict on which nodes CDI workload pods will be scheduled",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"affinity": {
+													Description: "affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"nodeAffinity": {
+															Description: "Describes node affinity scheduling rules for the pod.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"preference": {
+																					Description: "A node selector term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"weight": {
+																					Description: "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+																					Format:      "int32",
+																					Type:        "integer",
+																				},
+																			},
+																			Required: []string{
+																				"preference",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+																	Type:        "object",
+																	Properties: map[string]extv1.JSONSchemaProps{
+																		"nodeSelectorTerms": {
+																			Description: "Required. A list of node selector terms. The terms are ORed.",
+																			Type:        "array",
+																			Items: &extv1.JSONSchemaPropsOrArray{
+																				Schema: &extv1.JSONSchemaProps{
+																					Description: "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "A list of node selector requirements by node's labels.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchFields": {
+																							Description: "A list of node selector requirements by node's fields.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "The label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"nodeSelectorTerms",
+																	},
+																},
+															},
+														},
+														"podAffinity": {
+															Description: "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+														"podAntiAffinity": {
+															Description: "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"preferredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"podAffinityTerm": {
+																					Description: "Required. A pod affinity term, associated with the corresponding weight.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"labelSelector": {
+																							Description: "A label query over a set of resources, in this case pods.",
+																							Type:        "object",
+																							Properties: map[string]extv1.JSONSchemaProps{
+																								"matchExpressions": {
+																									Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																									Type:        "array",
+																									Items: &extv1.JSONSchemaPropsOrArray{
+																										Schema: &extv1.JSONSchemaProps{
+																											Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																											Type:        "object",
+																											Properties: map[string]extv1.JSONSchemaProps{
+																												"key": {
+																													Description: "key is the label key that the selector applies to.",
+																													Type:        "string",
+																												},
+																												"operator": {
+																													Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																													Type:        "string",
+																												},
+																												"values": {
+																													Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																													Type:        "array",
+																													Items: &extv1.JSONSchemaPropsOrArray{
+																														Schema: &extv1.JSONSchemaProps{
+																															Type: "string",
+																														},
+																													},
+																												},
+																											},
+																											Required: []string{
+																												"key",
+																												"operator",
+																											},
+																										},
+																									},
+																								},
+																								"matchLabels": {
+																									Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																									Type:        "object",
+																									AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																										Schema: &extv1.JSONSchemaProps{
+																											Type: "string",
+																										},
+																									},
+																								},
+																							},
+																						},
+																						"namespaces": {
+																							Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																						"topologyKey": {
+																							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																							Type:        "string",
+																						},
+																					},
+																					Required: []string{
+																						"topologyKey",
+																					},
+																				},
+																				"weight": {
+																					Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+																					Type:        "integer",
+																					Format:      "int32",
+																				},
+																			},
+																			Required: []string{
+																				"podAffinityTerm",
+																				"weight",
+																			},
+																		},
+																	},
+																},
+																"requiredDuringSchedulingIgnoredDuringExecution": {
+																	Description: "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+																	Type:        "array",
+																	Items: &extv1.JSONSchemaPropsOrArray{
+																		Schema: &extv1.JSONSchemaProps{
+																			Description: "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+																			Type:        "object",
+																			Properties: map[string]extv1.JSONSchemaProps{
+																				"labelSelector": {
+																					Description: "A label query over a set of resources, in this case pods.",
+																					Type:        "object",
+																					Properties: map[string]extv1.JSONSchemaProps{
+																						"matchExpressions": {
+																							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+																							Type:        "array",
+																							Items: &extv1.JSONSchemaPropsOrArray{
+																								Schema: &extv1.JSONSchemaProps{
+																									Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+																									Type:        "object",
+																									Properties: map[string]extv1.JSONSchemaProps{
+																										"key": {
+																											Description: "key is the label key that the selector applies to.",
+																											Type:        "string",
+																										},
+																										"operator": {
+																											Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+																											Type:        "string",
+																										},
+																										"values": {
+																											Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+																											Type:        "array",
+																											Items: &extv1.JSONSchemaPropsOrArray{
+																												Schema: &extv1.JSONSchemaProps{
+																													Type: "string",
+																												},
+																											},
+																										},
+																									},
+																									Required: []string{
+																										"key",
+																										"operator",
+																									},
+																								},
+																							},
+																						},
+																						"matchLabels": {
+																							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+																							Type:        "object",
+																							AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																								Schema: &extv1.JSONSchemaProps{
+																									Type: "string",
+																								},
+																							},
+																						},
+																					},
+																				},
+																				"namespaces": {
+																					Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+																					Type:        "array",
+																					Items: &extv1.JSONSchemaPropsOrArray{
+																						Schema: &extv1.JSONSchemaProps{
+																							Type: "string",
+																						},
+																					},
+																				},
+																				"topologyKey": {
+																					Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+																					Type:        "string",
+																				},
+																			},
+																			Required: []string{
+																				"topologyKey",
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"nodeSelector": {
+													Description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector",
+													Type:        "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "string",
+														},
+													},
+												},
+												"tolerations": {
+													Description: "tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.",
+													Type:        "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+															Type:        "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"effect": {
+																	Description: "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+																	Type:        "string",
+																},
+																"key": {
+																	Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+																	Type:        "string",
+																},
+																"operator": {
+																	Description: "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+																	Type:        "string",
+																},
+																"tolerationSeconds": {
+																	Description: "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+																	Type:        "integer",
+																	Format:      "int64",
+																},
+																"value": {
+																	Description: "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+																	Type:        "string",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"uninstallStrategy": {
+											Type:        "string",
+											Description: "CDIUninstallStrategy defines the state to leave CDI on uninstall",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"RemoveWorkloads"`),
+												},
+												{
+													Raw: []byte(`"BlockUninstallIfWorkloadsExist"`),
+												},
+											},
+										},
+									},
+									Type:        "object",
+									Description: "CDISpec defines our specification for the CDI installation",
+								},
+								"status": {
+									Type:        "object",
+									Description: "CDIStatus defines the status of the CDI installation",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"targetVersion": {
+											Description: "The desired version of the CDI resource",
+											Type:        "string",
+										},
+										"observedVersion": {
+											Description: "The observed version of the CDI resource",
+											Type:        "string",
+										},
+										"operatorVersion": {
+											Description: "The version of the CDI resource as defined by the operator",
+											Type:        "string",
+										},
+										"phase": {
+											Description: "CDIPhase is the current phase of the CDI deployment",
+											Type:        "string",
+										},
+										"conditions": {
+											Description: "A list of current conditions of the CDI resource",
+											Type:        "array",
+											Items: &extv1.JSONSchemaPropsOrArray{
+												Schema: &extv1.JSONSchemaProps{
+													Type:        "object",
+													Description: "Condition represents the state of the operator's reconciliation functionality.",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastHeartbeatTime": {
+															Type:   "string",
+															Format: "date-time",
+														},
+														"lastTransitionTime": {
+															Type:   "string",
+															Format: "date-time",
+														},
+														"message": {
+															Type: "string",
+														},
+														"reason": {
+															Type: "string",
+														},
+														"status": {
+															Type: "string",
+														},
+														"type": {
+															Description: "ConditionType is the state of the operator's reconciliation functionality.",
+															Type:        "string",
+														},
+													},
+													Required: []string{
+														"status",
+														"type",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Required: []string{
+								"spec",
+							},
+						},
+					},
+					AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+						{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+						{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+					},
+					Subresources: &extv1.CustomResourceSubresources{},
 				},
 			},
-		}
+			Conversion: &extv1.CustomResourceConversion{
+				Strategy: extv1.NoneConverter,
+			},
+			Names: extv1.CustomResourceDefinitionNames{
+				Kind:       "CDI",
+				ListKind:   "CDIList",
+				Plural:     "cdis",
+				Singular:   "cdi",
+				ShortNames: []string{"cdi", "cdis"},
+			},
+		},
 	}
-
-	return &c
 }
 
 func createOperatorEnvVar(operatorVersion, deployClusterResources, operatorImage, controllerImage, importerImage, clonerImage, apiServerImage, uploadProxyImage, uploadServerImage, verbosity, pullPolicy string) []corev1.EnvVar {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The new 'generator' way does not work when go is not installed. So this PR reverts that code, and adds all the required code to match the current state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

