### PR TITLE
Update builder to fedora 33

### DIFF
--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,7 +26,7 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.9}
+BUILDER_TAG=${BUILDER_TAG:-0.0.10}
 BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:b12b8f7a1b0c0cebe9985ed93dcdc5a04784e88ac7c982b7317d0b96b4f7526f}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER}"

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:31
+FROM registry.fedoraproject.org/fedora-minimal:33
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY fedora.repo /tmp/fedora_ci.dnf.repo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the parent image of `kubevirt-cdi-bazel-builder` image to fedora 33

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the parent image of kubevirt-cdi-bazel-builder to fedora 33
```

