### PR TITLE
Allow specifying in an environment variable the name of the container disk used during init of the registry-file-host

### DIFF
--- a/tools/cdi-func-test-registry-init/populate-registry.sh
+++ b/tools/cdi-func-test-registry-init/populate-registry.sh
@@ -4,6 +4,8 @@
 # Disk images are taken from /tmp/shared/images directory populated by cdi-func-test-registry-init
 # Container images are built with buildah 
 
+CONTAINER_DISK_IMAGE=${CONTAINER_DISK_IMAGE:-kubevirt/container-disk-v1alpha}
+
 #images args
 IMAGES_SRC=$1        #path to files to be encapsulated in docker image
 IMAGES_CTR=$2        #path to directories with Dockerfile per file
@@ -70,7 +72,7 @@ function prepareImages {
 
         FILE=$FILENAME$DIR"/"$DOCKERFILE
         /bin/cat  >$FILE <<-EOF
-                FROM kubevirt/container-disk-v1alpha
+                FROM $CONTAINER_DISK_IMAGE
                 COPY $FILENAME $IMAGE_LOCATION
 EOF
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1468 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

