### PR TITLE
Release to quay.io instead of docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ jobs:
     - curl -d "repo=github.com/kubevirt/containerized-data-importer" https://goreportcard.com/checks
 
 before_deploy:
-- docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
+- docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+- DOCKER_PREFIX=quay.io/kubevirt
 
 deploy:
   # Release :latest images

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,12 +93,13 @@ http_archive(
 # Pull base image fedora33
 container_pull(
     name = "fedora",
-    digest = "sha256:fdf235fa167d2aa5d820fba274ec1d2edeb0534bd32d28d602a19b31bad79b80",
-    registry = "index.docker.io",
-    repository = "fedora",
-    tag = "33",
+    digest = "sha256:46490f8d5bbe4559b61b9a25724c40a91dc2d20d980b955863b5e47368bfff0a",
+    registry = "quay.io",
+    repository = "fedora/fedora",
+    tag = "33-x86_64",
 )
 
+#No need to update this one until we re-enable the cinder lane, as only the lvm pod uses this.
 container_pull(
     name = "fedora-docker",
     digest = "sha256:fdf235fa167d2aa5d820fba274ec1d2edeb0534bd32d28d602a19b31bad79b80",

--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -3,14 +3,6 @@ load("@io_bazel_rules_container_rpm//rpm:rpm.bzl", "rpm_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
-rpm_image(
-    name = "cdi-cloner-base-image",
-    base = "@fedora//image",
-    rpms = [
-        "@tar//file",
-    ],
-)
-
 go_library(
     name = "go_default_library",
     srcs = ["clone-source.go"],
@@ -49,7 +41,7 @@ go_test(
 
 container_image(
     name = "cdi-cloner-image",
-    base = ":cdi-cloner-base-image",
+    base = "@fedora//image",
     directory = "/usr/bin",
     entrypoint = ["/usr/bin/cloner_startup.sh"],
     files = [":cdi-cloner"],

--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -14,7 +14,6 @@ rpm_image(
         "@nbdkit-curl-plugin//file",
         "@nbdkit-xz-filter//file",
         "@nbdkit-gzip-filter//file",
-        "@tar//file",
         "@qemu-img//file",
         "@qemu-block-curl//file",
         "@xen-libs//file",

--- a/cmd/cdi-uploadserver/BUILD.bazel
+++ b/cmd/cdi-uploadserver/BUILD.bazel
@@ -6,7 +6,6 @@ rpm_image(
     base = "@fedora//image",
     rpms = [
         "@libnbd//file",
-        "@tar//file",
         "@qemu-img//file",
         "@qemu-block-curl//file",
         "@xen-libs//file",

--- a/pkg/feature-gates/BUILD.bazel
+++ b/pkg/feature-gates/BUILD.bazel
@@ -16,11 +16,15 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["feature-gates_test.go"],
+    srcs = [
+        "feature-gates_suite_test.go",
+        "feature-gates_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core/v1beta1:go_default_library",
         "//pkg/common:go_default_library",
+        "//tests/reporters:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tools/vddk-test/BUILD.bazel
+++ b/tools/vddk-test/BUILD.bazel
@@ -18,7 +18,6 @@ rpm_image(
     base = ":vcenter-simulator-base-image",
     rpms = [
         "@golang-github-vmware-govmomi//file",
-        "@tar//file",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With the dockerhub rate limit, we are seeing a lot of CI failures due to rate limits on dockerhub. This PR makes it so we release on quay.io instead which doesn't have the rate limit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

