### PR TITLE
Implement certConfigMap for s3 datasources, reported missing on #1506

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3817,7 +3817,11 @@
      "url"
     ],
     "properties": {
-     "secretRef": {
+      "certConfigMap": {
+       "description": "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
+       "type": "string"
+      },
+      "secretRef": {
       "description": "SecretRef provides the secret reference needed to access the S3 source",
       "type": "string"
      },

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -157,7 +157,7 @@ func main() {
 		case controller.SourceRegistry:
 			dp = importer.NewRegistryDataSource(ep, acc, sec, certDir, insecureTLS)
 		case controller.SourceS3:
-			dp, err = importer.NewS3DataSource(ep, acc, sec)
+			dp, err = importer.NewS3DataSource(ep, acc, sec, certDir)
 			if err != nil {
 				klog.Errorf("%+v", err)
 				err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to s3 data source: %+v", err))

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -14290,6 +14290,13 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeSourceS3(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"certConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"url"},
 			},

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -105,6 +105,9 @@ type DataVolumeSourceS3 struct {
 	URL string `json:"url"`
 	//SecretRef provides the secret reference needed to access the S3 source
 	SecretRef string `json:"secretRef,omitempty"`
+	// CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate
+	// +optional
+	CertConfigMap string `json:"certConfigMap,omitempty"`
 }
 
 // DataVolumeSourceRegistry provides the parameters to create a Data Volume from an registry source

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -55,9 +55,10 @@ func (DataVolumeSourceUpload) SwaggerDoc() map[string]string {
 
 func (DataVolumeSourceS3) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":          "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
-		"url":       "URL is the url of the S3 source",
-		"secretRef": "SecretRef provides the secret reference needed to access the S3 source",
+		"":              "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
+		"url":           "URL is the url of the S3 source",
+		"secretRef":     "SecretRef provides the secret reference needed to access the S3 source",
+		"certConfigMap": "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate\n+optional",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -14318,6 +14318,13 @@ func schema_pkg_apis_core_v1beta1_DataVolumeSourceS3(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"certConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"url"},
 			},

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -108,6 +108,9 @@ type DataVolumeSourceS3 struct {
 	URL string `json:"url"`
 	//SecretRef provides the secret reference needed to access the S3 source
 	SecretRef string `json:"secretRef,omitempty"`
+	// CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate
+	// +optional
+	CertConfigMap string `json:"certConfigMap,omitempty"`
 }
 
 // DataVolumeSourceRegistry provides the parameters to create a Data Volume from an registry source

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -56,9 +56,10 @@ func (DataVolumeSourceUpload) SwaggerDoc() map[string]string {
 
 func (DataVolumeSourceS3) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":          "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
-		"url":       "URL is the url of the S3 source",
-		"secretRef": "SecretRef provides the secret reference needed to access the S3 source",
+		"":              "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
+		"url":           "URL is the url of the S3 source",
+		"secretRef":     "SecretRef provides the secret reference needed to access the S3 source",
+		"certConfigMap": "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate\n+optional",
 	}
 }
 

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1168,6 +1168,9 @@ func (r *DatavolumeReconciler) newPersistentVolumeClaim(dataVolume *cdiv1.DataVo
 		if dataVolume.Spec.Source.S3.SecretRef != "" {
 			annotations[AnnSecret] = dataVolume.Spec.Source.S3.SecretRef
 		}
+		if dataVolume.Spec.Source.S3.CertConfigMap != "" {
+			annotations[AnnCertConfigMap] = dataVolume.Spec.Source.S3.CertConfigMap
+		}
 	} else if dataVolume.Spec.Source.Registry != nil {
 		annotations[AnnSource] = SourceRegistry
 		annotations[AnnEndpoint] = dataVolume.Spec.Source.Registry.URL

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -2,15 +2,16 @@ package importer
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"io"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/pkg/errors"
 
@@ -49,12 +50,12 @@ type S3DataSource struct {
 }
 
 // NewS3DataSource creates a new instance of the S3DataSource
-func NewS3DataSource(endpoint, accessKey, secKey string) (*S3DataSource, error) {
+func NewS3DataSource(endpoint, accessKey, secKey string, certDir string) (*S3DataSource, error) {
 	ep, err := ParseEndpoint(endpoint)
 	if err != nil {
 		return nil, errors.Wrapf(err, fmt.Sprintf("unable to parse endpoint %q", endpoint))
 	}
-	s3Reader, err := createS3Reader(ep, accessKey, secKey)
+	s3Reader, err := createS3Reader(ep, accessKey, secKey, certDir)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +123,7 @@ func (sd *S3DataSource) Close() error {
 	return err
 }
 
-func createS3Reader(ep *url.URL, accessKey, secKey string) (io.ReadCloser, error) {
+func createS3Reader(ep *url.URL, accessKey, secKey string, certDir string) (io.ReadCloser, error) {
 	klog.V(3).Infoln("Using S3 client to get data")
 
 	endpoint := ep.Host
@@ -132,7 +133,7 @@ func createS3Reader(ep *url.URL, accessKey, secKey string) (io.ReadCloser, error
 
 	klog.V(1).Infof("bucket %s", bucket)
 	klog.V(1).Infof("object %s", object)
-	svc, err := newClientFunc(endpoint, accessKey, secKey)
+	svc, err := newClientFunc(endpoint, accessKey, secKey, certDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not build s3 client for %q", ep.Host)
 	}
@@ -149,7 +150,14 @@ func createS3Reader(ep *url.URL, accessKey, secKey string) (io.ReadCloser, error
 	return objectReader, nil
 }
 
-func getS3Client(endpoint, accessKey, secKey string) (S3Client, error) {
+func getS3Client(endpoint, accessKey, secKey string, certDir string) (S3Client, error) {
+	// Adding certs using CustomCABundle will overwrite the SystemCerts, so we opt by creating a custom HTTPClient
+	httpClient, err := createHTTPClient(certDir)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating http client for s3")
+	}
+
 	creds := credentials.NewStaticCredentials(accessKey, secKey, "")
 	region := extractRegion(endpoint)
 	sess, err := session.NewSession(&aws.Config{
@@ -157,6 +165,7 @@ func getS3Client(endpoint, accessKey, secKey string) (S3Client, error) {
 		Endpoint:         aws.String(endpoint),
 		Credentials:      creds,
 		S3ForcePathStyle: aws.Bool(true),
+		HTTPClient:       httpClient,
 	},
 	)
 	if err != nil {

--- a/pkg/operator/resources/cluster/datavolume.go
+++ b/pkg/operator/resources/cluster/datavolume.go
@@ -157,6 +157,10 @@ func createDataVolumeCRD() *extv1.CustomResourceDefinition {
 															Description: "SecretRef provides the secret reference needed to access the S3 source",
 															Type:        "string",
 														},
+														"certConfigMap": {
+															Description: "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
+															Type:        "string",
+														},
 													},
 													Required: []string{
 														"url",
@@ -597,6 +601,10 @@ func createDataVolumeCRD() *extv1.CustomResourceDefinition {
 														},
 														"secretRef": {
 															Description: "SecretRef provides the secret reference needed to access the S3 source",
+															Type:        "string",
+														},
+														"certConfigMap": {
+															Description: "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
 															Type:        "string",
 														},
 													},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, custom CA endpoints are only allowed to be http datasources. This PR implements the same feature for s3 endpoints.

**Which issue(s) this PR fixes**:
Fixes #1506

**Special notes for your reviewer**:
The implementation for s3 reuses the features from http datasources. Two alternatives were evaluated, first was using CustomCACerts from aws s3 library, but it overwrites the system certs, so the second one was selected, using a custom httpclient with new certs implemented reusing http datasource code.

A new test case has also been implemented for invalid certs as in http datasource tests.

**Release note**:
```release-note
- New field in s3 datasources for custom CA Config Map like in http datasources
```

