### PR TITLE
Add update-rpms-workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ builder-push:
 openshift-ci-image-push:
 	./hack/build/osci-image-builder.sh
 
+update-rpms-workspace:
+	./hack/build/update-rpms-workspace.sh
+
 help:
 	@echo "Usage: make [Targets ...]"
 	@echo " all "
@@ -196,6 +199,8 @@ help:
 	@echo "  : Run gofmt and golint against src files"
 	@echo " test-functional "
 	@echo "  : Run functional tests (in tests/ subdirectory)."
+	@echo " update-rpms-workspace"
+	@echo "  : Update rpms in the WORKSPACE"
 	@echo " vet	"
 	@echo "  : lint all CDI packages"
 

--- a/hack/build/docker/rpms/Dockerfile
+++ b/hack/build/docker/rpms/Dockerfile
@@ -1,0 +1,17 @@
+ARG VERSION
+FROM fedora:$VERSION
+
+RUN dnf update -y && dnf install -y \
+  yum-utils coreutils python3 rsync rsync-daemon
+
+RUN sed -i 's/^metalink/#metalink/g' /etc/yum.repos.d/fedora*.repo \
+    && sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/fedora*.repo \
+    && sed -i 's/download\.example/download\.fedoraproject\.org/g' /etc/yum.repos.d/fedora*.repo
+
+RUN dnf config-manager --set-disabled fedora-cisco-openh264 \
+    && dnf update -y \
+    && dnf clean all
+
+COPY rsyncd.conf /etc/rsyncd.conf
+COPY ./fetch-repo-workspace.py /fetch/fetch-repo-workspace.py
+WORKDIR /fetch

--- a/hack/build/docker/rpms/fetch-repo-workspace.py
+++ b/hack/build/docker/rpms/fetch-repo-workspace.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import re, sys, os, subprocess, hashlib, getopt
+import urllib.request
+
+# Get the correct name for the rpms
+def fix_name(name):
+    if name == "gperftools-lib":
+        return "gperftools-libs"
+    if name == "ncurses-lib":
+        return "ncurses-libs"
+    return name
+
+# Get the sha256sum
+def get_sha256(url):
+    hash = hashlib.sha256()
+    remote = urllib.request.urlopen(url)
+    hash.update(remote.read())
+    return hash.hexdigest()
+
+# Write the file o with the http_file and updated fields
+def update_http_output(o, name, url, sha):
+    o.writelines([
+    'http_file(\n', 
+    '    name = "'+name+'",\n',
+    '    sha256 = "'+sha+'",\n',
+    '    urls = [\n',
+    '        "'+url+'",\n',
+    '   ],\n',
+    ')\n\n'])
+
+def get_name_from_line(line):
+    return re.search('\".*?\"', line).group().strip('"')
+
+# Get the url for the dependency using yumdownloader
+def get_url(name):
+    fixname = fix_name(name)
+    print("Fetch dep:", name)
+    result = subprocess.run(["/usr/bin/yumdownloader", "--url", "--urlprotocols", "http", fixname] , stdout=subprocess.PIPE)
+    # Avoid the rpms for i686
+    return re.search('http\:.[^\n]*[^i686]\.rpm', result.stdout.decode("utf-8") , re.DOTALL).group().strip('"')
+
+
+inputfile = ''
+outputfile = ''
+
+opts, args = getopt.getopt(sys.argv[1:],"hi:o:w",["ifile=","ofile="])
+for opt, arg in opts:
+   if opt == '-h':
+      print("test.py: \n  -i <inputfile>\n  -w overwrite inputfile\n  -o <outputfile>\n  (-o and -w are mutually exclusive)")
+      sys.exit()
+   elif opt in ("-i", "--ifile"):
+      inputfile = arg
+   elif opt in ("-w"):
+       outputfile = inputfile
+   elif opt in ("-o", "--ofile") and opt != "-w":
+      outputfile = arg
+
+if inputfile == "":
+    print('Provide input file: -i <inputfile>')
+    sys.exit()
+
+if outputfile == "":
+    print('Provide output file: -o <outputfile> or -w to overwrite the inputfile')
+    sys.exit()
+
+# Read the input file
+f = open(inputfile, "r")
+lines = f.readlines()
+f.close()
+
+# Remove output file if exists
+if os.path.exists(outputfile):
+  os.remove(outputfile)
+o = open(outputfile, 'a+')
+
+find_next_parenthesis = False
+for l in lines:
+    # Get the name of the package
+    if find_next_parenthesis and "name =" in l:
+        name = get_name_from_line(l)
+        url = get_url(name)
+        sha = get_sha256(url)
+        update_http_output(o, name, url, sha) 
+
+    # Loop until we find the next ')'
+    if "http_file(" in l : 
+        find_next_parenthesis = True
+        continue
+
+    if find_next_parenthesis and l == ")":
+        find_next_parenthesis = False
+        continue
+    if find_next_parenthesis:
+        continue
+
+    o.write(l)

--- a/hack/build/docker/rpms/rsyncd.conf
+++ b/hack/build/docker/rpms/rsyncd.conf
@@ -1,0 +1,9 @@
+gid = 0
+uid = 0
+log file = /dev/stdout
+reverse lookup = no
+[build]
+    hosts allow = *
+    read only = false
+    path = /fetch
+    comment = input sources

--- a/hack/build/update-rpms-workspace.sh
+++ b/hack/build/update-rpms-workspace.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source "${script_dir}"/common.sh
+
+FETCH_RPMS_IMAGE=${FETCH_RPMS_IMAGE:-kubevirt/fetch-rpms-workspace}
+FEDORA_VERSION_RPMS=${FEDORA_VERSION_RPMS:-33}
+BUILD_DIR="${CDI_DIR}/hack/build/docker/rpms"
+# Build the container image 
+docker build -t ${FETCH_RPMS_IMAGE} --build-arg "VERSION=${FEDORA_VERSION_RPMS}" -f ${BUILD_DIR}/Dockerfile  ${BUILD_DIR}
+
+# Start rsync inside the container
+ID=$(docker run -w /fetch --rm -td --security-opt label=disable --expose 873 -P ${FETCH_RPMS_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+PORT=$(docker port $ID 873 | cut -d':' -f2)
+# Copy the WORKSPACE inside the container
+rsync -rlgoD ${CDI_DIR}/WORKSPACE rsync://root@127.0.0.1:${PORT}/build
+# Run the script to update the rpms
+docker exec -ti ${ID} /fetch/fetch-repo-workspace.py -i WORKSPACE -w
+# Copy back the WORKSPACE
+rsync -rlgoD  rsync://root@127.0.0.1:${PORT}/build/WORKSPACE ${CDI_DIR}/WORKSPACE
+# Clean up
+docker stop ${ID}
+


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds a new Makefile rule `make update-rpms-workspace` to automatically update the rpms in the WORKSPACE.

This setup is useful when you need to upgrade the base image version or fetching new versions of the rpms and you don't want to update the shas and urls manually in the WORKSPACE.

 **Release note**:

 ```
NONE
 ```

