### PR TITLE
[release-v1.28] VDDK/ImageIO cleanup after importer termination.

### DIFF
--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -4,7 +4,9 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -43,3 +45,13 @@ func CleanDir(dest string) error {
 	}
 	return nil
 }
+
+// GetTerminationChannel returns a channel that listens for SIGTERM
+func GetTerminationChannel() <-chan os.Signal {
+	terminationChannel := make(chan os.Signal, 1)
+	signal.Notify(terminationChannel, os.Interrupt, syscall.SIGTERM)
+	return terminationChannel
+}
+
+// newTerminationChannel should be overriden for unit tests
+var newTerminationChannel = GetTerminationChannel

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -120,3 +120,11 @@ var _ = Describe("Clean dir", func() {
 		Expect(0).To(Equal(len(dir)))
 	})
 })
+
+// For use in transfer cancellation unit tests, currently VDDK/ImageIO
+var mockTerminationChannel chan os.Signal
+
+func createMockTerminationChannel() <-chan os.Signal {
+	mockTerminationChannel = make(chan os.Signal, 1)
+	return mockTerminationChannel
+}


### PR DESCRIPTION
This is a cherry pick of #1670.

**What this PR does / why we need it**:
For ImageIO and VDDK data sources, this pull request allows the importer pod to catch SIGTERM and cleanly close any connections to RHEV or VMware. This is more important for ImageIO because RHEV can leave the disk locked, preventing another import attempt until a timeout (potentially several hours).

**Which issue(s) this PR fixes**
Fixes #1633
RHBZ#1924560

**Release note**:

```release-note
Unlock ImageIO disks when importer pod is terminated.
```

