### PR TITLE
Add insecureRegistries to CDIConfig

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3446,6 +3446,13 @@
       "description": "ImportProxy contains importer pod proxy configuration.",
       "$ref": "#/definitions/v1beta1.ImportProxy"
      },
+     "insecureRegistries": {
+      "description": "InsecureRegistries is a list of TLS disabled registries",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
      "podResourceRequirements": {
       "description": "ResourceRequirements describes the compute resource requirements.",
       "$ref": "#/definitions/v1.ResourceRequirements"

--- a/doc/cdi-config.md
+++ b/doc/cdi-config.md
@@ -16,7 +16,8 @@ CDI configuration in specified by administrators in the `spec.config` of the `CD
 | global                   | "0.055"       | The amount to reserve for a Filesystem volume unless a per-storageClass value is chosen.                                                                                                                                     |
 | storageClass             | nil           | A value of `local: "0.6"` is understood to mean that the overhead for the local storageClass is 0.6.                                                                                                                         |
 | preallocation            | nil           | Preallocation setting to use unless a per-dataVolume value is set                                                                                                                                                            |
-| ImportProxy              | nil           | The proxy configuration to be used by the importer pod when accessing a http data source. When the ImportProxy is empty, the Cluster Wide-Proxy (Openshift) configurations are used. ImportProxy has four parameters: `ImportProxy.HTTPProxy` that defines the proxy http url, the `ImportProxy.HTTPSProxy` that determines the roxy https url, and the `ImportProxy.NoProxy` which enforce that a list of hostnames and/or CIDRs will be not proxied, and finally, the `ImportProxy.TrustedCAProxy`, the ConfigMap name of an user-provided trusted certificate authority (CA) bundle to be added to the importer pod CA bundle. |
+| importProxy              | nil           | The proxy configuration to be used by the importer pod when accessing a http data source. When the ImportProxy is empty, the Cluster Wide-Proxy (Openshift) configurations are used. ImportProxy has four parameters: `ImportProxy.HTTPProxy` that defines the proxy http url, the `ImportProxy.HTTPSProxy` that determines the roxy https url, and the `ImportProxy.NoProxy` which enforce that a list of hostnames and/or CIDRs will be not proxied, and finally, the `ImportProxy.TrustedCAProxy`, the ConfigMap name of an user-provided trusted certificate authority (CA) bundle to be added to the importer pod CA bundle. |
+| insecureRegistries       | nil           | List of TLS disabled registries. |
 ### Example
 
 ```bash
@@ -25,7 +26,7 @@ kubectl patch cdi cdi --patch '{"spec": {"config": {"scratchSpaceStorageClass": 
 
 ## Getting
 
-CDI configuration configuration may be retrieved by any authenticated user in the cluster by checking the `status` of the `CDIConfig` singleton
+CDI configuration may be retrieved by any authenticated user in the cluster by checking the `status` of the `CDIConfig` singleton
 
 ### Options
 

--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -121,9 +121,8 @@ spec:
 
 To disable TLS security for a registry:
 
-Add the registry to the `cdi-insecure-registries` `ConfigMap` in the `cdi` namespace.
+Add the registry to CDIConfig insecureRegistries in the `cdi` namespace.
 
 ```bash
-kubectl patch configmap cdi-insecure-registries -n cdi \
-  --type merge -p '{"data":{"mykey": "my-private-registry-host:5000"}}'
+kubectl patch cdi cdi --patch '{"spec": {"config": {"insecureRegistries": ["my-private-registry-host:5000"]}}}' --type merge
 ```

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -13681,6 +13681,20 @@ func schema_pkg_apis_core_v1alpha1_CDIConfigSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"insecureRegistries": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InsecureRegistries is a list of TLS disabled registries",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1alpha1/types.go
+++ b/pkg/apis/core/v1alpha1/types.go
@@ -427,6 +427,8 @@ type CDIConfigSpec struct {
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`
+	// InsecureRegistries is a list of TLS disabled registries
+	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
 }
 
 //CDIConfigStatus provides the most recently observed status of the CDI Config resource

--- a/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -196,6 +196,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
+		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.InsecureRegistries != nil {
+		in, out := &in.InsecureRegistries, &out.InsecureRegistries
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -13693,6 +13693,20 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"insecureRegistries": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InsecureRegistries is a list of TLS disabled registries",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -463,6 +463,8 @@ type CDIConfigSpec struct {
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`
+	// InsecureRegistries is a list of TLS disabled registries
+	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
 }
 
 //CDIConfigStatus provides the most recently observed status of the CDI Config resource

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -233,6 +233,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
+		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.InsecureRegistries != nil {
+		in, out := &in.InsecureRegistries, &out.InsecureRegistries
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/operator/resources/cluster/cdiconfig.go
+++ b/pkg/operator/resources/cluster/cdiconfig.go
@@ -304,5 +304,14 @@ func CreateConfigPropertiesSchema() map[string]extv1.JSONSchemaProps {
 			Description: "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 			Type:        "boolean",
 		},
+		"insecureRegistries": {
+			Description: "InsecureRegistries is a list of TLS disabled registries",
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{
+					Type: "string",
+				},
+			},
+			Type: "array",
+		},
 	}
 }

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -77,9 +77,14 @@ var _ = Describe("Transport Tests", func() {
 		}
 
 		if insecureRegistry {
-			err = utils.SetInsecureRegistry(f.K8sClient, f.CdiInstallNs, ep())
+			err = utils.AddInsecureRegistry(f.CrClient, ep())
 			Expect(err).To(BeNil())
-			defer utils.ClearInsecureRegistry(f.K8sClient, f.CdiInstallNs)
+
+			hasInsecReg, err := utils.HasInsecureRegistry(f.CrClient, ep())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasInsecReg).To(BeTrue())
+
+			defer utils.RemoveInsecureRegistry(f.CrClient, ep())
 		}
 
 		By(fmt.Sprintf("Creating PVC with endpoint annotation %q", pvcAnn[controller.AnnEndpoint]))

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/apis/core/v1beta1:go_default_library",
         "//pkg/apis/upload/v1beta1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
-        "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/image:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"net/url"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -10,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
@@ -79,49 +77,4 @@ func CopyConfigMap(client kubernetes.Interface, srcNamespace, srcName, destNames
 	}
 
 	return destName, nil
-}
-
-const insecureRegistryKey = "test-registry"
-
-// SetInsecureRegistry sets the configmap entry to mark the registry as okay to be insecure
-func SetInsecureRegistry(client kubernetes.Interface, cdiNamespace, registryURL string) error {
-	cm, err := client.CoreV1().ConfigMaps(cdiNamespace).Get(context.TODO(), common.InsecureRegistryConfigMap, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	if cm.Data == nil {
-		cm.Data = map[string]string{}
-	}
-
-	parsedURL, err := url.Parse(registryURL)
-	if err != nil {
-		return err
-	}
-
-	cm.Data[insecureRegistryKey] = parsedURL.Host
-
-	_, err = client.CoreV1().ConfigMaps(cdiNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ClearInsecureRegistry undoes whatever SetInsecureRegistry does
-func ClearInsecureRegistry(client kubernetes.Interface, cdiNamespace string) error {
-	cm, err := client.CoreV1().ConfigMaps(cdiNamespace).Get(context.TODO(), common.InsecureRegistryConfigMap, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	delete(cm.Data, insecureRegistryKey)
-
-	_, err = client.CoreV1().ConfigMaps(cdiNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

Keep supporting original ConfigMap for upgrade.

**What this PR does / why we need it**:
This change will allow HCO to expose a configuration to disable TLS for a container registries

**Release note**:
```release-note
Add insecure registries to CDIConfig, but keep supporting original ConfigMap for upgrade
```

