### PR TITLE
Adding support for import of vmdk and vdi file types

### DIFF
--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -46,6 +46,18 @@ var knownHeaders = Headers{
 		SizeOff: 0,
 		SizeLen: 0,
 	},
+	"vmdk": Header{
+		Format:      "vmdk",
+		magicNumber: []byte{0x4B, 0x44, 0x4D, 0x56},
+		SizeOff: 0,
+		SizeLen: 0,
+	},
+	"vdi": Header{
+		Format:      "vdi",
+		magicNumber: []byte{0x3C, 0x3C, 0x3C, 0x20},
+		SizeOff: 0,
+		SizeLen: 0,
+	},
 }
 
 // Header represents our parameters for a file format header

--- a/pkg/image/filefmt_test.go
+++ b/pkg/image/filefmt_test.go
@@ -60,6 +60,14 @@ var _ = Describe("File format tests", func() {
 			fields{"gz", []byte{0x1F, 0x8B}, 0, 0, 0},
 			[]byte{'Q', 'F', 'I', 0xfb},
 			false),
+		table.Entry("match vmdk",
+			fields{"vmdk", []byte{0x4B, 0x44, 0x4D, 0x56}, 0, 24, 8},
+			[]byte{0x4B, 0x44, 0x4D, 0x56},
+			true),
+		table.Entry("match vdi",
+			fields{"vdi", []byte{0x3C, 0x3C, 0x3C, 0x20}, 0, 24, 8},
+			[]byte{0x3C, 0x3C, 0x3C, 0x20},
+			true),
 	)
 
 	tokenQcow := make([]byte, 20)

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -170,7 +170,7 @@ func (o *qemuOperations) Info(url *url.URL) (*ImgInfo, error) {
 
 func isSupportedFormat(value string) bool {
 	switch value {
-	case "raw", "qcow2":
+	case "raw", "qcow2", "vmdk", "vdi":
 		return true
 	default:
 		return false

--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -174,6 +174,12 @@ func (fr *FormatReaders) fileFormatSelector(hdr *image.Header) {
 		if err == nil {
 			fr.Archived = true
 		}
+	case "vmdk":
+		r = nil
+		fr.Convert = true
+	case "vdi":
+		r = nil
+		fr.Convert = true
 	}
 	if err == nil && r != nil {
 		fr.appendReader(rdrTypM[fFmt], r)


### PR DESCRIPTION
Signed-off-by: Vishesh Ajay Tanksale <vtanksale@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds support to importer VMDK and VDI type of VM Images

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Adding support to download and convert VMDK and VDI images
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding support to import vmdk and vdi VM Images
```

