### PR TITLE
Scratch import bug

### DIFF
--- a/cluster-sync/nfs/nfs-server.yaml
+++ b/cluster-sync/nfs/nfs-server.yaml
@@ -54,6 +54,16 @@ spec:
             chmod 777 /data/nfs/disk4;
             mkdir /data/nfs/disk5;
             chmod 777 /data/nfs/disk5;
+            mkdir /data/nfs/disk6;
+            chmod 777 /data/nfs/disk6;
+            mkdir /data/nfs/disk7;
+            chmod 777 /data/nfs/disk7;
+            mkdir /data/nfs/disk8;
+            chmod 777 /data/nfs/disk8;
+            mkdir /data/nfs/disk9;
+            chmod 777 /data/nfs/disk9;
+            mkdir /data/nfs/disk10;
+            chmod 777 /data/nfs/disk10;
             /usr/bin/nfsd.sh
       volumes:
       - name: nfsdata

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -265,7 +265,7 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 				for _, pod := range podsUsingPVC {
 					r.log.V(1).Info("can't create import pod, pvc in use by other pod",
 						"namespace", pvc.Namespace, "name", pvc.Name, "pod", pod.Name)
-					r.recorder.Eventf(pvc, corev1.EventTypeWarning, UploadTargetInUse,
+					r.recorder.Eventf(pvc, corev1.EventTypeWarning, ImportTargetInUse,
 						"pod %s/%s using PersistentVolumeClaim %s", pod.Namespace, pod.Name, pvc.Name)
 
 				}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -211,6 +211,7 @@ func CreateScratchPersistentVolumeClaim(client client.Client, pvc *v1.Persistent
 	scratchPvc := &v1.PersistentVolumeClaim{}
 	if err := client.Get(context.TODO(), types.NamespacedName{Name: scratchPvcSpec.Name, Namespace: pvc.Namespace}, scratchPvc); err != nil {
 		klog.Errorf("Unable to get scratch space pvc, %v\n", err)
+		return nil, err
 	}
 	klog.V(3).Infof("scratch PVC \"%s/%s\" created\n", scratchPvc.Namespace, scratchPvc.Name)
 	return scratchPvc, nil
@@ -512,6 +513,9 @@ func getPodsUsingPVCs(c client.Client, namespace string, names sets.String, allo
 
 	var pods []v1.Pod
 	for _, pod := range pl.Items {
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
 		for _, volume := range pod.Spec.Volumes {
 			if volume.VolumeSource.PersistentVolumeClaim != nil &&
 				names.Has(volume.PersistentVolumeClaim.ClaimName) &&

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1254,7 +1254,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("Should create a new scratch PVC when PVC is deleted during import", func() {
-			dvName := "scratch-space-delete"
+			dvName := "import-bug"
 			By(fmt.Sprintf("Creating new datavolume %s", dvName))
 			dv := utils.NewDataVolumeWithHTTPImport(dvName, "500Mi", tinyCoreQcow2URL())
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
@@ -1279,7 +1279,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					By(fmt.Sprintf("Deleted scratch PVC %s %v", scratchPvcName, deleteCounter))
 				}
 				return deleteCounter
-			}, 270*time.Second, 200*time.Millisecond).Should(BeNumerically(">=", 3))
+			}, 270*time.Second, 100*time.Millisecond).Should(BeNumerically(">=", 5))
 
 			By("Wait for PVC to be recreated")
 			scratchPvc, err := utils.WaitForPVC(f.K8sClient, f.Namespace.Name, scratchPvcName)

--- a/tests/framework/nfs-utils.go
+++ b/tests/framework/nfs-utils.go
@@ -16,7 +16,7 @@ import (
 const (
 	timeout         = time.Second * 90
 	pollingInterval = time.Second
-	pvCount         = 5
+	pvCount         = 10
 )
 
 func createNFSPVs(client *kubernetes.Clientset, cdiNs string) error {

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -27,6 +27,8 @@ const (
 const (
 	// TinyCoreIsoURL provides a test url for the tineyCore iso image
 	TinyCoreIsoURL = "http://cdi-file-host.%s/tinyCore.iso"
+	// TinyCoreQcow2URL provides a test url for the tineyCore qcow2 image
+	TinyCoreQcow2URL = "http://cdi-file-host.%s/tinyCore.qcow2"
 	//TinyCoreIsoRegistryURL provides a test url for the tinycore.qcow2 image wrapped in docker container
 	TinyCoreIsoRegistryURL = "docker://cdi-docker-registry-host.%s/tinycoreqcow2"
 	//TinyCoreIsoRegistryProxyURL provides a test url for the tinycore.qcow2 image wrapped in docker container available through rate-limiting proxy

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -40,8 +40,8 @@ func CreateVerifierPodWithPVC(clientSet *kubernetes.Clientset, namespace string,
 
 // DeleteVerifierPod deletes the verifier pod
 func DeleteVerifierPod(clientSet *kubernetes.Clientset, namespace string) error {
-	zero := int64(0)
-	return DeletePodByName(clientSet, VerifierPodName, namespace, &zero)
+	gracePeriod := int64(30)
+	return DeletePodByName(clientSet, VerifierPodName, namespace, &gracePeriod)
 }
 
 // CreateExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -40,8 +40,7 @@ func CreateVerifierPodWithPVC(clientSet *kubernetes.Clientset, namespace string,
 
 // DeleteVerifierPod deletes the verifier pod
 func DeleteVerifierPod(clientSet *kubernetes.Clientset, namespace string) error {
-	gracePeriod := int64(30)
-	return DeletePodByName(clientSet, VerifierPodName, namespace, &gracePeriod)
+	return DeletePodByName(clientSet, VerifierPodName, namespace, nil)
 }
 
 // CreateExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fixed the creation of scratch space (after it is being deleted) in some rare scenarios.

Here is the scenario that is fixed by the PR - after requesting the creation of the pod and the scratch-space:
1. The Pod is being created so it shows in the system as Pending (waits for all PVC to be available), this is observed in controller and it tries to create scratch again, but scratch is already in the system (also Pending), so controller sets  condition "Claim Pending" and returns.

2. Some external action - be it a script or a user - removes PVC (if I am not mistaken the finalizer: "kubernetes.io/pvc-protection" does not work if pod is Pending/not yet scheduled), now the only thing the controller can see is a PVC event, but the scratch PVC is not found so controller returns without taking any action.

No further events for the POD (still Pending - no changes). From this point the Pod stays in Pending state indefinitely. 

The **problem is fixed** by changing the event watcher query. When the scratch pvc event is received the PVC that owns the POD that OWNS the scratch pvc is added to the reconcile event queue. So if the ownership looks like this: 

`PVC A -> POD B -> ScratchPVC C 
`
and the `DeleteEvent` for `ScratchPVC C` is received then the `PVC A` is returned. This is the PVC that is the target for import. When this PVC is reconciled the scratch space is correctly re-created if needed.

Also an issue was found in the utility function to create a scratch PVC. It did not return an error.

Additional I have added a check in import controller so it now skips pvc that is in use by other pod. The same way as in upload and clone controller. Without this testing was almost impossible. And sometimes the `consumer pod ` was in "CreatingContainer" state even after the importer pod started.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Import controller now skips pvc that is in use by other pod. 
Fixed the creation of scratch space (after being deleted) in some rare scenario.
```

