### PR TITLE
Update github.com/ulikunitz/xz for CVE-2021-29482

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/cors v1.7.0
-	github.com/ulikunitz/xz v0.5.7
+	github.com/ulikunitz/xz v0.5.10
 	github.com/vmware/govmomi v0.23.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
+github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vbatts/tar-split v0.11.1 h1:0Odu65rhcZ3JZaPHxl7tCI3V/C/Q9Zf82UFravl02dE=

--- a/vendor/github.com/ulikunitz/xz/LICENSE
+++ b/vendor/github.com/ulikunitz/xz/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2020  Ulrich Kunitz
+Copyright (c) 2014-2021  Ulrich Kunitz
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/vendor/github.com/ulikunitz/xz/SECURITY.md
+++ b/vendor/github.com/ulikunitz/xz/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Supported Versions
+
+Currently the last minor version v0.5.x is supported.
+
+## Reporting a Vulnerability
+
+Report a vulnerability by creating a Github issue at
+<https://github.com/ulikunitz/xz/issues>. Expect a response in a week.

--- a/vendor/github.com/ulikunitz/xz/TODO.md
+++ b/vendor/github.com/ulikunitz/xz/TODO.md
@@ -8,19 +8,17 @@
 
 1. Review encoder and check for lzma improvements under xz.
 2. Fix binary tree matcher.
-3. Compare compression ratio with xz tool using comparable parameters
-   and optimize parameters
-4. Do some optimizations
-    - rename operation action and make it a simple type of size 8
-    - make maxMatches, wordSize parameters
-    - stop searching after a certain length is found (parameter sweetLen)
+3. Compare compression ratio with xz tool using comparable parameters and optimize parameters
+4. rename operation action and make it a simple type of size 8
+5. make maxMatches, wordSize parameters
+6. stop searching after a certain length is found (parameter sweetLen)
 
 ## Release v0.7
 
 1. Optimize code
 2. Do statistical analysis to get linear presets.
 3. Test sync.Pool compatability for xz and lzma Writer and Reader
-3. Fuzz optimized code.
+4. Fuzz optimized code.
 
 ## Release v0.8
 
@@ -44,51 +42,84 @@
 
 ## Package lzma
 
-### Release v0.6
+### v0.6
 
-- Rewrite Encoder into a simple greedy one-op-at-a-time encoder
-  including
-    + simple scan at the dictionary head for the same byte
-    + use the killer byte (requiring matches to get longer, the first
-      test should be the byte that would make the match longer)
-
+* Rewrite Encoder into a simple greedy one-op-at-a-time encoder including
+  * simple scan at the dictionary head for the same byte
+  * use the killer byte (requiring matches to get longer, the first test should be the byte that would make the match longer)
 
 ## Optimizations
 
-- There may be a lot of false sharing in lzma.State; check whether this
-  can be improved by reorganizing the internal structure of it.
-- Check whether batching encoding and decoding improves speed.
+* There may be a lot of false sharing in lzma. State; check whether this  can be improved by reorganizing the internal structure of it.
+
+* Check whether batching encoding and decoding improves speed.
 
 ### DAG optimizations
 
-- Use full buffer to create minimal bit-length above range encoder.
-- Might be too slow (see v0.4)
+* Use full buffer to create minimal bit-length above range encoder.
+* Might be too slow (see v0.4)
 
 ### Different match finders
 
-- hashes with 2, 3 characters additional to 4 characters
-- binary trees with 2-7 characters (uint64 as key, use uint32 as
+* hashes with 2, 3 characters additional to 4 characters
+* binary trees with 2-7 characters (uint64 as key, use uint32 as
+
   pointers into a an array)
-- rb-trees with 2-7 characters (uint64 as key, use uint32 as pointers
+
+* rb-trees with 2-7 characters (uint64 as key, use uint32 as pointers
+
   into an array with bit-steeling for the colors)
 
 ## Release Procedure
 
-- execute goch -l for all packages; probably with lower param like 0.5.
-- check orthography with gospell
-- Write release notes in doc/relnotes.
-- Update README.md
-- xb copyright . in xz directory to ensure all new files have Copyright
-  header
-- VERSION=<version> go generate github.com/ulikunitz/xz/... to update
-  version files
-- Execute test for Linux/amd64, Linux/x86 and Windows/amd64.
-- Update TODO.md - write short log entry
-- git checkout master && git merge dev
-- git tag -a <version>
-- git push
+* execute goch -l for all packages; probably with lower param like 0.5.
+* check orthography with gospell
+* Write release notes in doc/relnotes.
+* Update README.md
+* xb copyright . in xz directory to ensure all new files have Copyright header
+* `VERSION=<version> go generate github.com/ulikunitz/xz/...` to update version files
+* Execute test for Linux/amd64, Linux/x86 and Windows/amd64.
+* Update TODO.md - write short log entry
+* `git checkout master && git merge dev`
+* `git tag -a <version>`
+* `git push`
 
 ## Log
+
+### 2021-02-02
+
+Mituo Heijo has fuzzed xz and found a bug in the function readIndexBody. The
+function allocated a slice of records immediately after reading the value
+without further checks. Since the number has been too large the make function
+did panic. The fix is to check the number against the expected number of records
+before allocating the records.
+
+### 2020-12-17
+
+Release v0.5.9 fixes warnings, a typo and adds SECURITY.md.
+
+One fix is interesting.
+
+```go
+const (
+  a byte = 0x1
+  b      = 0x2
+)
+```
+
+The constants a and b don't have the same type. Correct is
+
+```go
+const (
+  a byte = 0x1
+  b byte = 0x2
+)
+```
+
+### 2020-08-19
+
+Release v0.5.8 fixes issue
+[issue #35](https://github.com/ulikunitz/xz/issues/35).
 
 ### 2020-02-24
 
@@ -203,8 +234,8 @@ MININT.
 
 ### 2015-06-04
 
-It has been a productive day. I improved the interface of lzma.Reader
-and lzma.Writer and fixed the error handling.
+It has been a productive day. I improved the interface of lzma. Reader
+and lzma. Writer and fixed the error handling.
 
 ### 2015-06-01
 
@@ -255,7 +286,7 @@ needed anymore.
 
 However I will implement a ReaderState and WriterState type to use
 static typing to ensure the right State object is combined with the
-right lzbase.Reader and lzbase.Writer.
+right lzbase. Reader and lzbase. Writer.
 
 As a start I have implemented ReaderState and WriterState to ensure
 that the state for reading is only used by readers and WriterState only
@@ -277,11 +308,11 @@ old lzma package has been completely removed.
 
 ### 2015-04-05
 
-Implemented lzma.Reader and tested it.
+Implemented lzma. Reader and tested it.
 
 ### 2015-04-04
 
-Implemented baseReader by adapting code form lzma.Reader.
+Implemented baseReader by adapting code form lzma. Reader.
 
 ### 2015-04-03
 
@@ -297,7 +328,7 @@ However in Francesco Campoy's presentation "Go for Javaneros
 (Javaïstes?)" is the the idea that using an embedded field E, all the
 methods of E will be defined on T. If E is an interface T satisfies E.
 
-https://talks.golang.org/2014/go4java.slide#51
+<https://talks.golang.org/2014/go4java.slide#51>
 
 I have never used this, but it seems to be a cool idea.
 
@@ -322,11 +353,11 @@ and the opCodec.
 
 1. Implemented simple lzmago tool
 2. Tested tool against large 4.4G file
-    - compression worked correctly; tested decompression with lzma
-    - decompression hits a full buffer condition
+   * compression worked correctly; tested decompression with lzma
+   * decompression hits a full buffer condition
 3. Fixed a bug in the compressor and wrote a test for it
 4. Executed full cycle for 4.4 GB file; performance can be improved ;-)
 
 ### 2015-01-11
 
-- Release v0.2 because of the working LZMA encoder and decoder
+* Release v0.2 because of the working LZMA encoder and decoder

--- a/vendor/github.com/ulikunitz/xz/bits.go
+++ b/vendor/github.com/ulikunitz/xz/bits.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -54,6 +54,8 @@ var errOverflowU64 = errors.New("xz: uvarint overflows 64-bit unsigned integer")
 
 // readUvarint reads a uvarint from the given byte reader.
 func readUvarint(r io.ByteReader) (x uint64, n int, err error) {
+	const maxUvarintLen = 10
+
 	var s uint
 	i := 0
 	for {
@@ -62,8 +64,11 @@ func readUvarint(r io.ByteReader) (x uint64, n int, err error) {
 			return x, i, err
 		}
 		i++
+		if i > maxUvarintLen {
+			return x, i, errOverflowU64
+		}
 		if b < 0x80 {
-			if i > 10 || i == 10 && b > 1 {
+			if i == maxUvarintLen && b > 1 {
 				return x, i, errOverflowU64
 			}
 			return x | uint64(b)<<s, i, nil

--- a/vendor/github.com/ulikunitz/xz/crc.go
+++ b/vendor/github.com/ulikunitz/xz/crc.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/internal/hash/cyclic_poly.go
+++ b/vendor/github.com/ulikunitz/xz/internal/hash/cyclic_poly.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/internal/hash/doc.go
+++ b/vendor/github.com/ulikunitz/xz/internal/hash/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/internal/hash/rabin_karp.go
+++ b/vendor/github.com/ulikunitz/xz/internal/hash/rabin_karp.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/internal/hash/roller.go
+++ b/vendor/github.com/ulikunitz/xz/internal/hash/roller.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/internal/xlog/xlog.go
+++ b/vendor/github.com/ulikunitz/xz/internal/xlog/xlog.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/bintree.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/bintree.go
@@ -1,14 +1,11 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package lzma
 
 import (
-	"bufio"
 	"errors"
-	"fmt"
-	"io"
 	"unicode"
 )
 
@@ -349,6 +346,7 @@ func dumpX(x uint32) string {
 	return string(a)
 }
 
+/*
 // dumpNode writes a representation of the node v into the io.Writer.
 func (t *binTree) dumpNode(w io.Writer, v uint32, indent int) {
 	if v == null {
@@ -377,6 +375,7 @@ func (t *binTree) dump(w io.Writer) error {
 	t.dumpNode(bw, t.root, 0)
 	return bw.Flush()
 }
+*/
 
 func (t *binTree) distance(v uint32) int {
 	dist := int(t.front) - int(v)

--- a/vendor/github.com/ulikunitz/xz/lzma/bitops.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/bitops.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -18,6 +18,7 @@ var ntz32Table = [32]int8{
 	30, 17, 8, 14, 29, 13, 28, 27,
 }
 
+/*
 // ntz32 computes the number of trailing zeros for an unsigned 32-bit integer.
 func ntz32(x uint32) int {
 	if x == 0 {
@@ -26,6 +27,7 @@ func ntz32(x uint32) int {
 	x = (x & -x) * ntz32Const
 	return int(ntz32Table[x>>27])
 }
+*/
 
 // nlz32 computes the number of leading zeros for an unsigned 32-bit integer.
 func nlz32(x uint32) int {

--- a/vendor/github.com/ulikunitz/xz/lzma/breader.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/breader.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/buffer.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/buffer.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/bytewriter.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/bytewriter.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/decoder.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/decoder.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -200,7 +200,7 @@ func (d *decoder) decompress() error {
 		op, err := d.readOp()
 		switch err {
 		case nil:
-			break
+			// break
 		case errEOS:
 			d.eos = true
 			if !d.rd.possiblyAtEnd() {

--- a/vendor/github.com/ulikunitz/xz/lzma/decoderdict.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/decoderdict.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -126,10 +126,3 @@ func (d *decoderDict) Available() int { return d.buf.Available() }
 
 // Read reads data from the buffer contained in the decoder dictionary.
 func (d *decoderDict) Read(p []byte) (n int, err error) { return d.buf.Read(p) }
-
-// Buffered returns the number of bytes currently buffered in the
-// decoder dictionary.
-func (d *decoderDict) buffered() int { return d.buf.Buffered() }
-
-// Peek gets data from the buffer without advancing the rear index.
-func (d *decoderDict) peek(p []byte) (n int, err error) { return d.buf.Peek(p) }

--- a/vendor/github.com/ulikunitz/xz/lzma/directcodec.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/directcodec.go
@@ -1,23 +1,12 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package lzma
 
-import "fmt"
-
 // directCodec allows the encoding and decoding of values with a fixed number
 // of bits. The number of bits must be in the range [1,32].
 type directCodec byte
-
-// makeDirectCodec creates a directCodec. The function panics if the number of
-// bits is not in the range [1,32].
-func makeDirectCodec(bits int) directCodec {
-	if !(1 <= bits && bits <= 32) {
-		panic(fmt.Errorf("bits=%d out of range", bits))
-	}
-	return directCodec(bits)
-}
 
 // Bits returns the number of bits supported by this codec.
 func (dc directCodec) Bits() int {

--- a/vendor/github.com/ulikunitz/xz/lzma/distcodec.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/distcodec.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -20,8 +20,6 @@ const (
 	posSlotBits = 6
 	// number of align bits
 	alignBits = 4
-	// maximum position slot
-	maxPosSlot = 63
 )
 
 // distCodec provides encoding and decoding of distance values.
@@ -43,20 +41,6 @@ func (dc *distCodec) deepcopy(src *distCodec) {
 		dc.posModel[i].deepcopy(&src.posModel[i])
 	}
 	dc.alignCodec.deepcopy(&src.alignCodec)
-}
-
-// distBits returns the number of bits required to encode dist.
-func distBits(dist uint32) int {
-	if dist < startPosModel {
-		return 6
-	}
-	// slot s > 3, dist d
-	// s = 2(bits(d)-1) + bit(d, bits(d)-2)
-	// s>>1 = bits(d)-1
-	// bits(d) = 32-nlz32(d)
-	// s>>1=31-nlz32(d)
-	// n = 5 + (s>>1) = 36 - nlz32(d)
-	return 36 - nlz32(dist)
 }
 
 // newDistCodec creates a new distance codec.

--- a/vendor/github.com/ulikunitz/xz/lzma/encoder.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/encoder.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/encoderdict.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/encoderdict.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,7 @@ type matcher interface {
 }
 
 // encoderDict provides the dictionary of the encoder. It includes an
-// addtional buffer atop of the actual dictionary.
+// additional buffer atop of the actual dictionary.
 type encoderDict struct {
 	buf      buffer
 	m        matcher

--- a/vendor/github.com/ulikunitz/xz/lzma/hashtable.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/hashtable.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/header.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/header.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/header2.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/header2.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -264,7 +264,7 @@ type chunkState byte
 // state
 const (
 	start chunkState = 'S'
-	stop             = 'T'
+	stop  chunkState = 'T'
 )
 
 // errors for the chunk state handling

--- a/vendor/github.com/ulikunitz/xz/lzma/lengthcodec.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/lengthcodec.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -54,19 +54,6 @@ func (lc *lengthCodec) init() {
 		lc.mid[i] = makeTreeCodec(3)
 	}
 	lc.high = makeTreeCodec(8)
-}
-
-// lBits gives the number of bits used for the encoding of the l value
-// provided to the range encoder.
-func lBits(l uint32) int {
-	switch {
-	case l < 8:
-		return 4
-	case l < 16:
-		return 5
-	default:
-		return 10
-	}
 }
 
 // Encode encodes the length offset. The length offset l can be compute by

--- a/vendor/github.com/ulikunitz/xz/lzma/literalcodec.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/literalcodec.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -122,11 +122,4 @@ const (
 const (
 	minLP = 0
 	maxLP = 4
-)
-
-// minState and maxState define a range for the state values stored in
-// the State values.
-const (
-	minState = 0
-	maxState = 11
 )

--- a/vendor/github.com/ulikunitz/xz/lzma/matchalgorithm.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/matchalgorithm.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/operation.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/operation.go
@@ -1,11 +1,10 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package lzma
 
 import (
-	"errors"
 	"fmt"
 	"unicode"
 )
@@ -22,30 +21,6 @@ type match struct {
 	distance int64
 	// length
 	n int
-}
-
-// verify checks whether the match is valid. If that is not the case an
-// error is returned.
-func (m match) verify() error {
-	if !(minDistance <= m.distance && m.distance <= maxDistance) {
-		return errors.New("distance out of range")
-	}
-	if !(1 <= m.n && m.n <= maxMatchLen) {
-		return errors.New("length out of range")
-	}
-	return nil
-}
-
-// l return the l-value for the match, which is the difference of length
-// n and 2.
-func (m match) l() uint32 {
-	return uint32(m.n - minMatchLen)
-}
-
-// dist returns the dist value for the match, which is one less of the
-// distance stored in the match.
-func (m match) dist() uint32 {
-	return uint32(m.distance - minDistance)
 }
 
 // Len returns the number of bytes matched.

--- a/vendor/github.com/ulikunitz/xz/lzma/prob.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/prob.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/properties.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/properties.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/rangecodec.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/rangecodec.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -129,32 +129,6 @@ type rangeDecoder struct {
 	br     io.ByteReader
 	nrange uint32
 	code   uint32
-}
-
-// init initializes the range decoder, by reading from the byte reader.
-func (d *rangeDecoder) init() error {
-	d.nrange = 0xffffffff
-	d.code = 0
-
-	b, err := d.br.ReadByte()
-	if err != nil {
-		return err
-	}
-	if b != 0 {
-		return errors.New("newRangeDecoder: first byte not zero")
-	}
-
-	for i := 0; i < 4; i++ {
-		if err = d.updateCode(); err != nil {
-			return err
-		}
-	}
-
-	if d.code >= d.nrange {
-		return errors.New("newRangeDecoder: d.code >= d.nrange")
-	}
-
-	return nil
 }
 
 // newRangeDecoder initializes a range decoder. It reads five bytes from the

--- a/vendor/github.com/ulikunitz/xz/lzma/reader.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/reader2.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/reader2.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -48,7 +48,6 @@ type Reader2 struct {
 	chunkReader io.Reader
 
 	cstate chunkState
-	ctype  chunkType
 }
 
 // NewReader2 creates a reader for an LZMA2 chunk sequence.

--- a/vendor/github.com/ulikunitz/xz/lzma/state.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/state.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -51,12 +51,6 @@ func (s *state) Reset() {
 	s.lenCodec.init()
 	s.repLenCodec.init()
 	s.distCodec.init()
-}
-
-// initState initializes the state.
-func initState(s *state, p Properties) {
-	*s = state{Properties: p}
-	s.Reset()
 }
 
 // newState creates a new state from the give Properties.

--- a/vendor/github.com/ulikunitz/xz/lzma/treecodecs.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/treecodecs.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/writer.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/writer2.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/writer2.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/lzmafilter.go
+++ b/vendor/github.com/ulikunitz/xz/lzmafilter.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/none-check.go
+++ b/vendor/github.com/ulikunitz/xz/none-check.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/ulikunitz/xz/writer.go
+++ b/vendor/github.com/ulikunitz/xz/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Ulrich Kunitz. All rights reserved.
+// Copyright 2014-2021 Ulrich Kunitz. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package xz
 
 import (
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 
@@ -190,6 +191,9 @@ func (c WriterConfig) NewWriter(xz io.Writer) (w *Writer, err error) {
 		return nil, err
 	}
 	data, err := w.h.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("w.h.MarshalBinary(): error %w", err)
+	}
 	if _, err = xz.Write(data); err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -392,7 +392,7 @@ github.com/rs/cors
 github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/ulikunitz/xz v0.5.7
+# github.com/ulikunitz/xz v0.5.10
 ## explicit
 github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash


### PR DESCRIPTION
See https://github.com/ulikunitz/xz/security/advisories/GHSA-25xm-hr59-7c27 for more information.

(Updating to the newest release, which is also what is supported, rather than just past the bug fix).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update github.com/ulikunitz/xz to obtain a fix for CVE-2021-29482
```

