### PR TITLE
VDDK: work with block devices better (BZ 1913756).

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -165,7 +165,7 @@ func main() {
 				os.Exit(1)
 			}
 		case controller.SourceVDDK:
-			dp, err = importer.NewVDDKDataSource(ep, acc, sec, thumbprint, uuid, backingFile, currentCheckpoint, previousCheckpoint, finalCheckpoint)
+			dp, err = importer.NewVDDKDataSource(ep, acc, sec, thumbprint, uuid, backingFile, currentCheckpoint, previousCheckpoint, finalCheckpoint, volumeMode)
 			if err != nil {
 				klog.Errorf("%+v", err)
 				err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to vddk data source: %+v", err))

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//vendor/github.com/vmware/govmomi/object:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
@@ -82,6 +83,7 @@ go_test(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -353,10 +353,10 @@ type mockVddkDataSink struct {
 	position int
 }
 
-func (sink *mockVddkDataSink) Ftruncate(size int64) error {
-	mockSinkBuffer = bytes.Repeat([]byte{0x00}, int(size))
-	sink.position = 0
-	return nil
+func (sink *mockVddkDataSink) ZeroRange(offset uint64, length uint32) error {
+	buf := bytes.Repeat([]byte{0x00}, int(length))
+	_, err := sink.Pwrite(buf, offset)
+	return err
 }
 
 func (sink *mockVddkDataSink) Pwrite(buf []byte, offset uint64) (int, error) {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -111,6 +111,81 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		return dataVolume
 	}
 
+	createVddkDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+		// Find vcenter-simulator pod
+		pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "vcenter-deployment", "app=vcenter")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
+
+		// Get test VM UUID
+		id, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmid")
+		Expect(err).To(BeNil())
+		vmid, err := uuid.Parse(strings.TrimSpace(id))
+		Expect(err).To(BeNil())
+
+		// Get disk name
+		disk, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmdisk")
+		Expect(err).To(BeNil())
+		disk = strings.TrimSpace(disk)
+		Expect(err).To(BeNil())
+
+		// Create VDDK login secret
+		stringData := map[string]string{
+			common.KeyAccess: "user",
+			common.KeySecret: "pass",
+		}
+		backingFile := disk
+		secretRef := "vddksecret"
+		thumbprint := "testprint"
+		s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, secretRef))
+
+		return utils.NewDataVolumeWithVddkImport(dataVolumeName, size, backingFile, s.Name, thumbprint, url, vmid.String())
+	}
+
+	createVddkWarmImportDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+		// Find vcenter-simulator pod
+		pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "vcenter-deployment", "app=vcenter")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
+
+		// Get test VM UUID
+		id, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmid")
+		Expect(err).To(BeNil())
+		vmid, err := uuid.Parse(strings.TrimSpace(id))
+		Expect(err).To(BeNil())
+
+		// Get snapshot 1 ID
+		previousCheckpoint, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmsnapshot1")
+		Expect(err).To(BeNil())
+		previousCheckpoint = strings.TrimSpace(previousCheckpoint)
+		Expect(err).To(BeNil())
+
+		// Get snapshot 2 ID
+		currentCheckpoint, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmsnapshot2")
+		Expect(err).To(BeNil())
+		currentCheckpoint = strings.TrimSpace(currentCheckpoint)
+		Expect(err).To(BeNil())
+
+		// Get disk name
+		disk, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmdisk")
+		Expect(err).To(BeNil())
+		disk = strings.TrimSpace(disk)
+		Expect(err).To(BeNil())
+
+		// Create VDDK login secret
+		stringData := map[string]string{
+			common.KeyAccess: "user",
+			common.KeySecret: "pass",
+		}
+		backingFile := disk
+		secretRef := "vddksecret"
+		thumbprint := "testprint"
+		finalCheckpoint := true
+		s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, secretRef))
+
+		return utils.NewDataVolumeWithVddkWarmImport(dataVolumeName, size, backingFile, s.Name, thumbprint, url, vmid.String(), currentCheckpoint, previousCheckpoint, finalCheckpoint)
+	}
+
 	AfterEach(func() {
 		if sourcePvc != nil {
 			By("[AfterEach] Clean up target PVC")
@@ -171,81 +246,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		createUploadDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
 			return utils.NewDataVolumeForUpload(dataVolumeName, size)
-		}
-
-		createVddkDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
-			// Find vcenter-simulator pod
-			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "vcenter-deployment", "app=vcenter")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pod).ToNot(BeNil())
-
-			// Get test VM UUID
-			id, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmid")
-			Expect(err).To(BeNil())
-			vmid, err := uuid.Parse(strings.TrimSpace(id))
-			Expect(err).To(BeNil())
-
-			// Get disk name
-			disk, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmdisk")
-			Expect(err).To(BeNil())
-			disk = strings.TrimSpace(disk)
-			Expect(err).To(BeNil())
-
-			// Create VDDK login secret
-			stringData := map[string]string{
-				common.KeyAccess: "user",
-				common.KeySecret: "pass",
-			}
-			backingFile := disk
-			secretRef := "vddksecret"
-			thumbprint := "testprint"
-			s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, secretRef))
-
-			return utils.NewDataVolumeWithVddkImport(dataVolumeName, size, backingFile, s.Name, thumbprint, url, vmid.String())
-		}
-
-		createVddkWarmImportDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
-			// Find vcenter-simulator pod
-			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "vcenter-deployment", "app=vcenter")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pod).ToNot(BeNil())
-
-			// Get test VM UUID
-			id, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmid")
-			Expect(err).To(BeNil())
-			vmid, err := uuid.Parse(strings.TrimSpace(id))
-			Expect(err).To(BeNil())
-
-			// Get snapshot 1 ID
-			previousCheckpoint, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmsnapshot1")
-			Expect(err).To(BeNil())
-			previousCheckpoint = strings.TrimSpace(previousCheckpoint)
-			Expect(err).To(BeNil())
-
-			// Get snapshot 2 ID
-			currentCheckpoint, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmsnapshot2")
-			Expect(err).To(BeNil())
-			currentCheckpoint = strings.TrimSpace(currentCheckpoint)
-			Expect(err).To(BeNil())
-
-			// Get disk name
-			disk, err := RunKubectlCommand(f, "exec", "-n", pod.Namespace, pod.Name, "--", "cat", "/tmp/vmdisk")
-			Expect(err).To(BeNil())
-			disk = strings.TrimSpace(disk)
-			Expect(err).To(BeNil())
-
-			// Create VDDK login secret
-			stringData := map[string]string{
-				common.KeyAccess: "user",
-				common.KeySecret: "pass",
-			}
-			backingFile := disk
-			secretRef := "vddksecret"
-			thumbprint := "testprint"
-			finalCheckpoint := true
-			s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, secretRef))
-
-			return utils.NewDataVolumeWithVddkWarmImport(dataVolumeName, size, backingFile, s.Name, thumbprint, url, vmid.String(), currentCheckpoint, previousCheckpoint, finalCheckpoint)
 		}
 
 		table.DescribeTable("should", func(args dataVolumeTestArguments) {
@@ -855,6 +855,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			switch name {
 			case "import-http":
 				dataVolume = utils.NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName, "1G", url(), f.BlockSCName)
+			case "import-vddk":
+				dataVolume = createVddkDataVolume(dataVolumeName, "1Gi", vcenterURL())
+				utils.ModifyDataVolumeWithVDDKImportToBlockPV(dataVolume, f.BlockSCName)
+			case "warm-import-vddk":
+				dataVolume = createVddkWarmImportDataVolume(dataVolumeName, "1Gi", vcenterURL())
+				utils.ModifyDataVolumeWithVDDKImportToBlockPV(dataVolume, f.BlockSCName)
 			}
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -888,6 +894,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}, timeout, pollingInterval).Should(BeTrue())
 		},
 			table.Entry("[test_id:3933]succeed creating import dv with given valid url", "import-http", "", tinyCoreIsoURL, "dv-phase-test-1", controller.ImportSucceeded, cdiv1.Succeeded),
+			table.Entry("[test_id:3935]succeed import from VDDK to block volume", "import-vddk", "", nil, "dv-vddk-import-test", controller.ImportSucceeded, cdiv1.Succeeded),
+			table.Entry("[test_id:3936]succeed warm import from VDDK to block volume", "warm-import-vddk", "", nil, "dv-vddk-warm-import-test", controller.ImportSucceeded, cdiv1.Succeeded),
 		)
 	})
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -321,6 +321,14 @@ func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registr
 	}
 }
 
+// ModifyDataVolumeWithVDDKImportToBlockPV modifies a DataVolume struct (created by NewDataVolumeWithVddkImport) for importing disks from vCenter/ESX to a block PV
+func ModifyDataVolumeWithVDDKImportToBlockPV(dataVolume *cdiv1.DataVolume, storageClassName string) *cdiv1.DataVolume {
+	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
+	dataVolume.Spec.PVC.VolumeMode = &volumeMode
+	dataVolume.Spec.PVC.StorageClassName = &storageClassName
+	return dataVolume
+}
+
 // NewDataVolumeWithVddkImport initializes a DataVolume struct for importing disks from vCenter/ESX
 func NewDataVolumeWithVddkImport(dataVolumeName string, size string, backingFile string, secretRef string, thumbprint string, httpURL string, uuid string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{


### PR DESCRIPTION
**What this PR does / why we need it**: Addresses BZ 1913756, where VDDK disk imports fail with block device destinations.

**Which issue(s) this PR fixes**
Fixes #1563 

**Release note**:
```release-note
BZ 1913756: fix VDDK import to block device destination volumes.
```

