### PR TITLE
Reduce the noise from the filesystem overhead functionality

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -294,15 +294,13 @@ func GetFilesystemOverhead(client client.Client, pvc *v1.PersistentVolumeClaim) 
 
 	targetStorageClass, err := GetStorageClassByName(client, pvc.Spec.StorageClassName)
 	if err != nil {
-		klog.V(1).Info("Storage class", pvc.Spec.StorageClassName, "not found, trying default storage class")
+		klog.V(3).Info("Storage class", pvc.Spec.StorageClassName, "not found, trying default storage class")
 		targetStorageClass, err = GetStorageClassByName(client, nil)
 		if err != nil {
-			klog.V(1).Info("No default storage class found, continuing with global overhead")
+			klog.V(3).Info("No default storage class found, continuing with global overhead")
 			return cdiConfig.Status.FilesystemOverhead.Global, nil
 		}
 	}
-
-	klog.V(1).Info("target storage class for overhead", targetStorageClass)
 
 	if cdiConfig.Status.FilesystemOverhead == nil {
 		klog.Errorf("CDIConfig filesystemOverhead used before config controller ran reconcile. Hopefully this only happens during unit testing.")
@@ -310,9 +308,11 @@ func GetFilesystemOverhead(client client.Client, pvc *v1.PersistentVolumeClaim) 
 	}
 
 	if targetStorageClass == nil {
-		klog.V(1).Info("Storage class", pvc.Spec.StorageClassName, "not found, continuing with global overhead")
+		klog.V(3).Info("Storage class", pvc.Spec.StorageClassName, "not found, continuing with global overhead")
 		return cdiConfig.Status.FilesystemOverhead.Global, nil
 	}
+
+	klog.V(3).Info("target storage class for overhead", targetStorageClass.GetName())
 
 	perStorageConfig := cdiConfig.Status.FilesystemOverhead.StorageClass
 


### PR DESCRIPTION
Printing just the name of the storageclass is just as descriptive
as printing the entire structure, and V(3) is probably preferred
for debug output.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduce the amount of output generated by the filesystem overhead functionality.
```

