### PR TITLE
Fix travis nightly to push from main.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
   script: make builder-push && make publish && make openshift-ci-image-push
   skip_cleanup: true
   on:
-    branch: master
+    branch: main
     repo: kubevirt/containerized-data-importer
  # Release versioned images
 - provider: script


### PR DESCRIPTION
We renamed the branch, but the release was looking for master. This
fixes travis to look for main.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

