### PR TITLE
Add `bazel clean --expunge` to the clean make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ all: manifests bazel-build-images
 
 clean:
 	${DO_BAZ} "./hack/build/build-go.sh clean; rm -rf bin/* _out/* manifests/generated/* .coverprofile release-announcement"
+	${DO_BAZ} bazel clean --expunge
 
 update-codegen:
 	${DO_BAZ} "./hack/update-codegen.sh"


### PR DESCRIPTION
When the system C headers change, sometimes we have bizarre failures from bazel.
We usually end up telling people to delete all their containers, but a lighter weight option is to run `bazel clean --expunge` in the bazel container.
To make this easier to do, add it to the clean target. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

