### PR TITLE
Get rid of contentType in cloner and uploadserver

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -29,17 +29,17 @@ fi
 echo "VOLUME_MODE=$VOLUME_MODE"
 echo "MOUNT_POINT=$MOUNT_POINT"
 
-if [ "$VOLUME_MODE" == "block" ]; then
+if [ "$VOLUME_MODE" == "Block" ]; then
     UPLOAD_BYTES=$(blockdev --getsize64 $MOUNT_POINT)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type blockdevice-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
+    /usr/bin/cdi-cloner -v=3 -alsologtostderr -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 else
     pushd $MOUNT_POINT
     UPLOAD_BYTES=$(du -sb . | cut -f1)
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type filesystem-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
+    /usr/bin/cdi-cloner -v=3 -alsologtostderr -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 
     popd
 fi

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -178,12 +178,6 @@ const (
 	// UploadContentTypeHeader is the header upload clients may use to set the content type explicitly
 	UploadContentTypeHeader = "x-cdi-content-type"
 
-	// FilesystemCloneContentType is the content type when cloning a filesystem
-	FilesystemCloneContentType = "filesystem-clone"
-
-	// BlockdeviceClone is the content type when cloning a block device
-	BlockdeviceClone = "blockdevice-clone"
-
 	// UploadPathSync is the path to POST CDI uploads
 	UploadPathSync = "/v1beta1/upload"
 

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -584,6 +584,10 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 							Name:  common.OwnerUID,
 							Value: ownerID,
 						},
+						{
+							Name:  "VOLUME_MODE",
+							Value: string(sourceVolumeMode),
+						},
 					},
 					Ports: []corev1.ContainerPort{
 						{
@@ -650,10 +654,6 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 		pod.Spec.Containers[0].VolumeDevices = addVolumeDevices()
 		addVars = []corev1.EnvVar{
 			{
-				Name:  "VOLUME_MODE",
-				Value: "block",
-			},
-			{
 				Name:  "MOUNT_POINT",
 				Value: common.WriteBlockPath,
 			},
@@ -666,10 +666,6 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 			},
 		}
 		addVars = []corev1.EnvVar{
-			{
-				Name:  "VOLUME_MODE",
-				Value: "filesystem",
-			},
 			{
 				Name:  "MOUNT_POINT",
 				Value: common.ClonerMountPath,

--- a/pkg/uploadserver/BUILD.bazel
+++ b/pkg/uploadserver/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/image:go_default_library",
         "//pkg/importer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -88,11 +88,11 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 	return client
 }
 
-func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (bool, error) {
+func saveProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool) (bool, error) {
 	return false, nil
 }
 
-func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (bool, error) {
+func saveProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool) (bool, error) {
 	return false, fmt.Errorf("Error using datastream")
 }
 
@@ -104,7 +104,7 @@ func withProcessorFailure(f func()) {
 	replaceProcessorFunc(saveProcessorFailure, f)
 }
 
-func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool, string) (bool, error), f func()) {
+func replaceProcessorFunc(replacement func(io.ReadCloser, string, string, float64, bool) (bool, error), f func()) {
 	origProcessorFunc := uploadProcessorFunc
 	uploadProcessorFunc = replacement
 	defer func() {
@@ -151,11 +151,11 @@ func (amd *AsyncMockDataSource) GetResumePhase() importer.ProcessingPhase {
 	return importer.ProcessingPhaseComplete
 }
 
-func saveAsyncProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
+func saveAsyncProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool) (*importer.DataProcessor, error) {
 	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false), nil
 }
 
-func saveAsyncProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
+func saveAsyncProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool) (*importer.DataProcessor, error) {
 	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false), fmt.Errorf("Error using datastream")
 }
 
@@ -388,8 +388,6 @@ func newFormRequest(path string) *http.Request {
 
 	req, err := http.NewRequest("POST", path, &b)
 	Expect(err).ToNot(HaveOccurred())
-
-	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	return req
 }


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
We removed contentType as a follow-up of PR #1597 to make our code a bit cleaner.
No need to pass it in the header, as uploadserver can learn it from the stream itself.
No need to pass it to the cloner as arg, as it can use volume mode from the env instead.  
Thanks for the tip @awels!

**Release note**:
```release-note
NONE
```

