### PR TITLE
Compare target MD5 to source MD5 in fsGroup test

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -103,9 +103,6 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			fmt.Fprintf(GinkgoWriter, "INFO: MD5SUM for source is: %s\n", sourceMD5[:32])
 
-			By("Deleting verifier pod")
-			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
-			Expect(err).ToNot(HaveOccurred())
 			completeClone(f, f.Namespace, targetPvc, diskImagePath, sourceMD5[:32], sourcePvcDiskGroup)
 		})
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -98,14 +98,15 @@ var _ = Describe("all clone tests", func() {
 			fmt.Fprintf(GinkgoWriter, "INFO: %s\n", sourcePvcDiskGroup)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("verifying pvc content")
-			sourceMD5, err := f.GetMD5(f.Namespace, pvc, diskImagePath, 0)
+			By("Calculating the md5sum of the source data volume")
+			sourceMD5, err := f.RunCommandAndCaptureOutput(utils.PersistentVolumeClaimFromDataVolume(dataVolume), "md5sum "+diskImagePath)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "INFO: MD5SUM for source is: %s\n", sourceMD5[:32])
 
 			By("Deleting verifier pod")
 			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
 			Expect(err).ToNot(HaveOccurred())
-			completeClone(f, f.Namespace, targetPvc, diskImagePath, sourceMD5, sourcePvcDiskGroup)
+			completeClone(f, f.Namespace, targetPvc, diskImagePath, sourceMD5[:32], sourcePvcDiskGroup)
 		})
 
 		It("[test_id:1355]Should clone data across different namespaces", func() {


### PR DESCRIPTION
This also indirectly fixes flakiness in the test:
We use a different name for the pod finding the source MD5.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

