### PR TITLE
Retry uploading until success

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1042,8 +1042,9 @@ var _ = Describe("Preallocation", func() {
 		Expect(token).ToNot(BeEmpty())
 
 		By("Do upload")
-		err = uploadImage(uploadProxyURL, token, http.StatusOK)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return uploadImage(uploadProxyURL, token, http.StatusOK)
+		}, timeout, pollingInterval).Should(BeNil(), "Upload should eventually succeed, even if initially pod is not ready")
 
 		phase = cdiv1.Succeeded
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
@@ -1129,8 +1130,9 @@ var _ = Describe("Preallocation", func() {
 		Expect(token).ToNot(BeEmpty())
 
 		By("Do upload")
-		err = uploadImage(uploadProxyURL, token, http.StatusOK)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return uploadImage(uploadProxyURL, token, http.StatusOK)
+		}, timeout, pollingInterval).Should(BeNil(), "Upload should eventually succeed, even if initially pod is not ready")
 
 		phase = cdiv1.Succeeded
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))


### PR DESCRIPTION
The upload pod might not be ready in time, causing these tests
to become flaky.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make upload functional tests less flaky
```

