### PR TITLE
Try to use the CDIConfig proxy URL if it is set, if not use port-forward

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -69,9 +69,12 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		pvc, err = f.CreateBoundPVCFromDefinition(utils.UploadPVCDefinition())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Set up port forwarding")
-		uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
-		Expect(err).ToNot(HaveOccurred())
+		uploadProxyURL = findProxyURLCdiConfig(f)
+		if uploadProxyURL == "" {
+			By("Set up port forwarding")
+			uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {
@@ -381,6 +384,15 @@ func uploadFileNameToPath(requestFunc uploadFileNameRequestCreator, fileName, po
 	return nil
 }
 
+func findProxyURLCdiConfig(f *framework.Framework) string {
+	config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	if config.Status.UploadProxyURL != nil {
+		return fmt.Sprintf("https://%s", *config.Status.UploadProxyURL)
+	}
+	return ""
+}
+
 var _ = Describe("Block PV upload Test", func() {
 	var (
 		pvc *v1.PersistentVolumeClaim
@@ -405,9 +417,12 @@ var _ = Describe("Block PV upload Test", func() {
 		pvc, err = f.CreateBoundPVCFromDefinition(utils.UploadBlockPVCDefinition(f.BlockSCName))
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Set up port forwarding")
-		uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
-		Expect(err).ToNot(HaveOccurred())
+		uploadProxyURL = findProxyURLCdiConfig(f)
+		if uploadProxyURL == "" {
+			By("Set up port forwarding")
+			uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {
@@ -497,9 +512,12 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 			}, timeout, pollingInterval).Should(BeTrue())
 		}
 
-		By("Set up port forwarding")
-		uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
-		Expect(err).ToNot(HaveOccurred())
+		uploadProxyURL = findProxyURLCdiConfig(f)
+		if uploadProxyURL == "" {
+			By("Set up port forwarding")
+			uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {
@@ -688,10 +706,12 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	)
 
 	BeforeEach(func() {
-		By("Set up port forwarding")
-		uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
-		Expect(err).ToNot(HaveOccurred())
-
+		uploadProxyURL = findProxyURLCdiConfig(f)
+		if uploadProxyURL == "" {
+			By("Set up port forwarding")
+			uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {
@@ -962,9 +982,12 @@ var _ = Describe("Preallocation", func() {
 	)
 
 	BeforeEach(func() {
-		By("Set up port forwarding")
-		uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
-		Expect(err).ToNot(HaveOccurred())
+		uploadProxyURL = findProxyURLCdiConfig(f)
+		if uploadProxyURL == "" {
+			By("Set up port forwarding")
+			uploadProxyURL, portForwardCmd, err = startUploadProxyPortForward(f)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We always use port-forward in our upload tests, but port-forward fails often and does not recover. This PR attempts to use the proxy URL specified in the CDIConfig instead before attempting port-forward. If the cluster being tested on has a more stable proxy URL it will be used instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

