### PR TITLE
Have the verifier pod use the hostnetwork

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -171,6 +171,11 @@ func (f *Framework) GetMD5(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolu
 	err = utils.WaitTimeoutForPodReady(f.K8sClient, executorPod.Name, namespace.Name, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+	pods, err := f.K8sClient.CoreV1().Pods(namespace.Name).List(context.TODO(), metav1.ListOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	for _, pod := range pods.Items {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: pod in namespace %s, %s\n", namespace.Name, pod.Name)
+	}
 	cmd := "md5sum " + fileName
 	if numBytes > 0 {
 		cmd = fmt.Sprintf("head -c %d %s | md5sum", numBytes, fileName)
@@ -392,6 +397,7 @@ func (f *Framework) NewPodWithPVC(podName, cmd string, pvc *k8sv1.PersistentVolu
 			SecurityContext: &k8sv1.PodSecurityContext{
 				FSGroup: &fsGroup,
 			},
+			HostNetwork: true,
 		},
 	}
 


### PR DESCRIPTION
 as we don't care about it having an ip address as it doesn't use the network at all.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are seeing random failures in verifier pods, and it appears to be when the cni plugin is unable to give the verifier pod an ip address. Since the verifier pod doesn't use the network at all, giving it the host network should eliminate the cni provider from the equation and hopefully improve stability.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

