### PR TITLE
Move smart clone tunable to CDIConfig.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3431,6 +3431,10 @@
     "description": "CDIConfigSpec defines specification for user configuration",
     "type": "object",
     "properties": {
+     "cloneStrategyOverride": {
+      "description": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+      "type": "string"
+     },
      "featureGates": {
       "description": "FeatureGates are a list of specific enabled feature gates",
       "type": "array",
@@ -3529,10 +3533,6 @@
      "certConfig": {
       "description": "certificate configuration",
       "$ref": "#/definitions/v1beta1.CDICertConfig"
-     },
-     "cloneStrategyOverride": {
-      "description": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
-      "type": "string"
      },
      "config": {
       "description": "CDIConfig at CDI level",

--- a/doc/smart-clone.md
+++ b/doc/smart-clone.md
@@ -38,10 +38,10 @@ Here is a description of the flow of the Smart-Cloning:
 ### Disabling smart cloning
 If for some reason you don't want to use smart cloning and prefer using a host-assisted copy, you can disable smart cloning by editing the CDI object:
 ```bash
-kubectl patch cdi cdi --type merge -p '{"spec":{"cloneStrategyOverride":"copy"}}'
+kubectl patch cdi cdi --type merge -p '{"spec":{"config":{"cloneStrategyOverride":"copy"}}}'
 ```
 
 To enable smart cloning again:
 ```bash
-kubectl patch cdi cdi --type merge -p '{"spec":{"cloneStrategyOverride":"snapshot"}}'
+kubectl patch cdi cdi --type merge -p '{"spec":{"config":{"cloneStrategyOverride":"snapshot"}}}'
 ```

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -13681,6 +13681,13 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"cloneStrategyOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -13822,13 +13829,6 @@ func schema_pkg_apis_core_v1alpha1_CDISpec(ref common.ReferenceCallback) common.
 						SchemaProps: spec.SchemaProps{
 							Description: "Restrict on which nodes CDI workload pods will be scheduled",
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
-						},
-					},
-					"cloneStrategyOverride": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
-							Type:        []string{"string"},
-							Format:      "",
 						},
 					},
 					"config": {

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -308,9 +308,6 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
-	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
-	// +kubebuilder:validation:Enum="copy";"snapshot"
-	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 	// CDIConfig at CDI level
 	Config *CDIConfigSpec `json:"config,omitempty"`
 	// certificate configuration
@@ -427,6 +424,9 @@ type CDIConfigSpec struct {
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`
+	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
+	// +kubebuilder:validation:Enum="copy";"snapshot"
+	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 }
 
 //CDIConfigStatus provides the most recently observed status of the CDI Config resource

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -148,14 +148,13 @@ func (CDICertConfig) SwaggerDoc() map[string]string {
 
 func (CDISpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                      "CDISpec defines our specification for the CDI installation",
-		"imagePullPolicy":       "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
-		"uninstallStrategy":     "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
-		"infra":                 "Rules on which nodes CDI infrastructure pods will be scheduled",
-		"workload":              "Restrict on which nodes CDI workload pods will be scheduled",
-		"cloneStrategyOverride": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
-		"config":                "CDIConfig at CDI level",
-		"certConfig":            "certificate configuration",
+		"":                  "CDISpec defines our specification for the CDI installation",
+		"imagePullPolicy":   "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
+		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
+		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
+		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
+		"config":            "CDIConfig at CDI level",
+		"certConfig":        "certificate configuration",
 	}
 }
 
@@ -196,6 +195,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
+		"cloneStrategyOverride":    "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CloneStrategyOverride != nil {
+		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
+		*out = new(CDICloneStrategy)
+		**out = **in
+	}
 	return
 }
 
@@ -271,11 +276,6 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
-	if in.CloneStrategyOverride != nil {
-		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
-		*out = new(CDICloneStrategy)
-		**out = **in
-	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(CDIConfigSpec)

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -13693,6 +13693,13 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"cloneStrategyOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -13834,13 +13841,6 @@ func schema_pkg_apis_core_v1beta1_CDISpec(ref common.ReferenceCallback) common.O
 						SchemaProps: spec.SchemaProps{
 							Description: "Restrict on which nodes CDI workload pods will be scheduled",
 							Ref:         ref("kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api.NodePlacement"),
-						},
-					},
-					"cloneStrategyOverride": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
-							Type:        []string{"string"},
-							Format:      "",
 						},
 					},
 					"config": {

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -362,9 +362,6 @@ type CDISpec struct {
 	Infra sdkapi.NodePlacement `json:"infra,omitempty"`
 	// Restrict on which nodes CDI workload pods will be scheduled
 	Workloads sdkapi.NodePlacement `json:"workload,omitempty"`
-	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
-	// +kubebuilder:validation:Enum="copy";"snapshot"
-	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 	// CDIConfig at CDI level
 	Config *CDIConfigSpec `json:"config,omitempty"`
 	// certificate configuration
@@ -459,6 +456,9 @@ type CDIConfigSpec struct {
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`
+	// Clone strategy override: should we use a host-assisted copy even if snapshots are available?
+	// +kubebuilder:validation:Enum="copy";"snapshot"
+	CloneStrategyOverride *CDICloneStrategy `json:"cloneStrategyOverride,omitempty"`
 }
 
 //CDIConfigStatus provides the most recently observed status of the CDI Config resource

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -185,14 +185,13 @@ func (CDICertConfig) SwaggerDoc() map[string]string {
 
 func (CDISpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                      "CDISpec defines our specification for the CDI installation",
-		"imagePullPolicy":       "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
-		"uninstallStrategy":     "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
-		"infra":                 "Rules on which nodes CDI infrastructure pods will be scheduled",
-		"workload":              "Restrict on which nodes CDI workload pods will be scheduled",
-		"cloneStrategyOverride": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
-		"config":                "CDIConfig at CDI level",
-		"certConfig":            "certificate configuration",
+		"":                  "CDISpec defines our specification for the CDI installation",
+		"imagePullPolicy":   "+kubebuilder:validation:Enum=Always;IfNotPresent;Never\nPullPolicy describes a policy for if/when to pull a container image",
+		"uninstallStrategy": "+kubebuilder:validation:Enum=RemoveWorkloads;BlockUninstallIfWorkloadsExist\nCDIUninstallStrategy defines the state to leave CDI on uninstall",
+		"infra":             "Rules on which nodes CDI infrastructure pods will be scheduled",
+		"workload":          "Restrict on which nodes CDI workload pods will be scheduled",
+		"config":            "CDIConfig at CDI level",
+		"certConfig":        "certificate configuration",
 	}
 }
 
@@ -233,6 +232,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
+		"cloneStrategyOverride":    "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CloneStrategyOverride != nil {
+		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
+		*out = new(CDICloneStrategy)
+		**out = **in
+	}
 	return
 }
 
@@ -271,11 +276,6 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 	}
 	in.Infra.DeepCopyInto(&out.Infra)
 	in.Workloads.DeepCopyInto(&out.Workloads)
-	if in.CloneStrategyOverride != nil {
-		in, out := &in.CloneStrategyOverride, &out.CloneStrategyOverride
-		*out = new(CDICloneStrategy)
-		**out = **in
-	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(CDIConfigSpec)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -655,11 +655,7 @@ func (r *DatavolumeReconciler) getCloneStrategy() (cdiv1.CDICloneStrategy, error
 		return cdiv1.CloneStrategySnapshot, fmt.Errorf("no active CDI")
 	}
 
-	if cr.Spec.Config == nil {
-		return cdiv1.CloneStrategySnapshot, nil
-	}
-
-	if cr.Spec.Config.CloneStrategyOverride == nil {
+	if cr.Spec.Config == nil || cr.Spec.Config.CloneStrategyOverride == nil {
 		return cdiv1.CloneStrategySnapshot, nil
 	}
 

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -655,12 +655,16 @@ func (r *DatavolumeReconciler) getCloneStrategy() (cdiv1.CDICloneStrategy, error
 		return cdiv1.CloneStrategySnapshot, fmt.Errorf("no active CDI")
 	}
 
-	if cr.Spec.CloneStrategyOverride == nil {
+	if cr.Spec.Config == nil {
 		return cdiv1.CloneStrategySnapshot, nil
 	}
 
-	r.log.V(3).Info(fmt.Sprintf("Overriding default clone strategy with %s", *cr.Spec.CloneStrategyOverride))
-	return *cr.Spec.CloneStrategyOverride, nil
+	if cr.Spec.Config.CloneStrategyOverride == nil {
+		return cdiv1.CloneStrategySnapshot, nil
+	}
+
+	r.log.V(3).Info(fmt.Sprintf("Overriding default clone strategy with %s", *cr.Spec.Config.CloneStrategyOverride))
+	return *cr.Spec.Config.CloneStrategyOverride, nil
 }
 
 func newSnapshot(dataVolume *cdiv1.DataVolume, snapshotClassName string) *snapshotv1.VolumeSnapshot {

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1047,7 +1047,9 @@ var _ = Describe("Smart clone", func() {
 		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "cdi"}, cr)
 		Expect(err).ToNot(HaveOccurred())
 
-		cr.Spec.CloneStrategyOverride = &expectedCloneStrategy
+		cr.Spec.Config = &cdiv1.CDIConfigSpec{
+			CloneStrategyOverride: &expectedCloneStrategy,
+		}
 		err = reconciler.client.Update(context.TODO(), cr)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/operator/resources/cluster/cdiconfig.go
+++ b/pkg/operator/resources/cluster/cdiconfig.go
@@ -188,6 +188,18 @@ func createAlphaV1ConfigCRDSchema() *extv1.CustomResourceValidation {
 							Description: "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 							Type:        "boolean",
 						},
+						"cloneStrategyOverride": {
+							Type:        "string",
+							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+							Enum: []extv1.JSON{
+								{
+									Raw: []byte(`"copy"`),
+								},
+								{
+									Raw: []byte(`"snapshot"`),
+								},
+							},
+						},
 					},
 				},
 				"status": {

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -1563,18 +1563,6 @@ func createAlphaV1CRDSchema() *extv1.CustomResourceValidation {
 								},
 							},
 						},
-						"cloneStrategyOverride": {
-							Type:        "string",
-							Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
-							Enum: []extv1.JSON{
-								{
-									Raw: []byte(`"copy"`),
-								},
-								{
-									Raw: []byte(`"snapshot"`),
-								},
-							},
-						},
 						"config": {
 							Description: "CDIConfig at CDI level",
 							Type:        "object",
@@ -1685,6 +1673,18 @@ func createAlphaV1CRDSchema() *extv1.CustomResourceValidation {
 								"preallocation": {
 									Description: "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 									Type:        "boolean",
+								},
+								"cloneStrategyOverride": {
+									Type:        "string",
+									Description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?",
+									Enum: []extv1.JSON{
+										{
+											Raw: []byte(`"copy"`),
+										},
+										{
+											Raw: []byte(`"snapshot"`),
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
Being the odd one out for CDI tunables is problematic if deployed
through HCO - it currently only allows editing CDI Spec.Config and
so this feature isn't visible.

[BZ #1917514](https://bugzilla.redhat.com/show_bug.cgi?id=1917514)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move cloneStrategyOverride parameter from CDI.Spec to CDI.Config.Spec
```

