### PR TITLE
Push builder to quay.io as well

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -23,7 +23,7 @@ BUILDER_SPEC="${BUILD_DIR}/docker/builder"
 
 # When building and pushing a new image we do not provide the sha hash
 # because docker assigns that for us.
-UNTAGGED_BUILDER_IMAGE=kubevirt/kubevirt-cdi-bazel-builder
+UNTAGGED_BUILDER_IMAGE=quay.io/kubevirt/kubevirt-cdi-bazel-builder
 
 # Build the encapsulated compile and test container
 (cd ${BUILDER_SPEC} && docker build --tag ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG} .)


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
During release we are logged into quay.io now, and we are attempting to push the builder to dockerhub, which obviously will fail. This PR switches the push to quay as well.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
On this is merged, and we are successfully pushing to quay.io, we need to alter config.sh to pull the builder image from quay.io as well

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

