### PR TITLE
Fix default content type validation for cloning

### DIFF
--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -71,10 +71,7 @@ func validateDataVolumeName(name string) []metav1.StatusCause {
 }
 
 func validateContentTypes(sourcePVC *v1.PersistentVolumeClaim, spec *cdiv1.DataVolumeSpec) (bool, cdiv1.DataVolumeContentType, cdiv1.DataVolumeContentType) {
-	sourceContentType := cdiv1.DataVolumeKubeVirt
-	if contentType, found := sourcePVC.Annotations[controller.AnnContentType]; found {
-		sourceContentType = cdiv1.DataVolumeContentType(contentType)
-	}
+	sourceContentType := cdiv1.DataVolumeContentType(controller.GetContentType(sourcePVC))
 	targetContentType := spec.ContentType
 	if targetContentType == "" {
 		targetContentType = cdiv1.DataVolumeKubeVirt

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -725,8 +725,8 @@ func ParseCloneRequestAnnotation(pvc *corev1.PersistentVolumeClaim) (exists bool
 
 // ValidateCanCloneSourceAndTargetContentType validates the pvcs passed has the same content type.
 func ValidateCanCloneSourceAndTargetContentType(sourcePvc, targetPvc *corev1.PersistentVolumeClaim) (cdiv1.DataVolumeContentType, error) {
-	sourceContentType := getContentType(sourcePvc)
-	targetContentType := getContentType(targetPvc)
+	sourceContentType := GetContentType(sourcePvc)
+	targetContentType := GetContentType(targetPvc)
 	if sourceContentType != targetContentType {
 		return "", fmt.Errorf("source contentType (%s) and target contentType (%s) do not match", sourceContentType, targetContentType)
 	}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -486,7 +486,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 func (r *ImportReconciler) createImportEnvVar(pvc *corev1.PersistentVolumeClaim) (*importPodEnvVar, error) {
 	podEnvVar := &importPodEnvVar{}
 	podEnvVar.source = getSource(pvc)
-	podEnvVar.contentType = getContentType(pvc)
+	podEnvVar.contentType = GetContentType(pvc)
 
 	var err error
 	if podEnvVar.source != SourceNone {
@@ -615,7 +615,7 @@ func (r *ImportReconciler) getSecretName(pvc *corev1.PersistentVolumeClaim) stri
 
 func (r *ImportReconciler) requiresScratchSpace(pvc *corev1.PersistentVolumeClaim) bool {
 	scratchRequired := false
-	contentType := getContentType(pvc)
+	contentType := GetContentType(pvc)
 	// All archive requires scratch space.
 	if contentType == "archive" {
 		scratchRequired = true
@@ -705,11 +705,11 @@ func getSource(pvc *corev1.PersistentVolumeClaim) string {
 	return source
 }
 
-// returns the source string which determines the type of source. If no source or invalid source found, default to http
-func getContentType(pvc *corev1.PersistentVolumeClaim) string {
+// GetContentType returns the content type of the source image. If invalid or not set, default to kubevirt
+func GetContentType(pvc *corev1.PersistentVolumeClaim) string {
 	contentType, found := pvc.Annotations[AnnContentType]
 	if !found {
-		contentType = ""
+		return string(cdiv1.DataVolumeKubeVirt)
 	}
 	switch contentType {
 	case

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -790,14 +790,14 @@ var _ = Describe("getInsecureTLS", func() {
 	)
 })
 
-var _ = Describe("getContentType", func() {
+var _ = Describe("GetContentType", func() {
 	pvcNoAnno := createPvc("testPVCNoAnno", "default", nil, nil)
 	pvcArchiveAnno := createPvc("testPVCArchiveAnno", "default", map[string]string{AnnContentType: string(cdiv1.DataVolumeArchive)}, nil)
 	pvcKubevirtAnno := createPvc("testPVCKubevirtAnno", "default", map[string]string{AnnContentType: string(cdiv1.DataVolumeKubeVirt)}, nil)
 	pvcInvalidValue := createPvc("testPVCInvalidValue", "default", map[string]string{AnnContentType: "iaminvalid"}, nil)
 
 	table.DescribeTable("should", func(pvc *corev1.PersistentVolumeClaim, expectedResult cdiv1.DataVolumeContentType) {
-		result := getContentType(pvc)
+		result := GetContentType(pvc)
 		Expect(result).To(BeEquivalentTo(expectedResult))
 	},
 		table.Entry("return kubevirt contenttype if no annotation provided", pvcNoAnno, cdiv1.DataVolumeKubeVirt),
@@ -1062,7 +1062,7 @@ func createImporterTestPod(pvc *corev1.PersistentVolumeClaim, dvname string, scr
 
 	ep, _ := getEndpoint(pvc)
 	source := getSource(pvc)
-	contentType := getContentType(pvc)
+	contentType := GetContentType(pvc)
 	imageSize, _ := getRequestedImageSize(pvc)
 	volumeMode := getVolumeMode(pvc)
 


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Fix content type validation for cloning, where the source content type is an empty string, which defaults to kubevirt.

**Which issue(s) this PR fixes**:
Fixes #1656

**Release note**:
```release-note
NONE
```

