### PR TITLE
core: Preallocate blank block volumes

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -108,7 +108,14 @@ func main() {
 			}
 		}
 
-		err := image.CreateBlankImage(common.ImporterWritePath, minSizeQuantity, preallocation)
+		var err error
+		if volumeMode == v1.PersistentVolumeFilesystem {
+			err = image.CreateBlankImage(common.ImporterWritePath, minSizeQuantity, preallocation)
+		} else if volumeMode == v1.PersistentVolumeBlock && preallocation {
+			klog.V(1).Info("Preallocating blank block volume")
+			err = image.PreallocateBlankBlock(common.WriteBlockPath, minSizeQuantity)
+		}
+
 		if err != nil {
 			klog.Errorf("%+v", err)
 			message := fmt.Sprintf("Unable to create blank image: %+v", err)

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -226,7 +226,7 @@ func (r *ImportReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 	// In case this is a request to create a blank disk on a block device, we do not create a pod.
 	// we just mark the DV as successful
 	volumeMode := getVolumeMode(pvc)
-	if volumeMode == corev1.PersistentVolumeBlock && pvc.GetAnnotations()[AnnSource] == SourceNone {
+	if volumeMode == corev1.PersistentVolumeBlock && pvc.GetAnnotations()[AnnSource] == SourceNone && pvc.GetAnnotations()[AnnPreallocationRequested] != "true" {
 		log.V(1).Info("attempting to create blank disk for block mode, this is a no-op, marking pvc with pod-phase succeeded")
 		if pvc.GetAnnotations() == nil {
 			pvc.SetAnnotations(make(map[string]string, 0))

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -259,3 +259,17 @@ func (o *qemuOperations) CreateBlankImage(dest string, size resource.Quantity, p
 
 	return nil
 }
+
+// PreallocateBlankBlock writes requested amount of zeros to block device mounted at dest
+func PreallocateBlankBlock(dest string, size resource.Quantity) error {
+	klog.V(3).Infof("block volume size is %s", size.String())
+
+	args := []string{"if=/dev/zero", "of=" + dest, "bs=" + convertQuantityToQemuSize(size), "count=1"}
+	_, err := qemuExecFunction(nil, nil, "dd", args...)
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Could not preallocate blank block volume at %s with size %s", dest, size.String()))
+	}
+
+	return nil
+}

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -965,5 +965,12 @@ var _ = Describe("Preallocation", func() {
 		Entry("Blank image", true, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeForBlankRawImage("import-dv", "100Mi")
 		}),
+		Entry("Blank block DataVolume", true, func() *cdiv1.DataVolume {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			return utils.NewDataVolumeForBlankRawImageBlock("import-dv", "100Mi", f.BlockSCName)
+		}),
 	)
 })


### PR DESCRIPTION

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Importer pod needs to be started for blank block volumes and it needs to
handle the case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

