### PR TITLE
Pass specific PVC annotations to the transfer pods

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -650,7 +650,7 @@ func MakeCloneSourcePodSpec(image, pullPolicy, sourcePvcName, sourcePvcNamespace
 	}
 
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
-
+	SetPodPvcAnnotations(pod, targetPvc)
 	return pod
 }
 

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -196,7 +196,8 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			AnnPodReady:         "true",
 			AnnCloneToken:       "foobaz",
 			AnnUploadClientName: "uploadclient",
-			AnnCloneSourcePod:   "default-testPvc1-source-pod"}, nil)
+			AnnCloneSourcePod:   "default-testPvc1-source-pod",
+			AnnPodNetwork:       "net1"}, nil)
 		sourcePvc := createPvc("source", "default", map[string]string{}, nil)
 		otherSourcePod := podFunc(sourcePvc)
 		objs := []runtime.Object{testPvc, sourcePvc}
@@ -220,6 +221,8 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).ToNot(BeNil())
 		Expect(sourcePod.GetLabels()[CloneUniqueID]).To(Equal("default-testPvc1-source-pod"))
+		By("Verifying source pod annotations passed from pvc")
+		Expect(sourcePod.GetAnnotations()[AnnPodNetwork]).To(Equal("net1"))
 		Expect(sourcePod.Spec.Affinity).ToNot(BeNil())
 		Expect(sourcePod.Spec.Affinity.PodAffinity).ToNot(BeNil())
 		l := len(sourcePod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -96,6 +96,8 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		dv.GetAnnotations()["test-ann-1"] = "test-value-1"
 		dv.GetAnnotations()["test-ann-2"] = "test-value-2"
 		dv.GetAnnotations()[AnnSource] = "invalid phase should not copy"
+		dv.GetAnnotations()[AnnPodNetwork] = "data-network"
+		dv.GetAnnotations()[AnnPodSidecarInjection] = "false"
 		reconciler = createDatavolumeReconciler(dv)
 		_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
@@ -107,6 +109,8 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Expect(pvc.GetAnnotations()["test-ann-1"]).To(Equal("test-value-1"))
 		Expect(pvc.GetAnnotations()["test-ann-2"]).To(Equal("test-value-2"))
 		Expect(pvc.GetAnnotations()[AnnSource]).To(Equal(SourceHTTP))
+		Expect(pvc.GetAnnotations()[AnnPodNetwork]).To(Equal("data-network"))
+		Expect(pvc.GetAnnotations()[AnnPodSidecarInjection]).To(Equal("false"))
 	})
 
 	It("Should pass annotation from DV with S3 source to created a PVC on a DV", func() {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -904,6 +904,7 @@ func makeImporterPodSpec(namespace, image, verbose, pullPolicy string, podEnvVar
 		fsGroup := common.QemuSubGid
 		pod.Spec.SecurityContext.FSGroup = &fsGroup
 	}
+	SetPodPvcAnnotations(pod, pvc)
 	return pod
 }
 

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -770,6 +770,6 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			MountPath: common.ScratchDataDir,
 		})
 	}
-
+	SetPodPvcAnnotations(pod, args.PVC)
 	return pod
 }

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -288,8 +288,8 @@ var _ = Describe("reconcilePVC loop", func() {
 			Expect(resultPvc.GetAnnotations()[AnnPodPhase]).To(BeEquivalentTo(uploadPod.Status.Phase))
 		})
 
-		It("Should create the service and pod", func() {
-			testPvc := createPvc(testPvcName, "default", map[string]string{AnnCloneRequest: "default/testPvc2", AnnUploadPod: uploadResourceName}, nil)
+		It("Should create the service and pod with passed annotations", func() {
+			testPvc := createPvc(testPvcName, "default", map[string]string{AnnCloneRequest: "default/testPvc2", AnnUploadPod: uploadResourceName, AnnPodNetwork: "net1"}, nil)
 			testPvcSource := createPvc("testPvc2", "default", map[string]string{}, nil)
 			reconciler := createUploadReconciler(testPvc, testPvcSource)
 			By("Verifying the pod and service do not exist")
@@ -310,6 +310,7 @@ var _ = Describe("reconcilePVC loop", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadPod.Name).To(Equal(uploadResourceName))
 			Expect(uploadPod.Labels[common.UploadTargetLabel]).To(Equal(string(testPvc.UID)))
+			Expect(uploadPod.GetAnnotations()[AnnPodNetwork]).To(Equal("net1"))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: naming.GetServiceNameFromResourceName(uploadResourceName), Namespace: "default"}, uploadService)

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -89,6 +89,13 @@ const (
 	podRunningReason = "Pod is running"
 )
 
+const (
+	// AnnPodNetwork is used for specifying Pod Network
+	AnnPodNetwork = "k8s.v1.cni.cncf.io/networks"
+	// AnnPodSidecarInjection is used for enabling/disabling Pod istio/AspenMesh sidecar injection
+	AnnPodSidecarInjection = "sidecar.istio.io/inject"
+)
+
 func checkPVC(pvc *v1.PersistentVolumeClaim, annotation string, log logr.Logger) bool {
 	// check if we have proper annotation
 	if !metav1.HasAnnotation(pvc.ObjectMeta, annotation) {
@@ -593,4 +600,15 @@ func IsPopulated(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
 		err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dv)
 		return dv, err
 	})
+}
+
+// SetPodPvcAnnotations applies PVC annotations on the pod
+func SetPodPvcAnnotations(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) {
+	allowedAnnotations := []string{AnnPodNetwork, AnnPodSidecarInjection}
+	for _, ann := range allowedAnnotations {
+		if val, ok := pvc.Annotations[ann]; ok {
+			klog.V(1).Info("Applying PVC annotation on the pod", ann, val)
+			pod.ObjectMeta.Annotations[ann] = val
+		}
+	}
 }

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -608,7 +608,10 @@ func SetPodPvcAnnotations(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) {
 	for _, ann := range allowedAnnotations {
 		if val, ok := pvc.Annotations[ann]; ok {
 			klog.V(1).Info("Applying PVC annotation on the pod", ann, val)
-			pod.ObjectMeta.Annotations[ann] = val
+			if pod.Annotations == nil {
+				pod.Annotations = map[string]string{}
+			}
+			pod.Annotations[ann] = val
 		}
 	}
 }

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -88,7 +88,7 @@ func NewCloningDataVolume(dataVolumeName, size string, sourcePvc *k8sv1.Persiste
 func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
+			Name:        dataVolumeName,
 			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
@@ -197,7 +197,7 @@ func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespac
 func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
+			Name:        dataVolumeName,
 			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
@@ -268,7 +268,7 @@ func NewDataVolumeForBlankRawImageBlock(dataVolumeName, size string, storageClas
 func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
 	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
+			Name:        dataVolumeName,
 			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -89,6 +89,7 @@ func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL str
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
+			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: cdiv1.DataVolumeSource{
@@ -197,6 +198,7 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
+			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: cdiv1.DataVolumeSource{
@@ -267,6 +269,7 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
+			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: cdiv1.DataVolumeSource{


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Specific PVC annotations are passed to the import/upload/clone pods.
The currently passed annotations are:
```
      k8s.v1.cni.cncf.io/networks: "some-network"
      sidecar.istio.io/inject: "true"/"false"
```

**Which issue(s) this PR fixes**:
Fixes #1364 
Fixes Bugzilla #1883232

**Special notes for your reviewer**:

**Release note**:
```release-note
Specific PVC annotations are passed to the import/upload/clone pods.
```