### PR TITLE
Expand negative too-big upload tests to xz, sync upload endpoint

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -207,8 +207,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Expect(token).ToNot(BeEmpty())
 
 		By("Do upload")
-		err = uploadFileNameToPath(binaryRequestFunc, filename, uploadProxyURL, asyncUploadPath, token, http.StatusBadRequest)
-		Expect(err).ToNot(HaveOccurred())
+		err = uploadFileNameToPath(binaryRequestFunc, filename, uploadProxyURL, asyncUploadPath, token, http.StatusOK)
+		Expect(err).To(HaveOccurred())
 	},
 		Entry("fail given a RAW XZ file", utils.UploadFileLargeVirtualDiskXz),
 		Entry("[test_id:4989]fail given a QCOW2 file", utils.UploadFileLargeVirtualDiskQcow),
@@ -242,7 +242,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			return log
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 	},
-		XEntry("fail given a RAW XZ file", utils.UploadFileLargeVirtualDiskXz),
+		PEntry("fail given a RAW XZ file", utils.UploadFileLargeVirtualDiskXz),
 		Entry("fail given a QCOW2 file", utils.UploadFileLargeVirtualDiskQcow),
 	)
 })

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -15,8 +15,10 @@ import (
 const (
 	// UploadFile is the file to upload
 	UploadFile = "./images/tinyCore.iso"
-	// UploadFileLargeVirtualDisk is the file to upload
-	UploadFileLargeVirtualDisk = "./images/cirros-large-vdisk.qcow2"
+	// UploadFileLargeVirtualDiskQcow is the file to upload (QCOW2)
+	UploadFileLargeVirtualDiskQcow = "./images/cirros-large-vdisk.qcow2"
+	// UploadFileLargeVirtualDiskXz is the file to upload (XZ-compressed RAW file)
+	UploadFileLargeVirtualDiskXz = "./images/cirros-large-vdisk.raw.xz"
 
 	// UploadFileSize is the size of UploadFile
 	UploadFileSize = 18874368


### PR DESCRIPTION
Note that this adds an XEntry, because the expected failure doesn't
happen with .raw.xz files.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

