### PR TITLE
core: Preallocate blank image disks as well

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -513,10 +513,11 @@ func (r *ImportReconciler) createImportEnvVar(pvc *corev1.PersistentVolumeClaim)
 		podEnvVar.previousCheckpoint = getValueFromAnnotation(pvc, AnnPreviousCheckpoint)
 		podEnvVar.currentCheckpoint = getValueFromAnnotation(pvc, AnnCurrentCheckpoint)
 		podEnvVar.finalCheckpoint = getValueFromAnnotation(pvc, AnnFinalCheckpoint)
-		if preallocation, err := strconv.ParseBool(getValueFromAnnotation(pvc, AnnPreallocationRequested)); err == nil {
-			podEnvVar.preallocation = preallocation
-		} // else use the default "false"
 	}
+
+	if preallocation, err := strconv.ParseBool(getValueFromAnnotation(pvc, AnnPreallocationRequested)); err == nil {
+		podEnvVar.preallocation = preallocation
+	} // else use the default "false"
 
 	//get the requested image size.
 	podEnvVar.imageSize, err = getRequestedImageSize(pvc)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -962,5 +962,8 @@ var _ = Describe("Preallocation", func() {
 
 			return utils.NewDataVolumeWithVddkImport("import-dv", "100Mi", backingFile, s.Name, thumbprint, vcenterURL(), vmid.String())
 		}),
+		Entry("Blank image", true, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForBlankRawImage("import-dv", "100Mi")
+		}),
 	)
 })


### PR DESCRIPTION

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fixes a bug where blank image disks were not preallocated.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1914177

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

