### PR TITLE
fix lsblk handling

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -30,7 +30,7 @@ echo "VOLUME_MODE=$VOLUME_MODE"
 echo "MOUNT_POINT=$MOUNT_POINT"
 
 if [ "$VOLUME_MODE" == "block" ]; then
-    UPLOAD_BYTES=$(lsblk -n -b -o SIZE $MOUNT_POINT)
+    UPLOAD_BYTES=$(lsblk -n -b -o SIZE $MOUNT_POINT | head -n 1)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
     /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type blockdevice-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
@@ -551,6 +553,47 @@ var _ = Describe("all clone tests", func() {
 			f.AddNamespaceToDelete(targetNs)
 
 			targetDV := utils.NewDataVolumeCloneToBlockPV("target-dv", "500M", sourcePvc.Namespace, sourcePvc.Name, f.BlockSCName)
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetPvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			fmt.Fprintf(GinkgoWriter, "INFO: wait for PVC claim phase: %s\n", targetPvc.Name)
+			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, f.Namespace.Name, v1.ClaimBound, targetPvc.Name)
+
+			err = utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, targetNs.Name, cdiv1.Succeeded, "target-dv", 3*90*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.VerifyTargetPVCContentMD5(targetNs, targetPvc, testBaseDir, sourceMD5)).To(BeTrue())
+		})
+
+		It("Should clone disk image across namespaces", func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			cirrosURL := fmt.Sprintf(utils.CirrosURL, f.CdiInstallNs)
+			sourceDv := utils.NewDataVolumeWithHTTPImport("source-dv", "500M", cirrosURL)
+			sourceDv.Spec.PVC.StorageClassName = &f.BlockSCName
+			volumeMode := corev1.PersistentVolumeBlock
+			sourceDv.Spec.PVC.VolumeMode = &volumeMode
+			sourceDv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for import to be completed")
+			utils.WaitForDataVolumePhaseWithTimeout(f.CdiClient, f.Namespace.Name, cdiv1.Succeeded, sourceDv.Name, 3*90*time.Second)
+			sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(sourceDv.Namespace).Get(sourceDv.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			sourceMD5, err := f.GetMD5(f.Namespace, sourcePvc, testBaseDir, 0)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetNs, err := f.CreateNamespace(f.NsPrefix, map[string]string{
+				framework.NsPrefixLabel: f.NsPrefix,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			f.AddNamespaceToDelete(targetNs)
+
+			targetDV := utils.NewDataVolumeCloneToBlockPV("target-dv", "500M", sourceDv.Namespace, sourceDv.Name, f.BlockSCName)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If a block device has been populated with a disk image, lsblk (as we invoke it) will return two rows of data. The first is the size of the entire device. The second is the size of the embedded disk image partition.

This was not an issue until we added the -mount param to the clone-source program.

Newer code uses `blockdev` instead of `lsblk` so apparently not a problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: fix lsblk output parsing
```

