### PR TITLE
Hold off AnnCloneOf until the target PVC is correctly updated.

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -288,11 +288,6 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 
 	log.V(3).Info("Pod phase for PVC", "PVC phase", pvc.Annotations[AnnPodPhase])
 
-	if podSucceededFromPVC(pvc) && pvc.Annotations[AnnCloneOf] != "true" {
-		log.V(1).Info("Adding CloneOf annotation to PVC")
-		pvc.Annotations[AnnCloneOf] = "true"
-		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cloneComplete)
-	}
 	if sourcePod != nil && sourcePod.Status.ContainerStatuses != nil {
 		// update pvc annotation tracking pod restarts only if the source pod restart count is greater
 		// see the same in upload-controller
@@ -304,10 +299,20 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		setConditionFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
 	}
 
+	var err error = nil
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {
-		return r.updatePVC(pvc)
+		err = r.updatePVC(pvc)
 	}
-	return nil
+
+	if err == nil && podSucceededFromPVC(pvc) && pvc.Annotations[AnnCloneOf] != "true" {
+		// Now PVC has been fully updated and cloning can be completed.
+		log.V(1).Info("Adding CloneOf annotation to PVC")
+		pvc.Annotations[AnnCloneOf] = "true"
+		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cloneComplete)
+
+		err = r.updatePVC(pvc)
+	}
+	return err
 }
 
 func (r *CloneReconciler) updatePVC(pvc *corev1.PersistentVolumeClaim) error {

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -332,6 +332,14 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			AnnCloneRequest: "default/source", AnnPodReady: "true", AnnCloneToken: "foobaz", AnnUploadClientName: "uploadclient", AnnCloneSourcePod: "default-testPvc1-source-pod", AnnPodPhase: string(corev1.PodSucceeded)}
 		err = reconciler.client.Update(context.TODO(), testPvc)
 		Expect(err).ToNot(HaveOccurred())
+
+		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
+		sourcePod.Status.Phase = corev1.PodSucceeded
+		err = reconciler.client.Update(context.TODO(), sourcePod)
+		Expect(err).ToNot(HaveOccurred())
+		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
+
 		_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When the cloning is complete, the conditions to set `AnnCloneOf` annotation and status annotations (`AnnSourceRunningCondition*`) are different: the former is set when the cloning is done, while the latter depend on clone pod to finish. Sometimes `AnnCloneOf` is set, while the others are not, because even though the cloning is done, the pod is still in the running state. As a result, during the next reconciliation loop the pod is cleared and the status annotations are not set at all.

This PR adds a verification that the pod actually finishes (succeeds or fails) before `AnnCloneOf` is set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

