### PR TITLE
Only test upgrading from latest release to current if random_cr not set

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -54,7 +54,8 @@ if [[ -n "$MULTI_UPGRADE" ]]; then
   export UPGRADE_FROM="v1.10.7 v1.11.0 v1.12.0 v1.13.2 v1.14.0 v1.15.0"
 fi
 
-if [[ -z "$UPGRADE_FROM" ]]; then
+# Don't upgrade if we are using a random CR name, otherwise the upgrade will fail
+if [[ -z "$UPGRADE_FROM" ]] && [[ -z "$RANDOM_CR" ]]; then
   export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
   echo "Upgrading from verions: $UPGRADE_FROM"
 fi


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Don't test the upgrade from latest release to current PR if RANDOM_CR variable is set. If it is set, then the wait will fail because it is looking for the wrong CR name. If it is set we explicitly want a different CR name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

