### PR TITLE
Fix: Compute fs overhead only for fs volumeMode

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1870,7 +1870,7 @@ func pvcFromStorage(client client.Client, recorder record.EventRecorder, log log
 		pvcSpec.VolumeMode = volumeMode
 	}
 
-	requestedVolumeSize, err := volumeSize(client, storage)
+	requestedVolumeSize, err := volumeSize(client, storage, pvcSpec.VolumeMode)
 	if err != nil {
 		return nil, err
 	}
@@ -1898,7 +1898,7 @@ func copyStorageAsPvc(log logr.Logger, storage *cdiv1.StorageSpec) *corev1.Persi
 	return pvcSpec
 }
 
-func volumeSize(c client.Client, storage *cdiv1.StorageSpec) (*resource.Quantity, error) {
+func volumeSize(c client.Client, storage *cdiv1.StorageSpec, volumeMode *corev1.PersistentVolumeMode) (*resource.Quantity, error) {
 	// resources.requests[storage] - just copy it to pvc,
 	requestedSize, found := storage.Resources.Requests[corev1.ResourceStorage]
 	if !found {
@@ -1906,7 +1906,7 @@ func volumeSize(c client.Client, storage *cdiv1.StorageSpec) (*resource.Quantity
 	}
 
 	// disk or image size, inflate it with overhead
-	if resolveVolumeMode(storage.VolumeMode) == corev1.PersistentVolumeFilesystem {
+	if resolveVolumeMode(volumeMode) == corev1.PersistentVolumeFilesystem {
 		fsOverhead, err := GetFilesystemOverheadForStorageClass(c, storage.StorageClassName)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -186,6 +186,14 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		It("Should set params on a PVC from default storageProfile when import DV has no storageClass and no accessMode", func() {
+			cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+			cdiConfig.Status = cdiv1.CDIConfigStatus{
+				ScratchSpaceStorageClass: testStorageClass,
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: cdiv1.Percent("0.5"),
+				},
+			}
+
 			scName := "testStorageClass"
 			importDataVolume := newImportDataVolumeWithPvc("test-dv", nil)
 			importDataVolume.Spec.Storage = &cdiv1.StorageSpec{
@@ -200,7 +208,12 @@ var _ = Describe("All DataVolume Tests", func() {
 			storageProfile := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, corev1.PersistentVolumeBlock)
 			anotherStorageProfile := createStorageProfile("anotherSp", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, corev1.PersistentVolumeFilesystem)
 
-			reconciler = createDatavolumeReconciler(storageClass, storageProfile, anotherStorageProfile, importDataVolume)
+			reconciler = createDatavolumeReconcilerWithoutConfig(
+				storageClass,
+				storageProfile,
+				anotherStorageProfile,
+				importDataVolume,
+				cdiConfig)
 
 			_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
@@ -212,6 +225,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(len(pvc.Spec.AccessModes)).To(BeNumerically("==", 1))
 			Expect(pvc.Spec.AccessModes[0]).To(Equal(corev1.ReadOnlyMany))
 			Expect(*pvc.Spec.VolumeMode).To(Equal(corev1.PersistentVolumeBlock))
+			expectedSize := resource.MustParse("1G")
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 		})
 
 		It("Should pass annotation from DV to created a PVC on a DV", func() {
@@ -1316,6 +1331,20 @@ func readyStatusByPhase(phase cdiv1.DataVolumePhase) corev1.ConditionStatus {
 }
 
 func createDatavolumeReconciler(objects ...runtime.Object) *DatavolumeReconciler {
+	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+	cdiConfig.Status = cdiv1.CDIConfigStatus{
+		ScratchSpaceStorageClass: testStorageClass,
+	}
+	cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
+
+	objs := []runtime.Object{}
+	objs = append(objs, objects...)
+	objs = append(objs, cdiConfig)
+
+	return createDatavolumeReconcilerWithoutConfig(objs...)
+}
+
+func createDatavolumeReconcilerWithoutConfig(objects ...runtime.Object) *DatavolumeReconciler {
 	objs := []runtime.Object{}
 	objs = append(objs, objects...)
 
@@ -1326,12 +1355,6 @@ func createDatavolumeReconciler(objects ...runtime.Object) *DatavolumeReconciler
 
 	objs = append(objs, MakeEmptyCDICR())
 
-	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
-	cdiConfig.Status = cdiv1.CDIConfigStatus{
-		ScratchSpaceStorageClass: testStorageClass,
-	}
-	cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
-	objs = append(objs, cdiConfig)
 	extfakeclientset := extfake.NewSimpleClientset()
 
 	// Create a fake client to mock API calls.

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1106,13 +1106,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		testFile := utils.DefaultPvcMountPath + "/source.txt"
 		fillCommand := "echo \"" + fillData + "\" >> " + testFile
 
-		createDataVolumeForImport := func(f *framework.Framework, storageClassName string) *cdiv1.DataVolume {
+		createDataVolumeForImport := func(f *framework.Framework, storageSpec cdiv1.StorageSpec) *cdiv1.DataVolume {
 			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
 				dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs))
 
-			dataVolume.Spec.Storage.AccessModes = nil
-			dataVolume.Spec.Storage.VolumeMode = nil
-			dataVolume.Spec.Storage.StorageClassName = &storageClassName
+			dataVolume.Spec.Storage = &storageSpec
 
 			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -1224,7 +1222,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}, 30*time.Second, time.Second)
 		})
 
-		It("[test_id:5911]succeeds creating a PVC from DV without accessModes", func() {
+		It("[test_id:5911]Import succeeds creating a PVC from DV without accessModes", func() {
 			defaultScName := utils.DefaultStorageClass.GetName()
 
 			By(fmt.Sprintf("configure storage profile %s", defaultScName))
@@ -1232,9 +1230,21 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeFilesystem)
+			requestedSize := resource.MustParse("100Mi")
+
+			spec := cdiv1.StorageSpec{
+				AccessModes:      nil,
+				VolumeMode:       nil,
+				StorageClassName: &defaultScName,
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: requestedSize,
+					},
+				},
+			}
 
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
-			dataVolume := createDataVolumeForImport(f, defaultScName)
+			dataVolume := createDataVolumeForImport(f, spec)
 
 			By("verifying pvc created with correct accessModes")
 			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
@@ -1245,11 +1255,22 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
-		It("[test_id:5912]fails creating a PVC from DV without accessModes, no profile", func() {
+		It("[test_id:5912]Import fails creating a PVC from DV without accessModes, no profile", func() {
 			// assumes local is available and has no volumeMode
 			defaultScName := findStorageProfileWithoutAccessModes(f.CrClient)
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
-			dataVolume := createDataVolumeForImport(f, defaultScName)
+			requestedSize := resource.MustParse("100Mi")
+			spec := cdiv1.StorageSpec{
+				AccessModes:      nil,
+				VolumeMode:       nil,
+				StorageClassName: &defaultScName,
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: requestedSize,
+					},
+				},
+			}
+			dataVolume := createDataVolumeForImport(f, spec)
 
 			By("verifying pvc not created")
 			_, err := utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
@@ -1268,11 +1289,22 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}, timeout, pollingInterval).Should(BeTrue())
 		})
 
-		It("[test_id:5913]DV recovers when user adds accessModes, no profile", func() {
+		It("[test_id:5913]Import recovers when user adds accessModes to profile", func() {
 			// assumes local is available and has no volumeMode
 			defaultScName := findStorageProfileWithoutAccessModes(f.CrClient)
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
-			dataVolume := createDataVolumeForImport(f, defaultScName)
+			requestedSize := resource.MustParse("100Mi")
+			spec := cdiv1.StorageSpec{
+				AccessModes:      nil,
+				VolumeMode:       nil,
+				StorageClassName: &defaultScName,
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: requestedSize,
+					},
+				},
+			}
+			dataVolume := createDataVolumeForImport(f, spec)
 
 			By("verifying pvc not created")
 			_, err := utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
@@ -1303,6 +1335,100 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			By("Restore the profile")
 			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
+		})
+
+		It("Import pod should not have size corrected on block", func() {
+			defaultScName := utils.DefaultStorageClass.GetName()
+			SetFilesystemOverhead(f, "0.50", "0.50")
+			requestedSize := resource.MustParse("100Mi")
+			// volumeMode Block, so no overhead applied
+			expectedSize := resource.MustParse("100Mi")
+
+			By("creating datavolume for upload")
+			volumeMode := v1.PersistentVolumeBlock
+			dataVolume := createDataVolumeForImport(f,
+				cdiv1.StorageSpec{
+					AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					VolumeMode:       &volumeMode,
+					StorageClassName: &defaultScName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: requestedSize,
+						},
+					},
+				})
+
+			By("verifying pvc created with correct size")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
+			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+		})
+
+		It("import pod should not have size corrected on block, when no volumeMode on DV", func() {
+			defaultScName := utils.DefaultStorageClass.GetName()
+			SetFilesystemOverhead(f, "0.50", "0.50")
+			requestedSize := resource.MustParse("100Mi")
+			// volumeMode Block, so no overhead applied
+			expectedSize := resource.MustParse("100Mi")
+
+			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
+			originalProfileSpec := configureStorageProfile(f.CrClient,
+				defaultScName,
+				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				v1.PersistentVolumeBlock)
+
+			By("creating datavolume for upload")
+			dataVolume := createDataVolumeForImport(f,
+				cdiv1.StorageSpec{
+					AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					StorageClassName: &defaultScName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: requestedSize,
+						},
+					},
+				})
+
+			By("verifying pvc created with correct size")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
+			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+			By("Restore the profile")
+			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
+		})
+
+		It("Import pod should have size corrected on filesystem", func() {
+			defaultScName := utils.DefaultStorageClass.GetName()
+			SetFilesystemOverhead(f, "0.50", "0.50")
+			requestedSize := resource.MustParse("100Mi")
+			// given 50 percent overhead, expected size is 2x requestedSize
+			expectedSize := resource.MustParse("200Mi")
+
+			By("creating clone dataVolume")
+			volumeMode := v1.PersistentVolumeFilesystem
+			dataVolume := createDataVolumeForImport(f,
+				cdiv1.StorageSpec{
+					AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					VolumeMode:       &volumeMode,
+					StorageClassName: &defaultScName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: requestedSize,
+						},
+					},
+				})
+
+			By("verifying pvc created with correct size")
+			// eventually because pvc will have to be resized if smart clone
+			Eventually(func() bool {
+				pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+				return pvc.Spec.Resources.Requests.Storage().Cmp(expectedSize) == 0
+			}, 1*time.Minute, 2*time.Second).Should(BeTrue())
 		})
 
 		It("[test_id:6099]Upload pvc should have size corrected on filesystem volume", func() {
@@ -1360,6 +1486,40 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
 		})
 
+		It("Upload pvc should not have size corrected on block volume, when no volumeMode on DV", func() {
+			defaultScName := utils.DefaultStorageClass.GetName()
+			SetFilesystemOverhead(f, "0.50", "0.50")
+			requestedSize := resource.MustParse("100Mi")
+			// volumeMode Block, so no overhead applied
+			expectedSize := resource.MustParse("100Mi")
+
+			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
+			originalProfileSpec := configureStorageProfile(f.CrClient,
+				defaultScName,
+				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				v1.PersistentVolumeBlock)
+
+			By("creating datavolume for upload")
+			dataVolume := createDataVolumeForUpload(f, cdiv1.StorageSpec{
+				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				StorageClassName: &defaultScName,
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: requestedSize,
+					},
+				},
+			})
+
+			By("verifying pvc created with correct accessModes and size")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
+			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+			By("Restore the profile")
+			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
+		})
+
 		It("[test_id:6101]Clone pod should not have size corrected on block", func() {
 			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
@@ -1386,6 +1546,41 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+		})
+
+		It("Clone pod should not have size corrected on block, when no volumeMode on DV", func() {
+			defaultScName := utils.DefaultStorageClass.GetName()
+			SetFilesystemOverhead(f, "0.50", "0.50")
+			requestedSize := resource.MustParse("100Mi")
+			// volumeMode Block, so no overhead applied
+			expectedSize := resource.MustParse("100Mi")
+
+			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
+			originalProfileSpec := configureStorageProfile(f.CrClient,
+				defaultScName,
+				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				v1.PersistentVolumeBlock)
+
+			By("creating datavolume for upload")
+			dataVolume := createCloneDataVolume(dataVolumeName,
+				cdiv1.StorageSpec{
+					AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					StorageClassName: &defaultScName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: requestedSize,
+						},
+					},
+				}, fillCommand)
+
+			By("verifying pvc created with correct size")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
+			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+			By("Restore the profile")
+			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
 		It("[test_id:6102]Clone pod should have size corrected on filesystem", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Correctly compute fs overhead for an effective VolumeMode. Effective, means one that is computed based on value in storage spec and the storageProfile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1961227

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

