### PR TITLE
Add "AwaitingVDDK" back to condition reason.

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -174,6 +174,8 @@ const (
 	VddkConfigMap = "v2v-vmware"
 	// VddkConfigDataKey is the name of the ConfigMap key of the VDDK image reference
 	VddkConfigDataKey = "vddk-init-image"
+	// AwaitingVDDK is a Pending condition reason that indicates the PVC is waiting for a VDDK image
+	AwaitingVDDK = "AwaitingVDDK"
 
 	// UploadContentTypeHeader is the header upload clients may use to set the content type explicitly
 	UploadContentTypeHeader = "x-cdi-content-type"

--- a/pkg/controller/datavolume-conditions.go
+++ b/pkg/controller/datavolume-conditions.go
@@ -137,7 +137,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending", pvc.Name), pvcPending)
 				conditions = updateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
-				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcPending)
+				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcCondition.Reason)
 				conditions = updateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			}
 		case corev1.ClaimLost:

--- a/pkg/controller/datavolume-conditions_test.go
+++ b/pkg/controller/datavolume-conditions_test.go
@@ -224,15 +224,16 @@ var _ = Describe("updateBoundCondition", func() {
 	})
 
 	It("should be pending if PVC pending, if scratch PVC is not bound, message should be combined", func() {
+		reason := "not bound"
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
-		pvc := createPvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: "not bound", AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
+		pvc := createPvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: reason, AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
 		pvc.Status.Phase = corev1.ClaimPending
 		conditions = updateBoundCondition(conditions, pvc)
 		Expect(len(conditions)).To(Equal(2))
 		condition := findConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
 		Expect(condition.Message).To(Equal("target PVC test Pending and scratch PVC not bound"))
-		Expect(condition.Reason).To(Equal(pvcPending))
+		Expect(condition.Reason).To(Equal(reason))
 		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 		condition = findConditionByType(cdiv1.DataVolumeReady, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeReady))

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -91,9 +91,6 @@ const (
 	// creatingScratch provides a const to indicate scratch is being created.
 	creatingScratch = "CreatingScratchSpace"
 
-	// awaitingVddk provides a const to indicate the PVC is waiting for a VDDK image
-	awaitingVddk = "AwaitingVDDK"
-
 	// ImportTargetInUse is reason for event created when an import pvc is in use
 	ImportTargetInUse = "ImportTargetInUse"
 )
@@ -489,7 +486,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 			anno := pvc.GetAnnotations()
 			anno[AnnBoundCondition] = "false"
 			anno[AnnBoundConditionMessage] = fmt.Sprintf("waiting for %s configmap for VDDK image", common.VddkConfigMap)
-			anno[AnnBoundConditionReason] = awaitingVddk
+			anno[AnnBoundConditionReason] = common.AwaitingVDDK
 			if updateErr := r.updatePVC(pvc, r.log); updateErr != nil {
 				return updateErr
 			}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -603,7 +603,7 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resPvc.GetAnnotations()[AnnBoundCondition]).To(Equal("false"))
 		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal("waiting for v2v-vmware configmap for VDDK image"))
-		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(awaitingVddk))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(common.AwaitingVDDK))
 
 		By("Checking again after creating configmap")
 		configmap := &corev1.ConfigMap{

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -192,13 +192,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		return utils.NewDataVolumeWithVddkWarmImport(dataVolumeName, size, backingFile, s.Name, thumbprint, url, vmid.String(), currentCheckpoint, previousCheckpoint, finalCheckpoint)
 	}
 
-	createVddkWithoutConfigMap := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
-		_, err := RunKubectlCommand(f, "delete", "configmap", "-n", f.CdiInstallNs, common.VddkConfigMap)
-		Expect(err).ToNot(HaveOccurred())
-
-		return createVddkDataVolume(dataVolumeName, size, url)
-	}
-
 	AfterEach(func() {
 		if sourcePvc != nil {
 			By("[AfterEach] Clean up target PVC")
@@ -269,7 +262,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			return utils.NewDataVolumeForUpload(dataVolumeName, size)
 		}
 
-		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+		testDataVolume := func(args dataVolumeTestArguments) {
 			// Have to call the function in here, to make sure the BeforeEach in the Framework has run.
 			dataVolume := args.dvFunc(args.name, args.size, args.url())
 			startTime := time.Now()
@@ -342,7 +335,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					return false
 				}, timeout, pollingInterval).Should(BeTrue())
 			}
-		},
+		}
+
+		table.DescribeTable("should", testDataVolume,
 			table.Entry("[rfe_id:1115][crit:high][test_id:1357]succeed creating import dv with given valid url", dataVolumeTestArguments{
 				name:             "dv-http-import",
 				size:             "1Gi",
@@ -773,11 +768,30 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Message: "Import Complete; VDDK: {\"Version\":\"1.2.3\",\"Host\":\"esx.test\"}",
 					Reason:  "Completed",
 				}}),
-			table.Entry("[test_id:5079]fail with \"AwaitingVDDK\" reason when VDDK credentials config map is not present", dataVolumeTestArguments{
+		)
+
+		// Similar to previous table, but with additional cleanup steps
+		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+			configMap, err := RunKubectlCommand(f, "get", "configmap", "-o", "yaml", "-n", f.CdiInstallNs, common.VddkConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = RunKubectlCommand(f, "delete", "configmap", "-n", f.CdiInstallNs, common.VddkConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			defer func() {
+				command := CreateKubectlCommand(f, "create", "-n", f.CdiInstallNs, "-f", "-")
+				command.Stdin = strings.NewReader(configMap)
+				err := command.Run()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			testDataVolume(args)
+		},
+			table.Entry("[test_id:5079]should fail with \"AwaitingVDDK\" reason when VDDK credentials config map is not present", dataVolumeTestArguments{
 				name:             "dv-awaiting-vddk",
 				size:             "1Gi",
 				url:              vcenterURL,
-				dvFunc:           createVddkWithoutConfigMap,
+				dvFunc:           createVddkDataVolume,
 				eventReason:      common.AwaitingVDDK,
 				phase:            cdiv1.ImportScheduled,
 				checkPermissions: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
When waiting for the PVC to be bound, copy the PVC's condition reason to the DataVolume instead of just "Pending".

**Which issue(s) this PR fixes**:
Fixes [BZ#1965181](https://bugzilla.redhat.com/show_bug.cgi?id=1965181)

**Release note**:
```release-note
Copy AwaitingVDDK condition reason to DV when PVC is waiting for v2v-vmware ConfigMap to be created.
```

