### PR TITLE
Add make targets cluster-sync-cdi & cluster-sync-test-infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,13 @@ cluster-down-purge: docker-registry-cleanup cluster-down
 cluster-clean:
 	./cluster-sync/clean.sh
 
-cluster-sync: cluster-clean
+cluster-sync-cdi: cluster-clean
 	./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
+
+cluster-sync-test-infra:
+	CDI_SYNC="test-infra" ./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
+
+cluster-sync: cluster-sync-cdi cluster-sync-test-infra
 
 bazel-generate:
 	${DO_BAZ} "./hack/build/bazel-generate.sh -- pkg/ tools/ tests/ cmd/ vendor/"

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -111,6 +111,20 @@ function wait_cdi_pods_updated {
   fi
 }
 
+# Start functional test HTTP server.
+# We skip the functional test additions for external provider for now, as they're specific
+if [ "${KUBEVIRT_PROVIDER}" != "external" ] && [ "${CDI_SYNC}" == "test-infra" ]; then
+  _kubectl delete all -n cdi -l cdi.kubevirt.io/testing
+  _kubectl apply -f "./_out/manifests/bad-webserver.yaml"
+  _kubectl apply -f "./_out/manifests/file-host.yaml"
+  _kubectl apply -f "./_out/manifests/registry-host.yaml"
+  # Imageio test service:
+  _kubectl apply -f "./_out/manifests/imageio.yaml"
+  # vCenter (VDDK) test service:
+  _kubectl apply -f "./_out/manifests/vcenter.yaml"
+  exit 0
+fi
+
 mkdir -p ./_out/tests
 rm -f $OLD_CDI_VER_PODS $NEW_CDI_VER_PODS
 
@@ -197,15 +211,3 @@ crds+=($operator_crds)
 check_structural_schema "${crds[@]}"
 
 configure_storage
-
-# Start functional test HTTP server.
-# We skip the functional test additions for external provider for now, as they're specific
-if [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
-  _kubectl apply -f "./_out/manifests/bad-webserver.yaml"
-  _kubectl apply -f "./_out/manifests/file-host.yaml"
-  _kubectl apply -f "./_out/manifests/registry-host.yaml"
-  # Imageio test service:
-  _kubectl apply -f "./_out/manifests/imageio.yaml"
-  # vCenter (VDDK) test service:
-  _kubectl apply -f "./_out/manifests/vcenter.yaml"
-fi

--- a/hack/build/cluster-sync-test.sh
+++ b/hack/build/cluster-sync-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+PODS_TIMEOUT=1800
+
+sync_log=$(date +"sync%y%m%d%H%M.log")
+k=cluster-up/kubectl.sh
+
+function wait_pods_ready {
+  echo_log "Waiting $PODS_TIMEOUT seconds for pods to be ready"
+  wait_time=0
+  not_ready_pods="something"
+  prev_pods=""
+  while [ -n "$not_ready_pods" ] && [ $wait_time -lt ${PODS_TIMEOUT} ]; do
+    not_ready_pods=$($k get pods -A -o'custom-columns=metadata:metadata.name,status:status.containerStatuses[*].ready' --no-headers | grep false)
+    if [ -n "$not_ready_pods" ] ; then
+      if [ "$not_ready_pods" != "$prev_pods" ] ; then
+        echo_log "Not ready pods: $not_ready_pods"
+        prev_pods=$not_ready_pods
+      fi
+      wait_time=$((wait_time + 5))
+      sleep 5
+    fi
+  done
+  echo_log "Waited $wait_time seconds"
+  if [ -z "$not_ready_pods" ] ; then
+    echo_log "All pods are ready"
+  else
+    echo_log "Not all pods are ready"
+  fi
+}
+
+function echo_log {
+  s=$(date +"%H:%M:%S $1")
+  echo $s
+  echo $s >> $sync_log
+}
+
+function run_time_log {
+  echo_log "$1"
+  SECONDS=0
+  $1
+  echo_log "$SECONDS sec"
+}
+
+echo_log "========================================================================================="
+run_time_log "make cluster-down"
+run_time_log "make cluster-up"
+wait_pods_ready
+run_time_log "make cluster-sync-cdi"
+wait_pods_ready
+run_time_log "make cluster-sync-cdi"
+wait_pods_ready
+run_time_log "make cluster-sync-cdi"
+wait_pods_ready
+echo_log "========================================================================================="
+run_time_log "make cluster-sync-test-infra"
+wait_pods_ready
+run_time_log "make cluster-sync-test-infra"
+wait_pods_ready
+run_time_log "make cluster-sync-test-infra"
+wait_pods_ready
+echo_log "========================================================================================="
+run_time_log "make cluster-down"
+run_time_log "make cluster-up"
+wait_pods_ready
+run_time_log "make cluster-sync"
+wait_pods_ready
+run_time_log "make cluster-sync"
+wait_pods_ready
+run_time_log "make cluster-sync"
+wait_pods_ready


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
CDI developer would prefer not to redeploy test containers on each cluster-sync. Currently each time we cluster-sync, it un-installs all of CDI, including test containers, and then re-installs newly compiled CDI containers, and then re-installs the test containers. The test containers don't change often, so it makes sense to not always reinstall them. This is helpful when you are developing and  not interested in the tests. It saves a lot of time.

**Release note**:
```NONE```

