### PR TITLE
Typedef for preallocation status

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -182,6 +182,27 @@ const (
 	UploadFormAsync = "/v1beta1/upload-form-async"
 )
 
+// PreallocationStatus is used to mark result of preallocation in importer and uploader
+type PreallocationStatus string
+
+const (
+	// PreallocationApplied is used to signal that preallocation was performed on the storage
+	PreallocationApplied PreallocationStatus = "true"
+	// PreallocationNotApplied is ued to singal that preallocation was not performed
+	PreallocationNotApplied PreallocationStatus = "false"
+	// PreallocationSkipped is used to signal that preallocation was not performed even though it was requested
+	PreallocationSkipped PreallocationStatus = "skipped"
+)
+
+// PreallocationStatusFromBool converts boolean value to PreallocationStatus
+func PreallocationStatusFromBool(preallocation bool) PreallocationStatus {
+	if preallocation {
+		return PreallocationApplied
+	}
+
+	return PreallocationNotApplied
+}
+
 // ProxyPaths are all supported paths
 var ProxyPaths = append(
 	append(SyncUploadPaths, AsyncUploadPaths...),

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -49,7 +49,7 @@ const (
 // UploadServer is the interface to uploadServerApp
 type UploadServer interface {
 	Run() error
-	PreallocationApplied() string
+	PreallocationApplied() common.PreallocationStatus
 }
 
 type uploadServerApp struct {
@@ -69,7 +69,7 @@ type uploadServerApp struct {
 	uploading            bool
 	processing           bool
 	done                 bool
-	preallocationApplied string
+	preallocationApplied common.PreallocationStatus
 	doneChan             chan struct{}
 	errChan              chan error
 	mutex                sync.Mutex
@@ -393,7 +393,7 @@ func (app *uploadServerApp) uploadHandler(irc imageReadCloser) http.HandlerFunc 
 	}
 }
 
-func (app *uploadServerApp) PreallocationApplied() string {
+func (app *uploadServerApp) PreallocationApplied() common.PreallocationStatus {
 	return app.preallocationApplied
 }
 
@@ -407,7 +407,7 @@ func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string,
 	return processor, processor.ProcessDataWithPause()
 }
 
-func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (string, error) {
+func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
 	if contentType == common.FilesystemCloneContentType {
 		return "false", filesystemCloneProcessor(stream, common.ImporterVolumePath)
 	}

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -88,12 +88,12 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 	return client
 }
 
-func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (string, error) {
-	return "false", nil
+func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
+	return common.PreallocationNotApplied, nil
 }
 
-func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (string, error) {
-	return "false", fmt.Errorf("Error using datastream")
+func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
+	return common.PreallocationNotApplied, fmt.Errorf("Error using datastream")
 }
 
 func withProcessorSuccess(f func()) {
@@ -104,7 +104,7 @@ func withProcessorFailure(f func()) {
 	replaceProcessorFunc(saveProcessorFailure, f)
 }
 
-func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (string, error), f func()) {
+func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (common.PreallocationStatus, error), f func()) {
 	origProcessorFunc := uploadProcessorFunc
 	uploadProcessorFunc = replacement
 	defer func() {


### PR DESCRIPTION
Instead of (ab)using raw strings, preallocation status in importer and
uploader use now a custom type.
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

