### PR TITLE
Support cloning from Filesystem to Block and vice-versa

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -575,6 +575,14 @@ func (r *DatavolumeReconciler) getSnapshotClassForSmartClone(dataVolume *cdiv1.D
 		return "", errors.New("source PVC not found")
 	}
 
+	sourceVolumeMode := GetVolumeMode(pvc.Spec.VolumeMode)
+	targetVolumeMode := GetVolumeMode(dataVolume.Spec.PVC.VolumeMode)
+	if sourceVolumeMode != targetVolumeMode {
+		r.log.V(3).Info("Source PVC and target PVC have different volume modes, falling back to host assisted clone", "source volume mode",
+			sourceVolumeMode, "target volume mode", targetVolumeMode)
+		return "", errors.New("Source PVC and target PVC have different volume modes, falling back to host assisted clone")
+	}
+
 	targetPvcStorageClassName := dataVolume.Spec.PVC.StorageClassName
 	targetStorageClass, err := GetStorageClassByName(r.client, targetPvcStorageClassName)
 	if err != nil {

--- a/pkg/feature-gates/BUILD.bazel
+++ b/pkg/feature-gates/BUILD.bazel
@@ -16,11 +16,15 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["feature-gates_test.go"],
+    srcs = [
+        "feature-gates_suite_test.go",
+        "feature-gates_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core/v1beta1:go_default_library",
         "//pkg/common:go_default_library",
+        "//tests/reporters:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -20,6 +20,7 @@
 package uploadserver
 
 import (
+	"archive/tar"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -29,7 +30,9 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/golang/snappy"
@@ -397,37 +400,76 @@ func (app *uploadServerApp) PreallocationApplied() common.PreallocationStatus {
 	return app.preallocationApplied
 }
 
-func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
-	if contentType == common.FilesystemCloneContentType {
+func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (*importer.DataProcessor, error) {
+	if sourceContentType == common.FilesystemCloneContentType {
 		return nil, fmt.Errorf("async filesystem clone not supported")
 	}
 
-	uds := importer.NewAsyncUploadDataSource(newContentReader(stream, contentType))
+	uds := importer.NewAsyncUploadDataSource(newContentReader(stream, sourceContentType))
 	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
 	return processor, processor.ProcessDataWithPause()
 }
 
-func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
-	if contentType == common.FilesystemCloneContentType {
-		return "false", filesystemCloneProcessor(stream, common.ImporterVolumePath)
+func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (common.PreallocationStatus, error) {
+	if sourceContentType == common.FilesystemCloneContentType {
+		return "false", filesystemCloneProcessor(stream, dest)
 	}
 
-	uds := importer.NewUploadDataSource(newContentReader(stream, contentType))
+	// Clone block device to block device or file system
+	uds := importer.NewUploadDataSource(newContentReader(stream, sourceContentType))
 	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
 	err := processor.ProcessData()
 	return processor.PreallocationApplied(), err
 }
 
-func filesystemCloneProcessor(stream io.ReadCloser, destDir string) error {
+// Clone file system to block device or file system
+func filesystemCloneProcessor(stream io.ReadCloser, dest string) error {
+	// Clone to block device
+	if dest == common.WriteBlockPath {
+		if err := untarToBlockdev(newSnappyReadCloser(stream), dest); err != nil {
+			return errors.Wrapf(err, "error unarchiving to %s", dest)
+		}
+		return nil
+	}
+
+	// Clone to file system
+	destDir := common.ImporterVolumePath
 	if err := importer.CleanDir(destDir); err != nil {
 		return errors.Wrapf(err, "error removing contents of %s", destDir)
 	}
-
 	if err := util.UnArchiveTar(newSnappyReadCloser(stream), destDir); err != nil {
 		return errors.Wrapf(err, "error unarchiving to %s", destDir)
 	}
-
 	return nil
+}
+
+func untarToBlockdev(stream io.Reader, dest string) error {
+	tr := tar.NewReader(stream)
+	for {
+		header, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		case header == nil:
+			continue
+		}
+		if header.Typeflag == tar.TypeGNUSparse && strings.Contains(header.Name, common.DiskImageName) {
+			klog.Infof("Untaring %d bytes to %s", header.Size, dest)
+			f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, os.ModeDevice|os.ModePerm)
+			if err != nil {
+				return err
+			}
+			written, err := io.Copy(f, tr)
+			if err != nil {
+				return err
+			}
+			klog.Infof("Written %d", written)
+			f.Close()
+			return nil
+		}
+	}
 }
 
 func newContentReader(stream io.ReadCloser, contentType string) io.ReadCloser {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -36,6 +36,7 @@ const (
 	cloneCompleteTimeout             = 270 * time.Second
 	verifyPodDeletedTimeout          = 270 * time.Second
 	controllerSkipPVCCompleteTimeout = 270 * time.Second
+	crossVolumeModeCloneMD5NumBytes  = 100000
 )
 
 var _ = Describe("all clone tests", func() {
@@ -249,6 +250,90 @@ var _ = Describe("all clone tests", func() {
 			fmt.Fprintf(GinkgoWriter, "INFO: wait for PVC claim phase: %s\n", targetPvc.Name)
 			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
 			completeClone(f, f.Namespace, targetPvc, filepath.Join(testBaseDir, testFile), fillDataFSMD5sum, "")
+		})
+		It("[test_id:cnv-5699]Should clone data from filesystem to block", func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
+			sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			targetDV := utils.NewDataVolumeCloneToBlockPV("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, f.BlockSCName)
+			tagretDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+			targetPvc, err := utils.WaitForPVC(f.K8sClient, tagretDataVolume.Namespace, tagretDataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for target PVC Bound phase")
+			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
+			By("Wait for target DV Succeeded phase")
+			err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, "target-dv", cloneCompleteTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Source file system pvc md5summing")
+			diskImagePath := filepath.Join(testBaseDir, testFile)
+			sourceMD5, err := f.GetMD5(f.Namespace, sourcePvc, diskImagePath, crossVolumeModeCloneMD5NumBytes)
+			Expect(err).ToNot(HaveOccurred())
+			By("Deleting verifier pod")
+			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = utils.WaitPodDeleted(f.K8sClient, utils.VerifierPodName, f.Namespace.Name, verifyPodDeletedTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Target block pvc md5summing")
+			targetMD5, err := f.GetMD5(f.Namespace, targetPvc, testBaseDir, crossVolumeModeCloneMD5NumBytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sourceMD5 == targetMD5).To(BeTrue())
+			By("Deleting verifier pod")
+			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("[test_id:cnv-5970]Should clone data from block to filesystem", func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+			dataVolume := utils.NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs), f.BlockSCName)
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
+			sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+			targetDV := utils.NewDataVolumeForImageCloning("target-dv", "2Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+			targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDataVolume)
+			targetPvc, err := utils.WaitForPVC(f.K8sClient, targetDataVolume.Namespace, targetDataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for target PVC Bound phase")
+			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
+			By("Wait for target DV Succeeded phase")
+			err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, "target-dv", cloneCompleteTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Source block pvc md5summing")
+			sourceMD5, err := f.GetMD5(f.Namespace, sourcePvc, testBaseDir, crossVolumeModeCloneMD5NumBytes)
+			Expect(err).ToNot(HaveOccurred())
+			By("Deleting verifier pod")
+			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = utils.WaitPodDeleted(f.K8sClient, utils.VerifierPodName, f.Namespace.Name, verifyPodDeletedTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Target file system pvc md5summing")
+			diskImagePath := filepath.Join(testBaseDir, testFile)
+			targetMD5, err := f.GetMD5(f.Namespace, targetPvc, diskImagePath, crossVolumeModeCloneMD5NumBytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sourceMD5 == targetMD5).To(BeTrue())
+			By("Deleting verifier pod")
+			err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
* validate source and target pvcs has the same content type - for all clones
* if source and target volume modes are different, validate content type is kubevirt, and fallback to host-assisted cloning
* unit & func tests

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Add support for cloning kubevirt disk residing on a filesystem mode PV to another PV that is block mode, and vice-versa.
```

