### PR TITLE
Fix size mismatch between source and target in smart clone tests.

### DIFF
--- a/doc/smart-clone.md
+++ b/doc/smart-clone.md
@@ -33,3 +33,4 @@ Here is a description of the flow of the Smart-Cloning:
 - If Smart-Cloning is not possible:
   * Trigger a (slower) host-assisted clone
 
+*Note: For some CSI driver when restoring from a snapshot, the new PVC size must equal the size of the PVC the snapshot was created from*

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -142,7 +142,7 @@ func createAndPopulateSourcePVC(dataVolumeName, command string, volumeMode v1.Pe
 	By(fmt.Sprintf("Storage Class name: %s", scName))
 	sourcePVCName := fmt.Sprintf("%s-src-pvc", dataVolumeName)
 	sourcePodFillerName := fmt.Sprintf("%s-filler-pod", dataVolumeName)
-	pvcDef := utils.NewPVCDefinition(sourcePVCName, "1G", nil, nil)
+	pvcDef := utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
 	pvcDef.Spec.VolumeMode = &volumeMode
 	if scName != "" {
 		pvcDef.Spec.StorageClassName = &scName


### PR DESCRIPTION
Ceph no longer allows target size > source size when restoring from snapshot.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes some failures on ceph which do not allow source PVC size < target PVC size when restoring from snapshots.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

