### PR TITLE
Decrease grace period to zero to make CI testing faster

### DIFF
--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -29,7 +29,8 @@ const (
 
 // DeleteVerifierPod deletes the verifier pod
 func DeleteVerifierPod(clientSet *kubernetes.Clientset, namespace string) error {
-	return DeletePodByName(clientSet, VerifierPodName, namespace, nil)
+	zero := int64(0)
+	return DeletePodByName(clientSet, VerifierPodName, namespace, &zero)
 }
 
 // CreatePod calls the Kubernetes API to create a Pod
@@ -52,7 +53,7 @@ func DeletePodByName(clientSet *kubernetes.Clientset, podName, namespace string,
 	})
 	return wait.PollImmediate(2*time.Second, podDeleteTime, func() (bool, error) {
 		_, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-		if !errors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err
@@ -61,8 +62,8 @@ func DeletePodByName(clientSet *kubernetes.Clientset, podName, namespace string,
 
 // DeletePodNoGrace deletes the passed in Pod from the passed in Namespace
 func DeletePodNoGrace(clientSet *kubernetes.Clientset, pod *k8sv1.Pod, namespace string) error {
-	zero := int64(0)
-	return DeletePodByName(clientSet, pod.Name, namespace, &zero)
+	one := int64(1)
+	return DeletePodByName(clientSet, pod.Name, namespace, &one)
 }
 
 // DeletePod deletes the passed in Pod from the passed in Namespace


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Setting the grace period of deletion of verifier pod might make CI testing faster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

