### PR TITLE
[release-v1.34] Fix: Compute fs overhead only for fs volumeMode #1791

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1839,7 +1839,7 @@ func pvcFromStorage(client client.Client, recorder record.EventRecorder, log log
 		pvcSpec.VolumeMode = volumeMode
 	}
 
-	requestedVolumeSize, err := volumeSize(client, storage)
+	requestedVolumeSize, err := volumeSize(client, storage, pvcSpec.VolumeMode)
 	if err != nil {
 		return nil, err
 	}
@@ -1867,7 +1867,7 @@ func copyStorageAsPvc(log logr.Logger, storage *cdiv1.StorageSpec) *corev1.Persi
 	return pvcSpec
 }
 
-func volumeSize(c client.Client, storage *cdiv1.StorageSpec) (*resource.Quantity, error) {
+func volumeSize(c client.Client, storage *cdiv1.StorageSpec, volumeMode *corev1.PersistentVolumeMode) (*resource.Quantity, error) {
 	// resources.requests[storage] - just copy it to pvc,
 	requestedSize, found := storage.Resources.Requests[corev1.ResourceStorage]
 	if !found {
@@ -1875,7 +1875,7 @@ func volumeSize(c client.Client, storage *cdiv1.StorageSpec) (*resource.Quantity
 	}
 
 	// disk or image size, inflate it with overhead
-	if resolveVolumeMode(storage.VolumeMode) == corev1.PersistentVolumeFilesystem {
+	if resolveVolumeMode(volumeMode) == corev1.PersistentVolumeFilesystem {
 		fsOverhead, err := GetFilesystemOverheadForStorageClass(c, storage.StorageClassName)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual cherry pick of #1791 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

