### PR TITLE
Skip test 2555 if running on openshift

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -217,6 +217,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			readyCondition   *cdiv1.DataVolumeCondition
 			boundCondition   *cdiv1.DataVolumeCondition
 			runningCondition *cdiv1.DataVolumeCondition
+			skipOpenshift    bool
 		}
 
 		createImageIoDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
@@ -256,6 +257,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+			if IsOpenshift(f.K8sClient) && args.skipOpenshift {
+				Skip("Test not expected to pass on OpenShift")
+			}
 			// Have to call the function in here, to make sure the BeforeEach in the Framework has run.
 			dataVolume := args.dvFunc(args.name, args.size, args.url())
 			startTime := time.Now()
@@ -421,7 +425,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Status:  v1.ConditionFalse,
 					Message: "Unable to process data: Invalid format qcow for image",
 					Reason:  "Error",
-				}}),
+				},
+				skipOpenshift: true,
+			}),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2554]fail creating import dv: invalid qcow large json", dataVolumeTestArguments{
 				name:         "dv-invalid-qcow-large-json",
 				size:         "1Gi",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -17,6 +18,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"kubevirt.io/containerized-data-importer/tests/framework"
 )
@@ -168,4 +170,33 @@ func PodSpecHasTestNodePlacementValues(f *framework.Framework, podSpec v1.PodSpe
 		return false
 	}
 	return true
+}
+
+//IsOpenshift checks if we are on OpenShift platform
+func IsOpenshift(client kubernetes.Interface) bool {
+	//OpenShift 3.X check
+	result := client.Discovery().RESTClient().Get().AbsPath("/oapi/v1").Do(context.TODO())
+	var statusCode int
+	result.StatusCode(&statusCode)
+
+	if result.Error() == nil {
+		// It is OpenShift
+		if statusCode == http.StatusOK {
+			return true
+		}
+	} else {
+		// Got 404 so this is not Openshift 3.X, let's check OpenShift 4
+		result = client.Discovery().RESTClient().Get().AbsPath("/apis/route.openshift.io").Do(context.TODO())
+		var statusCode int
+		result.StatusCode(&statusCode)
+
+		if result.Error() == nil {
+			// It is OpenShift
+			if statusCode == http.StatusOK {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We have a different build which uses a different versioned qemu-img.
This test only fails on newer versions of qemu-img, and it's causing our differential build to always have a single failure.
Skipping on OpenShift to ensure that no regressions enter - we still test kubernetes lanes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This can probably be reverted once #1466 merges.
But I would like to have it in previous release branches too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

