### PR TITLE
Files in tar archives can have paths relative to ./

### DIFF
--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -107,6 +107,11 @@ func copyFile(tarReader *tar.Reader, dstFile *os.File) error {
 	return nil
 }
 
+func hasPrefix(path string, pathPrefix string) bool {
+	return strings.HasPrefix(path, pathPrefix) ||
+		strings.HasPrefix(path, "./"+pathPrefix)
+}
+
 func isWhiteout(path string) bool {
 	return strings.HasPrefix(filepath.Base(path), whFilePrefix)
 }
@@ -148,7 +153,7 @@ func processLayer(ctx context.Context,
 			return false, errors.Wrap(err, "Error reading layer")
 		}
 
-		if strings.HasPrefix(hdr.Name, pathPrefix) && !isWhiteout(hdr.Name) && !isDir(hdr.Name) {
+		if hasPrefix(hdr.Name, pathPrefix) && !isWhiteout(hdr.Name) && !isDir(hdr.Name) {
 			klog.Infof("File '%v' found in the layer", hdr.Name)
 			destFile := filepath.Join(destDir, hdr.Name)
 
@@ -179,7 +184,7 @@ func processLayer(ctx context.Context,
 }
 
 func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry, stopAtFirst bool) error {
-	klog.Infof("Downloading image from %v, copying file from %v to %v", url, pathPrefix, destDir)
+	klog.Infof("Downloading image from '%v', copying file from '%v' to '%v'", url, pathPrefix, destDir)
 
 	ctx, cancel := commandTimeoutContext()
 	defer cancel()


### PR DESCRIPTION

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Files in tar archives can have paths relative to `./`. In such case tar entries in tar header have names prefixed with "./". This PR adds code to hande such case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

