### PR TITLE
core: Preallocate blank image disks as well

### DIFF
--- a/cmd/cdi-uploadserver/BUILD.bazel
+++ b/cmd/cdi-uploadserver/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/uploadserver:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/cmd/cdi-uploadserver/uploadserver.go
+++ b/cmd/cdi-uploadserver/uploadserver.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/pkg/uploadserver"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -83,11 +84,19 @@ func main() {
 		// Cloning instead of uploading.
 		clone = true
 	}
+	var message string
 	if clone {
-		err = util.WriteTerminationMessage("Clone Complete")
+		message = "Clone Complete"
 	} else {
-		err = util.WriteTerminationMessage("Upload Complete")
+		message = "Upload Complete"
 	}
+	switch server.PreallocationApplied() {
+	case "true":
+		message += ", " + controller.PreallocationApplied
+	case "skipped":
+		message += ", " + controller.PreallocationSkipped
+	}
+	err = util.WriteTerminationMessage(message)
 	if err != nil {
 		klog.Errorf("%+v", err)
 		os.Exit(1)

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -238,6 +239,16 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
 		if podRestarts > pvcAnnPodRestarts {
 			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
+		}
+
+		if pod.Status.ContainerStatuses[0].State.Terminated != nil &&
+			pod.Status.ContainerStatuses[0].State.Terminated.ExitCode == 0 {
+			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, PreallocationApplied) {
+				anno[AnnPreallocationApplied] = "true"
+			}
+			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, PreallocationSkipped) {
+				anno[AnnPreallocationApplied] = "skipped"
+			}
 		}
 	}
 	setConditionFromPodWithPrefix(anno, AnnRunningCondition, pod)

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -88,12 +88,12 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 	return client
 }
 
-func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) error {
-	return nil
+func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (string, error) {
+	return "false", nil
 }
 
-func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) error {
-	return fmt.Errorf("Error using datastream")
+func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (string, error) {
+	return "false", fmt.Errorf("Error using datastream")
 }
 
 func withProcessorSuccess(f func()) {
@@ -104,7 +104,7 @@ func withProcessorFailure(f func()) {
 	replaceProcessorFunc(saveProcessorFailure, f)
 }
 
-func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) error, f func()) {
+func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (string, error), f func()) {
 	origProcessorFunc := uploadProcessorFunc
 	uploadProcessorFunc = replacement
 	defer func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
@@ -794,13 +795,15 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 var _ = Describe("Preallocation", func() {
 	f := framework.NewFramework(namespacePrefix)
 	dvName := "import-dv"
-	importerPodName := "importer-" + dvName
-	preAllocAdded := "Added preallocation"
 
 	var (
-		dataVolume     *cdiv1.DataVolume
-		err            error
-		tinyCoreIsoURL = func() string { return fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs) }
+		dataVolume          *cdiv1.DataVolume
+		err                 error
+		tinyCoreIsoURL      = func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
+		tinyCoreQcow2URL    = func() string { return fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs) }
+		tinyCoreTarURL      = func() string { return fmt.Sprintf(utils.TarArchiveURL, f.CdiInstallNs) }
+		tinyCoreRegistryURL = func() string { return fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs) }
+		imageioURL          = func() string { return fmt.Sprintf(utils.ImageioURL, f.CdiInstallNs) }
 	)
 
 	AfterEach(func() {
@@ -829,18 +832,17 @@ var _ = Describe("Preallocation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindIfWaitForFirstConsumer(pvc)
 
-		Eventually(func() string {
-			log, err := tests.RunKubectlCommand(f, "logs", importerPodName, "-n", f.Namespace.Name)
-			if err != nil {
-				return ""
-			}
-			return log
-		}, controllerSkipPVCCompleteTimeout, 10*time.Millisecond).Should(ContainSubstring(preAllocAdded))
+		phase := cdiv1.Succeeded
+		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Or(Equal("true"), Equal("skipped")))
 	})
 
 	It("Importer should not add preallocation when preallocation=false", func() {
-		var log string
-
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))
 		dataVolume = utils.NewDataVolumeWithHTTPImport(dvName, "100Mi", tinyCoreIsoURL())
 		preallocation := false
@@ -853,13 +855,83 @@ var _ = Describe("Preallocation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindIfWaitForFirstConsumer(pvc)
 
-		Eventually(func() string {
-			log, err = tests.RunKubectlCommand(f, "logs", importerPodName, "-n", f.Namespace.Name)
-			if err != nil {
-				return ""
-			}
-			return log
-		}, controllerSkipPVCCompleteTimeout, 10*time.Millisecond).Should(ContainSubstring("Import complete"))
-		Expect(log).ToNot(ContainSubstring(preAllocAdded))
+		phase := cdiv1.Succeeded
+		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Or(Equal("true"), Equal("skipped")))
 	})
+
+	DescribeTable("All import paths should contain Preallocation step", func(shouldPreallocate bool, dvFunc func() *cdiv1.DataVolume) {
+		dv := dvFunc()
+		By(fmt.Sprintf("Creating new datavolume %s", dv.Name))
+		preallocation := true
+		dv.Spec.Preallocation = &preallocation
+		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+		Expect(err).ToNot(HaveOccurred())
+
+		pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		f.ForceBindIfWaitForFirstConsumer(pvc)
+
+		should := ContainSubstring("New phase: Preallocate")
+		if !shouldPreallocate {
+			should = Not(should)
+		}
+
+		phase := cdiv1.Succeeded
+		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+		if err != nil {
+			dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+			if dverr != nil {
+				Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))
+			}
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		if shouldPreallocate {
+			Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Or(Equal("true"), Equal("skipped")))
+		} else {
+			Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Or(Equal("true"), Equal("skipped")))
+		}
+	},
+		Entry("HTTP import (ISO image)", true, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreIsoURL())
+		}),
+		Entry("HTTP import (QCOW2 image)", true, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreQcow2URL())
+		}),
+		Entry("HTTP import (TAR image)", true, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreTarURL())
+		}),
+		Entry("HTTP import (archive content)", false, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithArchiveContent("import-dv", "100Mi", tinyCoreTarURL())
+		}),
+		Entry("ImageIO import", true, func() *cdiv1.DataVolume {
+			cm, err := utils.CopyImageIOCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
+			Expect(err).To(BeNil())
+			stringData := map[string]string{
+				common.KeyAccess: "YWRtaW5AaW50ZXJuYWw=",
+				common.KeySecret: "MTIzNDU2",
+			}
+			s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, "mysecret"))
+			return utils.NewDataVolumeWithImageioImport("import-dv", "100Mi", imageioURL(), s.Name, cm, "123")
+		}),
+		Entry("Registry import", true, func() *cdiv1.DataVolume {
+			dataVolume = utils.NewDataVolumeWithRegistryImport("import-dv", "100Mi", tinyCoreRegistryURL())
+			cm, err := utils.CopyRegistryCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
+			Expect(err).To(BeNil())
+			dataVolume.Spec.Source.Registry.CertConfigMap = cm
+			return dataVolume
+		}),
+		Entry("Blank image", true, func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForBlankRawImage("import-dv", "100Mi")
+		}),
+	)
 })

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -37,7 +37,7 @@ const (
 	HTTPSTinyCoreIsoURL = "https://cdi-file-host.%s/tinyCore.iso"
 	// HTTPSTinyCoreQcow2URL provides a test (https) url for the tineyCore qcow2 image
 	HTTPSTinyCoreQcow2URL = "https://cdi-file-host.%s/tinyCore.qcow2"
-	// TinyCoreQcow2URLRateLimit provides a test url for the tineyCore iso image
+	// TinyCoreQcow2URLRateLimit provides a test url for the tineyCore qcow2 image via rate-limiting proxy
 	TinyCoreQcow2URLRateLimit = "http://cdi-file-host.%s:82/tinyCore.qcow2"
 	// InvalidQcowImagesURL provides a test url for invalid qcow images
 	InvalidQcowImagesURL = "http://cdi-file-host.%s/invalid_qcow_images/"


### PR DESCRIPTION

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1914177
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fixes a bug where blank image disks were not preallocated.

This is a cherry-pick from master to v28, including all dependencies
required for functional tests but without new functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

