### PR TITLE
Update release description template (Docker Hub -> Quay.io)

### DIFF
--- a/hack/build/release-description.sh
+++ b/hack/build/release-description.sh
@@ -34,7 +34,7 @@ downloads() {
 The source code and selected binaries are available for download at:
 <$RELURL>.
 
-Pre-built CDI containers are published on Docker Hub and can be viewed at:
+Pre-built CDI containers are published on Quay.io and can be viewed at:
 <https://quay.io/repository/kubevirt/cdi-controller/>
 <https://quay.io/repository/kubevirt/cdi-importer/>
 <https://quay.io/repository/kubevirt/cdi-cloner/>


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We've changed links to CDI containers to Quay, but the description still mentions DOcker Hub.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

