### PR TITLE
Don't wait for NS to deleted in test before starting next test

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -104,7 +104,7 @@ func createConsumerPod(targetPvc *k8sv1.PersistentVolumeClaim, f *Framework) {
 	err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, namespace, k8sv1.ClaimBound, targetPvc.Name)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	utils.DeletePod(f.K8sClient, executorPod, namespace)
+	utils.DeletePodNoGrace(f.K8sClient, executorPod, namespace)
 }
 
 // VerifyPVCIsEmpty verifies a passed in PVC is empty, returns true if the PVC is empty, false if it is not. Optionaly, specify node for the pod.

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -88,6 +88,14 @@ func IsHostpathProvisioner() bool {
 	return DefaultStorageClass.Provisioner == "kubevirt.io/hostpath-provisioner"
 }
 
+// GetTestNamespaceList returns a list of namespaces that have been created by the functional tests.
+func GetTestNamespaceList(client *kubernetes.Clientset, nsPrefix string) (*corev1.NamespaceList, error) {
+	//Ensure that no namespaces with the prefix label exist
+	return client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: nsPrefix,
+	})
+}
+
 // CacheTestsData fetch and cache data required for tests
 func CacheTestsData(client *kubernetes.Clientset, cdiNs string) {
 	if DefaultStorageClass == nil {

--- a/tests/utils/pv.go
+++ b/tests/utils/pv.go
@@ -114,8 +114,11 @@ func pvPhase(clientSet *kubernetes.Clientset, pvName string, status k8sv1.Persis
 
 // DeletePV deletes the passed in PV
 func DeletePV(clientSet *kubernetes.Clientset, pv *k8sv1.PersistentVolume) error {
+	zero := int64(0)
 	return wait.PollImmediate(pvPollInterval, pvDeleteTime, func() (bool, error) {
-		err := clientSet.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.GetName(), metav1.DeleteOptions{})
+		err := clientSet.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.GetName(), metav1.DeleteOptions{
+			GracePeriodSeconds: &zero,
+		})
 		if err == nil || apierrs.IsNotFound(err) {
 			return true, nil
 		}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
During each test run, we wait until the NS of the current test is fully deleted before moving to the next test. This PR we just delete the NS, and continue to the next test while letting the system clean up the old ns. In theory this should shorten the runtime of a lane.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

