### PR TITLE
Increase polling speed for upload annotation test

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	pollingInterval = 2 * time.Second
-	timeout         = 270 * time.Second
+	fastPollingInterval = 20 * time.Millisecond
+	pollingInterval     = 2 * time.Second
+	timeout             = 270 * time.Second
 )
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", func() {
@@ -1111,7 +1112,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 						uploadPod, _ = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)
 					}
 					return sourcePod != nil && uploadPod != nil
-				}, timeout, pollingInterval).Should(BeTrue())
+				}, timeout, fastPollingInterval).Should(BeTrue())
 				verifyAnnotations(sourcePod)
 				verifyAnnotations(uploadPod)
 			}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are seeing failures because the pods are disappearing too fast. Attempt to fix this
by polling much faster so the odds of us being able to get both pods is increased.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

