### PR TITLE
update to kubevirtci with builtin rook/ceph

### DIFF
--- a/cluster-sync/external/resources/machineconfig-worker.yaml
+++ b/cluster-sync/external/resources/machineconfig-worker.yaml
@@ -1,0 +1,26 @@
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-set-selinux-for-hostpath-provisioner-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Set SELinux chcon for hostpath provisioner
+            Before=kubelet.service
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStartPre=-mkdir -p /var/hpvolumes
+            ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: hostpath-provisioner.service

--- a/cluster-sync/k8s-1.17/provider.sh
+++ b/cluster-sync/k8s-1.17/provider.sh
@@ -13,7 +13,10 @@ fi
 function configure_storage() {
   #Make sure local is not default
   _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-  if [[ $KUBEVIRT_STORAGE == "ceph" ]] ; then
+  if [[ $KUBEVIRT_STORAGE == "rook-ceph-default" ]] ; then
+    echo "Using builtin rook/ceph provisioner"
+  # ceph will be deprecated once changes to test lanes merged
+  elif [[ $KUBEVIRT_STORAGE == "ceph" ]] ; then
     echo "Installing ceph storage"
     configure_ceph
   elif [[ $KUBEVIRT_STORAGE == "hpp" ]] ; then

--- a/cluster-sync/k8s-1.18/provider.sh
+++ b/cluster-sync/k8s-1.18/provider.sh
@@ -13,7 +13,10 @@ fi
 function configure_storage() {
   #Make sure local is not default
   _kubectl patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-  if [[ $KUBEVIRT_STORAGE == "ceph" ]] ; then
+  if [[ $KUBEVIRT_STORAGE == "rook-ceph-default" ]] ; then
+    echo "Using builtin rook/ceph provisioner"
+  # ceph will be deprecated once changes to test lanes merged
+  elif [[ $KUBEVIRT_STORAGE == "ceph" ]] ; then
     echo "Installing ceph storage"
     configure_ceph
   elif [[ $KUBEVIRT_STORAGE == "hpp" ]] ; then

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -68,6 +68,14 @@ function _add_common_params() {
           params=" --etcd-capacity $KUBEVIRT_WITH_ETC_CAPACITY $params"
         fi
     fi
+    if [ $KUBEVIRT_DEPLOY_ISTIO == "true" ]; then
+       params=" --enable-istio $params"
+    fi
+
+    # alternate (new) way to specify storage providers
+    if [[ $KUBEVIRT_STORAGE == "rook-ceph-default" ]] && [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-ceph"* ]]; then
+        params=" --enable-ceph $params"
+    fi
 
     echo $params
 }

--- a/cluster-up/cluster/k8s-1.17/dev-guide.md
+++ b/cluster-up/cluster/k8s-1.17/dev-guide.md
@@ -106,7 +106,7 @@ root         1     0 36 13:39 ?        00:05:22 qemu-system-x86_64 -enable-kvm -
                 * Apply additional manifests, such as flannel.
                 * Wait for pods to become ready.
                 * Pull needed images such as Ceph CSI, fluentd logger.
-                * Create local volume directiories.
+                * Create local volume directories.
             * Shutdown the vm and commit its container.
 
 # Flow of K8s cluster-up (1.17 for example)
@@ -146,4 +146,3 @@ kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f "$custom_manifest"
     * The new manifest.
     * Updated cluster-provision/k8s/scripts/provision.sh
     * Updated cluster-up/cluster/images.sh.
-

--- a/cluster-up/cluster/k8s-1.18/dev-guide.md
+++ b/cluster-up/cluster/k8s-1.18/dev-guide.md
@@ -106,7 +106,7 @@ root         1     0 36 13:39 ?        00:05:22 qemu-system-x86_64 -enable-kvm -
                 * Apply additional manifests, such as flannel.
                 * Wait for pods to become ready.
                 * Pull needed images such as Ceph CSI, fluentd logger.
-                * Create local volume directiories.
+                * Create local volume directories.
             * Shutdown the vm and commit its container.
 
 # Flow of K8s cluster-up (1.18 for example)
@@ -146,4 +146,3 @@ kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f "$custom_manifest"
     * The new manifest.
     * Updated cluster-provision/k8s/scripts/provision.sh
     * Updated cluster-up/cluster/images.sh.
-

--- a/cluster-up/cluster/k8s-1.19/dev-guide.md
+++ b/cluster-up/cluster/k8s-1.19/dev-guide.md
@@ -106,7 +106,7 @@ root         1     0 36 13:39 ?        00:05:22 qemu-system-x86_64 -enable-kvm -
                 * Apply additional manifests, such as flannel.
                 * Wait for pods to become ready.
                 * Pull needed images such as Ceph CSI, fluentd logger.
-                * Create local volume directiories.
+                * Create local volume directories.
             * Shutdown the vm and commit its container.
 
 # Flow of K8s cluster-up (1.19 for example)
@@ -146,4 +146,3 @@ kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f "$custom_manifest"
     * The new manifest.
     * Updated cluster-provision/k8s/scripts/provision.sh
     * Updated cluster-up/cluster/images.sh.
-

--- a/cluster-up/cluster/k8s-1.20/dev-guide.md
+++ b/cluster-up/cluster/k8s-1.20/dev-guide.md
@@ -106,7 +106,7 @@ root         1     0 36 13:39 ?        00:05:22 qemu-system-x86_64 -enable-kvm -
                 * Apply additional manifests, such as flannel.
                 * Wait for pods to become ready.
                 * Pull needed images such as Ceph CSI, fluentd logger.
-                * Create local volume directiories.
+                * Create local volume directories.
             * Shutdown the vm and commit its container.
 
 # Flow of K8s cluster-up (1.20 for example)
@@ -146,4 +146,3 @@ kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f "$custom_manifest"
     * The new manifest.
     * Updated cluster-provision/k8s/scripts/provision.sh
     * Updated cluster-up/cluster/images.sh.
-

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
@@ -30,3 +30,15 @@ make cluster-down
 
 This destroys the whole cluster. 
 
+## Setting a custom kind version
+
+In order to use a custom kind image / kind version,
+export KIND_NODE_IMAGE, KIND_VERSION, KUBECTL_PATH before running cluster-up.
+For example in order to use kind 0.9.0 (which is based on k8s-1.19.1) use:
+```bash
+export KIND_NODE_IMAGE="kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
+export KIND_VERSION="0.9.0"
+export KUBECTL_PATH="/usr/bin/kubectl"
+```
+This allows users to test or use custom images / different kind versions before making them official.
+See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -3,9 +3,12 @@
 set -e
 
 export CLUSTER_NAME="sriov"
-export KIND_NODE_IMAGE="kindest/node:v1.17.0"
 
-source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
+function set_kind_params() {
+    export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"
+    export KIND_VERSION="${KIND_VERSION:-0.7.0}"
+    export KUBECTL_PATH="${KUBECTL_PATH:-/kind/bin/kubectl}"
+}
 
 function up() {
     if [[ "$KUBEVIRT_NUM_NODES" -ne 2 ]]; then
@@ -22,5 +25,12 @@ function up() {
 
     kind_up
 
+    # remove the rancher.io kind default storageClass
+    _kubectl delete sc standard
+
     ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/config_sriov.sh
 }
+
+set_kind_params
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -21,6 +21,7 @@ KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.18}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
 KUBEVIRT_NUM_SECONDARY_NICS=${KUBEVIRT_NUM_SECONDARY_NICS:-0}
+KUBEVIRT_DEPLOY_ISTIO=${KUBEVIRT_DEPLOY_ISTIO:-false}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized
@@ -34,4 +35,4 @@ provider_prefix=${JOB_NAME:-${KUBEVIRT_PROVIDER}}${EXECUTOR_NUMBER}
 job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}
 
 mkdir -p $KUBEVIRTCI_CONFIG_PATH/$KUBEVIRT_PROVIDER
-KUBEVIRTCI_TAG=2101140843-0224916
+KUBEVIRTCI_TAG=2103171059-c4b957e

--- a/hack/update-kubevirtci.sh
+++ b/hack/update-kubevirtci.sh
@@ -17,7 +17,7 @@
 SCRIPT_ROOT="$(cd "$(dirname $0)/../" && pwd -P)"
 
 # the kubevirtci commit hash to vendor from
-kubevirtci_git_hash=a2a78b78256486317adda21bbd34998e548b8c5a
+kubevirtci_git_hash=c4b957e4867a21c895edf6b22e1928fcb8310c4c
 
 # remove previous cluster-up dir entirely before vendoring
 rm -rf ${SCRIPT_ROOT}/cluster-up


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is the first part of updating to newer rook ceph.  Tests will still use old ceph until project-infra is updated.  Once project-infra is updated we can remove the ceph manifests here

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

