### PR TITLE
Removed hard coded registry:5000 for vddk datasource test.

### DIFF
--- a/manifests/templates/vcenter.yaml.in
+++ b/manifests/templates/vcenter.yaml.in
@@ -24,9 +24,6 @@ spec:
       - name: vcsim
         image: {{ .DockerRepo }}/vcenter-simulator:{{ .DockerTag }}
         imagePullPolicy: {{ .PullPolicy }}
-        env:
-          - name: NAMESPACE
-            value: {{ .Namespace }}
         command: ["/usr/bin/entrypoint.sh"]
         ports:
         - name: vcsim
@@ -46,3 +43,11 @@ spec:
   - name: vcsim
     port: 8989
     targetPort: 8989
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v2v-vmware
+  namespace: {{ .Namespace }}
+data:
+  vddk-init-image: {{ .DockerRepo }}/vddk-test:{{ .DockerTag}}

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -70,12 +70,12 @@ func FindMoRef(uuid string, sdkURL string) (string, error) {
 
 	// Log in to vCenter
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	conn, err := govmomi.NewClient(ctx, vmwURL, true)
 	if err != nil {
 		klog.Infof("Unable to connect to vCenter: %s\n", err)
 		return "", err
 	}
-	defer cancel()
 	defer conn.Logout(ctx)
 
 	// Get the list of datacenters to search for VM UUID

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -182,27 +182,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			vmid, err := uuid.Parse(strings.TrimSpace(id))
 			Expect(err).To(BeNil())
 
-			// Create v2v-vmware ConfigMap
-			stringData := map[string]string{
-				common.VddkConfigDataKey: "registry:5000/vddk-test",
-			}
-			configMap := v1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      common.VddkConfigMap,
-					Namespace: f.CdiInstallNs,
-				},
-				Data: stringData,
-			}
-			cm, err := utils.CreateOrUpdateConfigMap(f.K8sClient, f.CdiInstallNs, common.VddkConfigMap, &configMap)
-			Expect(err).To(BeNil())
-			Expect(cm).ToNot(BeNil())
-
 			// Create VDDK login secret
-			stringData = map[string]string{
+			stringData := map[string]string{
 				common.KeyAccess: "user",
 				common.KeySecret: "pass",
 			}

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -125,15 +125,3 @@ func ClearInsecureRegistry(client kubernetes.Interface, cdiNamespace string) err
 
 	return nil
 }
-
-// CreateOrUpdateConfigMap updates a given ConfigMap or creates it if it does not exist
-func CreateOrUpdateConfigMap(client kubernetes.Interface, cnvNamespace string, name string, configMap *v1.ConfigMap) (*v1.ConfigMap, error) {
-	cm, err := client.CoreV1().ConfigMaps(cnvNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		cm, err = client.CoreV1().ConfigMaps(cnvNamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
-	} else {
-		cm, err = client.CoreV1().ConfigMaps(cnvNamespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
-	}
-
-	return cm, err
-}


### PR DESCRIPTION
This allows people to run the test outside of the kubevirtci
environment and have it complete successfully.
Added configmap to vcenter.yaml.in that creates the CM that
lets users specify which init container to use. The default
is the test init container

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

