### PR TITLE
fix KUBEVIRT_STORAGE=nfs make cluster-sync

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -115,6 +115,7 @@ function wait_cdi_pods_updated {
 # We skip the functional test additions for external provider for now, as they're specific
 if [ "${KUBEVIRT_PROVIDER}" != "external" ] && [ "${CDI_SYNC}" == "test-infra" ]; then
   _kubectl delete all -n cdi -l cdi.kubevirt.io/testing
+  configure_storage
   _kubectl apply -f "./_out/manifests/bad-webserver.yaml"
   _kubectl apply -f "./_out/manifests/file-host.yaml"
   _kubectl apply -f "./_out/manifests/registry-host.yaml"
@@ -209,5 +210,3 @@ crds=($cdi_crds)
 operator_crds=$(_kubectl get crd -l operator.cdi.kubevirt.io -o jsonpath={.items[*].metadata.name})
 crds+=($operator_crds)
 check_structural_schema "${crds[@]}"
-
-configure_storage


### PR DESCRIPTION
Move configure_storage to test setup.

Some of the storage setup involves deploying pods, and they
are labelled with cdi.kubevirt.io/testing for the benefit of
the "CriticalAddonsTolerations" test.

The test setup deleted all the test pods before deploying,
which means that the storage pods were killed, breaking
KUBEVIRT_STORAGE=nfs make cluster-sync

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

