### PR TITLE
Add library function to determine if a PVC is waiting for first consu…

### DIFF
--- a/pkg/apis/core/v1alpha1/BUILD.bazel
+++ b/pkg/apis/core/v1alpha1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -24,5 +24,23 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "utils_test.go",
+        "v1alpha1_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//tests/reporters:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/apis/core/v1alpha1/utils_test.go
+++ b/pkg/apis/core/v1alpha1/utils_test.go
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("IsWaitForFirstConsumerBeforePopulating on Alpha1", func() {
+	It("Should return true if source pending, has ownerRef, dv is in WFFC phase", func() {
+		dv := newCloneDataVolume("source-dv", "default")
+		dv.Status.Phase = WaitForFirstConsumer
+		controller := true
+		sourcePvc := createPendingPvc("test", "default")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				return dv, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+	It("Should return false if source pending, has ownerRef, dv is NOT in WFFC phase", func() {
+		dv := newCloneDataVolume("source-dv", "default")
+		dv.Status.Phase = Pending
+		controller := true
+		sourcePvc := createPendingPvc("test", "default")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				return dv, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Should return false if source has no ownerRef", func() {
+		sourcePvc := createPendingPvc("test", "default")
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				Fail("getDv should never be executed")
+				return nil, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+})
+
+func createPendingPvc(name, ns string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			UID:       types.UID(ns + "-" + name),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany, corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1G"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	}
+}
+
+func newCloneDataVolume(name string, pvcNamespace string) *DataVolume {
+	var annCloneToken = "cdi.kubevirt.io/storage.clone.token"
+	return &DataVolume{
+		TypeMeta: metav1.TypeMeta{APIVersion: SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annCloneToken: "foobar",
+			},
+		},
+		Spec: DataVolumeSpec{
+			Source: DataVolumeSource{
+				PVC: &DataVolumeSourcePVC{
+					Name:      "test",
+					Namespace: pvcNamespace,
+				},
+			},
+			PVC: &corev1.PersistentVolumeClaimSpec{},
+		},
+	}
+}

--- a/pkg/apis/core/v1alpha1/utils_test.go
+++ b/pkg/apis/core/v1alpha1/utils_test.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	. "github.com/onsi/ginkgo"
-
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,44 +31,33 @@ import (
 )
 
 var _ = Describe("IsWaitForFirstConsumerBeforePopulating on Alpha1", func() {
-	It("Should return true if source pending, has ownerRef, dv is in WFFC phase", func() {
-		dv := newCloneDataVolume("source-dv", "default")
-		dv.Status.Phase = WaitForFirstConsumer
-		controller := true
-		sourcePvc := createPendingPvc("test", "default")
-		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
-			Kind:       "DataVolume",
-			Controller: &controller,
-			Name:       "source-dv",
-		})
-		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
-			func(name, namespace string) (*DataVolume, error) {
-				return dv, nil
-			})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(BeTrue())
-	})
-	It("Should return false if source pending, has ownerRef, dv is NOT in WFFC phase", func() {
-		dv := newCloneDataVolume("source-dv", "default")
-		dv.Status.Phase = Pending
-		controller := true
-		sourcePvc := createPendingPvc("test", "default")
-		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
-			Kind:       "DataVolume",
-			Controller: &controller,
-			Name:       "source-dv",
-		})
 
-		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
-			func(name, namespace string) (*DataVolume, error) {
-				return dv, nil
+	DescribeTable("PVC with DV as owner",
+		func(volumeClaimPhase corev1.PersistentVolumeClaimPhase, dataVolumePhase DataVolumePhase, expectedResponse bool) {
+
+			dv := newCloneDataVolume("source-dv", "default")
+			dv.Status.Phase = dataVolumePhase
+			controller := true
+			sourcePvc := createPvc("test", "default", volumeClaimPhase)
+			sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+				Kind:       "DataVolume",
+				Controller: &controller,
+				Name:       "source-dv",
 			})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(BeFalse())
-	})
+			res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+				func(name, namespace string) (*DataVolume, error) {
+					return dv, nil
+				})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(BeEquivalentTo(expectedResponse))
+		},
+		Entry("PVC Pending, dv is in WFFC phase", corev1.ClaimPending, WaitForFirstConsumer, true),
+		Entry("PVC Pending, dv is NOT in WFFC phase", corev1.ClaimPending, Pending, false),
+		Entry("PVC Bound, phase does not matter", corev1.ClaimBound, PhaseUnset, false),
+	)
 
 	It("Should return false if source has no ownerRef", func() {
-		sourcePvc := createPendingPvc("test", "default")
+		sourcePvc := createPvc("test", "default", corev1.ClaimPending)
 		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
 			func(name, namespace string) (*DataVolume, error) {
 				Fail("getDv should never be executed")
@@ -79,7 +68,7 @@ var _ = Describe("IsWaitForFirstConsumerBeforePopulating on Alpha1", func() {
 	})
 })
 
-func createPendingPvc(name, ns string) *corev1.PersistentVolumeClaim {
+func createPvc(name, ns string, claimPhase corev1.PersistentVolumeClaimPhase) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -95,7 +84,7 @@ func createPendingPvc(name, ns string) *corev1.PersistentVolumeClaim {
 			},
 		},
 		Status: corev1.PersistentVolumeClaimStatus{
-			Phase: corev1.ClaimPending,
+			Phase: claimPhase,
 		},
 	}
 }

--- a/pkg/apis/core/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/core/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,15 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"kubevirt.io/containerized-data-importer/tests/reporters"
+)
+
+func TestV1alpha1Target(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "V1Alpha1 Test Suite", reporters.NewReporters())
+}

--- a/pkg/apis/core/v1beta1/BUILD.bazel
+++ b/pkg/apis/core/v1beta1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -23,5 +23,23 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "utils_test.go",
+        "v1beta1_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//tests/reporters:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/apis/core/v1beta1/utils_test.go
+++ b/pkg/apis/core/v1beta1/utils_test.go
@@ -1,0 +1,122 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("IsWaitForFirstConsumerBeforePopulating on Beta1", func() {
+	It("Should return true if source pending, has ownerRef, dv is in WFFC phase", func() {
+		dv := newCloneDataVolume("source-dv", "default")
+		dv.Status.Phase = WaitForFirstConsumer
+		controller := true
+		sourcePvc := createPendingPvc("test", "default")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				return dv, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+	It("Should return false if source pending, has ownerRef, dv is NOT in WFFC phase", func() {
+		dv := newCloneDataVolume("source-dv", "default")
+		dv.Status.Phase = Pending
+		controller := true
+		sourcePvc := createPendingPvc("test", "default")
+		sourcePvc.OwnerReferences = append(sourcePvc.OwnerReferences, metav1.OwnerReference{
+			Kind:       "DataVolume",
+			Controller: &controller,
+			Name:       "source-dv",
+		})
+
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				return dv, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Should return false if source has no ownerRef", func() {
+		sourcePvc := createPendingPvc("test", "default")
+		res, err := IsWaitForFirstConsumerBeforePopulating(sourcePvc,
+			func(name, namespace string) (*DataVolume, error) {
+				Fail("getDv should never be executed")
+				return nil, nil
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+})
+
+func createPendingPvc(name, ns string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			UID:       types.UID(ns + "-" + name),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany, corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1G"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	}
+}
+
+func newCloneDataVolume(name string, pvcNamespace string) *DataVolume {
+	var annCloneToken = "cdi.kubevirt.io/storage.clone.token"
+	return &DataVolume{
+		TypeMeta: metav1.TypeMeta{APIVersion: SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annCloneToken: "foobar",
+			},
+		},
+		Spec: DataVolumeSpec{
+			Source: DataVolumeSource{
+				PVC: &DataVolumeSourcePVC{
+					Name:      "test",
+					Namespace: pvcNamespace,
+				},
+			},
+			PVC: &corev1.PersistentVolumeClaimSpec{},
+		},
+	}
+}

--- a/pkg/apis/core/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/core/v1beta1/v1beta1_suite_test.go
@@ -1,0 +1,15 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"kubevirt.io/containerized-data-importer/tests/reporters"
+)
+
+func TestV1beta1Target(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "V1Betas1 Test Suite", reporters.NewReporters())
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add library function to determine if a PVC is waiting for first consumer before binding (and before it can be populated).

IsWaitForFirstConsumerBeforePopulating indicates if the persistent volume passed in is in ClaimPending state and waiting for first consumer. It follows the logic:
1. If the PVC is not owned by a DataVolume, return false, we can not assume it will be populated
2. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase WaitForFirstConsumer return true
3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !WaitForFirstConsumer return false

This is needed so the users of CDI (kubevirt) can detect and correctly handle PVC's in this state. See https://github.com/kubevirt/kubevirt/pull/4025

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new library function IsWaitForFirstConsumerBeforePopulating  
```

