### PR TITLE
Replace dockerhub references with quay.io

### DIFF
--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -56,7 +56,7 @@ spec:
           initialDelaySeconds: 20
           periodSeconds: 20
       - name: s3
-        image: minio/minio:RELEASE.2018-08-02T23-11-36Z
+        image: quay.io/kubevirt/minio:RELEASE.2018-08-02T23-11-36Z
         imagePullPolicy: {{ .PullPolicy }}
         env:
         - name: MINIO_ACCESS_KEY

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -40,7 +40,7 @@ spec:
         args: ["-c", "openssl ca x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/cert.pem; cp /tmp/certs/tls.key /ovirt-imageio/daemon/test/pki/key.pem; cd ovirt-imageio/daemon; ./ovirt-imageio -c test/conf& sleep 3; curl --unix-socket /ovirt-imageio/daemon/test/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
-        image: machacekondra/fakeovirt:v3
+        image: quay.io/kubevirt/fakeovirt:v1.31.0
         imagePullPolicy: {{ .PullPolicy }}
         ports:
         - containerPort: 12346


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Found a few more locations that were using dockerhub which is now not usable for CI. This replaces it will the same images from quay.io.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

