### PR TITLE
Fix make target cluster-sync-cdi, add cluster-clean-cdi & cluster-clean-test-infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,18 @@ cluster-down:
 cluster-down-purge: docker-registry-cleanup cluster-down
 
 cluster-clean:
+	CDI_CLEAN="all" ./cluster-sync/clean.sh
+
+cluster-clean-cdi:
 	./cluster-sync/clean.sh
 
-cluster-sync-cdi: cluster-clean
+cluster-clean-test-infra:
+	CDI_CLEAN="test-infra" ./cluster-sync/clean.sh
+
+cluster-sync-cdi: cluster-clean-cdi
 	./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
 
-cluster-sync-test-infra:
+cluster-sync-test-infra: cluster-clean-test-infra
 	CDI_SYNC="test-infra" ./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
 
 cluster-sync: cluster-sync-cdi cluster-sync-test-infra

--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -1,10 +1,15 @@
 #!/bin/bash -e
-  
+
 source ./hack/build/config.sh
 source ./cluster-up/hack/common.sh
 source ./cluster-up/cluster/${KUBEVIRT_PROVIDER}/provider.sh
 
 echo "Cleaning up ..."
+
+if [ "${CDI_CLEAN}" == "test-infra" ]; then
+  _kubectl delete all -n cdi -l cdi.kubevirt.io/testing
+  exit 0
+fi
 
 OPERATOR_CR_MANIFEST=./_out/manifests/release/cdi-cr.yaml
 OPERATOR_MANIFEST=./_out/manifests/release/cdi-operator.yaml
@@ -23,7 +28,7 @@ if [ -f "${OPERATOR_CR_MANIFEST}" ]; then
     fi
 fi
 
-if [ -f "${OPERATOR_MANIFEST}" ]; then
+if [ "${CDI_CLEAN}" == "all" ] && [ -f "${OPERATOR_MANIFEST}" ]; then
 	echo "Deleting operator ..."
     _kubectl delete --ignore-not-found -f "${OPERATOR_MANIFEST}"
 fi
@@ -57,8 +62,7 @@ for label in ${LABELS[@]}; do
     done
 done
 
-
-if [ -n "$(_kubectl get ns | grep "cdi ")" ]; then
+if [ "${CDI_CLEAN}" == "all" ] && [ -n "$(_kubectl get ns | grep "cdi ")" ]; then
     echo "Clean cdi namespace"
     _kubectl delete ns $NAMESPACE
 

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -114,7 +114,6 @@ function wait_cdi_pods_updated {
 # Start functional test HTTP server.
 # We skip the functional test additions for external provider for now, as they're specific
 if [ "${KUBEVIRT_PROVIDER}" != "external" ] && [ "${CDI_SYNC}" == "test-infra" ]; then
-  _kubectl delete all -n cdi -l cdi.kubevirt.io/testing
   configure_storage
   _kubectl apply -f "./_out/manifests/bad-webserver.yaml"
   _kubectl apply -f "./_out/manifests/file-host.yaml"

--- a/hack/README.md
+++ b/hack/README.md
@@ -35,7 +35,7 @@ The standard workflow is performed inside a helper container to normalize the bu
 #### Make Targets
 
 - `all`: cleans up previous build artifacts, compiles all CDI packages and builds containers
-- `apidocs`: generate client-go code (same as 'make generate') and swagger docs.  
+- `apidocs`: generate client-go code (same as 'make generate') and swagger docs.
 - `build`: compile all CDI binary artifacts and generate controller and operator manifests
     - `build-controller`: compile cdi-controller binary
     - `build-importer`: compile cdi-importer binary
@@ -53,7 +53,8 @@ The standard workflow is performed inside a helper container to normalize the bu
 - `cluster-up`: start a default Kubernetes or Open Shift cluster. set KUBEVIRT_PROVIDER environment variable to either 'k8s-1.18' or 'os-3.11.0-crio' to select the type of cluster. set KUBEVIRT_NUM_NODES to something higher than 1 to have more than one node.
 - `cluster-down`: stop the cluster, doing a make cluster-down && make cluster-up will basically restart the cluster into an empty fresh state.
 - `cluster-down-purge`: cluster-down and cleanup all cached images from docker registry. Accepts [make variables](#make-variables) DOCKER_PREFIX. Removes all images of the specified repository. If not specified removes localhost repository of current cluster instance.
-- `cluster-sync`: builds the controller/importer/cloner, and pushes it into a running cluster. The cluster must be up before running a cluster sync. Also generates a manifest and applies it to the running cluster after pushing the images to it.
+- `cluster-sync`: 'make cluster-sync-cdi' followed by 'make cluster-sync-test-infra'
+- `cluster-sync-cdi`: builds the controller/importer/cloner, and pushes it into a running cluster. The cluster must be up before running a cluster sync. Also generates a manifest and applies it to the running cluster after pushing the images to it.
     - `cluster-sync-controller`: builds the controller and pushes it into a running cluster. 
     - `cluster-sync-importer`: builds the importer and pushes it into a running cluster.
     - `cluster-sync-cloner`: builds the cloner and pushes it into a running cluster.
@@ -61,6 +62,9 @@ The standard workflow is performed inside a helper container to normalize the bu
     - `cluster-sync-uploadproxy`: builds the uploadproxy and pushes it into a running cluster.
     - `cluster-sync-uploadserver`: builds the uploadserver and pushes it into a running cluster.
     - `cluster-sync-operator`: builds the operator and pushes it into a running cluster.
+- `cluster-sync-test-infra`: pushes the test-infra pods into a running cluster.
+- `cluster-clean-cdi`: cleans all cdi resources, but not test-infra (cdi.kubevirt.io/testing labeled), cdi namespace and operator manifest.
+- `cluster-clean-test-infra`: cleans all test-infra resources (cdi.kubevirt.io/testing labeled).
 - `deps-update`: runs 'go mod tidy' and 'go mod vendor'
 - `docker`: compile all binaries and build all containerized
     - `docker-controller`: compile cdi-controller and build cdi-controller image


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
`make cluster-sync-cdi` now depends on the new `cluster-clean-cdi` target which does not deletes the entire cdi namespace, and keeps the test pods running. Also, `make cluster-sync-test-infra` now depends on the new `cluster-clean-test-infra` target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1496 

**Release note**:
```release-note
NONE
```