### PR TITLE
Preallocate even if the size is too small

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -67,7 +67,7 @@ func main() {
 	previousCheckpoint, _ := util.ParseEnvVar(common.ImporterPreviousCheckpoint, false)
 	finalCheckpoint, _ := util.ParseEnvVar(common.ImporterFinalCheckpoint, false)
 	preallocation, err := strconv.ParseBool(os.Getenv(common.Preallocation))
-	var preallocationApplied common.PreallocationStatus
+	var preallocationApplied bool
 
 	//Registry import currently support kubevirt content type only
 	if contentType != string(cdiv1.DataVolumeKubeVirt) && (source == controller.SourceRegistry || source == controller.SourceImageio) {
@@ -98,19 +98,17 @@ func main() {
 	if source == controller.SourceNone && contentType == string(cdiv1.DataVolumeKubeVirt) {
 		requestImageSizeQuantity := resource.MustParse(imageSize)
 		minSizeQuantity := util.MinQuantity(resource.NewScaledQuantity(availableDestSpace, 0), &requestImageSizeQuantity)
-		preallocationApplied = common.PreallocationStatusFromBool(preallocation)
+		preallocationApplied = preallocation
 		if minSizeQuantity.Cmp(requestImageSizeQuantity) != 0 {
 			// Available dest space is smaller than the size we want to create
 			klog.Warningf("Available space less than requested size, creating blank image sized to available space: %s.\n", minSizeQuantity.String())
-			if preallocation {
-				preallocationApplied = common.PreallocationSkipped
-				preallocation = false
-			}
 		}
 
 		var err error
 		if volumeMode == v1.PersistentVolumeFilesystem {
-			err = image.CreateBlankImage(common.ImporterWritePath, minSizeQuantity, preallocation)
+			quantityWithFSOverhead := importer.GetUsableSpace(filesystemOverhead, minSizeQuantity.Value())
+			klog.Infof("Space adjusted for filesystem overhead: %d.\n", quantityWithFSOverhead)
+			err = image.CreateBlankImage(common.ImporterWritePath, *resource.NewScaledQuantity(quantityWithFSOverhead, 0), preallocation)
 		} else if volumeMode == v1.PersistentVolumeBlock && preallocation {
 			klog.V(1).Info("Preallocating blank block volume")
 			err = image.PreallocateBlankBlock(common.WriteBlockPath, minSizeQuantity)
@@ -119,9 +117,6 @@ func main() {
 		if err != nil {
 			klog.Errorf("%+v", err)
 			message := fmt.Sprintf("Unable to create blank image: %+v", err)
-			if preallocationApplied == common.PreallocationSkipped {
-				message += ", " + controller.PreallocationSkipped
-			}
 			err = util.WriteTerminationMessage(message)
 			if err != nil {
 				klog.Errorf("%+v", err)
@@ -206,11 +201,8 @@ func main() {
 		preallocationApplied = processor.PreallocationApplied()
 	}
 	message := "Import Complete"
-	switch preallocationApplied {
-	case common.PreallocationApplied:
+	if preallocationApplied {
 		message += ", " + controller.PreallocationApplied
-	case common.PreallocationSkipped:
-		message += ", " + controller.PreallocationSkipped
 	}
 	err = util.WriteTerminationMessage(message)
 	if err != nil {

--- a/cmd/cdi-uploadserver/uploadserver.go
+++ b/cmd/cdi-uploadserver/uploadserver.go
@@ -90,11 +90,8 @@ func main() {
 	} else {
 		message = "Upload Complete"
 	}
-	switch server.PreallocationApplied() {
-	case "true":
+	if server.PreallocationApplied() {
 		message += ", " + controller.PreallocationApplied
-	case "skipped":
-		message += ", " + controller.PreallocationSkipped
 	}
 	err = util.WriteTerminationMessage(message)
 	if err != nil {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -182,27 +182,6 @@ const (
 	UploadFormAsync = "/v1beta1/upload-form-async"
 )
 
-// PreallocationStatus is used to mark result of preallocation in importer and uploader
-type PreallocationStatus string
-
-const (
-	// PreallocationApplied is used to signal that preallocation was performed on the storage
-	PreallocationApplied PreallocationStatus = "true"
-	// PreallocationNotApplied is ued to singal that preallocation was not performed
-	PreallocationNotApplied PreallocationStatus = "false"
-	// PreallocationSkipped is used to signal that preallocation was not performed even though it was requested
-	PreallocationSkipped PreallocationStatus = "skipped"
-)
-
-// PreallocationStatusFromBool converts boolean value to PreallocationStatus
-func PreallocationStatusFromBool(preallocation bool) PreallocationStatus {
-	if preallocation {
-		return PreallocationApplied
-	}
-
-	return PreallocationNotApplied
-}
-
 // ProxyPaths are all supported paths
 var ProxyPaths = append(
 	append(SyncUploadPaths, AsyncUploadPaths...),

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -251,9 +251,6 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, PreallocationApplied) {
 				anno[AnnPreallocationApplied] = "true"
 			}
-			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, PreallocationSkipped) {
-				anno[AnnPreallocationApplied] = "skipped"
-			}
 		}
 	}
 	setConditionFromPodWithPrefix(anno, AnnRunningCondition, pod)

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -410,7 +410,7 @@ var _ = Describe("ResizeImage", func() {
 		})
 	},
 		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0)), "1500", int64(2048), false, true),
-		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false, false),
+		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false, true),
 		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024), 0)), "1024", int64(1024), false, false),
 		table.Entry("fail to resize to with blank imageSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "", int64(2048), true, false),
 		table.Entry("fail to resize to with blank imageSize", NewQEMUAllErrors(), "", int64(2048), true, false),

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -52,7 +52,7 @@ const (
 // UploadServer is the interface to uploadServerApp
 type UploadServer interface {
 	Run() error
-	PreallocationApplied() common.PreallocationStatus
+	PreallocationApplied() bool
 }
 
 type uploadServerApp struct {
@@ -72,7 +72,7 @@ type uploadServerApp struct {
 	uploading            bool
 	processing           bool
 	done                 bool
-	preallocationApplied common.PreallocationStatus
+	preallocationApplied bool
 	doneChan             chan struct{}
 	errChan              chan error
 	mutex                sync.Mutex
@@ -396,7 +396,7 @@ func (app *uploadServerApp) uploadHandler(irc imageReadCloser) http.HandlerFunc 
 	}
 }
 
-func (app *uploadServerApp) PreallocationApplied() common.PreallocationStatus {
+func (app *uploadServerApp) PreallocationApplied() bool {
 	return app.preallocationApplied
 }
 
@@ -410,9 +410,9 @@ func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string,
 	return processor, processor.ProcessDataWithPause()
 }
 
-func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (common.PreallocationStatus, error) {
+func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (bool, error) {
 	if sourceContentType == common.FilesystemCloneContentType {
-		return "false", filesystemCloneProcessor(stream, dest)
+		return false, filesystemCloneProcessor(stream, dest)
 	}
 
 	// Clone block device to block device or file system

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -88,12 +88,12 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 	return client
 }
 
-func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
-	return common.PreallocationNotApplied, nil
+func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (bool, error) {
+	return false, nil
 }
 
-func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (common.PreallocationStatus, error) {
-	return common.PreallocationNotApplied, fmt.Errorf("Error using datastream")
+func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (bool, error) {
+	return false, fmt.Errorf("Error using datastream")
 }
 
 func withProcessorSuccess(f func()) {
@@ -104,7 +104,7 @@ func withProcessorFailure(f func()) {
 	replaceProcessorFunc(saveProcessorFailure, f)
 }
 
-func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (common.PreallocationStatus, error), f func()) {
+func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (bool, error), f func()) {
 	origProcessorFunc := uploadProcessorFunc
 	uploadProcessorFunc = replacement
 	defer func() {


### PR DESCRIPTION
This PR removes "skipped" condition for preallocation. Importer/uploader
will preallocate to the available size.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

