### PR TITLE
[release-v1.23] Skip test 2555 if running on openshift (#1572)

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -132,6 +132,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			readyCondition   *cdiv1.DataVolumeCondition
 			boundCondition   *cdiv1.DataVolumeCondition
 			runningCondition *cdiv1.DataVolumeCondition
+			skipOpenshift    bool
 		}
 
 		createImageIoDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
@@ -196,6 +197,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+			if IsOpenshift(f.K8sClient) && args.skipOpenshift {
+				Skip("Test not expected to pass on OpenShift")
+			}
 			// Have to call the function in here, to make sure the BeforeEach in the Framework has run.
 			dataVolume := args.dvFunc(args.name, args.size, args.url())
 			startTime := time.Now()
@@ -361,7 +365,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Status:  v1.ConditionFalse,
 					Message: "Unable to process data: Invalid format qcow for image",
 					Reason:  "Error",
-				}}),
+				},
+				skipOpenshift: true,
+			}),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2554]fail creating import dv: invalid qcow large json", dataVolumeTestArguments{
 				name:         "dv-invalid-qcow-large-json",
 				size:         "1Gi",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -3,7 +3,6 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -18,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
@@ -33,7 +31,7 @@ var _ = Describe("Operator tests", func() {
 	f := framework.NewFramework("operator-test")
 
 	It("[test_id:3951]should create a route in OpenShift", func() {
-		if !isOpenshift(f.K8sClient) {
+		if !tests.IsOpenshift(f.K8sClient) {
 			Skip("This test is OpenShift specific")
 		}
 
@@ -69,7 +67,7 @@ var _ = Describe("Operator tests", func() {
 	})
 
 	It("[test_id:3952]add cdi-sa to containerized-data-importer scc", func() {
-		if !isOpenshift(f.K8sClient) {
+		if !tests.IsOpenshift(f.K8sClient) {
 			Skip("This test is OpenShift specific")
 		}
 
@@ -406,33 +404,4 @@ func updateUninstallStrategy(client cdiClientset.Interface, strategy *cdiv1.CDIU
 	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
 
 	return result
-}
-
-//IsOpenshift checks if we are on OpenShift platform
-func isOpenshift(client kubernetes.Interface) bool {
-	//OpenShift 3.X check
-	result := client.Discovery().RESTClient().Get().AbsPath("/oapi/v1").Do(context.TODO())
-	var statusCode int
-	result.StatusCode(&statusCode)
-
-	if result.Error() == nil {
-		// It is OpenShift
-		if statusCode == http.StatusOK {
-			return true
-		}
-	} else {
-		// Got 404 so this is not Openshift 3.X, let's check OpenShift 4
-		result = client.Discovery().RESTClient().Get().AbsPath("/apis/route.openshift.io").Do(context.TODO())
-		var statusCode int
-		result.StatusCode(&statusCode)
-
-		if result.Error() == nil {
-			// It is OpenShift
-			if statusCode == http.StatusOK {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/tests/framework"
@@ -167,4 +169,33 @@ func PodSpecHasTestNodePlacementValues(f *framework.Framework, podSpec v1.PodSpe
 		return false
 	}
 	return true
+}
+
+//IsOpenshift checks if we are on OpenShift platform
+func IsOpenshift(client kubernetes.Interface) bool {
+	//OpenShift 3.X check
+	result := client.Discovery().RESTClient().Get().AbsPath("/oapi/v1").Do(context.TODO())
+	var statusCode int
+	result.StatusCode(&statusCode)
+
+	if result.Error() == nil {
+		// It is OpenShift
+		if statusCode == http.StatusOK {
+			return true
+		}
+	} else {
+		// Got 404 so this is not Openshift 3.X, let's check OpenShift 4
+		result = client.Discovery().RESTClient().Get().AbsPath("/apis/route.openshift.io").Do(context.TODO())
+		var statusCode int
+		result.StatusCode(&statusCode)
+
+		if result.Error() == nil {
+			// It is OpenShift
+			if statusCode == http.StatusOK {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
* Move "isOpenshift" to utils and make public.

No functional change.

Signed-off-by: Maya Rashish <mrashish@redhat.com>

* Skip malformed too large qcow2 on openshift.

Whether this test fails depends on the qemu-img version. The way we
build and test it in this repo is fine, but external builds may fail.

Skipping only on OpenShift means we will continue testing it and
finding regressions.

Signed-off-by: Maya Rashish <mrashish@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #1572

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

