### PR TITLE
Fix cloning checking fsGroup test in case of use with OCS.

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -78,7 +78,7 @@ var _ = Describe("all clone tests", func() {
 
 		It("[test_id:4953]Should clone imported data within same namespace and preserve fsGroup", func() {
 			diskImagePath := filepath.Join(testBaseDir, testFile)
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "500Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -87,7 +87,7 @@ var _ = Describe("all clone tests", func() {
 			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 
 			// Create targetPvc in new NS.
-			targetDV := utils.NewCloningDataVolume("target-dv", "1G", pvc)
+			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", pvc)
 			targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDataVolume)


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
OCS doesn't allow snapshot restore into larger PVC than the PVC the snapshot was created from. This PR fixes a test that fails in case of OCS because the source was smaller than the target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

