### PR TITLE
Remove documentation note about VDDK 7 restriction.

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -158,7 +158,7 @@ spec:
 [Get certificate example](../manifests/example/cert-configmap.yaml)
 
 ## VDDK Data Volume
-VDDK sources come from VMware vCenter or ESX endpoints. You will need a secret containing administrative credentials for the API provided by the VMware endpoint, as well as a special sidecar image containing the non-redistributable VDDK library folder. Instructions for creating a VDDK image can be found [here](https://docs.openshift.com/container-platform/4.3/cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.html#cnv-creating-vddk-image_cnv-importing-vmware-vm), with the addendum that the ConfigMap should exist in the current CDI namespace and not 'openshift-cnv'. Note that version 7 of the VDDK is not supported yet.
+VDDK sources come from VMware vCenter or ESX endpoints. You will need a secret containing administrative credentials for the API provided by the VMware endpoint, as well as a special sidecar image containing the non-redistributable VDDK library folder. Instructions for creating a VDDK image can be found [here](https://docs.openshift.com/container-platform/4.3/cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.html#cnv-creating-vddk-image_cnv-importing-vmware-vm), with the addendum that the ConfigMap should exist in the current CDI namespace and not 'openshift-cnv'.
 
 ```yaml
 apiVersion: cdi.kubevirt.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes a documentation note about VMware imports not working with VDDK 7. This was true with the initial implementation, but the update to Fedora 33 included a version of nbdkit that works with VDDK 7.

**Release note**:
```release-note
Remove documentation note about VDDK 7 restriction.
```

