### PR TITLE
[release-v1.18] Don't consider deleted config maps for CR locking

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -186,6 +186,12 @@ func (r *ReconcileCDI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, err
 	}
 
+	if configMap != nil && configMap.DeletionTimestamp != nil {
+		// this is a left over from a previous CR, wait for it get deleted.
+		reqLogger.Info("Found previous config that is marked for deletion, requeueing")
+		return reconcile.Result{RequeueAfter: time.Second}, nil
+	}
+
 	if configMap == nil {
 		if cr.Status.Phase != "" {
 			reqLogger.Info("Reconciling to error state, no configmap")


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is a race condition in the reconcile if the follow happens:
1. CDI is deployed
2. The CDI CR is deleted
3. The operator will start to delete the appropriate resources including the configmap.
4. A new CDI CR is created but the configmap is still around, because the control plane is slow.
5. Currently in the reconcile loop the configmap associated with the old CR will be considered valid and the phase will be set to deploying.
6. Now the CM is actually removed
7. The reconcile loop will never try to create a new configmap due to way things are being checked.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix race with CDI CR locking configmap.
```

