### PR TITLE
Change clone authorization api to allow any k8s client version

### DIFF
--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//vendor/github.com/appscode/jsonpatch:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -59,7 +59,7 @@ func NewDataVolumeValidatingWebhook(client kubernetes.Interface) http.Handler {
 // NewDataVolumeMutatingWebhook creates a new DataVolumeMutation webhook
 func NewDataVolumeMutatingWebhook(client kubernetes.Interface, key *rsa.PrivateKey) http.Handler {
 	generator := newCloneTokenGenerator(key)
-	return newAdmissionHandler(&dataVolumeMutatingWebhook{client: client, tokenGenerator: generator})
+	return newAdmissionHandler(&dataVolumeMutatingWebhook{client: client, tokenGenerator: generator, proxy: &sarProxy{client: client}})
 }
 
 // NewCDIValidatingWebhook creates a new CDI validating webhook

--- a/pkg/clone/BUILD.bazel
+++ b/pkg/clone/BUILD.bazel
@@ -6,11 +6,9 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/clone",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/core/v1beta1:go_default_library",
+        "//pkg/apis/core/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/clone/auth.go
+++ b/pkg/clone/auth.go
@@ -20,20 +20,22 @@
 package clone
 
 import (
-	"context"
 	"fmt"
 
 	authentication "k8s.io/api/authentication/v1"
 	authorization "k8s.io/api/authorization/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 )
 
+// SubjectAccessReviewsProxy proxies calls to work with SubjectAccessReviews
+type SubjectAccessReviewsProxy interface {
+	Create(*authorization.SubjectAccessReview) (*authorization.SubjectAccessReview, error)
+}
+
 // CanUserClonePVC checks if a user has "appropriate" permission to clone from the given PVC
-func CanUserClonePVC(client kubernetes.Interface, sourceNamespace, pvcName, targetNamespace string,
+func CanUserClonePVC(client SubjectAccessReviewsProxy, sourceNamespace, pvcName, targetNamespace string,
 	userInfo authentication.UserInfo) (bool, string, error) {
 	if sourceNamespace == targetNamespace {
 		return true, "", nil
@@ -57,7 +59,7 @@ func CanUserClonePVC(client kubernetes.Interface, sourceNamespace, pvcName, targ
 }
 
 // CanServiceAccountClonePVC checks if a ServiceAccount has "appropriate" permission to clone from the given PVC
-func CanServiceAccountClonePVC(client kubernetes.Interface, pvcNamespace, pvcName, saNamespace, saName string) (bool, string, error) {
+func CanServiceAccountClonePVC(client SubjectAccessReviewsProxy, pvcNamespace, pvcName, saNamespace, saName string) (bool, string, error) {
 	if pvcNamespace == saNamespace {
 		return true, "", nil
 	}
@@ -72,7 +74,7 @@ func CanServiceAccountClonePVC(client kubernetes.Interface, pvcNamespace, pvcNam
 	return sendSubjectAccessReviews(client, pvcNamespace, pvcName, sarSpec)
 }
 
-func sendSubjectAccessReviews(client kubernetes.Interface, namespace, name string, sarSpec authorization.SubjectAccessReviewSpec) (bool, string, error) {
+func sendSubjectAccessReviews(client SubjectAccessReviewsProxy, namespace, name string, sarSpec authorization.SubjectAccessReviewSpec) (bool, string, error) {
 	allowed := false
 
 	for _, ra := range getResourceAttributes(namespace, name) {
@@ -83,7 +85,7 @@ func sendSubjectAccessReviews(client kubernetes.Interface, namespace, name strin
 
 		klog.V(3).Infof("Sending SubjectAccessReview %+v", sar)
 
-		response, err := client.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+		response, err := client.Create(sar)
 		if err != nil {
 			return false, "", err
 		}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//vendor/github.com/openshift/client-go/security/clientset/versioned:go_default_library",
         "//vendor/github.com/openshift/custom-resource-status/conditions/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

KubeVirt is on old k8s client so can't share any code that references k8s client directly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

