### PR TITLE
Fix a few more remaining references to docker.

### DIFF
--- a/hack/build/osci-image-builder.sh
+++ b/hack/build/osci-image-builder.sh
@@ -23,7 +23,7 @@ BUILDER_SPEC="hack/ci/Dockerfile.ci"
 
 # When building and pushing a new image we do not provide the sha hash
 # because docker assigns that for us.
-UNTAGGED_BUILDER_IMAGE=kubevirt/cdi-osci-builder
+UNTAGGED_BUILDER_IMAGE=quay.io/kubevirt/cdi-osci-builder
 
 # Build the encapsulated compile and test container
 docker build -f ${BUILDER_SPEC} --tag ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG} .

--- a/hack/build/release-description.sh
+++ b/hack/build/release-description.sh
@@ -35,13 +35,13 @@ The source code and selected binaries are available for download at:
 <$RELURL>.
 
 Pre-built CDI containers are published on Docker Hub and can be viewed at:
-<https://hub.docker.com/r/kubevirt/cdi-controller/>
-<https://hub.docker.com/r/kubevirt/cdi-importer/>
-<https://hub.docker.com/r/kubevirt/cdi-cloner/>
-<https://hub.docker.com/r/kubevirt/cdi-uploadproxy/>
-<https://hub.docker.com/r/kubevirt/cdi-apiserver/>
-<https://hub.docker.com/r/kubevirt/cdi-uploadserver/>
-<https://hub.docker.com/r/kubevirt/cdi-operator/>
+<https://quay.io/repository/kubevirt/cdi-controller/>
+<https://quay.io/repository/kubevirt/cdi-importer/>
+<https://quay.io/repository/kubevirt/cdi-cloner/>
+<https://quay.io/repository/kubevirt/cdi-uploadproxy/>
+<https://quay.io/repository/kubevirt/cdi-apiserver/>
+<https://quay.io/repository/kubevirt/cdi-uploadserver/>
+<https://quay.io/repository/kubevirt/cdi-operator/>
 EOF
 }
 

--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM docker.io/kubevirt/kubevirt-cdi-bazel-builder:0.0.8 AS builder
+FROM quay.io/kubevirt/kubevirt-cdi-bazel-builder:0.0.10 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/containerized-data-importer
 COPY . .
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
I missed a few references to dockerhub that causes the travis job to fail to push the images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

