### PR TITLE
Restore compatibility in specifying custom CAs by using Go client

### DIFF
--- a/doc/scratch-space.md
+++ b/doc/scratch-space.md
@@ -17,4 +17,5 @@ Operations that require scratch space are:
 | Registry imports | In order to import from registry container images, CDI has to first download the image to a scratch space, extract the layers to find the image file, and then pass that image file to QEMU-IMG for conversion to a raw disk |
 | Upload image | Because QEMU-IMG does not accept inputs from stdin yet, we cannot stream the upload directly to QEMU-IMG, so we have to save the upload to a scratch space first and then pass it to QEMU-IMG for conversion |
 | Http imports from unsupported server source for nbdkit | CDI uses ndbkit curl to stream the source content. However, nbdkit curl plugin cannot fetch the source when the server doesn't support accept ranges, or HTTP HEAD requests (for example, S3 servers). For those cases, the scratch space is still required|
+| Http imports of custom certificates | nbdkit handles custom certificates differently. To avoid breaking users we keep using a Go client that requires scratch space|
 

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -138,7 +138,11 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 	if hs.brokenForQemuImg {
 		return ProcessingPhaseTransferScratch, nil
 	}
-	if !hs.readers.Archived && hs.customCA == "" && hs.readers.Convert {
+	if hs.customCA != "" {
+		klog.V(1).Infof("Custom CA requested, using scratch space")
+		return ProcessingPhaseTransferScratch, nil
+	}
+	if !hs.readers.Archived && hs.readers.Convert {
 		// We can pass straight to conversion from the endpoint
 		return ProcessingPhaseConvert, nil
 	}

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -78,3 +78,32 @@ func CopyConfigMap(client kubernetes.Interface, srcNamespace, srcName, destNames
 
 	return destName, nil
 }
+
+// CreateCertConfigMapWeirdFilename copies a configmap with a different key value
+func CreateCertConfigMapWeirdFilename(client kubernetes.Interface, destNamespace, srcNamespace string) (string, error) {
+	var certBytes string
+	srcName := FileHostCertConfigMap
+	srcCm, err := client.CoreV1().ConfigMaps(srcNamespace).Get(context.TODO(), srcName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, value := range srcCm.Data {
+		certBytes = value
+	}
+	destName := srcName + "-" + strings.ToLower(util.RandAlphaNum(8))
+	dst := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: destName,
+		},
+		Data: map[string]string{
+			"weird-filename-should-still-be-accepted.crt": certBytes,
+		},
+	}
+	_, err = client.CoreV1().ConfigMaps(destNamespace).Create(context.TODO(), dst, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return destName, nil
+}

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -90,6 +90,7 @@ func CreateCertConfigMapWeirdFilename(client kubernetes.Interface, destNamespace
 
 	for _, value := range srcCm.Data {
 		certBytes = value
+		break
 	}
 	destName := srcName + "-" + strings.ToLower(util.RandAlphaNum(8))
 	dst := &v1.ConfigMap{


### PR DESCRIPTION
This restores support for the following scenarios:
- Now the system certs are considered as valid when a custom CA is used.
- The custom CA will be accepted regardless of the key value used in the configmap.
    
Add a test for the second scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1946100

**Special notes for your reviewer**:
The scenario of system-wide certs is not tested because it requires using an external server.

**Release note**:
```release-note
Restore compatibility: users are once again able to specify custom CAs for use in import in names other than tls.crt
```