### PR TITLE
Setup a default KUBEVIRT_PROVIDER for make functional-test

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -14,7 +14,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-set -euo pipefail
+set -eo pipefail
 
 readonly MAX_CDI_WAIT_RETRY=30
 readonly CDI_WAIT_TIME=10
@@ -22,6 +22,7 @@ readonly CDI_WAIT_TIME=10
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source hack/build/config.sh
 source hack/build/common.sh
+source cluster-up/hack/common.sh
 
 KUBEVIRTCI_CONFIG_PATH="$(
     cd "$(dirname "$BASH_SOURCE[0]")/../../"


### PR DESCRIPTION
This requires removing set -u because kubevirtci's scripts
use [ -z $KUBEVIRTCI_PATH ] to test for it being defined
and set -u makes this fail.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

