### PR TITLE
[release-v1.28] Bugfix: preallocating resized image erases data (#1747)

### DIFF
--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Convert to Raw", func() {
 	})
 
 	It("should add preallocation if requested", func() {
-		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "none", "-p", "-O", "raw", "/somefile/somewhere", "dest", "-o", "preallocation=falloc"), func() {
+		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-o", "preallocation=falloc", "-t", "none", "-p", "-O", "raw", "/somefile/somewhere", "dest"), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
 			err = ConvertToRawStream(ep, "dest", true)
@@ -199,7 +199,7 @@ var _ = Describe("Resize", func() {
 		size := convertQuantityToQemuSize(quantity)
 		replaceExecFunction(mockExecFunction("", "", nil, "resize", "-f", "raw", "image", size), func() {
 			o := NewQEMUOperations()
-			err = o.Resize("image", quantity)
+			err = o.Resize("image", quantity, false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -210,7 +210,7 @@ var _ = Describe("Resize", func() {
 		size := convertQuantityToQemuSize(quantity)
 		replaceExecFunction(mockExecFunction("", "exit 1", nil, "resize", "-f", "raw", "image", size), func() {
 			o := NewQEMUOperations()
-			err = o.Resize("image", quantity)
+			err = o.Resize("image", quantity, false)
 			Expect(err).To(HaveOccurred())
 			Expect(strings.Contains(err.Error(), "Error resizing image image")).To(BeTrue())
 		})

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -399,22 +399,21 @@ var _ = Describe("Resize", func() {
 
 var _ = Describe("ResizeImage", func() {
 	//fakeInfoRet has info.VirtualSize=1024
-	table.DescribeTable("calling ResizeImage", func(qemuOperations image.QEMUOperations, imageSize string, totalSpace int64, wantErr bool, wantResized bool) {
+	table.DescribeTable("calling ResizeImage", func(qemuOperations image.QEMUOperations, imageSize string, totalSpace int64, wantErr bool) {
 		replaceQEMUOperations(qemuOperations, func() {
-			resized, err := ResizeImage("dest", imageSize, totalSpace)
+			err := ResizeImage("dest", imageSize, totalSpace, false)
 			if !wantErr {
 				Expect(err).ToNot(HaveOccurred())
 			} else {
 				Expect(err).To(HaveOccurred())
 			}
-			Expect(resized).To(Equal(wantResized))
 		})
 	},
-		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0)), "1500", int64(2048), false, true),
-		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false, true),
-		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024), 0)), "1024", int64(1024), false, false),
-		table.Entry("fail to resize to with blank imageSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "", int64(2048), true, false),
-		table.Entry("fail to resize to with blank imageSize", NewQEMUAllErrors(), "", int64(2048), true, false),
+		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0)), "1500", int64(2048), false),
+		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false),
+		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024), 0)), "1024", int64(1024), false),
+		table.Entry("fail to resize to with blank imageSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "", int64(2048), true),
+		table.Entry("fail to resize to with blank imageSize", NewQEMUAllErrors(), "", int64(2048), true),
 	)
 })
 
@@ -457,7 +456,7 @@ func (o *fakeQEMUOperations) Validate(*url.URL, int64, float64) error {
 	return o.e5
 }
 
-func (o *fakeQEMUOperations) Resize(dest string, size resource.Quantity) error {
+func (o *fakeQEMUOperations) Resize(dest string, size resource.Quantity, preallocate bool) error {
 	if o.resizeQuantity != nil {
 		Expect(o.resizeQuantity.Cmp(size)).To(Equal(0))
 	}

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -104,8 +104,7 @@ var _ = Describe("Transport Tests", func() {
 			case controller.SourceHTTP, controller.SourceRegistry:
 				if file != targetFile {
 					By("Verify content")
-					// Size: 18874368 // md5sum after conversion: d41d8cd98f00b204e9800998ecf8427e
-					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", "d41d8cd98f00b204e9800998ecf8427e", 18874368)
+					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, 18874368)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(same).To(BeTrue())
 				}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1019,6 +1019,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 var _ = Describe("Preallocation", func() {
 	f := framework.NewFramework(namespacePrefix)
 	dvName := "upload-dv"
+	md5PrefixSize := int64(100000)
 
 	var (
 		dataVolume     *cdiv1.DataVolume
@@ -1098,7 +1099,12 @@ var _ = Describe("Preallocation", func() {
 
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Or(Equal("true"), Equal("skipped")))
+		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	})
 
 	It("Uploader should not add preallocation when preallocation=false", func() {
@@ -1143,6 +1149,11 @@ var _ = Describe("Preallocation", func() {
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	})
 
 	DescribeTable("Each upload path include preallocation/conversion", func(uploader uploadFunc) {
@@ -1185,7 +1196,12 @@ var _ = Describe("Preallocation", func() {
 
 		pvc, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Or(Equal("true"), Equal("skipped")))
+		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
+
+		By("Verify content")
+		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
 	},
 		Entry("sync", uploadImage),
 		Entry("async", uploadImageAsync),

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -57,6 +57,19 @@ const (
 	ImageioURL = "https://imageio.%s:12346/ovirt-engine/api"
 	// VcenterURL provides URL of vCenter/ESX simulator
 	VcenterURL = "https://vcenter.%s:8989/sdk"
+
+	// TinyCoreMD5 is the MD5 hash of first 100k bytes of tinyCore image
+	TinyCoreMD5 = "3710416a680523c7d07538cb1026c60c"
+	// TinyCoreTarMD5 is the MD5 hash of first 100k bytes of tinyCore tar image
+	TinyCoreTarMD5 = "aec1a39d753b4b7cc81ee02bc625a342"
+	// TinyCoreBlockMD5 is the MD5 hash of first 100k bytes of tinyCore image on block device
+	TinyCoreBlockMD5 = "d41d8cd98f00b204e9800998ecf8427e"
+	// ImageioMD5 is the MD5 hash of first 100k bytes of imageio image
+	ImageioMD5 = "91150be031835ccfac458744da57d4f6"
+	// VcenterMD5 is the MD5 hash of first 100k bytes of Vcenter image
+	VcenterMD5 = "91150be031835ccfac458744da57d4f6"
+	// BlankMD5 is the MD5 hash of first 100k bytes of blank image
+	BlankMD5 = "0019d23bef56a136a1891211d7007f6f"
 )
 
 // CreateDataVolumeFromDefinition is used by tests to create a testable Data Volume


### PR DESCRIPTION
* When qemu image is resized, it needs to be preallocated to the requested
size. In-place preallocation (using convert function of qemu-img)
cleans the data.

With this PR preallocation is applied simply when the image is resized.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

* Functional tests for preallocation verify content (MD5).

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

Signed-off-by: Tomasz Barański <tomob@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

