### PR TITLE
add finalizer to target PVC before creating clone source pod

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -190,10 +190,16 @@ func (r *CloneReconciler) Reconcile(req reconcile.Request) (reconcile.Result, er
 	_, nameExists := pvc.Annotations[AnnCloneSourcePod]
 	if !nameExists && sourcePod == nil {
 		pvc.Annotations[AnnCloneSourcePod] = createCloneSourcePodName(pvc)
+
+		// add finalizer before creating clone source pod
+		pvc = r.addFinalizer(pvc, cloneSourcePodFinalizer)
+
 		if err := r.updatePVC(pvc); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+
+		// will reconcile again after PVC update notification
+		return reconcile.Result{}, nil
 	}
 
 	if requeue, err := r.reconcileSourcePod(sourcePod, pvc, log); requeue || err != nil {
@@ -259,8 +265,6 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
 	currentPvcCopy := pvc.DeepCopyObject()
 	log.V(1).Info("Updating PVC from pod")
-
-	pvc = r.addFinalizer(pvc, cloneSourcePodFinalizer)
 
 	log.V(3).Info("Pod phase for PVC", "PVC phase", pvc.Annotations[AnnPodPhase])
 

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("error parsing %s annotation", AnnPodReady)))
 	})
 
-	It("Should create source pod name", func() {
+	It("Should create source pod name and add finalizer", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{
 			AnnCloneRequest:     "default/source",
 			AnnPodReady:         "true",
@@ -147,6 +147,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testPvc.Annotations[AnnCloneSourcePod]).To(Equal("default-testPvc1-source-pod"))
+		Expect(reconciler.hasFinalizer(testPvc, cloneSourcePodFinalizer)).To(BeTrue())
 	})
 
 	DescribeTable("Should NOT create new source pod if source PVC is in use", func(podFunc func(*corev1.PersistentVolumeClaim) *corev1.Pod) {
@@ -242,11 +243,6 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			},
 		}
 		Expect(pa).To(Equal(epa))
-
-		By("Verifying the PVC now has a finalizer")
-		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(reconciler.hasFinalizer(testPvc, cloneSourcePodFinalizer)).To(BeTrue())
 	},
 		Entry("no pods are using source PVC", func(pvc *corev1.PersistentVolumeClaim) *corev1.Pod {
 			return nil
@@ -298,10 +294,6 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod.GetLabels()[CloneUniqueID]).To(Equal("default-testPvc1-source-pod"))
-		By("Verifying the PVC now has a finalizer")
-		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(reconciler.hasFinalizer(testPvc, cloneSourcePodFinalizer)).To(BeTrue())
 	})
 
 	It("Should update the cloneof when complete", func() {
@@ -354,6 +346,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
+		By("Verifying the PVC does not have a finalizer")
+		testPvc = &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reconciler.hasFinalizer(testPvc, cloneSourcePodFinalizer)).To(BeFalse())
 	})
 
 	It("Should update the cloneof when complete, block mode", func() {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Should address the condition described here:  https://bugzilla.redhat.com/show_bug.cgi?id=1866593#c20

Currently, the finalizer is added to the target PVC after the clone source pod is created.  This means that the source pod may get orphaned if the target PVC is deleted before the finalizer is added

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

