### PR TITLE
Increasing timeout for controller plane

### DIFF
--- a/hack/build/run-unit-tests.sh
+++ b/hack/build/run-unit-tests.sh
@@ -22,6 +22,7 @@ source hack/build/common.sh
 # parsetTestOpts sets 'pkgs' and test_args
 parseTestOpts "${@}"
 export GO111MODULE=off
+export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=120s
 test_command="env OPERATOR_DIR=${CDI_DIR} go test -v -coverprofile=.coverprofile -test.timeout 180m ${pkgs} ${test_args:+-args $test_args}"
 echo "${test_command}"
 ${test_command}


### PR DESCRIPTION
Unit tests sometimes fail because of a timout related to controller
plane.
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

