### PR TITLE
Fix inverted logic - wait for the pod to stop existing.

### DIFF
--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -52,7 +52,7 @@ func DeletePodByName(clientSet *kubernetes.Clientset, podName, namespace string,
 	})
 	return wait.PollImmediate(2*time.Second, podDeleteTime, func() (bool, error) {
 		_, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-		if !errors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err


### PR DESCRIPTION

**What this PR does / why we need it**:
This is part of #1603 split into its own change.
I would like to have this as its own change so we can backport it right away, whereas #1603 is something we'd like to test to see if it's stable for a while.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

