### PR TITLE
[release-v1.28] Try different modes of preallocation (#1663)

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -78,7 +79,13 @@ var (
 		},
 		[]string{"ownerUID"},
 	)
-	ownerUID string
+	ownerUID             string
+	preallocationMethods = [][]string{
+		{"-o", "preallocation=falloc"},
+		{"-o", "preallocation=full"},
+		{"-S", "0"},
+	}
+	maxPreallocationMethods = len(preallocationMethods)
 )
 
 func init() {
@@ -101,11 +108,14 @@ func NewQEMUOperations() QEMUOperations {
 
 func convertToRaw(src, dest string, preallocate bool) error {
 	args := []string{"convert", "-t", "none", "-p", "-O", "raw", src, dest}
+	var err error
 	if preallocate {
-		klog.V(1).Info("Added preallocation")
-		args = append(args, []string{"-o", "preallocation=falloc"}...)
+		err = addPreallocation(preallocate, args, func(args []string) ([]byte, error) {
+			return qemuExecFunction(nil, nil, "qemu-img", args...)
+		})
+	} else {
+		_, err = qemuExecFunction(nil, nil, "qemu-img", args...)
 	}
-	_, err := qemuExecFunction(nil, nil, "qemu-img", args...)
 	if err != nil {
 		os.Remove(dest)
 		return errors.Wrap(err, "could not convert image to raw")
@@ -122,12 +132,15 @@ func (o *qemuOperations) ConvertToRawStream(url *url.URL, dest string, prealloca
 
 	jsonArg := fmt.Sprintf("json: {\"file.driver\": \"%s\", \"file.url\": \"%s\", \"file.timeout\": %d}", url.Scheme, url, networkTimeoutSecs)
 
+	var err error
 	args := []string{"convert", "-t", "none", "-p", "-O", "raw", jsonArg, dest}
 	if preallocate {
-		klog.V(1).Info("Added preallocation")
-		args = append(args, []string{"-o", "preallocation=falloc"}...)
+		err = addPreallocation(preallocate, args, func(args []string) ([]byte, error) {
+			return qemuExecFunction(nil, reportProgress, "qemu-img", args...)
+		})
+	} else {
+		_, err = qemuExecFunction(nil, reportProgress, "qemu-img", args...)
 	}
-	_, err := qemuExecFunction(nil, reportProgress, "qemu-img", args...)
 	if err != nil {
 		// TODO: Determine what to do here, the conversion failed, and we need to clean up the mess, but we could be writing to a block device
 		os.Remove(dest)
@@ -272,4 +285,24 @@ func PreallocateBlankBlock(dest string, size resource.Quantity) error {
 	}
 
 	return nil
+}
+
+func addPreallocation(preallocate bool, args []string, fn func(args []string) ([]byte, error)) error {
+	var err error
+	preallocationMethod := 0
+	for retry := true; retry; retry = err != nil && preallocationMethod < maxPreallocationMethods {
+		var argsToTry []string
+		var output []byte
+		if preallocate {
+			klog.V(1).Info("Added preallocation")
+			argsToTry = append(args, preallocationMethods[preallocationMethod]...)
+		}
+		output, err = fn(argsToTry)
+		if err != nil && strings.Contains(string(output), "Unsupported preallocation mode") {
+			preallocationMethod++
+			klog.V(1).Infof("Unsupported preallocation mode. Retrying with %s", preallocationMethods[preallocationMethod])
+		}
+	}
+
+	return err
 }

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -278,6 +278,12 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 		if err != nil {
 			return ProcessingPhaseError, errors.Wrap(err, "Resize of image failed")
 		}
+		if dp.preallocation {
+			if shouldPreallocate {
+				return ProcessingPhasePreallocate, nil
+			}
+			dp.preallocationApplied = false // qemu did not preallocate space for a resized file
+		}
 	}
 	if dp.dataFile != "" {
 		// Change permissions to 0660
@@ -286,12 +292,7 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 			err = errors.Wrap(err, "Unable to change permissions of target file")
 		}
 	}
-	if dp.preallocation {
-		if shouldPreallocate {
-			return ProcessingPhasePreallocate, nil
-		}
-		dp.preallocationApplied = false // qemu did not preallocate space for a resized file
-	}
+
 	return ProcessingPhaseComplete, nil
 }
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -913,6 +913,27 @@ var _ = Describe("Preallocation", func() {
 		Entry("HTTP import (archive content)", false, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeWithArchiveContent("import-dv", "100Mi", tinyCoreTarURL())
 		}),
+		Entry("HTTP Import (TAR image, block DataVolume)", true, func() *cdiv1.DataVolume {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreTarURL(), f.BlockSCName)
+		}),
+		Entry("HTTP Import (ISO image, block DataVolume)", true, func() *cdiv1.DataVolume {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreIsoURL(), f.BlockSCName)
+		}),
+		Entry("HTTP Import (QCOW2 image, block DataVolume)", true, func() *cdiv1.DataVolume {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreQcow2URL(), f.BlockSCName)
+		}),
 		Entry("ImageIO import", true, func() *cdiv1.DataVolume {
 			cm, err := utils.CopyImageIOCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
If the falloc mode is not supported, try full first and then zero-sized
sparse blocks.

Bugzilla-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1928730

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

Signed-off-by: Tomasz Barański <tomob@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

