### PR TITLE
VDDK: Add more debug logging around nbdkit.

### DIFF
--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -440,7 +440,7 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 
 		// Only log progress at approximately 1% intervals.
 		currentProgressBytes := i + uint64(written)
-		currentProgressPercent := uint(100.0 * (float32(currentProgressBytes) / float32(size)))
+		currentProgressPercent := uint(100.0 * (float64(currentProgressBytes) / float64(size)))
 		if currentProgressPercent > lastProgressPercent {
 			progressMessage := fmt.Sprintf("Transferred %d/%d bytes (%d%%)", currentProgressBytes, size, currentProgressPercent)
 

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -152,6 +152,13 @@ func FindMoRef(uuid string, sdkURL string) (string, error) {
 		} else {
 			moref = ref.Reference().Value
 			klog.Infof("VM %s found in datacenter %s: %s", uuid, datacenter, moref)
+			vm := object.NewVirtualMachine(conn.Client, ref.Reference())
+			state, err := vm.PowerState(ctx)
+			if err != nil {
+				klog.Warningf("Unable to get current VM power state: %v", err)
+			} else {
+				klog.Infof("Current VM power state: %s", state)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds some extra logging to the VDDK importer.

**Which issue(s) this PR fixes**:
Fixes #1464

**Special notes for your reviewer**:
One useful piece of this ended up in a different pull request: [this goroutine that logs nbdkit's stdout/stderr](https://github.com/mrnold/containerized-data-importer/commit/7edbcbb7fb6b93ec91e8bc25cfa9b34ca300ba33#diff-c46055929ede7b3ba517257f9a8614ee9507c33a99c80b8d51933e143c6fb864R242). I am only mentioning this in case anyone needs to backport this to CNV 2.5 without taking all of #1448. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

