### PR TITLE
Downgrade go-libnbd dependency a bit, to v1.3.9-cdi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
-	github.com/mrnold/go-libnbd v1.4.1-cdi
+	github.com/mrnold/go-libnbd v1.3.9-cdi
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mrnold/go-libnbd v1.4.1-cdi h1:bIszEpQZKre4DMqEIO5HCv/MA44ujD2w7BIQg/cOFts=
-github.com/mrnold/go-libnbd v1.4.1-cdi/go.mod h1:t/zovtHFkgtIy65eJ+Ay1mNBFz+yO6ESu6r6CluGzdI=
+github.com/mrnold/go-libnbd v1.3.9-cdi h1:rnmHAN/lyQMfFNLpaZ1TutDnM2D4xPcGsCIohnDjIUg=
+github.com/mrnold/go-libnbd v1.3.9-cdi/go.mod h1:t/zovtHFkgtIy65eJ+Ay1mNBFz+yO6ESu6r6CluGzdI=
 github.com/mtrmac/gpgme v0.1.2/go.mod h1:GYYHnGSuS7HK3zVS2n3y73y0okK/BeKzwnn5jgiVFNI=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/vendor/github.com/mrnold/go-libnbd/bindings.go
+++ b/vendor/github.com/mrnold/go-libnbd/bindings.go
@@ -51,13 +51,6 @@ const (
     TLS_REQUIRE = Tls(2)
 )
 
-type Size int
-const (
-    SIZE_MINIMUM = Size(0)
-    SIZE_PREFERRED = Size(1)
-    SIZE_MAXIMUM = Size(2)
-)
-
 /* Flags. */
 type CmdFlag uint32
 const (
@@ -253,84 +246,6 @@ func (h *Libnbd) GetExportName () (*string, error) {
     return &r, nil
 }
 
-/* SetFullInfo: control whether NBD_OPT_GO requests extra details */
-func (h *Libnbd) SetFullInfo (request bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_full_info")
-    }
-
-    var c_err C.struct_error
-    c_request := C.bool (request)
-
-    ret := C._nbd_set_full_info_wrapper (&c_err, h.h, c_request)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_full_info", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* GetFullInfo: see if NBD_OPT_GO requests extra details */
-func (h *Libnbd) GetFullInfo () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_full_info")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_get_full_info_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_full_info", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
-}
-
-/* GetCanonicalExportName: return the canonical export name, if the server has one */
-func (h *Libnbd) GetCanonicalExportName () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_canonical_export_name")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_get_canonical_export_name_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_canonical_export_name", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
-}
-
-/* GetExportDescription: return the export description, if the server has one */
-func (h *Libnbd) GetExportDescription () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_export_description")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_get_export_description_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_export_description", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
-}
-
 /* SetTls: enable or require TLS (authentication and encryption) */
 func (h *Libnbd) SetTls (tls Tls) error {
     if h.h == nil {
@@ -351,7 +266,7 @@ func (h *Libnbd) SetTls (tls Tls) error {
 }
 
 /* GetTls: get the TLS request setting */
-func (h *Libnbd) GetTls () (Tls, error) {
+func (h *Libnbd) GetTls () (uint, error) {
     if h.h == nil {
         return 0, closed_handle_error ("get_tls")
     }
@@ -360,7 +275,12 @@ func (h *Libnbd) GetTls () (Tls, error) {
 
     ret := C._nbd_get_tls_wrapper (&c_err, h.h)
     runtime.KeepAlive (h.h)
-    return Tls (ret), nil
+    if ret == -1 {
+        err := get_error ("get_tls", c_err)
+        C.free_error (&c_err)
+        return 0, err
+    }
+    return uint (ret), nil
 }
 
 /* GetTlsNegotiated: find out if TLS was negotiated on a connection */
@@ -577,7 +497,7 @@ func (h *Libnbd) SetHandshakeFlags (flags HandshakeFlag) error {
 }
 
 /* GetHandshakeFlags: see which handshake flags are supported */
-func (h *Libnbd) GetHandshakeFlags () (HandshakeFlag, error) {
+func (h *Libnbd) GetHandshakeFlags () (uint, error) {
     if h.h == nil {
         return 0, closed_handle_error ("get_handshake_flags")
     }
@@ -586,40 +506,40 @@ func (h *Libnbd) GetHandshakeFlags () (HandshakeFlag, error) {
 
     ret := C._nbd_get_handshake_flags_wrapper (&c_err, h.h)
     runtime.KeepAlive (h.h)
-    return HandshakeFlag (ret), nil
+    return uint (ret), nil
 }
 
-/* SetOptMode: control option mode, for pausing during option negotiation */
-func (h *Libnbd) SetOptMode (enable bool) error {
+/* SetListExports: set whether to list server exports */
+func (h *Libnbd) SetListExports (list bool) error {
     if h.h == nil {
-        return closed_handle_error ("set_opt_mode")
+        return closed_handle_error ("set_list_exports")
     }
 
     var c_err C.struct_error
-    c_enable := C.bool (enable)
+    c_list := C.bool (list)
 
-    ret := C._nbd_set_opt_mode_wrapper (&c_err, h.h, c_enable)
+    ret := C._nbd_set_list_exports_wrapper (&c_err, h.h, c_list)
     runtime.KeepAlive (h.h)
     if ret == -1 {
-        err := get_error ("set_opt_mode", c_err)
+        err := get_error ("set_list_exports", c_err)
         C.free_error (&c_err)
         return err
     }
     return nil
 }
 
-/* GetOptMode: return whether option mode was enabled */
-func (h *Libnbd) GetOptMode () (bool, error) {
+/* GetListExports: return whether list exports mode was enabled */
+func (h *Libnbd) GetListExports () (bool, error) {
     if h.h == nil {
-        return false, closed_handle_error ("get_opt_mode")
+        return false, closed_handle_error ("get_list_exports")
     }
 
     var c_err C.struct_error
 
-    ret := C._nbd_get_opt_mode_wrapper (&c_err, h.h)
+    ret := C._nbd_get_list_exports_wrapper (&c_err, h.h)
     runtime.KeepAlive (h.h)
     if ret == -1 {
-        err := get_error ("get_opt_mode", c_err)
+        err := get_error ("get_list_exports", c_err)
         C.free_error (&c_err)
         return false, err
     }
@@ -627,80 +547,43 @@ func (h *Libnbd) GetOptMode () (bool, error) {
     if r != 0 { return true, nil } else { return false, nil }
 }
 
-/* OptGo: end negotiation and move on to using an export */
-func (h *Libnbd) OptGo () error {
+/* GetNrListExports: return the number of exports returned by the server */
+func (h *Libnbd) GetNrListExports () (uint, error) {
     if h.h == nil {
-        return closed_handle_error ("opt_go")
+        return 0, closed_handle_error ("get_nr_list_exports")
     }
 
     var c_err C.struct_error
 
-    ret := C._nbd_opt_go_wrapper (&c_err, h.h)
+    ret := C._nbd_get_nr_list_exports_wrapper (&c_err, h.h)
     runtime.KeepAlive (h.h)
     if ret == -1 {
-        err := get_error ("opt_go", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* OptAbort: end negotiation and close the connection */
-func (h *Libnbd) OptAbort () error {
-    if h.h == nil {
-        return closed_handle_error ("opt_abort")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_opt_abort_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_abort", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* OptList: request the server to list all exports during negotiation */
-func (h *Libnbd) OptList (list ListCallback) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("opt_list")
-    }
-
-    var c_err C.struct_error
-    var c_list C.nbd_list_callback
-    c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
-    c_list.free = (*[0]byte)(C._nbd_list_callback_free)
-    c_list.user_data = unsafe.Pointer (C.long_to_vp (C.long (registerCallbackId (list))))
-
-    ret := C._nbd_opt_list_wrapper (&c_err, h.h, c_list)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_list", c_err)
+        err := get_error ("get_nr_list_exports", c_err)
         C.free_error (&c_err)
         return 0, err
     }
     return uint (ret), nil
 }
 
-/* OptInfo: request the server for information about an export */
-func (h *Libnbd) OptInfo () error {
+/* GetListExportName: return the i'th export name */
+func (h *Libnbd) GetListExportName (i int) (*string, error) {
     if h.h == nil {
-        return closed_handle_error ("opt_info")
+        return nil, closed_handle_error ("get_list_export_name")
     }
 
     var c_err C.struct_error
+    c_i := C.int (i)
 
-    ret := C._nbd_opt_info_wrapper (&c_err, h.h)
+    ret := C._nbd_get_list_export_name_wrapper (&c_err, h.h, c_i)
     runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_info", c_err)
+    if ret == nil {
+        err := get_error ("get_list_export_name", c_err)
         C.free_error (&c_err)
-        return err
+        return nil, err
     }
-    return nil
+    r := C.GoString (ret)
+    C.free (unsafe.Pointer (ret))
+    return &r, nil
 }
 
 /* AddMetaContext: ask server to negotiate metadata context */
@@ -1164,25 +1047,6 @@ func (h *Libnbd) GetSize () (uint64, error) {
     runtime.KeepAlive (h.h)
     if ret == -1 {
         err := get_error ("get_size", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
-}
-
-/* GetBlockSize: return a specific server block size constraint */
-func (h *Libnbd) GetBlockSize (size_type Size) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_block_size")
-    }
-
-    var c_err C.struct_error
-    c_size_type := C.int (size_type)
-
-    ret := C._nbd_get_block_size_wrapper (&c_err, h.h, c_size_type)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_block_size", c_err)
         C.free_error (&c_err)
         return 0, err
     }
@@ -1674,127 +1538,6 @@ func (h *Libnbd) AioConnectSystemdSocketActivation (argv []string) error {
     return nil
 }
 
-/* Struct carrying optional arguments for AioOptGo. */
-type AioOptGoOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-}
-
-/* AioOptGo: end negotiation and move on to using an export */
-func (h *Libnbd) AioOptGo (optargs *AioOptGoOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_go")
-    }
-
-    var c_err C.struct_error
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            c_completion.user_data = unsafe.Pointer (C.long_to_vp (C.long (registerCallbackId (optargs.CompletionCallback))))
-        }
-    }
-
-    ret := C._nbd_aio_opt_go_wrapper (&c_err, h.h, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_go", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* AioOptAbort: end negotiation and close the connection */
-func (h *Libnbd) AioOptAbort () error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_abort")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_aio_opt_abort_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_abort", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* Struct carrying optional arguments for AioOptList. */
-type AioOptListOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-}
-
-/* AioOptList: request the server to list all exports during negotiation */
-func (h *Libnbd) AioOptList (list ListCallback, optargs *AioOptListOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_list")
-    }
-
-    var c_err C.struct_error
-    var c_list C.nbd_list_callback
-    c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
-    c_list.free = (*[0]byte)(C._nbd_list_callback_free)
-    c_list.user_data = unsafe.Pointer (C.long_to_vp (C.long (registerCallbackId (list))))
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            c_completion.user_data = unsafe.Pointer (C.long_to_vp (C.long (registerCallbackId (optargs.CompletionCallback))))
-        }
-    }
-
-    ret := C._nbd_aio_opt_list_wrapper (&c_err, h.h, c_list, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_list", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
-/* Struct carrying optional arguments for AioOptInfo. */
-type AioOptInfoOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-}
-
-/* AioOptInfo: request the server for information about an export */
-func (h *Libnbd) AioOptInfo (optargs *AioOptInfoOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_info")
-    }
-
-    var c_err C.struct_error
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            c_completion.user_data = unsafe.Pointer (C.long_to_vp (C.long (registerCallbackId (optargs.CompletionCallback))))
-        }
-    }
-
-    ret := C._nbd_aio_opt_info_wrapper (&c_err, h.h, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_info", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
-}
-
 /* Struct carrying optional arguments for AioPread. */
 type AioPreadOptargs struct {
   /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
@@ -2269,25 +2012,6 @@ func (h *Libnbd) AioIsConnecting () (bool, error) {
     runtime.KeepAlive (h.h)
     if ret == -1 {
         err := get_error ("aio_is_connecting", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
-}
-
-/* AioIsNegotiating: check if connection is ready to send handshake option */
-func (h *Libnbd) AioIsNegotiating () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_negotiating")
-    }
-
-    var c_err C.struct_error
-
-    ret := C._nbd_aio_is_negotiating_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_negotiating", c_err)
         C.free_error (&c_err)
         return false, err
     }

--- a/vendor/github.com/mrnold/go-libnbd/closures.go
+++ b/vendor/github.com/mrnold/go-libnbd/closures.go
@@ -103,16 +103,3 @@ func extent_callback (callbackid C.long, metacontext *C.char, offset C.uint64_t,
     return C.int (ret);
 }
 
-type ListCallback func (name string, description string) int
-
-//export list_callback
-func list_callback (callbackid C.long, name *C.char, description *C.char) C.int {
-    callbackFunc := getCallbackId (int (callbackid));
-    callback, ok := callbackFunc.(ListCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    ret := callback (C.GoString (name), C.GoString (description))
-    return C.int (ret);
-}
-

--- a/vendor/github.com/mrnold/go-libnbd/wrappers.go
+++ b/vendor/github.com/mrnold/go-libnbd/wrappers.go
@@ -170,74 +170,6 @@ _nbd_get_export_name_wrapper (struct error *err,
 }
 
 int
-_nbd_set_full_info_wrapper (struct error *err,
-        struct nbd_handle *h, bool request)
-{
-#ifdef LIBNBD_HAVE_NBD_SET_FULL_INFO
-  int ret;
-
-  ret = nbd_set_full_info (h, request);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_SET_FULL_INFO
-  missing_function (err, "set_full_info");
-  return -1;
-#endif
-}
-
-int
-_nbd_get_full_info_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_GET_FULL_INFO
-  int ret;
-
-  ret = nbd_get_full_info (h);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_GET_FULL_INFO
-  missing_function (err, "get_full_info");
-  return -1;
-#endif
-}
-
-char *
-_nbd_get_canonical_export_name_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_GET_CANONICAL_EXPORT_NAME
-  char * ret;
-
-  ret = nbd_get_canonical_export_name (h);
-  if (ret == NULL)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_GET_CANONICAL_EXPORT_NAME
-  missing_function (err, "get_canonical_export_name");
-  return NULL;
-#endif
-}
-
-char *
-_nbd_get_export_description_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_GET_EXPORT_DESCRIPTION
-  char * ret;
-
-  ret = nbd_get_export_description (h);
-  if (ret == NULL)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_GET_EXPORT_DESCRIPTION
-  missing_function (err, "get_export_description");
-  return NULL;
-#endif
-}
-
-int
 _nbd_set_tls_wrapper (struct error *err,
         struct nbd_handle *h, int tls)
 {
@@ -262,9 +194,12 @@ _nbd_get_tls_wrapper (struct error *err,
   int ret;
 
   ret = nbd_get_tls (h);
+  if (ret == -1)
+    save_error (err);
   return ret;
 #else // !LIBNBD_HAVE_NBD_GET_TLS
   missing_function (err, "get_tls");
+  return -1;
 #endif
 }
 
@@ -455,12 +390,12 @@ _nbd_set_handshake_flags_wrapper (struct error *err,
 #endif
 }
 
-uint32_t
+unsigned
 _nbd_get_handshake_flags_wrapper (struct error *err,
         struct nbd_handle *h)
 {
 #ifdef LIBNBD_HAVE_NBD_GET_HANDSHAKE_FLAGS
-  uint32_t ret;
+  unsigned ret;
 
   ret = nbd_get_handshake_flags (h);
   return ret;
@@ -470,104 +405,70 @@ _nbd_get_handshake_flags_wrapper (struct error *err,
 }
 
 int
-_nbd_set_opt_mode_wrapper (struct error *err,
-        struct nbd_handle *h, bool enable)
+_nbd_set_list_exports_wrapper (struct error *err,
+        struct nbd_handle *h, bool list)
 {
-#ifdef LIBNBD_HAVE_NBD_SET_OPT_MODE
+#ifdef LIBNBD_HAVE_NBD_SET_LIST_EXPORTS
   int ret;
 
-  ret = nbd_set_opt_mode (h, enable);
+  ret = nbd_set_list_exports (h, list);
   if (ret == -1)
     save_error (err);
   return ret;
-#else // !LIBNBD_HAVE_NBD_SET_OPT_MODE
-  missing_function (err, "set_opt_mode");
+#else // !LIBNBD_HAVE_NBD_SET_LIST_EXPORTS
+  missing_function (err, "set_list_exports");
   return -1;
 #endif
 }
 
 int
-_nbd_get_opt_mode_wrapper (struct error *err,
+_nbd_get_list_exports_wrapper (struct error *err,
         struct nbd_handle *h)
 {
-#ifdef LIBNBD_HAVE_NBD_GET_OPT_MODE
+#ifdef LIBNBD_HAVE_NBD_GET_LIST_EXPORTS
   int ret;
 
-  ret = nbd_get_opt_mode (h);
+  ret = nbd_get_list_exports (h);
   if (ret == -1)
     save_error (err);
   return ret;
-#else // !LIBNBD_HAVE_NBD_GET_OPT_MODE
-  missing_function (err, "get_opt_mode");
+#else // !LIBNBD_HAVE_NBD_GET_LIST_EXPORTS
+  missing_function (err, "get_list_exports");
   return -1;
 #endif
 }
 
 int
-_nbd_opt_go_wrapper (struct error *err,
+_nbd_get_nr_list_exports_wrapper (struct error *err,
         struct nbd_handle *h)
 {
-#ifdef LIBNBD_HAVE_NBD_OPT_GO
+#ifdef LIBNBD_HAVE_NBD_GET_NR_LIST_EXPORTS
   int ret;
 
-  ret = nbd_opt_go (h);
+  ret = nbd_get_nr_list_exports (h);
   if (ret == -1)
     save_error (err);
   return ret;
-#else // !LIBNBD_HAVE_NBD_OPT_GO
-  missing_function (err, "opt_go");
+#else // !LIBNBD_HAVE_NBD_GET_NR_LIST_EXPORTS
+  missing_function (err, "get_nr_list_exports");
   return -1;
 #endif
 }
 
-int
-_nbd_opt_abort_wrapper (struct error *err,
-        struct nbd_handle *h)
+char *
+_nbd_get_list_export_name_wrapper (struct error *err,
+        struct nbd_handle *h, int i)
 {
-#ifdef LIBNBD_HAVE_NBD_OPT_ABORT
-  int ret;
+#ifdef LIBNBD_HAVE_NBD_GET_LIST_EXPORT_NAME
+  char * ret;
 
-  ret = nbd_opt_abort (h);
-  if (ret == -1)
+  ret = nbd_get_list_export_name (h, i);
+  if (ret == NULL)
     save_error (err);
   return ret;
-#else // !LIBNBD_HAVE_NBD_OPT_ABORT
-  missing_function (err, "opt_abort");
-  return -1;
-#endif
-}
-
-int
-_nbd_opt_list_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_list_callback list_callback)
-{
-#ifdef LIBNBD_HAVE_NBD_OPT_LIST
-  int ret;
-
-  ret = nbd_opt_list (h, list_callback);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_OPT_LIST
-  missing_function (err, "opt_list");
-  return -1;
-#endif
-}
-
-int
-_nbd_opt_info_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_OPT_INFO
-  int ret;
-
-  ret = nbd_opt_info (h);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_OPT_INFO
-  missing_function (err, "opt_info");
-  return -1;
+#else // !LIBNBD_HAVE_NBD_GET_LIST_EXPORT_NAME
+  missing_function (err, "get_list_export_name");
+  return NULL;
 #endif
 }
 
@@ -979,23 +880,6 @@ _nbd_get_size_wrapper (struct error *err,
 #endif
 }
 
-int64_t
-_nbd_get_block_size_wrapper (struct error *err,
-        struct nbd_handle *h, int size_type)
-{
-#ifdef LIBNBD_HAVE_NBD_GET_BLOCK_SIZE
-  int64_t ret;
-
-  ret = nbd_get_block_size (h, size_type);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_GET_BLOCK_SIZE
-  missing_function (err, "get_block_size");
-  return -1;
-#endif
-}
-
 int
 _nbd_pread_wrapper (struct error *err,
         struct nbd_handle *h, void *buf, size_t count, uint64_t offset,
@@ -1310,75 +1194,6 @@ _nbd_aio_connect_systemd_socket_activation_wrapper (struct error *err,
 #endif
 }
 
-int
-_nbd_aio_opt_go_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_completion_callback completion_callback)
-{
-#ifdef LIBNBD_HAVE_NBD_AIO_OPT_GO
-  int ret;
-
-  ret = nbd_aio_opt_go (h, completion_callback);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_AIO_OPT_GO
-  missing_function (err, "aio_opt_go");
-  return -1;
-#endif
-}
-
-int
-_nbd_aio_opt_abort_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_AIO_OPT_ABORT
-  int ret;
-
-  ret = nbd_aio_opt_abort (h);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_AIO_OPT_ABORT
-  missing_function (err, "aio_opt_abort");
-  return -1;
-#endif
-}
-
-int
-_nbd_aio_opt_list_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_list_callback list_callback,
-        nbd_completion_callback completion_callback)
-{
-#ifdef LIBNBD_HAVE_NBD_AIO_OPT_LIST
-  int ret;
-
-  ret = nbd_aio_opt_list (h, list_callback, completion_callback);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_AIO_OPT_LIST
-  missing_function (err, "aio_opt_list");
-  return -1;
-#endif
-}
-
-int
-_nbd_aio_opt_info_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_completion_callback completion_callback)
-{
-#ifdef LIBNBD_HAVE_NBD_AIO_OPT_INFO
-  int ret;
-
-  ret = nbd_aio_opt_info (h, completion_callback);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_AIO_OPT_INFO
-  missing_function (err, "aio_opt_info");
-  return -1;
-#endif
-}
-
 int64_t
 _nbd_aio_pread_wrapper (struct error *err,
         struct nbd_handle *h, void *buf, size_t count, uint64_t offset,
@@ -1640,23 +1455,6 @@ _nbd_aio_is_connecting_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_AIO_IS_CONNECTING
   missing_function (err, "aio_is_connecting");
-  return -1;
-#endif
-}
-
-int
-_nbd_aio_is_negotiating_wrapper (struct error *err,
-        struct nbd_handle *h)
-{
-#ifdef LIBNBD_HAVE_NBD_AIO_IS_NEGOTIATING
-  int ret;
-
-  ret = nbd_aio_is_negotiating (h);
-  if (ret == -1)
-    save_error (err);
-  return ret;
-#else // !LIBNBD_HAVE_NBD_AIO_IS_NEGOTIATING
-  missing_function (err, "aio_is_negotiating");
   return -1;
 #endif
 }
@@ -1934,20 +1732,6 @@ _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
 
 void
 _nbd_extent_callback_free (void *user_data)
-{
-  extern void freeCallbackId (long);
-  freeCallbackId ((long)user_data);
-}
-
-int
-_nbd_list_callback_wrapper (void *user_data, const char *name,
-                            const char *description)
-{
-  return list_callback ((long)user_data, name, description);
-}
-
-void
-_nbd_list_callback_free (void *user_data)
 {
   extern void freeCallbackId (long);
   freeCallbackId ((long)user_data);

--- a/vendor/github.com/mrnold/go-libnbd/wrappers.h
+++ b/vendor/github.com/mrnold/go-libnbd/wrappers.h
@@ -85,14 +85,6 @@ int _nbd_set_export_name_wrapper (struct error *err,
         struct nbd_handle *h, const char *export_name);
 char * _nbd_get_export_name_wrapper (struct error *err,
         struct nbd_handle *h);
-int _nbd_set_full_info_wrapper (struct error *err,
-        struct nbd_handle *h, bool request);
-int _nbd_get_full_info_wrapper (struct error *err,
-        struct nbd_handle *h);
-char * _nbd_get_canonical_export_name_wrapper (struct error *err,
-        struct nbd_handle *h);
-char * _nbd_get_export_description_wrapper (struct error *err,
-        struct nbd_handle *h);
 int _nbd_set_tls_wrapper (struct error *err,
         struct nbd_handle *h, int tls);
 int _nbd_get_tls_wrapper (struct error *err,
@@ -119,20 +111,16 @@ int _nbd_get_structured_replies_negotiated_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_set_handshake_flags_wrapper (struct error *err,
         struct nbd_handle *h, uint32_t flags);
-uint32_t _nbd_get_handshake_flags_wrapper (struct error *err,
+unsigned _nbd_get_handshake_flags_wrapper (struct error *err,
         struct nbd_handle *h);
-int _nbd_set_opt_mode_wrapper (struct error *err,
-        struct nbd_handle *h, bool enable);
-int _nbd_get_opt_mode_wrapper (struct error *err,
+int _nbd_set_list_exports_wrapper (struct error *err,
+        struct nbd_handle *h, bool list);
+int _nbd_get_list_exports_wrapper (struct error *err,
         struct nbd_handle *h);
-int _nbd_opt_go_wrapper (struct error *err,
+int _nbd_get_nr_list_exports_wrapper (struct error *err,
         struct nbd_handle *h);
-int _nbd_opt_abort_wrapper (struct error *err,
-        struct nbd_handle *h);
-int _nbd_opt_list_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_list_callback list_callback);
-int _nbd_opt_info_wrapper (struct error *err,
-        struct nbd_handle *h);
+char * _nbd_get_list_export_name_wrapper (struct error *err,
+        struct nbd_handle *h, int i);
 int _nbd_add_meta_context_wrapper (struct error *err,
         struct nbd_handle *h, const char *name);
 int _nbd_set_uri_allow_transports_wrapper (struct error *err,
@@ -181,8 +169,6 @@ const char * _nbd_get_protocol_wrapper (struct error *err,
         struct nbd_handle *h);
 int64_t _nbd_get_size_wrapper (struct error *err,
         struct nbd_handle *h);
-int64_t _nbd_get_block_size_wrapper (struct error *err,
-        struct nbd_handle *h, int size_type);
 int _nbd_pread_wrapper (struct error *err,
         struct nbd_handle *h, void *buf, size_t count, uint64_t offset,
         uint32_t flags);
@@ -227,15 +213,6 @@ int _nbd_aio_connect_command_wrapper (struct error *err,
         struct nbd_handle *h, char **argv);
 int _nbd_aio_connect_systemd_socket_activation_wrapper (struct error *err,
         struct nbd_handle *h, char **argv);
-int _nbd_aio_opt_go_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_completion_callback completion_callback);
-int _nbd_aio_opt_abort_wrapper (struct error *err,
-        struct nbd_handle *h);
-int _nbd_aio_opt_list_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_list_callback list_callback,
-        nbd_completion_callback completion_callback);
-int _nbd_aio_opt_info_wrapper (struct error *err,
-        struct nbd_handle *h, nbd_completion_callback completion_callback);
 int64_t _nbd_aio_pread_wrapper (struct error *err,
         struct nbd_handle *h, void *buf, size_t count, uint64_t offset,
         nbd_completion_callback completion_callback, uint32_t flags);
@@ -276,8 +253,6 @@ int _nbd_aio_notify_write_wrapper (struct error *err,
 int _nbd_aio_is_created_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_aio_is_connecting_wrapper (struct error *err,
-        struct nbd_handle *h);
-int _nbd_aio_is_negotiating_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_aio_is_ready_wrapper (struct error *err,
         struct nbd_handle *h);
@@ -330,11 +305,5 @@ int _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
                                   uint64_t offset, uint32_t *entries,
                                   size_t nr_entries, int *error);
 void _nbd_extent_callback_free (void *user_data);
-
-extern int list_callback ();
-
-int _nbd_list_callback_wrapper (void *user_data, const char *name,
-                                const char *description);
-void _nbd_list_callback_free (void *user_data);
 
 #endif /* LIBNBD_GOLANG_WRAPPERS_H */

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,7 +256,7 @@ github.com/mitchellh/mapstructure
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/mrnold/go-libnbd v1.4.1-cdi
+# github.com/mrnold/go-libnbd v1.3.9-cdi
 ## explicit
 github.com/mrnold/go-libnbd
 # github.com/nxadm/tail v1.4.4


### PR DESCRIPTION
go-libnbd is very pinned to specific versions of libnbd. This
one works with Fedora 31 (libnbd-1.4.1), but not with an older
libnbd (1.2.2).

This is a quick fix to avoid problems in a second build environment.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```