### PR TITLE
Allow passing default multus network annotation to transfer pods

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -93,6 +93,8 @@ const (
 const (
 	// AnnPodNetwork is used for specifying Pod Network
 	AnnPodNetwork = "k8s.v1.cni.cncf.io/networks"
+	// AnnPodMultusDefaultNetwork is used for specifying default Pod Network
+	AnnPodMultusDefaultNetwork = "v1.multus-cni.io/default-network"
 	// AnnPodSidecarInjection is used for enabling/disabling Pod istio/AspenMesh sidecar injection
 	AnnPodSidecarInjection = "sidecar.istio.io/inject"
 )
@@ -593,7 +595,7 @@ func IsPopulated(pvc *v1.PersistentVolumeClaim, c client.Client) (bool, error) {
 
 // SetPodPvcAnnotations applies PVC annotations on the pod
 func SetPodPvcAnnotations(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) {
-	allowedAnnotations := []string{AnnPodNetwork, AnnPodSidecarInjection}
+	allowedAnnotations := []string{AnnPodNetwork, AnnPodSidecarInjection, AnnPodMultusDefaultNetwork}
 	for _, ann := range allowedAnnotations {
 		if val, ok := pvc.Annotations[ann]; ok {
 			klog.V(1).Info("Applying PVC annotation on the pod", ann, val)


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Multus adds an extra nic to the pod as passed by annotation `k8s.v1.cni.cncf.io/networks` from the dv, but to set it as default nic of the pod we need to pass `v1.multus-cni.io/default-network` annotation instead.

**Release note**:
```release-note
NONE
```

