### PR TITLE
Change how we look up the node placement.

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -117,13 +117,6 @@ func newReconciler(mgr manager.Manager) (*ReconcileCDI, error) {
 		return nil, err
 	}
 
-	infraNodePlacement, err := getInfraNodePlacement(uncachedClient)
-	if err != nil {
-		return nil, err
-	}
-
-	namespacedArgs.InfraNodePlacement = infraNodePlacement
-
 	r := &ReconcileCDI{
 		client:         mgr.GetClient(),
 		uncachedClient: uncachedClient,
@@ -240,6 +233,8 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		reqLogger.Info("Reconciling to error state, unwanted CDI object")
 		return r.reconcileError(reqLogger, cr, "Reconciling to error state, unwanted CDI object")
 	}
+
+	r.namespacedArgs.InfraNodePlacement = &cr.Spec.Infra
 
 	currentConditionValues := GetConditionValues(cr.Status.Conditions)
 	reqLogger.Info("Doing reconcile update")
@@ -1054,14 +1049,4 @@ func sameResource(obj1, obj2 runtime.Object) bool {
 	}
 
 	return true
-}
-
-func getInfraNodePlacement(c client.Client) (*cdiv1.NodePlacement, error) {
-	cr := &cdiv1.CDI{}
-	crKey := client.ObjectKey{Namespace: "", Name: "cdi"}
-	if err := c.Get(context.TODO(), crKey, cr); err != nil {
-		return nil, err
-	}
-
-	return &cr.Spec.Infra, nil
 }

--- a/pkg/operator/resources/operator/BUILD.bazel
+++ b/pkg/operator/resources/operator/BUILD.bazel
@@ -16,18 +16,12 @@ go_library(
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1:go_default_library",
         "//vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version:go_default_library",
-        "//vendor/golang.org/x/tools/go/packages:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/sigs.k8s.io/controller-tools/pkg/crd:go_default_library",
-        "//vendor/sigs.k8s.io/controller-tools/pkg/crd/markers:go_default_library",
-        "//vendor/sigs.k8s.io/controller-tools/pkg/loader:go_default_library",
-        "//vendor/sigs.k8s.io/controller-tools/pkg/markers:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Instead of trying to do it during the reconcile object creation, do it during the reconcile loop where
we already look up the CR anyway, and setting the value is free.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes an issue where we tried to look up the CR to find the node placement information during the creation of the reconciler. The CR might not exist at that point in time and it would fail. For example here: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/803 Instead set the node placement information during the reconcile loop since we are
already looking up the CR there anyway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

