### PR TITLE
Clone auth for serviceaccounts should include groups

### DIFF
--- a/pkg/clone/auth.go
+++ b/pkg/clone/auth.go
@@ -65,7 +65,8 @@ func CanServiceAccountClonePVC(client kubernetes.Interface, pvcNamespace, pvcNam
 	user := fmt.Sprintf("system:serviceaccount:%s:%s", saNamespace, saName)
 
 	sarSpec := authorization.SubjectAccessReviewSpec{
-		User: user,
+		User:   user,
+		Groups: []string{"system:serviceaccounts", "system:serviceaccounts:" + saNamespace},
 	}
 
 	return sendSubjectAccessReviews(client, pvcNamespace, pvcName, sarSpec)

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/util/naming:go_default_library",
         "//tests/reporters:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1:go_default_library",
+        "//vendor/github.com/kubevirt/controller-lifecycle-operator-sdk/pkg/sdk/api:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -176,6 +176,11 @@ func createConfigReaderClusterRoleBinding(name string) *rbacv1.ClusterRoleBindin
 				Name:     "system:authenticated",
 				APIGroup: "rbac.authorization.k8s.io",
 			},
+			{
+				Kind:     "Group",
+				Name:     "system:serviceaccount",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Need this in order easily implement cloning from "golden namespace"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

