### PR TITLE
Skip the test if CDI CR is called something else

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -143,6 +143,9 @@ var _ = Describe("[rfe_id:4784][crit:high] Importer respects node placement", fu
 	BeforeEach(func() {
 		var err error
 		cr, err = f.CdiClient.CdiV1beta1().CDIs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			Skip("CDI CR 'cdi' does not exist.  Probably managed by another operator so skipping.")
+		}
 		Expect(err).ToNot(HaveOccurred())
 
 		oldSpec = cr.Spec.DeepCopy()


### PR DESCRIPTION
For example if it's deployed by HCO

**What this PR does / why we need it**:

Follow up to #1383, this is how the operator_tests.go code handles it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

