### PR TITLE
Make sure the DV is the main resource and single source of truth for …

### DIFF
--- a/pkg/apis/core/v1alpha1/utils.go
+++ b/pkg/apis/core/v1alpha1/utils.go
@@ -47,7 +47,7 @@ func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespa
 // 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !WaitForFirstConsumer return false
 func IsWaitForFirstConsumerBeforePopulating(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
-	if pvc.Status.Phase == corev1.ClaimPending && pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
+	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
 		// Find the data volume:
 		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
 		if err != nil {

--- a/pkg/apis/core/v1beta1/utils.go
+++ b/pkg/apis/core/v1beta1/utils.go
@@ -47,7 +47,7 @@ func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespa
 // 3. If the PVC is owned by a DataVolume, look up the DV and check the phase, if phase !WaitForFirstConsumer return false
 func IsWaitForFirstConsumerBeforePopulating(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
-	if pvc.Status.Phase == corev1.ClaimPending && pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
+	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
 		// Find the data volume:
 		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
 		if err != nil {


### PR DESCRIPTION
…WaitForFirstConsumer.


Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Make sure the DV is the main resource and single source of truth for WaitForFirstConsumer logic. 

Removed a shortcut that checked if PVC is Pending, so now it always checks DataVolume. That way we are sure that other tools that sync on DV or use this helper function will see the same results.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
The problem was found while working on https://github.com/kubevirt/kubevirt/pull/4025

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

