### PR TITLE
Add library function to determine if a PVC has been populated fully.

### DIFF
--- a/pkg/apis/core/v1alpha1/BUILD.bazel
+++ b/pkg/apis/core/v1alpha1/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "register.go",
         "types.go",
         "types_swagger_generated.go",
+        "utils.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1",

--- a/pkg/apis/core/v1alpha1/utils.go
+++ b/pkg/apis/core/v1alpha1/utils.go
@@ -21,11 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// PopulationComplete indicates if the persistent volume passed in has been fully populated. It follow the following logic
+// IsPopulated indicates if the persistent volume passed in has been fully populated. It follow the following logic
 // 1. If the PVC is not owned by a DataVolume, return true, we assume someone else has properly populated the image
 // 2. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase succeeded return true
 // 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !succeeded return false
-func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
+func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
 	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
 		// Find the data volume:
@@ -33,10 +33,9 @@ func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, 
 		if err != nil {
 			return false, err
 		}
-		if dv.Status.Phase == Succeeded {
-			return true, nil
+		if dv.Status.Phase != Succeeded {
+			return false, nil
 		}
-		return false, nil
 	}
 	return true, nil
 }

--- a/pkg/apis/core/v1alpha1/utils.go
+++ b/pkg/apis/core/v1alpha1/utils.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PopulationComplete indicates if the persistent volume passed in has been fully populated. It follow the following logic
+// 1. If the PVC is not owned by a DataVolume, return true, we assume someone else has properly populated the image
+// 2. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase succeeded return true
+// 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !succeeded return false
+func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
+	pvcOwner := metav1.GetControllerOf(pvc)
+	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
+		// Find the data volume:
+		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
+		if err != nil {
+			return false, err
+		}
+		if dv.Status.Phase == Succeeded {
+			return true, nil
+		}
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/apis/core/v1beta1/BUILD.bazel
+++ b/pkg/apis/core/v1beta1/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "register.go",
         "types.go",
         "types_swagger_generated.go",
+        "utils.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1",

--- a/pkg/apis/core/v1beta1/utils.go
+++ b/pkg/apis/core/v1beta1/utils.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PopulationComplete indicates if the persistent volume passed in has been fully populated. It follow the following logic
+// 1. If the PVC is not owned by a DataVolume, return true, we assume someone else has properly populated the image
+// 2. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase succeeded return true
+// 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !succeeded return false
+func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
+	pvcOwner := metav1.GetControllerOf(pvc)
+	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
+		// Find the data volume:
+		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
+		if err != nil {
+			return false, err
+		}
+		if dv.Status.Phase == Succeeded {
+			return true, nil
+		}
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/apis/core/v1beta1/utils.go
+++ b/pkg/apis/core/v1beta1/utils.go
@@ -21,11 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// PopulationComplete indicates if the persistent volume passed in has been fully populated. It follow the following logic
+// IsPopulated indicates if the persistent volume passed in has been fully populated. It follow the following logic
 // 1. If the PVC is not owned by a DataVolume, return true, we assume someone else has properly populated the image
 // 2. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase succeeded return true
 // 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !succeeded return false
-func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
+func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
 	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
 		// Find the data volume:
@@ -33,10 +33,9 @@ func PopulationComplete(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, 
 		if err != nil {
 			return false, err
 		}
-		if dv.Status.Phase == Succeeded {
-			return true, nil
+		if dv.Status.Phase != Succeeded {
+			return false, nil
 		}
-		return false, nil
 	}
 	return true, nil
 }

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -89,7 +89,6 @@ go_test(
         "//pkg/util/naming:go_default_library",
         "//tests/reporters:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1:go_default_library",
-        "//vendor/github.com/kubevirt/controller-lifecycle-operator-sdk/pkg/sdk/api:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -213,7 +213,7 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 			return false, err
 		}
 
-		sourcePopulated, err := PopulationComplete(sourcePvc, r.client)
+		sourcePopulated, err := IsPopulated(sourcePvc, r.client)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -213,6 +213,14 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 			return false, err
 		}
 
+		sourcePopulated, err := PopulationComplete(sourcePvc, r.client)
+		if err != nil {
+			return false, err
+		}
+		if !sourcePopulated {
+			return true, nil
+		}
+
 		if err := r.validateSourceAndTarget(sourcePvc, targetPvc); err != nil {
 			return false, err
 		}

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -404,7 +403,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		Expect(err.Error()).To(ContainSubstring("source volumeMode (Filesystem) and target volumeMode (Block) do not match"))
 	})
 
-	It("Should error when source and target volume modes do not match (fs->block)", func() {
+	It("Should error when source and target volume modes do not match (block->fs)", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{
 			AnnCloneRequest: "default/source", AnnPodReady: "true", AnnCloneToken: "foobaz", AnnUploadClientName: "uploadclient", AnnCloneSourcePod: "default-testPvc1-source-pod"}, nil)
 		reconciler = createCloneReconciler(testPvc, createBlockPvc("source", "default", map[string]string{}, nil))
@@ -421,6 +420,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("source volumeMode (Block) and target volumeMode (Filesystem) do not match"))
 	})
+
 })
 
 var _ = Describe("ParseCloneRequestAnnotation", func() {
@@ -567,7 +567,7 @@ var _ = Describe("TokenValidation", func() {
 		}
 	}
 
-	source := &v1.PersistentVolumeClaim{
+	source := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "source",
 			Namespace: "sourcens",
@@ -601,7 +601,7 @@ var _ = Describe("TokenValidation", func() {
 			panic("error generating token")
 		}
 
-		target := &v1.PersistentVolumeClaim{
+		target := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "target",
 				Namespace: "targetns",

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -264,7 +264,7 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 			if requeue, err := r.sourceInUse(datavolume); requeue || err != nil {
 				return reconcile.Result{Requeue: requeue}, err
 			}
-			if populated, err := r.sourcePVCPopulated(datavolume); !populated || err != nil {
+			if populated, err := r.isSourcePVCPopulated(datavolume); !populated || err != nil {
 				return reconcile.Result{Requeue: !populated}, err
 			}
 			newSnapshot := newSnapshot(datavolume, snapshotClassName)
@@ -293,12 +293,12 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 }
 
 // Verify that the source PVC has been completely populated.
-func (r *DatavolumeReconciler) sourcePVCPopulated(dv *cdiv1.DataVolume) (bool, error) {
+func (r *DatavolumeReconciler) isSourcePVCPopulated(dv *cdiv1.DataVolume) (bool, error) {
 	sourcePvc := &corev1.PersistentVolumeClaim{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: dv.Spec.Source.PVC.Name, Namespace: dv.Spec.Source.PVC.Namespace}, sourcePvc); err != nil {
 		return false, err
 	}
-	return PopulationComplete(sourcePvc, r.client)
+	return IsPopulated(sourcePvc, r.client)
 }
 
 func (r *DatavolumeReconciler) sourceInUse(dv *cdiv1.DataVolume) (bool, error) {

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -264,6 +264,9 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 			if requeue, err := r.sourceInUse(datavolume); requeue || err != nil {
 				return reconcile.Result{Requeue: requeue}, err
 			}
+			if populated, err := r.sourcePVCPopulated(datavolume); !populated || err != nil {
+				return reconcile.Result{Requeue: !populated}, err
+			}
 			newSnapshot := newSnapshot(datavolume, snapshotClassName)
 			if err := r.client.Create(context.TODO(), newSnapshot); err != nil {
 				if k8serrors.IsAlreadyExists(err) {
@@ -287,6 +290,15 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 	// Finally, we update the status block of the DataVolume resource to reflect the
 	// current state of the world
 	return r.reconcileDataVolumeStatus(datavolume, pvc)
+}
+
+// Verify that the source PVC has been completely populated.
+func (r *DatavolumeReconciler) sourcePVCPopulated(dv *cdiv1.DataVolume) (bool, error) {
+	sourcePvc := &corev1.PersistentVolumeClaim{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: dv.Spec.Source.PVC.Name, Namespace: dv.Spec.Source.PVC.Namespace}, sourcePvc); err != nil {
+		return false, err
+	}
+	return PopulationComplete(sourcePvc, r.client)
 }
 
 func (r *DatavolumeReconciler) sourceInUse(dv *cdiv1.DataVolume) (bool, error) {

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -554,6 +554,68 @@ var _ = Describe("Reconcile Datavolume status", func() {
 	)
 })
 
+var _ = Describe("sourcePVCPopulated", func() {
+	var (
+		reconciler *DatavolumeReconciler
+	)
+
+	It("Should return true if source has no ownerRef", func() {
+		sourcePvc := createPvc("test", "default", nil, nil)
+		targetDv := newCloneDataVolume("test-dv")
+		reconciler = createDatavolumeReconciler(sourcePvc)
+		res, err := reconciler.sourcePVCPopulated(targetDv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+
+	It("Should return false and error if source has an ownerRef, but it doesn't exist", func() {
+		controller := true
+		sourcePvc := createPvc("test", "default", nil, nil)
+		targetDv := newCloneDataVolume("test-dv")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+		})
+		reconciler = createDatavolumeReconciler(sourcePvc)
+		res, err := reconciler.sourcePVCPopulated(targetDv)
+		Expect(err).To(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Should return false if source has an ownerRef, but it is not succeeded", func() {
+		controller := true
+		sourcePvc := createPvc("test", "default", nil, nil)
+		targetDv := newCloneDataVolume("test-dv")
+		sourceDv := newImportDataVolume("source-dv")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+		reconciler = createDatavolumeReconciler(sourcePvc, sourceDv)
+		res, err := reconciler.sourcePVCPopulated(targetDv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Should return true if source has an ownerRef, but it is succeeded", func() {
+		controller := true
+		sourcePvc := createPvc("test", "default", nil, nil)
+		targetDv := newCloneDataVolume("test-dv")
+		sourceDv := newImportDataVolume("source-dv")
+		sourceDv.Status.Phase = cdiv1.Succeeded
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+		reconciler = createDatavolumeReconciler(sourcePvc, sourceDv)
+		res, err := reconciler.sourcePVCPopulated(targetDv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+})
+
 func podUsingCloneSource(dv *cdiv1.DataVolume, readOnly bool) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -563,7 +563,7 @@ var _ = Describe("sourcePVCPopulated", func() {
 		sourcePvc := createPvc("test", "default", nil, nil)
 		targetDv := newCloneDataVolume("test-dv")
 		reconciler = createDatavolumeReconciler(sourcePvc)
-		res, err := reconciler.sourcePVCPopulated(targetDv)
+		res, err := reconciler.isSourcePVCPopulated(targetDv)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})
@@ -577,7 +577,7 @@ var _ = Describe("sourcePVCPopulated", func() {
 			Controller: &controller,
 		})
 		reconciler = createDatavolumeReconciler(sourcePvc)
-		res, err := reconciler.sourcePVCPopulated(targetDv)
+		res, err := reconciler.isSourcePVCPopulated(targetDv)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -593,7 +593,7 @@ var _ = Describe("sourcePVCPopulated", func() {
 			Name:       "source-dv",
 		})
 		reconciler = createDatavolumeReconciler(sourcePvc, sourceDv)
-		res, err := reconciler.sourcePVCPopulated(targetDv)
+		res, err := reconciler.isSourcePVCPopulated(targetDv)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -610,7 +610,7 @@ var _ = Describe("sourcePVCPopulated", func() {
 			Name:       "source-dv",
 		})
 		reconciler = createDatavolumeReconciler(sourcePvc, sourceDv)
-		res, err := reconciler.sourcePVCPopulated(targetDv)
+		res, err := reconciler.isSourcePVCPopulated(targetDv)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -472,3 +472,12 @@ func GetWorkloadNodePlacement(c client.Client) (*sdkapi.NodePlacement, error) {
 	}
 	return &crList.Items[0].Spec.Workloads, nil
 }
+
+// PopulationComplete returns if the passed in PVC has been populated according to the rules outlined in pkg/apis/core/<version>/utils.go
+func PopulationComplete(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
+	return cdiv1.PopulationComplete(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
+		dv := &cdiv1.DataVolume{}
+		err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dv)
+		return dv, err
+	})
+}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -473,9 +473,9 @@ func GetWorkloadNodePlacement(c client.Client) (*sdkapi.NodePlacement, error) {
 	return &crList.Items[0].Spec.Workloads, nil
 }
 
-// PopulationComplete returns if the passed in PVC has been populated according to the rules outlined in pkg/apis/core/<version>/utils.go
-func PopulationComplete(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
-	return cdiv1.PopulationComplete(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
+// IsPopulated returns if the passed in PVC has been populated according to the rules outlined in pkg/apis/core/<version>/utils.go
+func IsPopulated(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
+	return cdiv1.IsPopulated(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
 		dv := &cdiv1.DataVolume{}
 		err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dv)
 		return dv, err


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added a library function that checks if a PVC is fully populated. The logic is as following:
If PVC has no ownerRef, then we assume something else fully populated it and
will return true
If PVC has an ownerRef and its a DataVolume, then look up the DataVolume
If DV.status.Phase == succeeded, return true, return false otherwise.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: When cloning a source owned by a DV, the clone now waits for the source to be fully populated before cloning
```

