### PR TITLE
Add extra information when CDI pods are not ready

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -78,6 +78,8 @@ done
 if [ $retry_counter -eq $MAX_CDI_WAIT_RETRY ]; then
     echo "Not all CDI pods became ready"
     ./cluster-up/kubectl.sh get pods -n $CDI_NAMESPACE
+    ./cluster-up/kubectl.sh get pods -n $CDI_NAMESPACE -o yaml
+    ./cluster-up/kubectl.sh describe pods -n $CDI_NAMESPACE
     exit 1
 fi
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Dump pod yamls and describes on failure so we can identify what went wrong.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

