### PR TITLE
Designate CDI as CDIConfig authority

### DIFF
--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -31,6 +31,11 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
+// AnnConfigAuthority is the annotation specifying a resource as the CDIConfig authority
+const (
+	AnnConfigAuthority = "cdi.kubevirt.io/configAuthority"
+)
+
 // CDIConfigReconciler members
 type CDIConfigReconciler struct {
 	client client.Client
@@ -102,6 +107,10 @@ func (r *CDIConfigReconciler) setOperatorParams(config *cdiv1.CDIConfig) error {
 	}
 
 	if cdiCR == nil {
+		return nil
+	}
+
+	if _, ok := cdiCR.Annotations[AnnConfigAuthority]; !ok {
 		return nil
 	}
 

--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1beta1:go_default_library",
         "//pkg/common:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/operator:go_default_library",
         "//pkg/operator/resources/cert:go_default_library",
         "//pkg/operator/resources/cluster:go_default_library",

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -21,13 +21,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/callbacks"
-
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -35,7 +32,10 @@ import (
 	sdk "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	cdicontroller "kubevirt.io/containerized-data-importer/pkg/controller"
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/callbacks"
 )
 
 func addReconcileCallbacks(r *ReconcileCDI) {
@@ -46,7 +46,7 @@ func addReconcileCallbacks(r *ReconcileCDI) {
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCreateRoute)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteSecrets)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileInitializeCRD)
-
+	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileSetConfigAuthority)
 }
 
 func isControllerDeployment(d *appsv1.Deployment) bool {
@@ -172,4 +172,48 @@ func deleteWorkerResources(l logr.Logger, c client.Client) error {
 	}
 
 	return nil
+}
+
+func reconcileSetConfigAuthority(args *callbacks.ReconcileCallbackArgs) error {
+	if args.State != callbacks.ReconcileStatePostRead {
+		return nil
+	}
+
+	crd := args.CurrentObject.(*extv1.CustomResourceDefinition)
+	if crd.Name != "cdiconfigs.cdi.kubevirt.io" {
+		return nil
+	}
+
+	cdi, ok := args.Resource.(*cdiv1.CDI)
+	if !ok {
+		return nil
+	}
+
+	if _, ok = cdi.Annotations[cdicontroller.AnnConfigAuthority]; ok {
+		return nil
+	}
+
+	if cdi.Spec.Config == nil {
+		cl := &cdiv1.CDIConfigList{}
+		err := args.Client.List(context.TODO(), cl)
+		if err != nil {
+			return err
+		}
+
+		if len(cl.Items) != 1 {
+			return nil
+		}
+
+		cs := cl.Items[0].Spec.DeepCopy()
+		if !reflect.DeepEqual(cs, &cdiv1.CDIConfigSpec{}) {
+			cdi.Spec.Config = cs
+		}
+	}
+
+	if cdi.Annotations == nil {
+		cdi.Annotations = map[string]string{}
+	}
+	cdi.Annotations[cdicontroller.AnnConfigAuthority] = ""
+
+	return args.Client.Update(context.TODO(), cdi)
 }

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -197,6 +198,10 @@ func reconcileSetConfigAuthority(args *callbacks.ReconcileCallbackArgs) error {
 		cl := &cdiv1.CDIConfigList{}
 		err := args.Client.List(context.TODO(), cl)
 		if err != nil {
+			if meta.IsNoMatchError(err) {
+				return nil
+			}
+
 			return err
 		}
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -99,6 +99,17 @@ var _ = Describe("Operator tests", func() {
 		Expect(conditionMap[conditions.ConditionProgressing]).To(Equal(corev1.ConditionFalse))
 		Expect(conditionMap[conditions.ConditionDegraded]).To(Equal(corev1.ConditionFalse))
 	})
+
+	It("should make CDI config authority", func() {
+		Eventually(func() bool {
+			cdiObjects, err := f.CdiClient.CdiV1beta1().CDIs().List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(cdiObjects.Items)).To(Equal(1))
+			cdiObject := cdiObjects.Items[0]
+			_, ok := cdiObject.Annotations["cdi.kubevirt.io/configAuthority"]
+			return ok
+		}, 1*time.Minute, 2*time.Second).Should(BeTrue())
+	})
 })
 
 var _ = Describe("Tests needing the restore of nodes", func() {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Formally designate CDI as CDIConfig authority by adding annotation `cdi.kubevirt.io/configAuthority` to CDI after copying values from existing CDIConfig.

If the annotation does not exist, the config controller will ignore values in CDI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

