### PR TITLE
Wait for clone to succeed before checking MD5.

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -92,8 +92,8 @@ var _ = Describe("all clone tests", func() {
 
 			targetPvc, err := utils.WaitForPVC(f.K8sClient, targetDataVolume.Namespace, targetDataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
-			fmt.Fprintf(GinkgoWriter, "INFO: wait for PVC claim phase: %s\n", targetPvc.Name)
-			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
+			fmt.Fprintf(GinkgoWriter, "INFO: wait for target DV phase Succeeded: %s\n", targetPvc.Name)
+			utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, targetDV.Name, 3*90*time.Second)
 			sourcePvcDiskGroup, err := f.GetDiskGroup(f.Namespace, pvc, true)
 			fmt.Fprintf(GinkgoWriter, "INFO: %s\n", sourcePvcDiskGroup)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
If the verifier runs first, it seems to crash repeatedly and
never lets the clone proceed, hitting a timeout.

Failure seen here: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1600/pull-containerized-data-importer-e2e-k8s-1.18-upg/1352653678372196352

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONEe
```

