### PR TITLE
When cleaning up NFS disks, recursively delete their contents.

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -183,7 +183,7 @@ func (f *Framework) AfterEach() {
 			nfsServerPod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "nfs-server", "app=nfs-server")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for i := 1; i <= pvCount; i++ {
-				stdout, stderr, err := f.ExecShellInPod(nfsServerPod.Name, f.CdiInstallNs, fmt.Sprintf("/bin/rm -f /data/nfs/disk%d/*", i))
+				stdout, stderr, err := f.ExecShellInPod(nfsServerPod.Name, f.CdiInstallNs, fmt.Sprintf("/bin/rm -rf /data/nfs/disk%d/*", i))
 				if err != nil {
 					fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: cleaning up nfs disk%d failed: %s, %s\n", i, stdout, stderr)
 				}


### PR DESCRIPTION
Datavolumes made for archive volumes are expected to contain a directory
called "data" with the archive contents, and we want to clean those up as
well.

**What this PR does / why we need it**:
See the following run for an example: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1558/pull-containerized-data-importer-e2e-k8s-1.18-nfs/1349861219908980736

If we look at the build-log.txt, we see messages like:
```
STEP: Destroying namespace "cdi-e2e-tests-cdiconfig-test-r2kfb" for this suite.
STEP: Deleting NFS PVs after the test
[WARN] error executing command ["/bin/sh" "-c" "/bin/rm -f /data/nfs/disk3/*"], error: command terminated with exit code 1
INFO: cleaning up nfs disk3 failed: , rm: '/data/nfs/disk3/disk' is a directory
[WARN] error executing command ["/bin/sh" "-c" "/bin/rm -f /data/nfs/disk6/*"], error: command terminated with exit code 1
INFO: cleaning up nfs disk6 failed: , rm: '/data/nfs/disk6/disk' is a directory
```
Which will hopefully stop happening after this PR.

Fixes #1577

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When running the functional tests on NFS, do a better job of cleaning the leftover data.
```

