### PR TITLE
[Bugfix] wrong interpretation of custom cert rotation params

### DIFF
--- a/pkg/operator/controller/certrotation_test.go
+++ b/pkg/operator/controller/certrotation_test.go
@@ -172,11 +172,11 @@ var _ = Describe("Cert rotation tests", func() {
 			n := time.Now()
 
 			args := &cert.FactoryArgs{
-				Namespace:      namespace,
-				SignerValidity: pt(50 * time.Hour),
-				SignerRefresh:  pt(25 * time.Hour),
-				TargetValidity: pt(26 * time.Hour),
-				TargetRefresh:  pt(13 * time.Hour),
+				Namespace:         namespace,
+				SignerDuration:    pt(50 * time.Hour),
+				SignerRenewBefore: pt(25 * time.Hour),
+				TargetDuration:    pt(26 * time.Hour),
+				TargetRenewBefore: pt(13 * time.Hour),
 			}
 
 			certs = cert.CreateCertificateDefinitions(args)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -190,21 +190,21 @@ func (r *ReconcileCDI) getCertificateDefinitions(cdi *cdiv1.CDI) []cdicerts.Cert
 	if cdi != nil && cdi.Spec.CertConfig != nil {
 		if cdi.Spec.CertConfig.CA != nil {
 			if cdi.Spec.CertConfig.CA.Duration != nil {
-				args.SignerValidity = &cdi.Spec.CertConfig.CA.Duration.Duration
+				args.SignerDuration = &cdi.Spec.CertConfig.CA.Duration.Duration
 			}
 
 			if cdi.Spec.CertConfig.CA.RenewBefore != nil {
-				args.SignerRefresh = &cdi.Spec.CertConfig.CA.RenewBefore.Duration
+				args.SignerRenewBefore = &cdi.Spec.CertConfig.CA.RenewBefore.Duration
 			}
 		}
 
 		if cdi.Spec.CertConfig.Server != nil {
 			if cdi.Spec.CertConfig.Server.Duration != nil {
-				args.TargetValidity = &cdi.Spec.CertConfig.Server.Duration.Duration
+				args.TargetDuration = &cdi.Spec.CertConfig.Server.Duration.Duration
 			}
 
 			if cdi.Spec.CertConfig.Server.RenewBefore != nil {
-				args.TargetRefresh = &cdi.Spec.CertConfig.Server.RenewBefore.Duration
+				args.TargetRenewBefore = &cdi.Spec.CertConfig.Server.RenewBefore.Duration
 			}
 		}
 	}

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -782,7 +782,7 @@ var _ = Describe("Controller", func() {
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					deploymentOrig, ok := toModify.(*appsv1.Deployment)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					deployment := deploymentOrig.DeepCopy()
 					deployment.Annotations["fake.anno.1"] = "fakeannotation1"
@@ -815,17 +815,13 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desiredDep.Annotations) > len(postDep.Annotations) {
-						return false
-					}
-
-					return true
+					return len(desiredDep.Annotations) <= len(postDep.Annotations)
 				}),
 			Entry("verify - deployment updated on upgrade - labels changed",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					deploymentOrig, ok := toModify.(*appsv1.Deployment)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					deployment := deploymentOrig.DeepCopy()
 					deployment.Labels["fake.label.1"] = "fakelabel1"
@@ -856,17 +852,13 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desiredDep.Labels) > len(postDep.Labels) {
-						return false
-					}
-
-					return true
+					return len(desiredDep.Labels) <= len(postDep.Labels)
 				}),
 			Entry("verify - deployment updated on upgrade - deployment spec changed - modify container",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					deploymentOrig, ok := toModify.(*appsv1.Deployment)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					deployment := deploymentOrig.DeepCopy()
 
@@ -909,17 +901,13 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desiredDep.Spec.Template.Spec.Containers[0].Env) != len(postDep.Spec.Template.Spec.Containers[0].Env) {
-						return false
-					}
-
-					return true
+					return len(desiredDep.Spec.Template.Spec.Containers[0].Env) == len(postDep.Spec.Template.Spec.Containers[0].Env)
 				}),
 			Entry("verify - deployment updated on upgrade - deployment spec changed - add new container",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					deploymentOrig, ok := toModify.(*appsv1.Deployment)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					deployment := deploymentOrig.DeepCopy()
 
@@ -963,17 +951,13 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desiredDep.Spec.Template.Spec.Containers) > len(postDep.Spec.Template.Spec.Containers) {
-						return false
-					}
-
-					return true
+					return len(desiredDep.Spec.Template.Spec.Containers) <= len(postDep.Spec.Template.Spec.Containers)
 				}),
 			Entry("verify - deployment updated on upgrade - deployment spec changed - remove existing container",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					deploymentOrig, ok := toModify.(*appsv1.Deployment)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					deployment := deploymentOrig.DeepCopy()
 
@@ -1012,7 +996,7 @@ var _ = Describe("Controller", func() {
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					serviceOrig, ok := toModify.(*corev1.Service)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					service := serviceOrig.DeepCopy()
 					service.Annotations["fake.anno.1"] = "fakeannotation1"
@@ -1043,17 +1027,14 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desired.Annotations) > len(post.Annotations) {
-						return false
-					}
-					return true
+					return len(desired.Annotations) <= len(post.Annotations)
 				}),
 
 			Entry("verify - services updated on upgrade - label changed",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					serviceOrig, ok := toModify.(*corev1.Service)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					service := serviceOrig.DeepCopy()
 					service.Labels["fake.label.1"] = "fakelabel1"
@@ -1084,18 +1065,14 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desired.Labels) > len(post.Labels) {
-						return false
-					}
-
-					return true
+					return len(desired.Labels) <= len(post.Labels)
 				}),
 
 			Entry("verify - services updated on upgrade - service port changed",
 				func(toModify runtime.Object) (runtime.Object, runtime.Object, error) { //Modify
 					serviceOrig, ok := toModify.(*corev1.Service)
 					if !ok {
-						return toModify, toModify, generrors.New(fmt.Sprint("wrong type"))
+						return toModify, toModify, generrors.New("wrong type")
 					}
 					service := serviceOrig.DeepCopy()
 					service.Spec.Ports = []corev1.ServicePort{
@@ -1129,11 +1106,7 @@ var _ = Describe("Controller", func() {
 						}
 					}
 
-					if len(desired.Spec.Ports) != len(post.Spec.Ports) {
-						return false
-					}
-
-					return true
+					return len(desired.Spec.Ports) == len(post.Spec.Ports)
 				}),
 			//CRD update
 			// - update CRD label

--- a/pkg/operator/resources/cert/factory.go
+++ b/pkg/operator/resources/cert/factory.go
@@ -31,11 +31,13 @@ const day = 24 * time.Hour
 type FactoryArgs struct {
 	Namespace string
 
-	SignerValidity *time.Duration
-	SignerRefresh  *time.Duration
+	SignerDuration *time.Duration
+	// Duration to subtract from cert NotAfter value
+	SignerRenewBefore *time.Duration
 
-	TargetValidity *time.Duration
-	TargetRefresh  *time.Duration
+	TargetDuration *time.Duration
+	// Duration to subtract from cert NotAfter value
+	TargetRenewBefore *time.Duration
 }
 
 // CertificateConfig contains cert configuration data
@@ -86,20 +88,22 @@ func CreateCertificateDefinitions(args *FactoryArgs) []CertificateDefinition {
 		}
 
 		if def.Configurable {
-			if args.SignerValidity != nil {
-				def.SignerConfig.Lifetime = *args.SignerValidity
+			if args.SignerDuration != nil {
+				def.SignerConfig.Lifetime = *args.SignerDuration
 			}
 
-			if args.SignerRefresh != nil {
-				def.SignerConfig.Refresh = *args.SignerRefresh
+			if args.SignerRenewBefore != nil {
+				// convert to time from cert NotBefore
+				def.SignerConfig.Refresh = def.SignerConfig.Lifetime - *args.SignerRenewBefore
 			}
 
-			if args.TargetValidity != nil {
-				def.TargetConfig.Lifetime = *args.TargetValidity
+			if args.TargetDuration != nil {
+				def.TargetConfig.Lifetime = *args.TargetDuration
 			}
 
-			if args.TargetRefresh != nil {
-				def.TargetConfig.Refresh = *args.TargetRefresh
+			if args.TargetRenewBefore != nil {
+				// convert to time from cert NotBefore
+				def.TargetConfig.Refresh = def.TargetConfig.Lifetime - *args.TargetRenewBefore
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We stole the idea of `Duration` and `RenewBefore` from cert-manager.  See here for interpretation: https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/apis/core/v1beta1/types.go#L388-L393

We were not handling `RenewBefore` correctly.  It is supposed to be time before a cert's "not after."  But we were treating it is time from "not before".

Conversion is easy and will be done automatically on all certs after upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1957521

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix:  Interpret custom cert rotation params correctly
```

