### PR TITLE
Documentation update - describe cdi.kubevirt.io/storage.bind.immediat…

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -9,6 +9,8 @@ Why is this an improvement over simply looking at the state annotation created a
 The following statuses are possible.
 * 'Blank': No status available.
 * Pending: The operation is pending, but has not been scheduled yet.
+* WaitForFirstConsumer: The PVC associated with the operation is Pending, and the storage has
+  a WaitForFirstConsumer binding mode. PVC [waits for a consumer](waitforfirstconsumer-storage-handling.md) Pod.
 * PVCBound: The PVC associated with the operation has been bound.
 * Import/Clone/UploadScheduled: The operation (import/clone/upload) has been scheduled.
 * Import/Clone/UploadInProgress: The operation (import/clone/upload) is in progress.

--- a/doc/waitforfirstconsumer-storage-handling.md
+++ b/doc/waitforfirstconsumer-storage-handling.md
@@ -25,7 +25,12 @@ to detect a DV phase and handle the initial scheduling which causes the PVC to c
 
 **NOTE:** The workload should not attempt to use the contents of the DV until CDI has finished the transfer. 
 
-## Config
+## Force immidiate binding
+
+Add the annotation: `cdi.kubevirt.io/storage.bind.immediate.requested` to DataVolume to force scheduling of a CDI worker pod
+and immediately bind the PVC. This is useful for use cases that do not require binding to a particular node (like uploading a golden image to the cluster).      
+
+## Configuration - Opt in
 
 To be fully compatible with any external tools that may already use CDI, this new feature has to be enabled by 
 the feature gate: `HonorWaitForFirstConsumer`. It is available in the `CDIConfig` custom resource (see [cdi-config doc](cdi-config.md)).


### PR DESCRIPTION


Describes new annotation for skipping WaitForFirstConsumer handling, and adds WaitForFirstConsumer phase to DV docs.

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Documentation update - describe cdi.kubevirt.io/storage.bind.immediate.requested annotation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

