### PR TITLE
Simplify shouldReconcile function arguments.

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -178,11 +178,10 @@ func addImportControllerWatches(mgr manager.Manager, importController controller
 	return nil
 }
 
-func shouldReconcilePVC(pvc *corev1.PersistentVolumeClaim,
-	isImmediateBindingRequested bool,
-	featureGates featuregates.FeatureGates,
+func (r *ImportReconciler) shouldReconcilePVC(pvc *corev1.PersistentVolumeClaim,
 	log logr.Logger) (bool, error) {
-	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, featureGates)
+	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
+	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, r.featureGates)
 
 	if err != nil {
 		return false, err
@@ -211,9 +210,8 @@ func (r *ImportReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 		}
 		return reconcile.Result{}, err
 	}
-	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
 
-	shouldReconcile, err := shouldReconcilePVC(pvc, isImmediateBindingRequested, r.featureGates, log)
+	shouldReconcile, err := r.shouldReconcilePVC(pvc, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -116,13 +116,12 @@ func (r *UploadReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 
 	_, isUpload := pvc.Annotations[AnnUploadRequest]
 	_, isCloneTarget := pvc.Annotations[AnnCloneRequest]
-	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
 
 	if isUpload && isCloneTarget {
 		log.V(1).Info("PVC has both clone and upload annotations")
 		return reconcile.Result{}, errors.New("PVC has both clone and upload annotations")
 	}
-	shouldReconcile, err := r.shouldReconcile(isUpload, isCloneTarget, isImmediateBindingRequested, pvc, log)
+	shouldReconcile, err := r.shouldReconcile(isUpload, isCloneTarget, pvc, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -144,7 +143,8 @@ func (r *UploadReconciler) Reconcile(req reconcile.Request) (reconcile.Result, e
 	return r.reconcilePVC(log, pvc, isCloneTarget)
 }
 
-func (r *UploadReconciler) shouldReconcile(isUpload bool, isCloneTarget bool, isImmediateBindingRequested bool, pvc *v1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
+func (r *UploadReconciler) shouldReconcile(isUpload bool, isCloneTarget bool, pvc *v1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
+	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
 	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, r.featureGates)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
By having the function itself grab things it needs and are easily
obtained.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

