### PR TITLE
nbd: use modern uri for nbd

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -128,7 +128,7 @@ func convertToRaw(src, dest string, preallocate bool) error {
 }
 
 func (o *qemuOperations) ConvertToRawStream(url *url.URL, dest string, preallocate bool) error {
-	if len(url.Scheme) == 0 || url.Scheme == "nbd" {
+	if len(url.Scheme) == 0 || url.Scheme == "nbd+unix" {
 		// File, instead of URL
 		return convertToRaw(url.String(), dest, preallocate)
 	}
@@ -206,7 +206,7 @@ func (o *qemuOperations) Info(url *url.URL) (*ImgInfo, error) {
 	var source string
 
 	switch {
-	case url.Scheme == "nbd":
+	case url.Scheme == "nbd+unix":
 		source = url.String()
 	case len(url.Scheme) > 0:
 		// Image is a URL, make sure the timeout is long enough.

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -120,7 +120,7 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 		klog.Errorf("Error creating readers: %v", err)
 		return ProcessingPhaseError, err
 	}
-	hs.url, _ = url.Parse(fmt.Sprintf("nbd:unix:%s", nbdkitSocket))
+	hs.url, _ = url.Parse(fmt.Sprintf("nbd+unix:///?socket=%s", nbdkitSocket))
 	if hs.readers.ArchiveGz {
 		hs.n.AddFilter(image.NbdkitGzipFilter)
 		klog.V(2).Infof("Added nbdkit gzip filter")

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Http data source", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(expectedPhase).To(Equal(newPhase))
 			if newPhase == ProcessingPhaseConvert {
-				expectURL, err := url.Parse("nbd:unix:/var/run/nbdkit.sock")
+				expectURL, err := url.Parse("nbd+unix:///?socket=/var/run/nbdkit.sock")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(expectURL).To(Equal(dp.GetURL()))
 			}


### PR DESCRIPTION
Change the old nbd style nbd:unix to nbd+unix:///?socket=socket

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

