### PR TITLE
Bugfix: preallocating resized image erases data

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -652,11 +652,16 @@ func (r *ImportReconciler) requiresScratchSpace(pvc *corev1.PersistentVolumeClai
 			scratchRequired = true
 		}
 	}
-	value, ok := pvc.Annotations[AnnRequiresScratch]
-	if ok {
+	if value, ok := pvc.Annotations[AnnRequiresScratch]; ok {
 		boolVal, _ := strconv.ParseBool(value)
 		scratchRequired = scratchRequired || boolVal
 	}
+
+	if value, ok := pvc.Annotations[AnnPreallocationRequested]; ok {
+		boolVal, _ := strconv.ParseBool(value)
+		scratchRequired = scratchRequired || boolVal
+	}
+
 	return scratchRequired
 }
 


### PR DESCRIPTION
When qemu image is resized, it needs to be preallocated to the requested
size. In-place preallocation (using `convert` function of qemu-img)
cleans the data.

Preallocation step now uses scratch space to perform safe conversion.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

