### PR TITLE
Remove the "Process" data processor phase, simplify state machine.

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -46,8 +46,6 @@ const (
 	ProcessingPhaseTransferDataFile ProcessingPhase = "TransferDataFile"
 	// ProcessingPhaseValidatePause is the phase in which the data processor should validate and then pause.
 	ProcessingPhaseValidatePause ProcessingPhase = "ValidatePause"
-	// ProcessingPhaseProcess is the phase in which the data source processes the data just written to the scratch space.
-	ProcessingPhaseProcess ProcessingPhase = "Process"
 	// ProcessingPhaseConvert is the phase in which the data is taken from the url provided by the source, and it is converted to the target RAW disk image format.
 	// The url can be an http end point or file system end point.
 	ProcessingPhaseConvert ProcessingPhase = "Convert"
@@ -86,8 +84,6 @@ type DataSourceInterface interface {
 	Transfer(path string) (ProcessingPhase, error)
 	// TransferFile is called to transfer the data from the source to the file passed in.
 	TransferFile(fileName string) (ProcessingPhase, error)
-	// Process is called to do any special processing before giving the url to the data back to the processor
-	Process() (ProcessingPhase, error)
 	// Geturl returns the url that the data processor can use when converting the data.
 	GetURL() *url.URL
 	// Close closes any readers or other open resources.
@@ -202,11 +198,6 @@ func (dp *DataProcessor) ProcessDataWithPause() error {
 				err = validateErr
 			}
 			dp.currentPhase = ProcessingPhasePause
-		case ProcessingPhaseProcess:
-			dp.currentPhase, err = dp.source.Process()
-			if err != nil {
-				err = errors.Wrap(err, "Unable to process source data to intermediate state before transferring to target")
-			}
 		case ProcessingPhaseConvert:
 			dp.currentPhase, err = dp.convert(dp.source.GetURL())
 			if err != nil {

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -143,7 +143,7 @@ func (hs *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
 		}
 		// If we successfully wrote to the file, then the parse will succeed.
 		hs.url, _ = url.Parse(file)
-		return ProcessingPhaseProcess, nil
+		return ProcessingPhaseConvert, nil
 	} else if hs.contentType == cdiv1.DataVolumeArchive {
 		if err := util.UnArchiveTar(hs.readers.TopReader(), path); err != nil {
 			return ProcessingPhaseError, errors.Wrap(err, "unable to untar files from endpoint")
@@ -162,11 +162,6 @@ func (hs *HTTPDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		return ProcessingPhaseError, err
 	}
 	return ProcessingPhaseResize, nil
-}
-
-// Process is called to do any special processing before giving the URI to the data back to the processor
-func (hs *HTTPDataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseConvert, nil
 }
 
 // GetURL returns the URI that the data processor can use when converting the data.

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Http data source", func() {
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(expectedPhase).To(Equal(newPhase))
-			if newPhase == ProcessingPhaseProcess {
+			if newPhase == ProcessingPhaseConvert {
 				file, err := os.Open(filepath.Join(scratchPath, tempFile))
 				Expect(err).NotTo(HaveOccurred())
 				defer file.Close()
@@ -160,7 +160,7 @@ var _ = Describe("Http data source", func() {
 		table.Entry("return Error with invalid content type ", cirrosFileName, cdiv1.DataVolumeContentType("invalid"), ProcessingPhaseError, "", cirrosData, true),
 		table.Entry("return Complete with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseComplete, "", diskimageArchiveData, false),
 		table.Entry("return Error with invalid target path and archive", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseError, "/imaninvalidpath", cirrosData, true),
-		table.Entry("return Process with scratch space and valid qcow file", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseProcess, "", cirrosData, false),
+		table.Entry("return Process with scratch space and valid qcow file", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseConvert, "", cirrosData, false),
 	)
 
 	It("TransferFile should succeed when writing to valid file, and reading raw gz", func() {
@@ -194,17 +194,6 @@ var _ = Describe("Http data source", func() {
 		result, err = dp.TransferFile("/invalidpath/invalidfile")
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
-	})
-
-	It("calling Process should return Convert", func() {
-		flushRead = cirrosData
-		dp, err = NewHTTPDataSource(ts.URL+"/"+cirrosFileName, "", "", "", cdiv1.DataVolumeKubeVirt)
-		Expect(err).NotTo(HaveOccurred())
-		_, err := dp.Info()
-		Expect(err).NotTo(HaveOccurred())
-		newPhase, err := dp.Process()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(newPhase))
 	})
 })
 

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -106,7 +106,7 @@ func (is *ImageioDataSource) Transfer(path string) (ProcessingPhase, error) {
 	}
 	// If we successfully wrote to the file, then the parse will succeed.
 	is.url, _ = url.Parse(file)
-	return ProcessingPhaseProcess, nil
+	return ProcessingPhaseConvert, nil
 }
 
 // TransferFile is called to transfer the data from the source to the passed in file.
@@ -117,11 +117,6 @@ func (is *ImageioDataSource) TransferFile(fileName string) (ProcessingPhase, err
 		return ProcessingPhaseError, err
 	}
 	return ProcessingPhaseResize, nil
-}
-
-// Process is called to do any special processing before giving the URI to the data back to the processor
-func (is *ImageioDataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseConvert, nil
 }
 
 // GetURL returns the URI that the data processor can use when converting the data.

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -108,13 +108,6 @@ var _ = Describe("Imageio data source", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("NewImageioDataSource proccess should not fail with valid endpoint ", func() {
-		dp, err := NewImageioDataSource(ts.URL, "", "", tempDir, "")
-		Expect(err).ToNot(HaveOccurred())
-		_, err = dp.Process()
-		Expect(err).ToNot(HaveOccurred())
-	})
-
 	It("NewImageioDataSource tranfer should fail if invalid path", func() {
 		dp, err := NewImageioDataSource(ts.URL, "", "", tempDir, "")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -39,8 +39,7 @@ const (
 // RegistryDataSource is the struct containing the information needed to import from a registry data source.
 // Sequence of phases:
 // 1. Info -> Transfer
-// 2. Transfer -> Process
-// 3. Process -> Convert (In the process phase the container image layers are extracted, and the url is pointed to the file determined to be the disk image)
+// 2. Transfer -> Convert
 type RegistryDataSource struct {
 	endpoint    string
 	accessKey   string
@@ -86,16 +85,6 @@ func (rd *RegistryDataSource) Transfer(path string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, errors.Wrapf(err, "Failed to read registry image")
 	}
 
-	return ProcessingPhaseProcess, nil
-}
-
-// TransferFile is called to transfer the data from the source to the passed in file.
-func (rd *RegistryDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
-	return ProcessingPhaseError, errors.New("Transferfile should not be called")
-}
-
-// Process is called to do any special processing before giving the url to the data back to the processor
-func (rd *RegistryDataSource) Process() (ProcessingPhase, error) {
 	imageFile, err := getImageFileName(rd.imageDir)
 	if err != nil {
 		return ProcessingPhaseError, errors.Wrapf(err, "Cannot locate image file")
@@ -105,6 +94,11 @@ func (rd *RegistryDataSource) Process() (ProcessingPhase, error) {
 	rd.url, _ = url.Parse(filepath.Join(rd.imageDir, imageFile))
 	klog.V(3).Infof("Successfully found file. VM disk image filename is %s", rd.url.String())
 	return ProcessingPhaseConvert, nil
+}
+
+// TransferFile is called to transfer the data from the source to the passed in file.
+func (rd *RegistryDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	return ProcessingPhaseError, errors.New("Transferfile should not be called")
 }
 
 // GetURL returns the url that the data processor can use when converting the data.

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -2,7 +2,6 @@ package importer
 
 import (
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +9,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
-	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 var (
@@ -55,43 +52,17 @@ var _ = Describe("Registry data source", func() {
 		result, err := ds.Transfer(scratchPath)
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ProcessingPhaseProcess).To(Equal(result))
+			Expect(ProcessingPhaseConvert).To(Equal(result))
 			Expect(filepath.Join(scratchPath, containerDiskImageDir)).To(Equal(ds.imageDir))
 		} else {
 			Expect(err).To(HaveOccurred())
 			Expect(ProcessingPhaseError).To(Equal(result))
 		}
 	},
-		table.Entry("successfully return Process on valid scratch space and empty user parameters", "oci-archive:"+imageFile, "", "", "", "", true, false),
-		table.Entry("successfully return Process on valid scratch space and parameters", "oci-archive:"+imageFile, "username", "password", "/path/to/cert", "", true, false),
+		table.Entry("successfully return Convert on valid scratch space and empty user parameters", "oci-archive:"+imageFile, "", "", "", "", true, false),
+		table.Entry("successfully return Convert on valid scratch space and parameters", "oci-archive:"+imageFile, "username", "password", "/path/to/cert", "", true, false),
 		table.Entry("return Error on invalid scratch space", "oci-archive:"+imageFile, "", "", "", "/invalid", true, true),
 		table.Entry("return Error on valid scratch space, but CopyImage failed", "invalid", "", "", "", "", true, true),
-	)
-
-	table.DescribeTable("Process should ", func(scratchPath string, wantErr bool) {
-		ds = NewRegistryDataSource("", "", "", "", true)
-		if scratchPath == "" {
-			scratchPath = tmpDir
-			err := os.Mkdir(filepath.Join(scratchPath, containerDiskImageDir), os.ModeDir)
-			Expect(err).NotTo(HaveOccurred())
-			err = util.CopyFile(cirrosFilePath, filepath.Join(scratchPath, containerDiskImageDir, cirrosFileName))
-			Expect(err).NotTo(HaveOccurred())
-		}
-		ds.imageDir = filepath.Join(scratchPath, containerDiskImageDir)
-		result, err := ds.Process()
-		if !wantErr {
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ProcessingPhaseConvert).To(Equal(result))
-			imageFileName, err := url.Parse(filepath.Join(scratchPath, containerDiskImageDir, cirrosFileName))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(imageFileName).To(Equal(ds.GetURL()))
-		} else {
-			Expect(err).To(HaveOccurred())
-			Expect(ProcessingPhaseError).To(Equal(result))
-		}
-	},
-		table.Entry("successfully return Convert on valid image file", "", false),
-		table.Entry("return Error on invalid image file", "/invalid", true),
 	)
 
 	It("TransferFile should not be called", func() {

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -97,7 +97,7 @@ func (sd *S3DataSource) Transfer(path string) (ProcessingPhase, error) {
 	}
 	// If streaming succeeded, then parsing the file into URL will also succeed, no need to check error status
 	sd.url, _ = url.Parse(file)
-	return ProcessingPhaseProcess, nil
+	return ProcessingPhaseConvert, nil
 }
 
 // TransferFile is called to transfer the data from the source to the passed in file.
@@ -107,11 +107,6 @@ func (sd *S3DataSource) TransferFile(fileName string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, err
 	}
 	return ProcessingPhaseResize, nil
-}
-
-// Process is called to do any special processing before giving the url to the data back to the processor
-func (sd *S3DataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseConvert, nil
 }
 
 // GetURL returns the url that the data processor can use when converting the data.

--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -111,7 +111,7 @@ var _ = Describe("S3 data source", func() {
 		result, err := sd.Transfer(scratchPath)
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ProcessingPhaseProcess).To(Equal(result))
+			Expect(ProcessingPhaseConvert).To(Equal(result))
 			file, err := os.Open(filepath.Join(scratchPath, tempFile))
 			Expect(err).NotTo(HaveOccurred())
 			defer file.Close()
@@ -179,19 +179,6 @@ var _ = Describe("S3 data source", func() {
 		result, err = sd.TransferFile("/invalidpath/invalidfile")
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
-	})
-
-	It("Process should return Convert", func() {
-		// Don't need to defer close, since ud.Close will close the reader
-		file, err := os.Open(cirrosFilePath)
-		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "")
-		Expect(err).NotTo(HaveOccurred())
-		// Replace minio.Object with a reader we can use.
-		sd.s3Reader = file
-		result, err := sd.Process()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(result))
 	})
 
 	It("GetS3Client should return a real client", func() {

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -14,9 +14,8 @@ import (
 // Sequence of phases:
 // 1a. ProcessingPhaseInfo -> ProcessingPhaseTransferScratch (In Info phase the format readers are configured) In case the readers don't contain a raw file.
 // 1b. ProcessingPhaseInfo -> ProcessingPhaseTransferDataFile, in the case the readers contain a raw file.
-// 2a. ProcessingPhaseTransferScratch -> ProcessingPhaseProcess
+// 2a. ProcessingPhaseTransferScratch -> ProcessingPhaseConvert
 // 2b. ProcessingPhaseTransferDataFile -> ProcessingPhaseResize
-// 3. ProcessingPhaseProcess -> ProcessingPhaseConvert
 type UploadDataSource struct {
 	// Data strean
 	stream io.ReadCloser
@@ -66,7 +65,7 @@ func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
 	}
 	// If we successfully wrote to the file, then the parse will succeed.
 	ud.url, _ = url.Parse(file)
-	return ProcessingPhaseProcess, nil
+	return ProcessingPhaseConvert, nil
 }
 
 // TransferFile is called to transfer the data from the source to the passed in file.
@@ -78,11 +77,6 @@ func (ud *UploadDataSource) TransferFile(fileName string) (ProcessingPhase, erro
 	// If we successfully wrote to the file, then the parse will succeed.
 	ud.url, _ = url.Parse(fileName)
 	return ProcessingPhaseResize, nil
-}
-
-// Process is called to do any special processing before giving the url to the data back to the processor
-func (ud *UploadDataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseConvert, nil
 }
 
 // GetURL returns the url that the data processor can use when converting the data.
@@ -138,7 +132,7 @@ func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error)
 	}
 	// If we successfully wrote to the file, then the parse will succeed.
 	aud.uploadDataSource.url, _ = url.Parse(file)
-	aud.ResumePhase = ProcessingPhaseProcess
+	aud.ResumePhase = ProcessingPhaseConvert
 	return ProcessingPhaseValidatePause, nil
 }
 
@@ -152,11 +146,6 @@ func (aud *AsyncUploadDataSource) TransferFile(fileName string) (ProcessingPhase
 	aud.uploadDataSource.url, _ = url.Parse(fileName)
 	aud.ResumePhase = ProcessingPhaseResize
 	return ProcessingPhaseValidatePause, nil
-}
-
-// Process is called to do any special processing before giving the url to the data back to the processor
-func (aud *AsyncUploadDataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseConvert, nil
 }
 
 // Close closes any readers or other open resources.

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Upload data source", func() {
 		result, err := ud.Transfer(scratchPath)
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ProcessingPhaseProcess).To(Equal(result))
+			Expect(ProcessingPhaseConvert).To(Equal(result))
 			file, err := os.Open(filepath.Join(scratchPath, tempFile))
 			Expect(err).NotTo(HaveOccurred())
 			defer file.Close()
@@ -135,16 +135,6 @@ var _ = Describe("Upload data source", func() {
 		result, err = ud.TransferFile("/invalidpath/invalidfile")
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
-	})
-
-	It("Process should return Convert", func() {
-		// Don't need to defer close, since ud.Close will close the reader
-		file, err := os.Open(cirrosFilePath)
-		Expect(err).NotTo(HaveOccurred())
-		ud = NewUploadDataSource(file)
-		result, err := ud.Process()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(result))
 	})
 
 	It("Close with nil stream should not fail", func() {
@@ -221,7 +211,7 @@ var _ = Describe("Async Upload data source", func() {
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ProcessingPhaseValidatePause).To(Equal(result))
-			Expect(ProcessingPhaseProcess).To(Equal(aud.GetResumePhase()))
+			Expect(ProcessingPhaseConvert).To(Equal(aud.GetResumePhase()))
 		} else {
 			Expect(err).To(HaveOccurred())
 		}
@@ -270,16 +260,6 @@ var _ = Describe("Async Upload data source", func() {
 		result, err = aud.TransferFile("/invalidpath/invalidfile")
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
-	})
-
-	It("Process should return Convert", func() {
-		// Don't need to defer close, since ud.Close will close the reader
-		file, err := os.Open(cirrosFilePath)
-		Expect(err).NotTo(HaveOccurred())
-		aud = NewAsyncUploadDataSource(file)
-		result, err := aud.Process()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(result))
 	})
 
 	It("Close with nil stream should not fail", func() {

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -232,11 +232,6 @@ func (vs *VDDKDataSource) GetURL() *url.URL {
 	return vs.NbdSocket
 }
 
-// Process is called to do any special processing before giving the url to the data back to the processor
-func (vs *VDDKDataSource) Process() (ProcessingPhase, error) {
-	return ProcessingPhaseTransferDataFile, nil
-}
-
 // Transfer is called to transfer the data from the source to the path passed in.
 func (vs *VDDKDataSource) Transfer(path string) (ProcessingPhase, error) {
 	return ProcessingPhaseTransferDataFile, nil


### PR DESCRIPTION
This phase can mean three things:
HTTP, imageio, s3, upload: Go directly to Convert
VDDK: unreachable code, points to arbitrary other phase.
registry: do minor processing after transfer.

Only registry makes actual use of this phase.

Point all current users directly to Convert, and fold the
work done in the registry Process phase into the previous
phase.

**Special notes for your reviewer**:
I did some reading of the state diagram for the purpose of adding an unconditional validation, it was pretty complicated and this seems like a possible simplification. Let me know if you disagree. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

