### PR TITLE
Fix lsblk command parsing

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -14,7 +14,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-set -euo pipefail
+set -euox pipefail
 
 if [[ -z "$VOLUME_MODE" ]]; then
     echo "VOLUME_MODE missing" 1>&2
@@ -30,7 +30,7 @@ echo "VOLUME_MODE=$VOLUME_MODE"
 echo "MOUNT_POINT=$MOUNT_POINT"
 
 if [ "$VOLUME_MODE" == "block" ]; then
-    UPLOAD_BYTES=$(blockdev --getsize64 $MOUNT_POINT)
+    UPLOAD_BYTES=$(lsblk -n -b -o SIZE $MOUNT_POINT | head -n 1)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
     /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type blockdevice-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If a block device has been populated with a disk image, `lsblk` (as we invoke it) will return two rows of data.  The first is the size of the entire device.  The second is the size of the embedded disk image partition.

This was not an issue until we added the `-mount` param to the `clone-source` program.  And it appears to only be a problem with 1.18 (and earlier?).  I assume this is because 1.18 is built with older go version.  I suspect argument parsing changed.  But I'm not sure.  Nevertheless I am adding this in master because it is more correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: fix lsblk output parsing
```

