### PR TITLE
Fix flaky test: failure when checking permissions

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -32,6 +32,7 @@ const (
 	fastPollingInterval = 20 * time.Millisecond
 	pollingInterval     = 2 * time.Second
 	timeout             = 270 * time.Second
+	shortTimeout        = 30 * time.Second
 )
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", func() {
@@ -315,7 +316,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				if args.checkPermissions {
 					// Verify the created disk image has the right permissions.
 					By("Verifying permissions are 660")
-					Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")
+					Eventually(func() bool {
+						result, _ := f.VerifyPermissions(f.Namespace, pvc)
+						return result
+					}, shortTimeout, pollingInterval).Should(BeTrue(), "Permissions on disk image are not 660")
 					err := utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
 					Expect(err).ToNot(HaveOccurred())
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes the test fails because `ls` called in a container returns an
empty string. The fix is surround the test with a `Eventually` clause,
so that the command is retried when needed.

Example failure: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1603/pull-containerized-data-importer-e2e-k8s-1.18-hpp/1355110491671760896

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

