### PR TITLE
Remove the logic

### DIFF
--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -415,7 +415,7 @@ func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string,
 
 	uds := importer.NewAsyncUploadDataSource(newContentReader(stream, sourceContentType))
 	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
-	return processor, processor.ProcessDataWithPause()
+	return processor, nil
 }
 
 func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (bool, error) {


### PR DESCRIPTION
Signed-off-by: ZP-AlwaysWin

This logic has been activated twice


```
// Start processing.
		go func() {
			defer close(app.doneChan)
			if err := processor.ProcessDataResume(); err != nil {
				klog.Errorf("Error during resumed processing: %v", err)
				app.errChan <- err
			}
			app.mutex.Lock()
			defer app.mutex.Unlock()
			app.processing = false
			app.done = true
			app.preallocationApplied = processor.PreallocationApplied()
			klog.Infof("Wrote data to %s", app.destination)
		}()
```