### PR TITLE
Use a method of deleting the pod that waits for it to no longer exist

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -140,7 +140,7 @@ func (f *Framework) CreateAndPopulateSourcePVC(pvcDef *k8sv1.PersistentVolumeCla
 
 	err = f.WaitTimeoutForPodStatus(pod.Name, k8sv1.PodSucceeded, utils.PodWaitForTime)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	err = f.DeletePod(pod)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return sourcePvc
 }


### PR DESCRIPTION
Smartclone can begin its clone prior to the pod-using-PVC being gone.
We need this wait to guarantee that there are no pending writes in
the kernel cache.

Intended to fix a flaky test, seen failing here:
https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1752/pull-containerized-data-importer-e2e-k8s-1.17-ceph/1390637610644279296

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

