### PR TITLE
Compare logs while ignoring differences in spaces

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -844,11 +844,11 @@ var _ = Describe("all clone tests", func() {
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 
 			By("Verify Quota was exceeded in logs")
-			matchString := fmt.Sprintf("\"namespace\": \"%s\", \"error\": \"pods \\\"cdi-upload-target-dv\\\" is forbidden: exceeded quota: test-quota, requested", targetNs.Name)
+			matchString := strings.Trim(fmt.Sprintf("\"namespace\": \"%s\", \"error\": \"pods \\\"cdi-upload-target-dv\\\" is forbidden: exceeded quota: test-quota, requested", targetNs.Name), " ")
 			Eventually(func() string {
 				log, err := RunKubectlCommand(f, "logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
 				Expect(err).NotTo(HaveOccurred())
-				return log
+				return strings.Trim(log, " ")
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 		})
 	})

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -492,11 +492,11 @@ var _ = Describe("Namespace with quota", func() {
 		f.ForceBindIfWaitForFirstConsumer(pvc)
 
 		By("Verify Quota was exceeded in logs")
-		matchString := fmt.Sprintf(`"name": "import-image-to-pvc", "namespace": "%s", "error": "pods \"importer-import-image-to-pvc\" is forbidden: exceeded quota: test-quota`, f.Namespace.Name)
+		matchString := strings.Trim(fmt.Sprintf(`"name": "import-image-to-pvc", "namespace": "%s", "error": "pods \"importer-import-image-to-pvc\" is forbidden: exceeded quota: test-quota`, f.Namespace.Name), " ")
 		Eventually(func() string {
 			log, err := tests.RunKubectlCommand(f, "logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
 			Expect(err).NotTo(HaveOccurred())
-			return log
+			return strings.Trim(log, " ")
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 	})
 
@@ -521,11 +521,11 @@ var _ = Describe("Namespace with quota", func() {
 		f.ForceBindIfWaitForFirstConsumer(pvc)
 
 		By("Verify Quota was exceeded in logs")
-		matchString := fmt.Sprintf(`"name": "import-image-to-pvc", "namespace": "%s", "error": "pods \"importer-import-image-to-pvc\" is forbidden: exceeded quota: test-quota`, f.Namespace.Name)
+		matchString := strings.Trim(fmt.Sprintf(`"name": "import-image-to-pvc", "namespace": "%s", "error": "pods \"importer-import-image-to-pvc\" is forbidden: exceeded quota: test-quota`, f.Namespace.Name), " ")
 		Eventually(func() string {
 			log, err := tests.RunKubectlCommand(f, "logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
 			Expect(err).NotTo(HaveOccurred())
-			return log
+			return strings.Trim(log, " ")
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
 		err = f.UpdateQuotaInNs(int64(2), int64(512*1024*1024), int64(2), int64(512*1024*1024))


### PR DESCRIPTION
Some OpenShift versions seem to not add spaces between different
components of the message, become more resilient for this scenario.

**Release note**:
```release-note
Fix some tests failing in newer versions of OpenShift due to whitespace differences
```

