### PR TITLE
Fix incorrect region parsing from aws s3 endpoint

### DIFF
--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -173,8 +174,15 @@ func getS3Client(endpoint, accessKey, secKey string) (S3Client, error) {
 }
 
 func extractRegion(s string) string {
-	splitted := strings.Split(s, ".")
-	return splitted[0]
+	var region string
+	r, _ := regexp.Compile("s3\\.(.+)\\.amazonaws\\.com")
+	if matches := r.FindStringSubmatch(s); matches != nil {
+		region = matches[1]
+	} else {
+		region = strings.Split(s, ".")[0]
+	}
+
+	return region
 }
 
 func extractBucketAndObject(s string) (string, string) {


### PR DESCRIPTION
Signed-off-by: Yao-Tsung Hsu <ytsunghsu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In Amazon S3, path-style URLs follow the format `https://s3.<region>.amazonaws.com/<bucket-name>/<key-name>`. 
(Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html)

In this PR, the extractRegion function uses regular expression to see whether the endpoint is an aws s3 endpoint.
If it is an aws s3 endpoint, extract region from the submatch; otherwise, fallback to the original method of extracting the region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1381

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

