### PR TITLE
Adding support for gosec scan on CDI repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ bazel-cdi-generate:
 bazel-build:
 	${DO_BAZ} "./hack/build/bazel-build.sh"
 
+gosec:
+	${DO_BAZ} "GOSEC=${GOSEC} ./hack/build/gosec.sh"
+
 bazel-build-images:	bazel-cdi-generate bazel-build
 	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build/bazel-build-images.sh"
 

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -28,7 +28,7 @@ FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 FUNC_TEST_PROXY="cdi-func-test-proxy"
 # update this whenever builder Dockerfile is updated
 BUILDER_TAG=${BUILDER_TAG:-0.0.11}
-BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:13de53f8b31aed4b1b66ac9533ab27d29e0dde8d70eba28908673085d9b0fe39
+BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:145765dd23572a0bc085f351848f937e2df630f6570794b10041400b47bc0552
 }
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER} tools/${FUNC_TEST_PROXY}"

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -28,7 +28,7 @@ FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 FUNC_TEST_PROXY="cdi-func-test-proxy"
 # update this whenever builder Dockerfile is updated
 BUILDER_TAG=${BUILDER_TAG:-0.0.11}
-BUILDER_IMAGE=${BUILDER_IMAGE:-kubevirt/kubevirt-cdi-bazel-builder@sha256:145765dd23572a0bc085f351848f937e2df630f6570794b10041400b47bc0552
+BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder@sha256:145765dd23572a0bc085f351848f937e2df630f6570794b10041400b47bc0552
 }
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER} tools/${FUNC_TEST_PROXY}"

--- a/hack/build/gosec.sh
+++ b/hack/build/gosec.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+source hack/build/common.sh
+source hack/build/config.sh
+
+export GOSECOUT=${OUT_DIR}/gosec
+
+mkdir -p $GOSECOUT
+
+cd $CDI_DIR/pkg
+echo "Running gosec.."
+gosec -sort -no-fail -quiet -out=${GOSECOUT}/junit-gosec.xml -fmt=junit-xml ./...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adding [gosec](https://github.com/securego/gosec) to the repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/containerized-data-importer/issues/1615

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support to run gosec security scanner
```

