### PR TITLE
Read-only mounts in clone source pods

### DIFF
--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			return podUsingPVC(pvc, true)
 		}),
 		Entry("other clone source pod using source PVC", func(pvc *corev1.PersistentVolumeClaim) *corev1.Pod {
-			pod := podUsingPVC(pvc, false)
+			pod := podUsingPVC(pvc, true)
 			pod.Labels = map[string]string{"cdi.kubevirt.io": "cdi-clone-source"}
 			return pod
 		}),

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -543,18 +543,6 @@ func getPodsUsingPVCs(c client.Client, namespace string, names sets.String, allo
 	return pods, nil
 }
 
-func filterCloneSourcePods(input []v1.Pod) []v1.Pod {
-	var output []v1.Pod
-
-	for _, pod := range input {
-		if pod.Labels[common.CDIComponentLabel] != common.ClonerSourcePodName {
-			output = append(output, pod)
-		}
-	}
-
-	return output
-}
-
 // GetWorkloadNodePlacement extracts the workload-specific nodeplacement values from the CDI CR
 func GetWorkloadNodePlacement(c client.Client) (*sdkapi.NodePlacement, error) {
 	cr, err := GetActiveCDI(c)

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -44,6 +44,7 @@ func addReconcileCallbacks(r *ReconcileCDI) {
 	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileServiceAccountRead)
 	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileServiceAccounts)
 	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileCreateSCC)
+	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileSELinuxPerms)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCreateRoute)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteSecrets)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileInitializeCRD)

--- a/pkg/operator/controller/scc.go
+++ b/pkg/operator/controller/scc.go
@@ -63,7 +63,7 @@ func ensureSCCExists(logger logr.Logger, c client.Client, saNamespace, saName st
 				Type: secv1.RunAsUserStrategyRunAsAny,
 			},
 			SELinuxContext: secv1.SELinuxContextStrategyOptions{
-				Type: secv1.SELinuxStrategyMustRunAs,
+				Type: secv1.SELinuxStrategyRunAsAny,
 			},
 			SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
 				Type: secv1.SupplementalGroupsStrategyRunAsAny,


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Read/write mounts will minimize errors when a source PVC is mounted multiple times on the same node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

This is two part of a two PR fix for https://bugzilla.redhat.com/show_bug.cgi?id=1893363

Once this and #521 are merged I will add a new functional test to stress cloning hard

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clone source pods mount PVCs read-only
```

