### PR TITLE
k8s-reporter: Add Endpoints logging

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -630,6 +630,7 @@ func (r *KubernetesReporter) Dump(kubeCli *kubernetes.Clientset, cdiClient *cdiC
 	r.logPVs(kubeCli)
 	r.logPods(kubeCli)
 	r.logServices(kubeCli)
+	r.logEndpoints(kubeCli)
 	r.logLogs(kubeCli, since)
 }
 
@@ -681,6 +682,29 @@ func (r *KubernetesReporter) logServices(kubeCli *kubernetes.Clientset) {
 	}
 
 	j, err := json.MarshalIndent(services, "", "    ")
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logEndpoints(kubeCli *kubernetes.Clientset) {
+
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_endpoints.log", r.FailureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	endpoints, err := kubeCli.CoreV1().Endpoints(v1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch endpointss: %v\n", err)
+		return
+	}
+
+	j, err := json.MarshalIndent(endpoints, "", "    ")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Endpoints objects indicates which pods related to a service, it helps debugging a Service.

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add Endpoints logging to test framework. After failed tests a new endpoints log will be available to help troubleshooting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

