### PR TITLE
Remove dependency update when building the OR CI build image

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -6,7 +6,6 @@ ENV KUBEVIRT_RUN_UNNESTED=true
 
 RUN source /etc/profile.d/gimme.sh && \
     export GOPATH="/go" && \
-    go mod vendor && \
     ./hack/ci/build.sh
 
 ENTRYPOINT [ "/entrypoint-bazel.sh" ]


### PR DESCRIPTION
When there is a problem with dependencies, the build fails for the
entire CDI.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Failure when building a OR CI image should not fail the entire CDI build.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

