### PR TITLE
Add scripts to do releases with PROW

### DIFF
--- a/automation/git-askpass.sh
+++ b/automation/git-askpass.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat "$GITHUB_TOKEN_PATH"

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+function cleanup_gh_install() {
+    [ -n "${gh_cli_dir}" ] && [ -d "${gh_cli_dir}" ] && rm -rf "${gh_cli_dir:?}/"
+}
+
+function ensure_gh_cli_installed() {
+    if command -V gh; then
+        return
+    fi
+
+    trap 'cleanup_gh_install' EXIT SIGINT SIGTERM
+
+    # install gh cli for uploading release artifacts, with prompt disabled to enforce non-interactive mode
+    gh_cli_dir=$(mktemp -d)
+    (
+        cd  "$gh_cli_dir/"
+        curl -sSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" -o "gh_${GH_CLI_VERSION}_linux_amd64.tar.gz"
+        tar xvf "gh_${GH_CLI_VERSION}_linux_amd64.tar.gz"
+    )
+    export PATH="$gh_cli_dir/gh_${GH_CLI_VERSION}_linux_amd64/bin:$PATH"
+    if ! command -V gh; then
+        echo "gh cli not installed successfully"
+        exit 1
+    fi
+    gh config set prompt disabled
+}
+
+function build_release_artifacts() {
+    make apidocs
+    make manifests
+    make build-functest
+}
+
+function update_github_release() {
+    # note: for testing purposes we set the target repository, gh cli seems to always automatically choose the
+    # upstream repository automatically, even when you are in a fork
+
+    set +e
+    if ! gh release view --repo "$GITHUB_REPOSITORY" "$DOCKER_TAG" ; then
+        set -e
+        gh release create --repo "$GITHUB_REPOSITORY" "$DOCKER_TAG" --prerelease --title="$DOCKER_TAG"
+    else
+        set -e
+    fi
+
+    gh release upload --repo "$GITHUB_REPOSITORY" --clobber "$DOCKER_TAG" \
+        _out/manifests/release/*.yaml \
+        _out/tests/tests.test
+}
+
+function main() {
+    DOCKER_TAG="$(git tag --points-at HEAD | head -1)"
+    if [ -z "$DOCKER_TAG" ]; then
+        echo "commit $(git show -s --format=%h) doesn't have a tag, exiting..."
+        exit 0
+    fi
+
+    export DOCKER_TAG
+
+    GIT_ASKPASS="$(pwd)/automation/git-askpass.sh"
+    [ -f "$GIT_ASKPASS" ] || exit 1
+    export GIT_ASKPASS
+
+    ensure_gh_cli_installed
+
+    gh auth login --with-token <"$GITHUB_TOKEN_PATH"
+
+    build_release_artifacts
+    update_github_release
+
+    bash hack/gen-swagger-doc/deploy.sh
+}
+
+main "$@"
+

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-set -e
+set -exo pipefail
 
 GITHUB_FQDN=github.com
-API_REF_REPO=kubevirt/cdi-api-reference
+API_REF_REPO=${API_REF_REPO:-kubevirt/cdi-api-reference}
 API_REF_DIR=/tmp/cdi-api-reference
 GITHUB_IO_FQDN="https://kubevirt.io/cdi-api-reference"
 
-TARGET_DIR="$TRAVIS_BRANCH"
-if [ -n "${TRAVIS_TAG}" ]; then
-    TARGET_DIR="$TRAVIS_TAG"
+TARGET_DIR="$PULL_BASE_REF"
+if [ -n "${DOCKER_TAG}" ]; then
+    TARGET_DIR="$DOCKER_TAG"
 fi
 
 rm -rf "${API_REF_DIR}"
 git clone \
-    "https://${API_REFERENCE_PUSH_TOKEN}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
+    "https://${GIT_USER_NAME}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
     "${API_REF_DIR}" >/dev/null 2>&1
 mkdir -p ${API_REF_DIR}/${TARGET_DIR}
 cp -f _out/apidocs/html/*.html "${API_REF_DIR}/${TARGET_DIR}/"
@@ -35,13 +35,13 @@ __EOF__
 find * -type d -regex "^v[0-9.]*" \
     -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" \; >>README.md
 
-git config --global user.email "travis@travis-ci.org"
-git config --global user.name "Travis CI"
+git config --global user.email "${GIT_AUTHOR_NAME:-kubevirt-bot}"
+git config --global user.name "${GIT_AUTHOR_EMAIL:-rmohr+kubebot@redhat.com}"
 
-# NOTE: exclude index.html from match, becasue it is static except commit hash.
+# NOTE: exclude index.html from match, because it is static except commit hash.
 if git status --porcelain | grep -v "index[.]html" | grep --quiet "^ [AM]"; then
     git add -A README.md "${TARGET_DIR}"/*.html
-    git commit --message "API Reference update by Travis Build ${TRAVIS_BUILD_NUMBER}"
+    git commit --message "API Reference update by KubeVirt Prow build ${BUILD_ID}"
 
     git push origin master >/dev/null 2>&1
     echo "API Reference updated for ${TARGET_DIR}."


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR includes the necessary scripts that will allow prow jobs to make releases based on tags pushed to the repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Releases are now done using PROW instead of travis.
```

