### PR TITLE
Verify with qemu-img that image has been preallocated

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -977,6 +977,10 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.TinyCoreMD5))
+
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
 	})
 
 	It("Importer should not add preallocation when preallocation=false", func() {
@@ -1005,6 +1009,11 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.TinyCoreMD5))
+
+		By("Verify preallocated size")
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
 	})
 
 	DescribeTable("All import paths should contain Preallocation step", func(shouldPreallocate bool, expectedMD5, path string, dvFunc func() *cdiv1.DataVolume) {
@@ -1044,6 +1053,13 @@ var _ = Describe("Preallocation", func() {
 			md5, err := f.GetMD5(f.Namespace, pvc, path, md5PrefixSize)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(md5).To(Equal(expectedMD5))
+
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				// Block volumes can't be read with qemu-img
+				ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			}
 		} else {
 			Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Equal("true"))
 		}
@@ -1168,6 +1184,10 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.BlankMD5))
+
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
 	})
 })
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1105,6 +1105,10 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
+
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
 	})
 
 	It("Uploader should not add preallocation when preallocation=false", func() {
@@ -1154,6 +1158,10 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
+
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
 	})
 
 	DescribeTable("Each upload path include preallocation/conversion", func(uploader uploadFunc) {
@@ -1202,6 +1210,10 @@ var _ = Describe("Preallocation", func() {
 		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.UploadFileMD5100kbytes))
+
+		ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
 	},
 		Entry("sync", uploadImage),
 		Entry("async", uploadImageAsync),


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

This PR adds a step to prellocation verification tests which looks at the output of qemu-img and compares actual and virtual sizes of the image. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

