### PR TITLE
VDDK/ImageIO cleanup after importer termination.

### DIFF
--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -34,12 +34,14 @@ var _ = Describe("Imageio reader", func() {
 
 	BeforeEach(func() {
 		newOvirtClientFunc = createMockOvirtClient
+		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
 		ts = createTestServer(imageDir)
 		disk.SetTotalSize(1024)
 		disk.SetId("123")
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
 		it.SetTransferUrl(ts.URL + "/" + cirrosFileName)
+		it.SetId("123")
 		diskCreateError = nil
 		diskAvailable = true
 	})
@@ -77,12 +79,14 @@ var _ = Describe("Imageio data source", func() {
 
 	BeforeEach(func() {
 		newOvirtClientFunc = createMockOvirtClient
+		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
 		ts = createTestServer(imageDir)
 		disk.SetTotalSize(1024)
 		disk.SetId("123")
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
 		it.SetTransferUrl(ts.URL)
+		it.SetId("123")
 		diskAvailable = true
 		diskCreateError = nil
 	})
@@ -220,6 +224,25 @@ var _ = Describe("Imageio pollprogress", func() {
 	})
 })
 
+var _ = Describe("Imageio cancel", func() {
+	It("should cancel transfer on SIGTERM", func() {
+		newOvirtClientFunc = createMockOvirtClient
+		newTerminationChannel = createMockTerminationChannel
+		tempDir := createCert()
+		ts := createTestServer(imageDir)
+		disk.SetTotalSize(1024)
+		disk.SetId("123")
+		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
+		it.SetTransferUrl(ts.URL)
+		it.SetId("123")
+
+		_, err := NewImageioDataSource(ts.URL, "", "", tempDir, "")
+		Expect(err).ToNot(HaveOccurred())
+		mockTerminationChannel <- os.Interrupt
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
 // MockOvirtClient is a mock minio client
 type MockOvirtClient struct {
 	ep     string
@@ -232,12 +255,20 @@ type MockAddService struct {
 	client *MockOvirtClient
 }
 
+type MockCancelService struct {
+	client *MockOvirtClient
+}
+
 type MockFinalizeService struct {
 	client *MockOvirtClient
 }
 
 type MockImageTransfersServiceAddResponse struct {
 	srv *ovirtsdk4.ImageTransfersServiceAddResponse
+}
+
+type MockImageTransferServiceCancelResponse struct {
+	srv *ovirtsdk4.ImageTransferServiceCancelResponse
 }
 
 type MockImageTransferServiceFinalizeResponse struct {
@@ -272,6 +303,12 @@ func (conn *MockOvirtClient) ImageTransferService(string) ImageTransferServiceIn
 	return conn
 }
 
+func (conn *MockOvirtClient) Cancel() ImageTransferServiceCancelRequestInterface {
+	return &MockCancelService{
+		client: conn,
+	}
+}
+
 func (conn *MockOvirtClient) Finalize() ImageTransferServiceFinalizeRequestInterface {
 	return &MockFinalizeService{
 		client: conn,
@@ -289,6 +326,10 @@ func (conn *MockAddService) ImageTransfer(imageTransfer *ovirtsdk4.ImageTransfer
 
 func (conn *MockAddService) Send() (ImageTransfersServiceAddResponseInterface, error) {
 	return &MockImageTransfersServiceAddResponse{srv: nil}, nil
+}
+
+func (conn *MockCancelService) Send() (ImageTransferServiceCancelResponseInterface, error) {
+	return &MockImageTransferServiceCancelResponse{srv: nil}, nil
 }
 
 func (conn *MockFinalizeService) Send() (ImageTransferServiceFinalizeResponseInterface, error) {

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -235,6 +235,8 @@ var _ = Describe("Imageio cancel", func() {
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
 		it.SetTransferUrl(ts.URL)
 		it.SetId("123")
+		diskAvailable = true
+		diskCreateError = nil
 
 		_, err := NewImageioDataSource(ts.URL, "", "", tempDir, "")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -4,7 +4,9 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -43,3 +45,13 @@ func CleanDir(dest string) error {
 	}
 	return nil
 }
+
+// GetTerminationChannel returns a channel that listens for SIGTERM
+func GetTerminationChannel() <-chan os.Signal {
+	terminationChannel := make(chan os.Signal, 1)
+	signal.Notify(terminationChannel, os.Interrupt, syscall.SIGTERM)
+	return terminationChannel
+}
+
+// newTerminationChannel should be overriden for unit tests
+var newTerminationChannel = GetTerminationChannel

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -120,3 +120,11 @@ var _ = Describe("Clean dir", func() {
 		Expect(0).To(Equal(len(dir)))
 	})
 })
+
+// For use in transfer cancellation unit tests, currently VDDK/ImageIO
+var mockTerminationChannel chan os.Signal
+
+func createMockTerminationChannel() <-chan os.Signal {
+	mockTerminationChannel = make(chan os.Signal, 1)
+	return mockTerminationChannel
+}

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -291,12 +291,14 @@ func createVMwareClient(endpoint string, accessKey string, secKey string, thumbp
 	conn, err := govmomi.NewClient(ctx, vmwURL, true)
 	if err != nil {
 		klog.Errorf("Unable to connect to vCenter: %v", err)
+		cancel()
 		return nil, err
 	}
 
 	moref, vm, err := FindVM(ctx, conn, uuid)
 	if err != nil {
 		klog.Errorf("Unable to find MORef for VM with UUID %s!", uuid)
+		cancel()
 		return nil, err
 	}
 
@@ -857,6 +859,14 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 		Size:             size,
 		VolumeMode:       volumeMode,
 	}
+
+	terminationChannel := newTerminationChannel()
+	go func() {
+		<-terminationChannel
+		klog.Infof("Caught termination signal, closing nbdkit.")
+		source.Close()
+	}()
+
 	return source, nil
 }
 
@@ -869,7 +879,10 @@ func (vs *VDDKDataSource) Info() (ProcessingPhase, error) {
 // Close closes any readers or other open resources.
 func (vs *VDDKDataSource) Close() error {
 	vs.NbdKit.Handle.Close()
-	return vs.NbdKit.Command.Process.Kill()
+	if vs.NbdKit.Command.Process != nil {
+		return vs.NbdKit.Command.Process.Signal(os.Interrupt)
+	}
+	return nil
 }
 
 // GetURL returns the url that the data processor can use when converting the data.

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"net/url"
+	"os"
 	"os/exec"
 
 	libnbd "github.com/mrnold/go-libnbd"
@@ -46,6 +47,7 @@ var _ = Describe("VDDK data source", func() {
 		newVddkDataSink = createMockVddkDataSink
 		newVMwareClient = createMockVMwareClient
 		newNbdKitWrapper = createMockNbdKitWrapper
+		newTerminationChannel = createMockTerminationChannel
 		currentExport = defaultMockNbdExport()
 		currentVMwareFunctions = defaultMockVMwareFunctions()
 	})
@@ -319,6 +321,25 @@ var _ = Describe("VDDK data source", func() {
 		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "false", v1.PersistentVolumeFilesystem)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("disk 'testdisk.vmdk' is not present in VM hardware config or snapshot list"))
+	})
+
+	It("should cancel transfer on SIGTERM", func() {
+		newVddkDataSource = createVddkDataSource
+		diskName := "testdisk.vmdk"
+
+		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
+			switch out := result.(type) {
+			case *mo.VirtualMachine:
+				if property[0] == "config.hardware.device" {
+					out.Config = createVirtualDiskConfig(diskName, 12345)
+				}
+			}
+			return nil
+		}
+		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "snapshot-1", "snapshot-2", "false", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+		mockTerminationChannel <- os.Interrupt
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For ImageIO and VDDK data sources, this pull request allows the importer pod to catch SIGTERM and cleanly close any connections to RHEV or VMware. This is more important for ImageIO because RHEV can leave the disk locked, preventing another import attempt until a timeout (potentially several hours).

**Which issue(s) this PR fixes**:
Fixes #1633 
RHBZ[#1924560](https://bugzilla.redhat.com/show_bug.cgi?id=1924560)

**Release note**:
```release-note
Unlock ImageIO disks when importer pod is terminated.
```

