### PR TITLE
Add a DV/PVC annotation "storage.bind.immediate.requested"

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -179,16 +179,17 @@ func addImportControllerWatches(mgr manager.Manager, importController controller
 }
 
 func shouldReconcilePVC(pvc *corev1.PersistentVolumeClaim,
+	isImmediateBindingRequested bool,
 	featureGates featuregates.FeatureGates,
 	log logr.Logger) (bool, error) {
+	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, featureGates)
 
-	honorWaitForFirstConsumer, err := featureGates.HonorWaitForFirstConsumerEnabled()
 	if err != nil {
 		return false, err
 	}
 	return !isPVCComplete(pvc) &&
 			(checkPVC(pvc, AnnEndpoint, log) || checkPVC(pvc, AnnSource, log)) &&
-			shouldHandlePvc(pvc, honorWaitForFirstConsumer, log),
+			shouldHandlePvc(pvc, waitForFirstConsumerEnabled, log),
 		nil
 }
 
@@ -210,7 +211,9 @@ func (r *ImportReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 		}
 		return reconcile.Result{}, err
 	}
-	shouldReconcile, err := shouldReconcilePVC(pvc, r.featureGates, log)
+	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
+
+	shouldReconcile, err := shouldReconcilePVC(pvc, isImmediateBindingRequested, r.featureGates, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -94,6 +94,20 @@ var _ = Describe("Test PVC annotations status", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint}, nil)
 		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
 	})
+
+	It("Should NOT be interesting if NOT BOUND, and endpoint and source is set, and honorWaitForFirstConsumerEnabled", func() {
+		testPvc := createPendingPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint, AnnSource: SourceHTTP}, nil)
+		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: true}, importLog)).To(BeFalse())
+	})
+
+	It("Should be interesting if NOT BOUND, and endpoint and source is set, and honorWaitForFirstConsumerEnabled and isImmediateBindingRequested is requested", func() {
+		testPvc := createPendingPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint, AnnSource: SourceHTTP}, nil)
+		Expect(shouldReconcilePVC(testPvc, true, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: true}, importLog)).To(BeTrue())
+	})
+	It("Should be interesting if NOT BOUND, and endpoint and source is set, and honorWaitForFirstConsumerEnabled is false and isImmediateBindingRequested is requested", func() {
+		testPvc := createPendingPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint, AnnSource: SourceHTTP}, nil)
+		Expect(shouldReconcilePVC(testPvc, true, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
+	})
 })
 
 var _ = Describe("ImportConfig Controller reconcile loop", func() {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -77,22 +77,22 @@ var _ = Describe("Test PVC annotations status", func() {
 
 	It("Should be interesting if NOT complete, and endpoint and source is set", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint, AnnSource: SourceHTTP}, nil)
-		Expect(shouldReconcilePVC(testPvc, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
+		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
 	})
 
 	It("Should NOT be interesting if complete, and endpoint and source is set", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodSucceeded), AnnEndpoint: testEndPoint, AnnSource: SourceHTTP}, nil)
-		Expect(shouldReconcilePVC(testPvc, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeFalse())
+		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeFalse())
 	})
 
 	It("Should be interesting if NOT complete, and endpoint missing and source is set", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodRunning), AnnSource: SourceHTTP}, nil)
-		Expect(shouldReconcilePVC(testPvc, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
+		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
 	})
 
 	It("Should be interesting if NOT complete, and endpoint set and source is missing", func() {
 		testPvc := createPvc("testPvc1", "default", map[string]string{AnnPodPhase: string(corev1.PodPending), AnnEndpoint: testEndPoint}, nil)
-		Expect(shouldReconcilePVC(testPvc, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
+		Expect(shouldReconcilePVC(testPvc, false, &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}, importLog)).To(BeTrue())
 	})
 })
 

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -116,12 +116,13 @@ func (r *UploadReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 
 	_, isUpload := pvc.Annotations[AnnUploadRequest]
 	_, isCloneTarget := pvc.Annotations[AnnCloneRequest]
+	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
 
 	if isUpload && isCloneTarget {
 		log.V(1).Info("PVC has both clone and upload annotations")
 		return reconcile.Result{}, errors.New("PVC has both clone and upload annotations")
 	}
-	shouldReconcile, err := r.shouldReconcile(isUpload, isCloneTarget, pvc, log)
+	shouldReconcile, err := r.shouldReconcile(isUpload, isCloneTarget, isImmediateBindingRequested, pvc, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -143,14 +144,14 @@ func (r *UploadReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 	return r.reconcilePVC(log, pvc, isCloneTarget)
 }
 
-func (r *UploadReconciler) shouldReconcile(isUpload bool, isCloneTarget bool, pvc *v1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
-	honorWaitForFirstConsumer, err := r.featureGates.HonorWaitForFirstConsumerEnabled()
+func (r *UploadReconciler) shouldReconcile(isUpload bool, isCloneTarget bool, isImmediateBindingRequested bool, pvc *v1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
+	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, r.featureGates)
 	if err != nil {
 		return false, err
 	}
 
 	return (isUpload || isCloneTarget) &&
-			shouldHandlePvc(pvc, honorWaitForFirstConsumer, log),
+			shouldHandlePvc(pvc, waitForFirstConsumerEnabled, log),
 		nil
 }
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1247,6 +1247,113 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		)
 	})
 
+	Describe("[crit:high] DataVolume - WaitForFirstConsumer", func() {
+		type dataVolumeTestArguments struct {
+			name             string
+			size             string
+			url              string
+			dvFunc           func(string, string, string) *cdiv1.DataVolume
+			errorMessage     string
+			eventReason      string
+			phase            cdiv1.DataVolumePhase
+			repeat           int
+			checkPermissions bool
+			readyCondition   *cdiv1.DataVolumeCondition
+			boundCondition   *cdiv1.DataVolumeCondition
+			runningCondition *cdiv1.DataVolumeCondition
+		}
+
+		createBlankRawDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+			return utils.NewDataVolumeForBlankRawImage(dataVolumeName, size)
+		}
+		createHTTPSDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, size, url)
+			cm, err := utils.CopyFileHostCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
+			Expect(err).To(BeNil())
+			dataVolume.Spec.Source.HTTP.CertConfigMap = cm
+			return dataVolume
+		}
+		createUploadDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+			return utils.NewDataVolumeForUpload(dataVolumeName, size)
+		}
+
+		createCloneDataVolume := func(dataVolumeName, size, command string) *cdiv1.DataVolume {
+			sourcePodFillerName := fmt.Sprintf("%s-filler-pod", dataVolumeName)
+			pvcDef := utils.NewPVCDefinition(pvcName, size, nil, nil)
+			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
+
+			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
+			return utils.NewCloningDataVolume(dataVolumeName, size, sourcePvc)
+		}
+
+		table.DescribeTable("WFFC Feature Gate enabled - ImmediateBinding requested", func(
+			dvName string,
+			url func() string,
+			dvFunc func(string, string, string) *cdiv1.DataVolume,
+			phase cdiv1.DataVolumePhase) {
+			if !utils.IsHostpathProvisioner() {
+				Skip("Not HPP")
+			}
+			size := "1Gi"
+
+			dataVolume := dvFunc(dvName, size, url())
+			dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
+
+			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			// verify PVC was created
+			By("verifying pvc was created and is Bound")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimBound, pvc.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))
+			err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+			if err != nil {
+				dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				if dverr != nil {
+					Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))
+				}
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Cleaning up")
+			err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() bool {
+				_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				if k8serrors.IsNotFound(err) {
+					return true
+				}
+				return false
+			}, timeout, pollingInterval).Should(BeTrue())
+		},
+			table.Entry("Import qcow2 scratch space",
+				"dv-immediate-wffc-qcow2-import",
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
+				createHTTPSDataVolume,
+				cdiv1.Succeeded),
+			table.Entry("Import blank image",
+				"dv-immediate-wffc-blank-import",
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
+				createBlankRawDataVolume,
+				cdiv1.Succeeded),
+			table.Entry("Upload - positive flow",
+				"dv-immediate-wffc-upload",
+				func() string { return fmt.Sprintf(utils.HTTPSTinyCoreQcow2URL, f.CdiInstallNs) },
+				createUploadDataVolume,
+				cdiv1.UploadReady),
+			table.Entry("Clone - positive flow",
+				"dv-immediate-wffc-clone",
+				func() string { return fillCommand }, // its not URL, but command, but the parameter lines up.
+				createCloneDataVolume,
+				cdiv1.Succeeded),
+		)
+	})
+
 	Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:component][test] CDI Import from HTTP/S3", func() {
 		const (
 			originalImageName = "cirros-qcow2.img"

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -220,7 +220,8 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 func NewDataVolumeForBlankRawImage(dataVolumeName, size string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
+			Name:        dataVolumeName,
+			Annotations: map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: cdiv1.DataVolumeSource{


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When the annotation is applied the CDI will force bind the PVC (by scheduling worker pods), ignoring the logic to handle WaitForFirstConsumer binding mode.

This is useful when uploading "template" images to the cluster on local storage with WaitForFirstConsumer binding. In this case the image has to be available somewhere on the cluster, the actual placement of image on specific node is not important, so the CDI worker node can be used as a first consumer.

For storage with immediate binging it is effectively a NOOP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- [x] Upload done, import and clone will follow shortly 
- [x] tests needed

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add an annotation "storage.bind.immediate.requested"
```

