### PR TITLE
[release-v1.23] Clone source pod abort on tar error

### DIFF
--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,12 +22,35 @@ import (
 
 var (
 	contentType string
+	mountPoint  string
 	uploadBytes uint64
 )
 
+type execReader struct {
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+}
+
+func (er *execReader) Read(p []byte) (n int, err error) {
+	n, err = er.stdout.Read(p)
+	if err == io.EOF {
+		if err2 := er.cmd.Wait(); err2 != nil {
+			errBytes, _ := ioutil.ReadAll(er.stderr)
+			klog.Fatalf("Subprocess did not execute successfully, result is: %q\n%s", er.cmd.ProcessState.ExitCode(), string(errBytes))
+		}
+	}
+	return
+}
+
+func (er *execReader) Close() error {
+	return er.stdout.Close()
+}
+
 func init() {
-	flag.StringVar(&contentType, "content_type", "", "archive|kubevirt|filesystem-clone|blockdevice-clone")
-	flag.Uint64Var(&uploadBytes, "upload_bytes", 0, "approx number of bytes in input")
+	flag.StringVar(&contentType, "content-type", "", "filesystem-clone|blockdevice-clone")
+	flag.StringVar(&mountPoint, "mount", "", "pvc mount point")
+	flag.Uint64Var(&uploadBytes, "upload-bytes", 0, "approx number of bytes in input")
 	klog.InitFlags(nil)
 }
 
@@ -105,12 +129,68 @@ func pipeToSnappy(reader io.ReadCloser) io.ReadCloser {
 	return pr
 }
 
+func validateContentType() {
+	switch contentType {
+	case "filesystem-clone", "blockdevice-clone":
+	default:
+		klog.Fatalf("Invalid content-type %q", contentType)
+	}
+}
+
+func validateMount() {
+	if mountPoint == "" {
+		klog.Fatalf("Invalid mount %q", mountPoint)
+	}
+}
+
+func newTarReader() (io.ReadCloser, error) {
+	cmd := exec.Command("/usr/bin/tar", "Scv", ".")
+	cmd.Dir = mountPoint
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err = cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return &execReader{cmd: cmd, stdout: stdout, stderr: ioutil.NopCloser(&stderr)}, nil
+}
+
+func getInputStream() (rc io.ReadCloser) {
+	var err error
+	switch contentType {
+	case "filesystem-clone":
+		rc, err = newTarReader()
+		if err != nil {
+			klog.Fatalf("Error creating tar reader for %q: %+v", mountPoint, err)
+		}
+	case "blockdevice-clone":
+		rc, err = os.Open(mountPoint)
+		if err != nil {
+			klog.Fatalf("Error opening block device %q: %+v", mountPoint, err)
+		}
+	default:
+		klog.Fatalf("Invalid content-type %q", contentType)
+	}
+	return
+}
+
 func main() {
 	flag.Parse()
 	defer klog.Flush()
 
-	klog.Infof("content_type is %q\n", contentType)
-	klog.Infof("upload_bytes is %d", uploadBytes)
+	klog.Infof("content-type is %q\n", contentType)
+	klog.Infof("mount is %q\n", mountPoint)
+	klog.Infof("upload-bytes is %d", uploadBytes)
+
+	validateContentType()
+	validateMount()
 
 	ownerUID := getEnvVarOrDie(common.OwnerUID)
 
@@ -122,7 +202,7 @@ func main() {
 
 	klog.V(1).Infoln("Starting cloner target")
 
-	reader := pipeToSnappy(createProgressReader(os.Stdin, ownerUID, uploadBytes))
+	reader := pipeToSnappy(createProgressReader(getInputStream(), ownerUID, uploadBytes))
 
 	startPrometheus()
 

--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -33,13 +33,13 @@ if [ "$VOLUME_MODE" == "block" ]; then
     UPLOAD_BYTES=$(blockdev --getsize64 $MOUNT_POINT)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content_type blockdevice-clone -upload_bytes $UPLOAD_BYTES <$MOUNT_POINT
+    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type blockdevice-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 else
     pushd $MOUNT_POINT
     UPLOAD_BYTES=$(du -sb . | cut -f1)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    tar Scv . | /usr/bin/cdi-cloner -v=3 -alsologtostderr -content_type filesystem-clone -upload_bytes $UPLOAD_BYTES
+    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type filesystem-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 
     popd
 fi


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Cherrypick of #1521 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1907623

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Clone source pod will detect tar errors and abort rather than silently ignore
```

