### PR TITLE
VDDK: avoid crash when specified disk isn't in VM.

### DIFF
--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -394,10 +394,14 @@ func (vmware *VMwareClient) FindDiskFromName(fileName string) (*types.VirtualDis
 		klog.Errorf("Unable to list snapshots: %s\n", err)
 		return nil, err
 	}
-	if disk := vmware.FindDiskInSnapshotTree(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
-		return disk, nil
+	if snapshot.Snapshot == nil {
+		klog.Errorf("No snapshots on this virtual machine.")
+	} else {
+		if disk := vmware.FindDiskInSnapshotTree(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
+			return disk, nil
+		}
 	}
-	return nil, errors.New("could not find target VMware disk")
+	return nil, fmt.Errorf("disk '%s' is not present in VM hardware config or snapshot list", fileName)
 }
 
 // FindSnapshotDiskName finds the name of the given disk at the time the snapshot was taken


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request avoids a VDDK importer crash when the specified disk is not in the source VM's hardware configuration, and the VM has never had any snapshots taken. Now it will return a slightly more helpful error message.

**Which issue(s) this PR fixes**
Fixes #1634

**Release note**:
```release-note
Avoid VDDK importer crash when source VM does not contain specified disk.
```

