### PR TITLE
Simplify file host, now a new image only has to be added to bazel.

### DIFF
--- a/hack/build/build-cdi-func-test-file-host.sh
+++ b/hack/build/build-cdi-func-test-file-host.sh
@@ -32,7 +32,5 @@ DOCKER_PREFIX=""
 ${BUILD_DIR}/build-copy-artifacts.sh "${FILE_INIT_PATH}"
 
 cp ${BUILD_DIR}/docker/${FILE_HOST}/* ${OUT_PATH}/${FILE_HOST}/
-cp "${CDI_DIR}/tests/images/tinyCore.iso" "${OUT_PATH}/${FILE_INIT}/"
-cp "${CDI_DIR}/tests/images/archive.tar" "${OUT_PATH}/${FILE_INIT}/"
+cp "${CDI_DIR}/tests/images/*" "${OUT_PATH}/${FILE_INIT}/"
 cp -R "${CDI_DIR}/tests/images/invalid_qcow_images" "${OUT_PATH}/${FILE_INIT}/"
-cp "${CDI_DIR}/tests/images/cirros-qcow2.img" "${OUT_PATH}/${FILE_INIT}/"

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -60,18 +60,7 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	// copy archive file
-	if err := util.CopyFile("/tmp/source/archive.tar", filepath.Join(*outDir, "archive.tar")); err != nil {
-		klog.Fatal(err)
-	}
-
-	// copy invalid qcow files
-	if err := util.CopyDir("/tmp/source/invalid_qcow_images", filepath.Join(*outDir, "invalid_qcow_images")); err != nil {
-		klog.Fatal(err)
-	}
-
-	// copy cirros qcow file
-	if err := util.CopyFile("/tmp/source/cirros-qcow2.img", filepath.Join(*outDir, "cirros-qcow2.img")); err != nil {
+	if err := util.CopyDir("/tmp/source/", *outDir); err != nil {
 		klog.Fatal(err)
 	}
 


### PR DESCRIPTION
same goals as #1462 but without significant functional changes.
As a side effect, this means all the test-images file group (specified in BUILD.bazel) will be available through the file host, and not just the subset that was specified in tools/cdi-func-test-file-host-init/main.go.

```release-note
NONE
```

