### PR TITLE
Bugfix: preallocating resized image erases data

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -51,8 +51,6 @@ const (
 	ProcessingPhaseConvert ProcessingPhase = "Convert"
 	// ProcessingPhaseResize the disk image, this is only needed when the target contains a file system (block device do not need a resize)
 	ProcessingPhaseResize ProcessingPhase = "Resize"
-	// ProcessingPhasePreallocate is the step to preallocate the file after resize
-	ProcessingPhasePreallocate ProcessingPhase = "Preallocate"
 	// ProcessingPhaseComplete is the phase where the entire process completed successfully and we can exit gracefully.
 	ProcessingPhaseComplete ProcessingPhase = "Complete"
 	// ProcessingPhasePause is the phase where we pause processing and end the loop, and expect something to call the process loop again.
@@ -223,11 +221,6 @@ func (dp *DataProcessor) ProcessDataWithPause() error {
 			if err != nil {
 				err = errors.Wrap(err, "Unable to resize disk image to requested size")
 			}
-		case ProcessingPhasePreallocate:
-			dp.currentPhase, err = dp.preallocate()
-			if err != nil {
-				err = errors.Wrap(err, "Unable to preallocate disk image to requested size")
-			}
 		default:
 			return errors.Errorf("Unknown processing phase %s", dp.currentPhase)
 		}
@@ -269,12 +262,10 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 	size, _ := getAvailableSpaceBlockFunc(dp.dataFile)
 	klog.V(3).Infof("Available space in dataFile: %d", size)
 	isBlockDev := size >= int64(0)
-	shouldPreallocate := false
 	if !isBlockDev {
 		if dp.requestImageSize != "" {
-			var err error
 			klog.V(3).Infoln("Resizing image")
-			shouldPreallocate, err = ResizeImage(dp.dataFile, dp.requestImageSize, dp.getUsableSpace())
+			err := ResizeImage(dp.dataFile, dp.requestImageSize, dp.getUsableSpace(), dp.preallocation)
 			if err != nil {
 				return ProcessingPhaseError, errors.Wrap(err, "Resize of image failed")
 			}
@@ -288,12 +279,7 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 		if err != nil {
 			return ProcessingPhaseError, err
 		}
-		if dp.preallocation {
-			if shouldPreallocate {
-				return ProcessingPhasePreallocate, nil
-			}
-			dp.preallocationApplied = false // qemu did not preallocate space for a resized file
-		}
+		dp.preallocationApplied = dp.preallocation
 	}
 	if dp.dataFile != "" {
 		// Change permissions to 0660
@@ -306,32 +292,14 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 	return ProcessingPhaseComplete, nil
 }
 
-func (dp *DataProcessor) preallocate() (ProcessingPhase, error) {
-	if !dp.preallocation {
-		klog.V(3).Infoln("Preallocation not needed")
-		return ProcessingPhaseComplete, nil
-	}
-
-	klog.V(3).Infoln("Preallocating")
-	// Preallocation is implemented as a copy from file to itself
-	destURL, _ := url.Parse(dp.dataFile)
-	err := qemuOperations.ConvertToRawStream(destURL, dp.dataFile, dp.preallocation)
-	if err != nil {
-		return ProcessingPhaseError, errors.Wrap(err, "Preallocation or resized image failed")
-	}
-	dp.preallocationApplied = true
-
-	return ProcessingPhaseComplete, nil
-}
-
 // ResizeImage resizes the images to match the requested size. Sometimes provisioners misbehave and the available space
 // is not the same as the requested space. For those situations we compare the available space to the requested space and
 // use the smallest of the two values.
-func ResizeImage(dataFile, imageSize string, totalTargetSpace int64) (bool, error) {
+func ResizeImage(dataFile, imageSize string, totalTargetSpace int64, preallocation bool) error {
 	dataFileURL, _ := url.Parse(dataFile)
 	info, err := qemuOperations.Info(dataFileURL)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if imageSize != "" {
 		currentImageSizeQuantity := resource.NewScaledQuantity(info.VirtualSize, 0)
@@ -343,13 +311,12 @@ func ResizeImage(dataFile, imageSize string, totalTargetSpace int64) (bool, erro
 		}
 		if currentImageSizeQuantity.Cmp(minSizeQuantity) == 0 {
 			klog.V(1).Infof("No need to resize image. Requested size: %s, Image size: %d.\n", imageSize, info.VirtualSize)
-			return false, nil
+			return nil
 		}
 		klog.V(1).Infof("Expanding image size to: %s\n", minSizeQuantity.String())
-		err := qemuOperations.Resize(dataFile, minSizeQuantity)
-		return err == nil, err
+		return qemuOperations.Resize(dataFile, minSizeQuantity, preallocation)
 	}
-	return false, errors.New("Image resize called with blank resize")
+	return errors.New("Image resize called with blank resize")
 }
 
 func (dp *DataProcessor) calculateTargetSize() int64 {

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -858,5 +858,5 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		}
 	}
 
-	return ProcessingPhasePreallocate, nil
+	return ProcessingPhaseResize, nil
 }

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -95,7 +95,7 @@ var _ = Describe("VDDK data source", func() {
 		Expect(phase).To(Equal(ProcessingPhaseTransferDataFile))
 		phase, err = dp.TransferFile("")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(phase).To(Equal(ProcessingPhasePreallocate))
+		Expect(phase).To(Equal(ProcessingPhaseResize))
 	})
 
 	It("VDDK data source should fail if TransferFile fails", func() {
@@ -151,7 +151,7 @@ var _ = Describe("VDDK data source", func() {
 
 		phase, err := dp.TransferFile(".")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(phase).To(Equal(ProcessingPhasePreallocate))
+		Expect(phase).To(Equal(ProcessingPhaseResize))
 
 		sourceSum := md5.Sum(sourceBytes)
 		destSum := md5.Sum(mockSinkBuffer)
@@ -177,7 +177,7 @@ var _ = Describe("VDDK data source", func() {
 
 		phase, err := snap1.TransferFile(".")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(phase).To(Equal(ProcessingPhasePreallocate))
+		Expect(phase).To(Equal(ProcessingPhaseResize))
 
 		sourceSum := md5.Sum(sourceBytes)
 		destSum := md5.Sum(mockSinkBuffer)
@@ -199,7 +199,7 @@ var _ = Describe("VDDK data source", func() {
 
 		phase, err = snap2.TransferFile(".")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(phase).To(Equal(ProcessingPhasePreallocate))
+		Expect(phase).To(Equal(ProcessingPhaseResize))
 
 		deltaSum := md5.Sum(mockSinkBuffer)
 		Expect(changedSourceSum).To(Equal(deltaSum))

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -104,8 +104,7 @@ var _ = Describe("Transport Tests", func() {
 			case controller.SourceHTTP, controller.SourceRegistry:
 				if file != targetFile {
 					By("Verify content")
-					// Size: 18874368 // md5sum after conversion: d41d8cd98f00b204e9800998ecf8427e
-					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", "d41d8cd98f00b204e9800998ecf8427e", 18874368)
+					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, 18874368)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(same).To(BeTrue())
 				}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1019,6 +1019,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 var _ = Describe("Preallocation", func() {
 	f := framework.NewFramework(namespacePrefix)
 	dvName := "upload-dv"
+	md5PrefixSize := int64(100000)
 
 	var (
 		dataVolume     *cdiv1.DataVolume
@@ -1099,6 +1100,11 @@ var _ = Describe("Preallocation", func() {
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	})
 
 	It("Uploader should not add preallocation when preallocation=false", func() {
@@ -1143,6 +1149,11 @@ var _ = Describe("Preallocation", func() {
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	})
 
 	DescribeTable("Each upload path include preallocation/conversion", func(uploader uploadFunc) {
@@ -1186,6 +1197,11 @@ var _ = Describe("Preallocation", func() {
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	},
 		Entry("sync", uploadImage),
 		Entry("async", uploadImageAsync),

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -57,6 +57,19 @@ const (
 	ImageioURL = "https://imageio.%s:12346/ovirt-engine/api"
 	// VcenterURL provides URL of vCenter/ESX simulator
 	VcenterURL = "https://vcenter.%s:8989/sdk"
+
+	// TinyCoreMD5 is the MD5 hash of first 100k bytes of tinyCore image
+	TinyCoreMD5 = "3710416a680523c7d07538cb1026c60c"
+	// TinyCoreTarMD5 is the MD5 hash of first 100k bytes of tinyCore tar image
+	TinyCoreTarMD5 = "aec1a39d753b4b7cc81ee02bc625a342"
+	// TinyCoreBlockMD5 is the MD5 hash of first 100k bytes of tinyCore image on block device
+	TinyCoreBlockMD5 = "d41d8cd98f00b204e9800998ecf8427e"
+	// ImageioMD5 is the MD5 hash of first 100k bytes of imageio image
+	ImageioMD5 = "91150be031835ccfac458744da57d4f6"
+	// VcenterMD5 is the MD5 hash of first 100k bytes of Vcenter image
+	VcenterMD5 = "91150be031835ccfac458744da57d4f6"
+	// BlankMD5 is the MD5 hash of first 100k bytes of blank image
+	BlankMD5 = "0019d23bef56a136a1891211d7007f6f"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
When qemu image is resized, it needs to be preallocated to the requested
size. In-place preallocation (using convert function of qemu-img)
cleans the data.

With this PR preallocation is applied simply when the image is resized.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

