### PR TITLE
Allow passing default annotation value to transfer pods

### DIFF
--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -223,6 +223,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		Expect(sourcePod.GetLabels()[CloneUniqueID]).To(Equal("default-testPvc1-source-pod"))
 		By("Verifying source pod annotations passed from pvc")
 		Expect(sourcePod.GetAnnotations()[AnnPodNetwork]).To(Equal("net1"))
+		Expect(sourcePod.GetAnnotations()[AnnPodSidecarInjection]).To(Equal(AnnPodSidecarInjectionDefault))
 		Expect(sourcePod.Spec.Affinity).ToNot(BeNil())
 		Expect(sourcePod.Spec.Affinity.PodAffinity).ToNot(BeNil())
 		l := len(sourcePod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -310,8 +310,9 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		Expect(foundEndPoint).To(BeTrue())
 		By("Verifying the fsGroup of the pod is the qemu user")
 		Expect(*pod.Spec.SecurityContext.FSGroup).To(Equal(int64(107)))
-		By("Verifying the pod is annotated with network")
+		By("Verifying the pod is annotated correctly")
 		Expect(pod.GetAnnotations()[AnnPodNetwork]).To(Equal("net1"))
+		Expect(pod.GetAnnotations()[AnnPodSidecarInjection]).To(Equal(AnnPodSidecarInjectionDefault))
 	})
 
 	It("Should not pass non-approved PVC annotation to created POD", func() {

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -324,6 +324,7 @@ var _ = Describe("reconcilePVC loop", func() {
 			Expect(uploadPod.Name).To(Equal(uploadResourceName))
 			Expect(uploadPod.Labels[common.UploadTargetLabel]).To(Equal(string(testPvc.UID)))
 			Expect(uploadPod.GetAnnotations()[AnnPodNetwork]).To(Equal("net1"))
+			Expect(uploadPod.GetAnnotations()[AnnPodSidecarInjection]).To(Equal(AnnPodSidecarInjectionDefault))
 
 			uploadService = &corev1.Service{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: naming.GetServiceNameFromResourceName(uploadResourceName), Namespace: "default"}, uploadService)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1003,6 +1003,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		verifyAnnotations := func(pod *v1.Pod) {
 			By("verifying passed annotation")
 			Expect(pod.Annotations[controller.AnnPodNetwork]).To(Equal("net1"))
+			Expect(pod.Annotations[controller.AnnPodSidecarInjection]).To(Equal(controller.AnnPodSidecarInjectionDefault))
 			By("verifying non-passed annotation")
 			Expect(pod.Annotations["annot1"]).ToNot(Equal("value1"))
 		}


### PR DESCRIPTION
when the annotation is not set explicitly in the DV/PVC

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Disable Istio sidecar injection to transfer pods by default, as the pods currently don't support it and may crash during transfer. 
Default can be overridden using `sidecar.istio.io/inject` annotation in the DV/PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1914833

**Special notes for your reviewer**:

**Release note**:
```release-note
Disable Istio sidecar injection to transfer pods by default.
Default can be overridden using `sidecar.istio.io/inject` annotation in the DV/PVC.
```

