### PR TITLE
Fix cluster proxy part of proxy test

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -75,25 +75,25 @@ func BuildTestSuite() {
 		// clients
 		kcs, err := framework.ClientsInstance.GetKubeClient()
 		if err != nil {
-			ginkgo.Fail("ERROR, unable to create K8SClient")
+			ginkgo.Fail(fmt.Sprintf("ERROR, unable to create K8SClient: %v", err))
 		}
 		framework.ClientsInstance.K8sClient = kcs
 
 		cs, err := framework.ClientsInstance.GetCdiClient()
 		if err != nil {
-			ginkgo.Fail("ERROR, unable to create CdiClient")
+			ginkgo.Fail(fmt.Sprintf("ERROR, unable to create CdiClient: %v", err))
 		}
 		framework.ClientsInstance.CdiClient = cs
 
 		extcs, err := framework.ClientsInstance.GetExtClient()
 		if err != nil {
-			ginkgo.Fail("ERROR, unable to create CsiClient")
+			ginkgo.Fail(fmt.Sprintf("ERROR, unable to create CsiClient: %v", err))
 		}
 		framework.ClientsInstance.ExtClient = extcs
 
 		crClient, err := framework.ClientsInstance.GetCrClient()
 		if err != nil {
-			ginkgo.Fail("ERROR, unable to create CrClient")
+			ginkgo.Fail(fmt.Sprintf("ERROR, unable to create CrClient: %v", err))
 		}
 		framework.ClientsInstance.CrClient = crClient
 


### PR DESCRIPTION
We were setting the cluster proxy noProxy to * to have it ignore
all URLs, but then set it to "" in CDI CR without cleaning up.
This PR leaves it blank.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes PROXY test on Open Shift with a cluster wide proxy.
Also improve some of the error logging to understand why clients cannot be created.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

