### PR TITLE
Change verbosity for preallocation messages, avoid infinite loop

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -102,7 +102,7 @@ func NewQEMUOperations() QEMUOperations {
 func convertToRaw(src, dest string, preallocate bool) error {
 	args := []string{"convert", "-t", "none", "-p", "-O", "raw", src, dest}
 	if preallocate {
-		klog.V(3).Info("Added preallocation")
+		klog.V(1).Info("Added preallocation")
 		args = append(args, []string{"-o", "preallocation=falloc"}...)
 	}
 	_, err := qemuExecFunction(nil, nil, "qemu-img", args...)
@@ -124,7 +124,7 @@ func (o *qemuOperations) ConvertToRawStream(url *url.URL, dest string, prealloca
 
 	args := []string{"convert", "-t", "none", "-p", "-O", "raw", jsonArg, dest}
 	if preallocate {
-		klog.V(3).Info("Added preallocation")
+		klog.V(1).Info("Added preallocation")
 		args = append(args, []string{"-o", "preallocation=falloc"}...)
 	}
 	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", args...)
@@ -243,7 +243,7 @@ func (o *qemuOperations) CreateBlankImage(dest string, size resource.Quantity, p
 	klog.V(3).Infof("image size is %s", size.String())
 	args := []string{"create", "-f", "raw", dest, convertQuantityToQemuSize(size)}
 	if preallocate {
-		klog.V(3).Infof("Added preallocation")
+		klog.V(1).Infof("Added preallocation")
 		args = append(args, []string{"-o", "preallocation=falloc"}...)
 	}
 	_, err := qemuExecFunction(nil, nil, "qemu-img", args...)


### PR DESCRIPTION
- D/S the importer pod has verbosity=1 => the preallocation messages are not present in log
- Due to this, we hit an infinite loop in the preallocation tests
  (Import completed without preallocation message => pod doesn't exist anymore but sampling continues)

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

