### PR TITLE
Add an API for disabling smart-cloning.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3492,6 +3492,10 @@
     "description": "CDISpec defines our specification for the CDI installation",
     "type": "object",
     "properties": {
+     "cloneStrategyOverride": {
+      "description": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+      "type": "string"
+     },
      "config": {
       "description": "CDIConfig at CDI level",
       "$ref": "#/definitions/v1beta1.CDIConfigSpec"

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -13754,6 +13754,13 @@ func schema_pkg_apis_core_v1alpha1_CDISpec(ref common.ReferenceCallback) common.
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
 						},
 					},
+					"cloneStrategyOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CDIConfig at CDI level",

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -282,9 +282,20 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
+	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
+	// +kubebuilder:validation:Enum="copy";"snapshot"
+	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 	// CDIConfig at CDI level
 	Config *CDIConfigSpec `json:"config,omitempty"`
 }
+
+// CDICloneStrategy defines the preferred method for performing a CDI clone (override snapshot?)
+type CDICloneStrategy string
+
+const (
+	// CloneStrategyHostAssisted specifies slower, host-assisted copy
+	CloneStrategyHostAssisted = "copy"
+)
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall
 type CDIUninstallStrategy string

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -295,6 +295,9 @@ type CDICloneStrategy string
 const (
 	// CloneStrategyHostAssisted specifies slower, host-assisted copy
 	CloneStrategyHostAssisted = "copy"
+
+	// CloneStrategySnapshot specifies snapshot-based copying
+	CloneStrategySnapshot = "snapshot"
 )
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -130,12 +130,13 @@ func (CDI) SwaggerDoc() map[string]string {
 
 func (CDISpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                  "CDISpec defines our specification for the CDI installation",
-		"imagePullPolicy":   "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
-		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
-		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
-		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
-		"config":            "CDIConfig at CDI level",
+		"":                      "CDISpec defines our specification for the CDI installation",
+		"imagePullPolicy":       "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
+		"uninstallStrategy":     "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
+		"infra":                 "Rules on which nodes CDI infrastructure pods will be scheduled",
+		"workload":              "Restrict on which nodes CDI workload pods will be scheduled",
+		"cloneStrategyOverride": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
+		"config":                "CDIConfig at CDI level",
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -224,6 +224,11 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
+	if in.CloneStrategyOverride != nil {
+		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
+		*out = new(CDICloneStrategy)
+		**out = **in
+	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(CDIConfigSpec)

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -13768,6 +13768,13 @@ func schema_pkg_apis_core_v1beta1_CDISpec(ref common.ReferenceCallback) common.O
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
 						},
 					},
+					"cloneStrategyOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CDIConfig at CDI level",

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -284,9 +284,23 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
+	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
+	// +kubebuilder:validation:Enum="copy";"snapshot"
+	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 	// CDIConfig at CDI level
 	Config *CDIConfigSpec `json:"config,omitempty"`
 }
+
+// CDICloneStrategy defines the preferred method for performing a CDI clone (override snapshot?)
+type CDICloneStrategy string
+
+const (
+	// CloneStrategyHostAssisted specifies slower, host-assisted copy
+	CloneStrategyHostAssisted = "copy"
+
+	// CloneStrategySnapshot specifies snapshot-based copying
+	CloneStrategySnapshot = "snapshot"
+)
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall
 type CDIUninstallStrategy string

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -130,12 +130,13 @@ func (CDI) SwaggerDoc() map[string]string {
 
 func (CDISpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                  "CDISpec defines our specification for the CDI installation",
-		"imagePullPolicy":   "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
-		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
-		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
-		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
-		"config":            "CDIConfig at CDI level",
+		"":                      "CDISpec defines our specification for the CDI installation",
+		"imagePullPolicy":       "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
+		"uninstallStrategy":     "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
+		"infra":                 "Rules on which nodes CDI infrastructure pods will be scheduled",
+		"workload":              "Restrict on which nodes CDI workload pods will be scheduled",
+		"cloneStrategyOverride": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
+		"config":                "CDIConfig at CDI level",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
+	if in.CloneStrategyOverride != nil {
+		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
+		*out = new(CDICloneStrategy)
+		**out = **in
+	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(CDIConfigSpec)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -272,8 +272,12 @@ func (r *DatavolumeReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 	}
 
 	if !pvcExists {
+		cloneStrategy, err := r.getCloneStrategy()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume)
-		if err == nil {
+		if (err == nil) && (cloneStrategy == cdiv1.CloneStrategySnapshot) {
 			r.log.V(3).Info("Smart-Clone via Snapshot is available with Volume Snapshot Class", "snapshotClassName", snapshotClassName)
 			if requeue, err := r.sourceInUse(datavolume); requeue || err != nil {
 				return reconcile.Result{Requeue: requeue}, err
@@ -486,6 +490,21 @@ func (r *DatavolumeReconciler) getSnapshotClassForSmartClone(dataVolume *cdiv1.D
 
 	r.log.V(3).Info("Could not match snapshotter with storage class, falling back to host assisted clone")
 	return "", errors.New("could not match snapshotter with storage class, falling back to host assisted clone")
+}
+
+func (r *DatavolumeReconciler) getCloneStrategy() (cdiv1.CDICloneStrategy, error) {
+	crList := &cdiv1.CDIList{}
+	if err := r.client.List(context.TODO(), crList, &client.ListOptions{}); err != nil {
+		return cdiv1.CloneStrategySnapshot, err
+	}
+	if len(crList.Items) != 1 {
+		return cdiv1.CloneStrategySnapshot, fmt.Errorf("Number of CDI CRs != 1")
+	}
+	if crList.Items[0].Spec.CloneStrategyOverride == nil {
+		return cdiv1.CloneStrategySnapshot, nil
+	}
+	r.log.V(3).Info(fmt.Sprintf("Overriding default clone strategy with %s", *crList.Items[0].Spec.CloneStrategyOverride))
+	return *crList.Items[0].Spec.CloneStrategyOverride, nil
 }
 
 func newSnapshot(dataVolume *cdiv1.DataVolume, snapshotClassName string) *snapshotv1.VolumeSnapshot {

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -1512,6 +1512,18 @@ func createCDIListCRD() *extv1.CustomResourceDefinition {
 												},
 											},
 										},
+										"cloneStrategyOverride": {
+											Type:        "string",
+											Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"copy"`),
+												},
+												{
+													Raw: []byte(`"snapshot"`),
+												},
+											},
+										},
 										"config": {
 											Description: "CDIConfig at CDI level",
 											Type:        "object",
@@ -2825,6 +2837,18 @@ func createCDIListCRD() *extv1.CustomResourceDefinition {
 												},
 												{
 													Raw: []byte(`"BlockUninstallIfWorkloadsExist"`),
+												},
+											},
+										},
+										"cloneStrategyOverride": {
+											Type:        "string",
+											Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+											Enum: []extv1.JSON{
+												{
+													Raw: []byte(`"copy"`),
+												},
+												{
+													Raw: []byte(`"snapshot"`),
 												},
 											},
 										},


### PR DESCRIPTION
We used to detect the possibility of smart-cloning and always use it
if it's there. This might not be the desirable behaviour if:
- Snapshots cost more money than a host-assisted clone
- Snapshots are broken

The API is:
kubectl edit cdi
cdi.Spec.cloneStrategyOverride = "Host"

We use an enum rather than a boolean for this in an attempt to future
proof if more strategies are available, but only the value that is
currently necessary is used.

If no value is defined, we continue with the existing behaviour of
preferring smart clone if possible.

**Special notes for your reviewer**:
I've only defined a value in the spec portion of the CDI CR, and not in the status, or in CDIConfig.
Avoiding the config controller feels like it might be the right move, but we have spoken about this enough that I'm not sure.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a tunable to disable smart-clone and always prefer host-assisted copy.
CDI.spec.cloneStrategyOverride: "copy"
If this value is not defined to anything, the existing behaviour is unchanged. That is, smart-clone when possible.
```

