### PR TITLE
Add CDIConfig to CDI

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3489,6 +3489,10 @@
     "description": "CDISpec defines our specification for the CDI installation",
     "type": "object",
     "properties": {
+     "config": {
+      "description": "CDIConfig at CDI level",
+      "$ref": "#/definitions/v1beta1.CDIConfigSpec"
+     },
      "imagePullPolicy": {
       "description": "PullPolicy describes a policy for if/when to pull a container image",
       "type": "string"

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -13753,11 +13753,17 @@ func schema_pkg_apis_core_v1alpha1_CDISpec(ref common.ReferenceCallback) common.
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CDIConfig at CDI level",
+							Ref:         ref("kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.CDIConfigSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"},
+			"kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.CDIConfigSpec", "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"},
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -268,6 +268,8 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
+	// CDIConfig at CDI level
+	Config *CDIConfigSpec `json:"config,omitempty"`
 }
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -125,6 +125,7 @@ func (CDISpec) SwaggerDoc() map[string]string {
 		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
 		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
 		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
+		"config":            "CDIConfig at CDI level",
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -224,6 +224,11 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = new(CDIConfigSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -13767,11 +13767,17 @@ func schema_pkg_apis_core_v1beta1_CDISpec(ref common.ReferenceCallback) common.O
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CDIConfig at CDI level",
+							Ref:         ref("kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1.CDIConfigSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"},
+			"kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1.CDIConfigSpec", "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"},
 	}
 }
 

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -270,6 +270,8 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
+	// CDIConfig at CDI level
+	Config *CDIConfigSpec `json:"config,omitempty"`
 }
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -125,6 +125,7 @@ func (CDISpec) SwaggerDoc() map[string]string {
 		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
 		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
 		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
+		"config":            "CDIConfig at CDI level",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = new(CDIConfigSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -1512,6 +1512,84 @@ func createCDIListCRD() *extv1.CustomResourceDefinition {
 												},
 											},
 										},
+										"config": {
+											Description: "CDIConfig at CDI level",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"uploadProxyURLOverride": {
+													Description: "Override the URL used when uploading to a DataVolume",
+													Type:        "string",
+												},
+												"scratchSpaceStorageClass": {
+													Description: "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space",
+													Type:        "string",
+												},
+												"podResourceRequirements": {
+													Description: "ResourceRequirements describes the compute resource requirements.",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"limits": {
+															Description: "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+															Type:        "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	AnyOf: []extv1.JSONSchemaProps{
+																		{
+																			Type: "integer",
+																		},
+																		{
+																			Type: "string",
+																		},
+																	},
+																	Pattern:      "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+																	XIntOrString: true,
+																},
+															},
+														},
+														"requests": {
+															Description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+															Type:        "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	AnyOf: []extv1.JSONSchemaProps{
+																		{
+																			Type: "integer",
+																		},
+																		{
+																			Type: "string",
+																		},
+																	},
+																	Pattern:      "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+																	XIntOrString: true,
+																},
+															},
+														},
+													},
+												},
+												"filesystemOverhead": {
+													Description: "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"global": {
+															Description: "Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)",
+															Type:        "string",
+															Pattern:     `^(0(?:\.\d{1,3})?|1)$`,
+														},
+														"storageClass": {
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	Type:        "string",
+																	Pattern:     `^(0(?:\.\d{1,3})?|1)$`,
+																	Description: "Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)",
+																},
+															},
+															Description: "StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value",
+															Type:        "object",
+														},
+													},
+												},
+											},
+										},
 									},
 									Type:        "object",
 									Description: "CDISpec defines our specification for the CDI installation",
@@ -2747,6 +2825,93 @@ func createCDIListCRD() *extv1.CustomResourceDefinition {
 												},
 												{
 													Raw: []byte(`"BlockUninstallIfWorkloadsExist"`),
+												},
+											},
+										},
+										"config": {
+											Description: "CDIConfig at CDI level",
+											Type:        "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"featureGates": {
+													Description: "FeatureGates are a list of specific enabled feature gates",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "string",
+														},
+													},
+													Type: "array",
+												},
+												"uploadProxyURLOverride": {
+													Description: "Override the URL used when uploading to a DataVolume",
+													Type:        "string",
+												},
+												"scratchSpaceStorageClass": {
+													Description: "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space",
+													Type:        "string",
+												},
+												"podResourceRequirements": {
+													Description: "ResourceRequirements describes the compute resource requirements.",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"limits": {
+															Description: "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+															Type:        "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	AnyOf: []extv1.JSONSchemaProps{
+																		{
+																			Type: "integer",
+																		},
+																		{
+																			Type: "string",
+																		},
+																	},
+																	Pattern:      "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+																	XIntOrString: true,
+																},
+															},
+														},
+														"requests": {
+															Description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+															Type:        "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	AnyOf: []extv1.JSONSchemaProps{
+																		{
+																			Type: "integer",
+																		},
+																		{
+																			Type: "string",
+																		},
+																	},
+																	Pattern:      "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+																	XIntOrString: true,
+																},
+															},
+														},
+													},
+												},
+												"filesystemOverhead": {
+													Description: "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"global": {
+															Description: "Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)",
+															Type:        "string",
+															Pattern:     `^(0(?:\.\d{1,3})?|1)$`,
+														},
+														"storageClass": {
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Schema: &extv1.JSONSchemaProps{
+																	Type:        "string",
+																	Pattern:     `^(0(?:\.\d{1,3})?|1)$`,
+																	Description: "Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)",
+																},
+															},
+															Description: "StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value",
+															Type:        "object",
+														},
+													},
 												},
 											},
 										},

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -659,10 +659,10 @@ var _ = Describe("all clone tests", func() {
 
 		AfterEach(func() {
 			By("Restoring CDIConfig to original state")
-			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+			err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+				config.PodResourceRequirements = orgConfig
+			})
 			Expect(err).ToNot(HaveOccurred())
-			config.Spec.PodResourceRequirements = orgConfig
-			_, err = f.CdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
 			Eventually(func() bool {
 				config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -959,7 +959,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		noSuchFileFileURL := utils.InvalidQcowImagesURL + "no-such-file.img"
 
 		BeforeEach(func() {
-			previousValue, err := utils.DisableFeatureGate(f.CdiClient, featuregates.HonorWaitForFirstConsumer)
+			previousValue, err := utils.DisableFeatureGate(f.CrClient, featuregates.HonorWaitForFirstConsumer)
 			Expect(err).ToNot(HaveOccurred())
 			original = previousValue
 		})
@@ -967,7 +967,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		AfterEach(func() {
 			if original != nil && *original {
 				// restore
-				_, err := utils.EnableFeatureGate(f.CdiClient, featuregates.HonorWaitForFirstConsumer)
+				_, err := utils.EnableFeatureGate(f.CrClient, featuregates.HonorWaitForFirstConsumer)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -288,8 +288,8 @@ func (c *Clients) GetCrClient() (crclient.Client, error) {
 	return client, nil
 }
 
-// GetCdiClientForServiceAccount returns a cdi client for a service account
-func (f *Framework) GetCdiClientForServiceAccount(namespace, name string) (*cdiClientset.Clientset, error) {
+// GetRESTConfigForServiceAccount returns a RESTConfig for SA
+func (f *Framework) GetRESTConfigForServiceAccount(namespace, name string) (*rest.Config, error) {
 	var secretName string
 
 	sl, err := f.K8sClient.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{})
@@ -321,13 +321,21 @@ func (f *Framework) GetCdiClientForServiceAccount(namespace, name string) (*cdiC
 		return nil, fmt.Errorf("no token key")
 	}
 
-	cfg := &rest.Config{
+	return &rest.Config{
 		Host:        f.RestConfig.Host,
 		APIPath:     f.RestConfig.APIPath,
 		BearerToken: string(token),
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: true,
 		},
+	}, nil
+}
+
+// GetCdiClientForServiceAccount returns a cdi client for a service account
+func (f *Framework) GetCdiClientForServiceAccount(namespace, name string) (*cdiClientset.Clientset, error) {
+	cfg, err := f.GetRESTConfigForServiceAccount(namespace, name)
+	if err != nil {
+		return nil, err
 	}
 
 	cdiClient, err := cdiClientset.NewForConfig(cfg)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -420,16 +420,16 @@ var _ = Describe("Namespace with quota", func() {
 
 	AfterEach(func() {
 		By("Restoring CDIConfig to original state")
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+		err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+			config.PodResourceRequirements = orgConfig
+		})
 		Expect(err).ToNot(HaveOccurred())
-		config.Spec.PodResourceRequirements = orgConfig
-		_, err = f.CdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
 		Eventually(func() bool {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return reflect.DeepEqual(config.Spec.PodResourceRequirements, orgConfig)
 		}, timeout, pollingInterval).Should(BeTrue(), "CDIConfig not properly restored to original value")
-		config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		fmt.Fprintf(GinkgoWriter, "INFO: new config: %v\n", config.Spec.PodResourceRequirements)
 	})

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -113,11 +114,12 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cl.Items).To(HaveLen(1))
 
-		cfg, err := client.CdiV1beta1().CDIConfigs().Get(context.TODO(), cl.Items[0].Name, metav1.GetOptions{})
+		_, err = client.CdiV1beta1().CDIConfigs().Get(context.TODO(), cl.Items[0].Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		cfg.Spec.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
-		cfg, err = client.CdiV1beta1().CDIConfigs().Update(context.TODO(), cfg, metav1.UpdateOptions{})
+		err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+			config.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
+		})
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("[test_id:3948]can do everything with admin", "admin"),
@@ -153,11 +155,12 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cl.Items).To(HaveLen(1))
 
-		cfg, err := client.CdiV1beta1().CDIConfigs().Get(context.TODO(), cl.Items[0].Name, metav1.GetOptions{})
+		_, err = client.CdiV1beta1().CDIConfigs().Get(context.TODO(), cl.Items[0].Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		cfg.Spec.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
-		cfg, err = client.CdiV1beta1().CDIConfigs().Update(context.TODO(), cfg, metav1.UpdateOptions{})
+		err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+			config.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
+		})
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -504,10 +504,9 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 
 	AfterEach(func() {
 		By("Restoring CDIConfig to original state")
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		config.Spec = *origSpec
-		_, err = f.CdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
+		err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+			origSpec.DeepCopyInto(config)
+		})
 		Eventually(func() bool {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -635,11 +634,9 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 		if scOverhead != "" {
 			testedFilesystemOverhead.StorageClass = map[string]cdiv1.Percent{defaultSCName: cdiv1.Percent(scOverhead)}
 		}
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		config.Spec.FilesystemOverhead = testedFilesystemOverhead.DeepCopy()
-		By(fmt.Sprintf("Updating CDIConfig filesystem overhead to %v", config.Spec.FilesystemOverhead))
-		_, err = f.CdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
+		err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+			config.FilesystemOverhead = testedFilesystemOverhead.DeepCopy()
+		})
 		Expect(err).ToNot(HaveOccurred())
 		By(fmt.Sprintf("Waiting for filsystem overhead status to be set to %v", testedFilesystemOverhead))
 		Eventually(func() bool {

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/apis/upload/v1beta1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/common:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/image:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/naming:go_default_library",
@@ -32,6 +33,7 @@ go_library(
         "//vendor/github.com/ulikunitz/xz:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -41,5 +43,6 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -6,12 +6,13 @@ import (
 	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
-	cdiclientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
-	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
 )
 
 // cdi-file-host pod/service relative values
@@ -124,21 +125,43 @@ func IsNfs() bool {
 	return true
 }
 
-// EnableFeatureGate sets specified FeatureGate in the CDIConfig
-func EnableFeatureGate(client *cdiclientset.Clientset, feature string) (*bool, error) {
-	var previousValue = false
-	config, err := client.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+// UpdateCDIConfigWithOptions updates CDIConfig with specific UpdateOptions
+func UpdateCDIConfigWithOptions(c client.Client, opts metav1.UpdateOptions, updateFunc func(*cdiv1.CDIConfigSpec)) error {
+	cdi, err := controller.GetActiveCDI(c)
 	if err != nil {
-		return nil, err
-	}
-	if HasFeature(config, feature) {
-		previousValue = true
-		return &previousValue, nil
+		return err
 	}
 
-	config.Spec.FeatureGates = append(config.Spec.FeatureGates, feature)
-	config, err = client.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
-	if err != nil {
+	if cdi.Spec.Config == nil {
+		cdi.Spec.Config = &cdiv1.CDIConfigSpec{}
+	}
+
+	updateFunc(cdi.Spec.Config)
+
+	if apiequality.Semantic.DeepEqual(cdi.Spec.Config, &cdiv1.CDIConfigSpec{}) {
+		cdi.Spec.Config = nil
+	}
+
+	return c.Update(context.TODO(), cdi, &client.UpdateOptions{Raw: &opts})
+}
+
+// UpdateCDIConfig updates CDIConfig
+func UpdateCDIConfig(c client.Client, updateFunc func(*cdiv1.CDIConfigSpec)) error {
+	return UpdateCDIConfigWithOptions(c, metav1.UpdateOptions{}, updateFunc)
+}
+
+// EnableFeatureGate sets specified FeatureGate in the CDIConfig
+func EnableFeatureGate(c client.Client, feature string) (*bool, error) {
+	var previousValue = false
+
+	if err := UpdateCDIConfig(c, func(config *cdiv1.CDIConfigSpec) {
+		if HasFeature(config, feature) {
+			previousValue = true
+			return
+		}
+
+		config.FeatureGates = append(config.FeatureGates, feature)
+	}); err != nil {
 		return nil, err
 	}
 
@@ -146,21 +169,18 @@ func EnableFeatureGate(client *cdiclientset.Clientset, feature string) (*bool, e
 }
 
 // DisableFeatureGate unsets specified FeatureGate in the CDIConfig
-func DisableFeatureGate(client *cdiclientset.Clientset, featureGate string) (*bool, error) {
+func DisableFeatureGate(c client.Client, featureGate string) (*bool, error) {
 	var previousValue = false
-	config, err := client.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if !HasFeature(config, featureGate) {
-		return &previousValue, nil
-	}
 
-	previousValue = true
-	config.Spec.FeatureGates = removeString(config.Spec.FeatureGates, featureGate)
-	config, err = client.CdiV1beta1().CDIConfigs().Update(context.TODO(), config, metav1.UpdateOptions{})
-	if err != nil {
-		return nil, nil
+	if err := UpdateCDIConfig(c, func(config *cdiv1.CDIConfigSpec) {
+		if !HasFeature(config, featureGate) {
+			return
+		}
+
+		previousValue = true
+		config.FeatureGates = removeString(config.FeatureGates, featureGate)
+	}); err != nil {
+		return nil, err
 	}
 
 	return &previousValue, nil
@@ -177,8 +197,8 @@ func removeString(featureGates []string, featureGate string) []string {
 }
 
 // HasFeature - helper to check if specified FeatureGate is in the CDIConfig
-func HasFeature(config *cdiv1.CDIConfig, featureGate string) bool {
-	for _, fg := range config.Spec.FeatureGates {
+func HasFeature(config *cdiv1.CDIConfigSpec, featureGate string) bool {
+	for _, fg := range config.FeatureGates {
 		if fg == featureGate {
 			return true
 		}


### PR DESCRIPTION
Make CDIConfig singleton mirror data in "active" CDI

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CDI is now _the_ place for setting CDIConfig.  The singleton CDIConfig instance is still created.  But the spec mirrors whatever is in CDI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Embedded CDIConfigSpec in CDI resource
```

