### PR TITLE
Only run clone across nodes on filesystem PVs only.

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -139,7 +139,7 @@ var _ = Describe("all clone tests", func() {
 			cloneOfAnnoExistenceTest(f, f.Namespace.Name)
 		})
 
-		It("[posneg:negative][test_id:3617]Should clone across nodes when multiple local volumes exist,", func() {
+		It("[posneg:negative][test_id:3617]Should clone across nodes when multiple local filesystem volumes exist,", func() {
 			// Get nodes, need at least 2
 			nodeList, err := f.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -160,8 +160,8 @@ var _ = Describe("all clone tests", func() {
 			// Verify we have PVs to at least 2 nodes.
 			pvNodeNames := make(map[string]int)
 			for _, pv := range pvList.Items {
-				if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil || len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
-					// Not a local volume PV
+				if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil || len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 || (pv.Spec.VolumeMode != nil && *pv.Spec.VolumeMode == v1.PersistentVolumeBlock) {
+					// Not a local volume filesystem PV
 					continue
 				}
 				pvNode := pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
@@ -175,7 +175,7 @@ var _ = Describe("all clone tests", func() {
 				}
 			}
 			if len(pvNodeNames) < 2 {
-				Skip("Need PVs on at least 2 nodes to test")
+				Skip("Need filesystem PVs on at least 2 nodes to test")
 			}
 
 			// Find the source and target PVs so we can label them.


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The clone across nodes checks if we have at least 2 nodes with local PVs, before attempting to run the test. However the test assumes those are filesystem PVs because it writes a file which is then cloned. This fails when you only have local block PVs in your cluster. Our test was not properly filtering out those types of PVs, this PR resolves that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

