### PR TITLE
Add diagnostic to flaky test

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -763,8 +763,10 @@ var _ = Describe("ALL Operator tests", func() {
 						naa := s.Annotations["auth.openshift.io/certificate-not-after"]
 						t2, err := time.Parse(time.RFC3339, naa)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(t2.Sub(t) >= time.Minute*20).To(BeTrue())
-						Expect((t2.Sub(t) - (time.Minute * 20)) <= time.Second).To(BeTrue())
+						Expect(t2.Sub(t)).To(BeNumerically(">=", time.Minute*20),
+							fmt.Sprintf("Not-Before (%s) should be 20 minutes before Not-After (%s)", nba, naa))
+						Expect(t2.Sub(t)-(time.Minute*20)).To(BeNumerically("<=", time.Second),
+							fmt.Sprintf("Not-Before (%s) should be 20 minutes before Not-After (%s) with 1 second toleration", nba, naa))
 					}
 
 					for _, s := range serverSecrets {
@@ -774,8 +776,10 @@ var _ = Describe("ALL Operator tests", func() {
 						naa := s.Annotations["auth.openshift.io/certificate-not-after"]
 						t2, err := time.Parse(time.RFC3339, naa)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(t2.Sub(t) >= time.Minute*5).To(BeTrue())
-						Expect((t2.Sub(t) - (time.Minute * 5)) <= time.Second).To(BeTrue())
+						Expect(t2.Sub(t)).To(BeNumerically(">=", time.Minute*5),
+							fmt.Sprintf("Not-Before (%s) should be 5 minutes before Not-After (%s)", nba, naa))
+						Expect(t2.Sub(t)-(time.Minute*5)).To(BeNumerically("<=", time.Second),
+							fmt.Sprintf("Not-Before (%s) should be 5 minutes before Not-After (%s) with 1 second toleration", nba, naa))
 					}
 
 					return true


### PR DESCRIPTION
**What this PR does / why we need it**:

Operator cert config tests fails sometimes during CI. This PR adds
some diagnostic output that can help understand the failure.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

