### PR TITLE
Update WORKSPACE packages to non-404 ones, and add a second mirror.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -241,49 +241,55 @@ http_file(
 
 http_file(
     name = "lvm2",
-    sha256 = "790256fe3d3b39700a4345649fcaab1da8dc1d13104577480d1807a108c0273f",
+    sha256 = "a05d7866e05d7eb7231afb0e9036a1fe562398e3553576cfbdf060f23b1fbf7a",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/lvm2-2.03.05-2.fc31.x86_64.rpm",
+        "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/l/lvm2-2.03.09-1.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/l/lvm2-2.03.09-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "lvm2-libs",
-    sha256 = "c8125a5f282f6022a2ca0c287c6804301262432646aba5a5b8ec06eeacb83102",
+    sha256 = "3a48ad6a0a7bd17e6f373ccd4d1b8a005c6be86062c08a5fa74f79031ab066fb",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/lvm2-libs-2.03.05-2.fc31.x86_64.rpm",
+        "http://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/l/lvm2-libs-2.03.09-1.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/l/lvm2-libs-2.03.09-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "device-mapper",
-    sha256 = "d8fa0b0947084bce50438b7eaf5a5085abd35e36c69cfb13d5f58e98a258e36f",
+    sha256 = "a532b72993cb867fe1811ee4bd96a2060ed9910ffa2dd0bfbb7f0b347f1faf45",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-1.02.163-2.fc31.x86_64.rpm",
+        "http://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/d/device-mapper-1.02.171-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/d/device-mapper-1.02.171-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "device-mapper-libs",
-    sha256 = "0ebd37bcd6d2beb5692b7c7e3d94b90a26d45b059696d954b502d85d738b7732",
+    sha256 = "53ecaa8eb8cfd574d8c6ead4b720ff7702dc9d7c506f1d28f3424158a04b5cf7",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-libs-1.02.163-2.fc31.x86_64.rpm",
+        "http://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/d/device-mapper-libs-1.02.171-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/d/device-mapper-libs-1.02.171-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "device-mapper-event",
-    sha256 = "9dfb6c534d23d3058d83dfaf669544b58318c34351ae46e7341cdeee51be2ab8",
+    sha256 = "dae095c0916c93cb767cf55777d5f168e70ab3606f970dfdbfa624d028fb4390",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-event-1.02.163-2.fc31.x86_64.rpm",
+        "http://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/d/device-mapper-event-1.02.171-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/d/device-mapper-event-1.02.171-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "device-mapper-event-libs",
-    sha256 = "3d9ed59c05d68649e255ab6961ce7b8b758ab82cbe74d6912d0f4395c7ebd4f3",
+    sha256 = "a0cbbee35e50015bb72b6b7c7261d1bc9976e4372ba222c50ed3ef19cb9323ac",
     urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-event-libs-1.02.163-2.fc31.x86_64.rpm",
+        "http://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/d/device-mapper-event-libs-1.02.171-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/d/device-mapper-event-libs-1.02.171-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -292,6 +298,7 @@ http_file(
     sha256 = "4a3eef2bea1e3a1fe305b9c2acbf46d6bc6063d415fe0c33c25416ed42791cee",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/device-mapper-persistent-data-0.8.5-2.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/d/device-mapper-persistent-data-0.8.5-2.fc31.x86_64.rpm",
     ],
 )
 
@@ -300,6 +307,7 @@ http_file(
     sha256 = "03179d5423784f6a61d18dcbb35fe986fb318ebac65330c0228bbef4e835c992",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/c/compat-readline5-5.2-34.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/c/compat-readline5-5.2-34.fc31.x86_64.rpm",
     ],
 )
 
@@ -308,6 +316,7 @@ http_file(
     sha256 = "ec22cf64138373b6f28dab0b824fbf9cdec8060bf7b8ce8216a361ab70f0849b",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/k/kmod-26-4.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/k/kmod-26-4.fc31.x86_64.rpm",
     ],
 )
 
@@ -316,6 +325,7 @@ http_file(
     sha256 = "20ef955e5f735233a425725b9af41d960b5602dfb0ae812ae720e37c9bf8a292",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/b/basesystem-11-8.fc31.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/b/basesystem-11-8.fc31.noarch.rpm",
     ],
 )
 
@@ -324,6 +334,7 @@ http_file(
     sha256 = "09f5522e833a03fd66e7ea9368331b7f316f494db26decda59cbacb6ea4185b3",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/b/bash-5.0.7-3.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/b/bash-5.0.7-3.fc31.x86_64.rpm",
     ],
 )
 
@@ -332,6 +343,7 @@ http_file(
     sha256 = "f2ae011207332ac90d0cf50b1f0b9eb0ce8be1d4d4c7186463dff38a90af0f3d",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-gpg-keys-31-1.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/f/fedora-gpg-keys-31-1.noarch.rpm",
     ],
 )
 
@@ -340,6 +352,7 @@ http_file(
     sha256 = "40eee4e4234c781277a202aa0e834c2be8afc28a3e4012b07d6c24058b0f4add",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-release-31-1.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/f/fedora-release-31-1.noarch.rpm",
     ],
 )
 
@@ -348,6 +361,7 @@ http_file(
     sha256 = "e566c03caeeaa58db28c0b257f5d36ea92adfe2a18884208f03611c35397a6a1",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-release-common-31-1.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/f/fedora-release-common-31-1.noarch.rpm",
     ],
 )
 
@@ -356,6 +370,7 @@ http_file(
     sha256 = "9c9250ccd816e5d8c2bfdee14d16e9e71d2038707009e36e7642c136d7c62e4c",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/fedora-repos-31-1.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/f/fedora-repos-31-1.noarch.rpm",
     ],
 )
 
@@ -364,6 +379,7 @@ http_file(
     sha256 = "ce05d442cca1de33cb9b4dfb72b94d8b97a072e2add394e075131d395ef463ff",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/f/filesystem-3.12-2.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/f/filesystem-3.12-2.fc31.x86_64.rpm",
     ],
 )
 
@@ -372,6 +388,7 @@ http_file(
     sha256 = "33e0ad9b92d40c4e09d6407df1c8549b3d4d3d64fdd482439e66d12af6004f13",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-2.30-5.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/g/glibc-2.30-5.fc31.x86_64.rpm",
     ],
 )
 
@@ -380,6 +397,7 @@ http_file(
     sha256 = "f67d5cc67029c6c38185f94b72aaa9034a49f5c4f166066c8268b41e1b18a202",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-all-langpacks-2.30-5.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/g/glibc-all-langpacks-2.30-5.fc31.x86_64.rpm",
     ],
 )
 
@@ -388,6 +406,7 @@ http_file(
     sha256 = "1098c7738ca3b78a999074fbb93a268acac499ee8994c29757b1b858f59381bb",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/glibc-common-2.30-5.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/g/glibc-common-2.30-5.fc31.x86_64.rpm",
     ],
 )
 
@@ -396,6 +415,7 @@ http_file(
     sha256 = "4106397648e9ef9ed7de9527f0da24c7e5698baa5bc1961b44707b55730ad5e1",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libgcc-9.2.1-1.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/l/libgcc-9.2.1-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -404,6 +424,7 @@ http_file(
     sha256 = "b75fe6088e737720ea81a9377655874e6ac6919600a5652576f9ebb0d9232e5e",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libselinux-2.9-5.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/l/libselinux-2.9-5.fc31.x86_64.rpm",
     ],
 )
 
@@ -412,6 +433,7 @@ http_file(
     sha256 = "2ebd4efba62115da56ed54b7f0a5c2817f9acd29242a0334f62e8c645b81534f",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libsepol-2.9-2.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/l/libsepol-2.9-2.fc31.x86_64.rpm",
     ],
 )
 
@@ -420,6 +442,7 @@ http_file(
     sha256 = "cbd9d78da00aea6c1e98398fe883d5566971b3bc6764a07c5e945cd317013686",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/ncurses-base-6.1-12.20190803.fc31.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/n/ncurses-base-6.1-12.20190803.fc31.noarch.rpm",
     ],
 )
 
@@ -428,6 +451,7 @@ http_file(
     sha256 = "7b3ba4cdf8c0f1c4c807435d7b7a4a93ecb02737a95d064f3f20299e5bb3a106",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-12.20190803.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-12.20190803.fc31.x86_64.rpm",
     ],
 )
 
@@ -436,6 +460,7 @@ http_file(
     sha256 = "017d8f5d4abb5f925c1b6d46467020c4fd5e8a8dcb4cc6650cab5627269e99d7",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/pcre2-10.33-14.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/p/pcre2-10.33-14.fc31.x86_64.rpm",
     ],
 )
 
@@ -444,6 +469,7 @@ http_file(
     sha256 = "4c859170bc4705a8ff4592f7376918fd2a97435c13cde79f24475c0a0866251d",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/s/setup-2.13.3-2.fc31.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/s/setup-2.13.3-2.fc31.noarch.rpm",
     ],
 )
 
@@ -452,6 +478,7 @@ http_file(
     sha256 = "f0847b05feed5f47260e38b9ea40935644c061ccde2b82da5c68874190d59034",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/t/tzdata-2019c-1.fc31.noarch.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/t/tzdata-2019c-1.fc31.noarch.rpm",
     ],
 )
 
@@ -460,6 +487,7 @@ http_file(
     sha256 = "a3fab3da01bfcbeb3cfe223810f55ce6652976d51d07990f59cab2854498d90e",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
     ],
 )
 
@@ -468,6 +496,7 @@ http_file(
     sha256 = "c557c2145799e5a5e45f8fdab25fd823c63babc36bb131e57c7c0e222ef6a911",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-iscsiuio-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/i/iscsi-initiator-utils-iscsiuio-6.2.0.876-10.gitf3c8e90.fc31.x86_64.rpm",
     ],
 )
 
@@ -476,6 +505,7 @@ http_file(
     sha256 = "6805cf46806ab4b5975bccdb06bd33612bde50c0e09fbaafdc91d4498a45ea1b",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/i/isns-utils-libs-0.97-9.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/i/isns-utils-libs-0.97-9.fc31.x86_64.rpm",
     ],
 )
 
@@ -484,6 +514,7 @@ http_file(
     sha256 = "20289b472fc2f075db4d9e993505ff088852417527a06e29e457778cb7f55183",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/nbdkit-server-1.14.2-1.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/n/nbdkit-server-1.14.2-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -492,6 +523,7 @@ http_file(
     sha256 = "b9b2eb86b0f8d8355be6a1ef42107526aa7f7d35e5b31af7441750e6b770e9b4",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/n/nbdkit-vddk-plugin-1.14.2-1.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/n/nbdkit-vddk-plugin-1.14.2-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -500,6 +532,7 @@ http_file(
     sha256 = "de561ae2ce6394c9b77d5002a52bd9ee9ffea642ffea39bd8fb84d21dce0825c",
     urls = [
         "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/l/libxcrypt-compat-4.4.17-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/l/libxcrypt-compat-4.4.17-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -508,14 +541,16 @@ http_file(
     sha256 = "779d1ba6fc8d794c067679f5cb3762b78afe9e44c203a80424a27f94ed4969b6",
     urls = [
         "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/l/libxcrypt-4.4.17-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/l/libxcrypt-4.4.17-1.fc31.x86_64.rpm",
     ],
 )
 
 http_file(
     name = "mkpasswd",
-    sha256 = "cfe92e9aff4080b8eec8fd0668bcd3e12450a05bf503ba13c739f8e0d7893709",
+    sha256 = "2509fd65ff4a26ef4a619b94e5aca3f576de426107190506d534bc05291ce464",
     urls = [
-        "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/m/mkpasswd-5.5.6-1.fc31.x86_64.rpm",
+        "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/m/mkpasswd-5.5.7-1.fc31.x86_64.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/m/mkpasswd-5.5.7-1.fc31.x86_64.rpm",
     ],
 )
 
@@ -524,6 +559,7 @@ http_file(
     sha256 = "b345fb463c541c6ea69d5308b41b044fa8ef3739206fb3993c019e5538b449e9",
     urls = [
         "https://download.fedoraproject.org/pub/fedora/linux/updates/31/Everything/x86_64/Packages/w/whois-nls-5.5.6-1.fc31.noarch.rpm",
+        "https://mirror.isoc.org.il/pub/fedora/updates/31/Everything/x86_64/Packages/w/whois-nls-5.5.6-1.fc31.noarch.rpm",
     ],
 )
 
@@ -532,5 +568,6 @@ http_file(
     sha256 = "9ace85ca6a9a6dfd6a9e621fe9012fadd704ba5c9fbf1d042244eb0f250b3115",
     urls = [
         "http://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/golang-github-vmware-govmomi-0.21.0-2.fc31.x86_64.rpm",
+        "http://mirror.isoc.org.il/pub/fedora/releases/31/Everything/x86_64/os/Packages/g/golang-github-vmware-govmomi-0.21.0-2.fc31.x86_64.rpm",
     ],
 )


### PR DESCRIPTION
This will still be problematic the moment the packages are updated,
but it's at least going to give us a fallback for the one CI server
that is failing to resolve the mirror it's being redirected to, and
give valid URLs that can be mirrored.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

