### PR TITLE
[release-v1.18] Skip test 2555 if running on openshift (#1572)

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -79,6 +79,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			readyCondition   *cdiv1.DataVolumeCondition
 			boundCondition   *cdiv1.DataVolumeCondition
 			runningCondition *cdiv1.DataVolumeCondition
+			skipOpenshift    bool
 		}
 
 		createImageIoDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
@@ -126,6 +127,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+			if IsOpenshift(f.K8sClient) && args.skipOpenshift {
+				Skip("Test not expected to pass on OpenShift")
+			}
 			// Have to call the function in here, to make sure the BeforeEach in the Framework has run.
 			dataVolume := args.dvFunc(args.name, args.size, args.url)
 			startTime := time.Now()
@@ -281,7 +285,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Status:  v1.ConditionFalse,
 					Message: "Unable to process data: Invalid format qcow for image " + invalidQcowLargeSizeURL,
 					Reason:  "Error",
-				}}),
+				},
+				skipOpenshift: true,
+			}),
 			table.Entry("[rfe_id:1120][crit:high][posneg:negative][test_id:2554]fail creating import dv: invalid qcow large json", dataVolumeTestArguments{
 				name:         "dv-invalid-qcow-large-json",
 				size:         "1Gi",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3,12 +3,15 @@ package tests
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
 	"time"
 
 	"github.com/onsi/ginkgo"
+
+	"k8s.io/client-go/kubernetes"
 
 	"kubevirt.io/containerized-data-importer/tests/framework"
 )
@@ -106,4 +109,33 @@ func GetKubeVersion(f *framework.Framework) string {
 		return ""
 	}
 	return ""
+}
+
+//IsOpenshift checks if we are on OpenShift platform
+func IsOpenshift(client kubernetes.Interface) bool {
+	//OpenShift 3.X check
+	result := client.Discovery().RESTClient().Get().AbsPath("/oapi/v1").Do()
+	var statusCode int
+	result.StatusCode(&statusCode)
+
+	if result.Error() == nil {
+		// It is OpenShift
+		if statusCode == http.StatusOK {
+			return true
+		}
+	} else {
+		// Got 404 so this is not Openshift 3.X, let's check OpenShift 4
+		result = client.Discovery().RESTClient().Get().AbsPath("/apis/route.openshift.io").Do()
+		var statusCode int
+		result.StatusCode(&statusCode)
+
+		if result.Error() == nil {
+			// It is OpenShift
+			if statusCode == http.StatusOK {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
* Move "isOpenshift" to utils and make public.

No functional change.

Signed-off-by: Maya Rashish <mrashish@redhat.com>

* Skip malformed too large qcow2 on openshift.

Whether this test fails depends on the qemu-img version. The way we
build and test it in this repo is fine, but external builds may fail.

Skipping only on OpenShift means we will continue testing it and
finding regressions.

**What this PR does / why we need it**:
Backport of #1572

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

