### PR TITLE
Separate nbdkit plugin arguments.

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -188,8 +188,20 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 		argsNbdkit = append(argsNbdkit, a)
 	}
 	// append nbdkit plugin arguments
-	argsNbdkit = append(argsNbdkit, string(n.plugin), strings.Join(n.pluginArgs, " "), n.getSourceArg(source))
-	klog.V(3).Infof("Start nbdkit with: %v", argsNbdkit)
+	argsNbdkit = append(argsNbdkit, string(n.plugin))
+	argsNbdkit = append(argsNbdkit, n.pluginArgs...)
+	argsNbdkit = append(argsNbdkit, n.getSourceArg(source))
+
+	quotedArgs := make([]string, len(argsNbdkit))
+	for index, value := range argsNbdkit {
+		if strings.HasPrefix(value, "password=") {
+			quotedArgs[index] = "'password=*****'"
+		} else {
+			quotedArgs[index] = "'" + value + "'"
+		}
+	}
+	klog.V(3).Infof("Start nbdkit with: %v", quotedArgs)
+
 	n.c = exec.Command("nbdkit", argsNbdkit...)
 	var stdout io.ReadCloser
 	stdout, err = n.c.StdoutPipe()

--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -20,16 +20,25 @@
 
 #define THREAD_MODEL NBDKIT_THREAD_MODEL_SERIALIZE_ALL_REQUESTS
 
+#define EXPECTED_ARG_COUNT 7
+int arg_count = 0;
+
 void fakevddk_close(void *handle) {
     close(*((int *) handle));
 }
 
 int fakevddk_config(const char *key, const char *value) {
+    arg_count++;
     return 0;
 }
 
 int fakevddk_config_complete(void) {
-    return 0;
+    if (arg_count == EXPECTED_ARG_COUNT) {
+        return 0;
+    } else {
+        nbdkit_error("Expected %d arguments to fake VDDK test plugin, but got %d!\n", EXPECTED_ARG_COUNT, arg_count);
+        return -1;
+    }
 }
 
 void *fakevddk_open(int readonly) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request splits nbdkit plugin parameters into separate command line arguments instead of concatenating them into one string, so VDDK imports will work again.

**Which issue(s) this PR fixes**:
Fixes #1700 

**Special notes for your reviewer**:
This also adds a quick parameter count check so that functional tests will fail if the same problem happens again, and formats the relevant log message so it's easier to see which parameters are stuck together.

**Release note**:
```release-note
NONE
```

