### PR TITLE
Have the healthz server check for the uploadserver first.

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -210,4 +211,9 @@ var SyncUploadFormPaths = []string{
 var AsyncUploadFormPaths = []string{
 	UploadFormAsync,
 	"/v1alpha1/upload-form-async",
+}
+
+// ErrConnectionRefused checks whether the error is "connection refused"
+func ErrConnectionRefused(err error) bool {
+	return strings.Contains(err.Error(), "connection refused")
 }

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1064,7 +1064,7 @@ func updateProgressUsingPod(dataVolumeCopy *cdiv1.DataVolume, pod *corev1.Pod) e
 		url := fmt.Sprintf("https://%s:%d/metrics", pod.Status.PodIP, port)
 		resp, err := httpClient.Get(url)
 		if err != nil {
-			if errConnectionRefused(err) {
+			if common.ErrConnectionRefused(err) {
 				return nil
 			}
 			return err
@@ -1086,10 +1086,6 @@ func updateProgressUsingPod(dataVolumeCopy *cdiv1.DataVolume, pod *corev1.Pod) e
 		return nil
 	}
 	return err
-}
-
-func errConnectionRefused(err error) bool {
-	return strings.Contains(err.Error(), "connection refused")
 }
 
 func getPodMetricsPort(pod *corev1.Pod) (int, error) {

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -253,7 +253,15 @@ func (app *uploadServerApp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *uploadServerApp) healthzHandler(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "OK")
+	// Is the upload server alive?
+	uploadURL := fmt.Sprintf("https://localhost:%d/v1beta1/upload", app.bindPort)
+	_, err := http.Get(uploadURL)
+	if common.ErrConnectionRefused(err) {
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, fmt.Sprintf("%s", err))
+	} else {
+		io.WriteString(w, "OK")
+	}
 }
 
 func (app *uploadServerApp) validateShouldHandleRequest(w http.ResponseWriter, r *http.Request) bool {

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Upload server tests", func() {
 		})
 	})
 
-	It("healthz", func() {
+	It("healthz fails without the uploadserver", func() {
 		req, err := http.NewRequest("GET", healthzPath, nil)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -203,7 +203,7 @@ var _ = Describe("Upload server tests", func() {
 		server.Handler.ServeHTTP(rr, req)
 
 		status := rr.Code
-		Expect(status).To(Equal(http.StatusOK))
+		Expect(status).To(Equal(http.StatusInternalServerError))
 
 	})
 


### PR DESCRIPTION
Uploadserver and healthz run in separate goroutine, so we need
to synchronize them. This seems to be the easiest way.

**Special notes for your reviewer**:
Alternative paths considered:
- Unifying them.
  This is troublesome, because the uploadserver requires client certs, and the kubernetes readiness probe doesn't provide them.
- Synchronize using some builtin: somewhat difficult because we either use a blocking function, or a separate goroutine, which means we don't know if it started.
- 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Eliminate a very short window where an upload pod is UploadReady but an upload would fail.
```

