### PR TITLE
Add a datavolume condition for the image being too large

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -37,6 +37,8 @@ const (
 	ImporterWritePath = ImporterVolumePath + "/" + DiskImageName
 	// WriteBlockPath provides a constant for the path where the PV is mounted.
 	WriteBlockPath = "/dev/cdi-block-volume"
+	// NbdkitLogPath provides a constant for the path in which the nbdkit log messages are stored.
+	NbdkitLogPath = "/tmp/nbdkit.log"
 	// PodTerminationMessageFile is the name of the file to write the termination message to.
 	PodTerminationMessageFile = "/dev/termination-log"
 	// ImporterPodName provides a constant to use as a prefix for Pods created by CDI (controller only)

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -302,7 +302,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		if podRestarts > annPodRestarts {
 			pvc.Annotations[AnnPodRestarts] = strconv.Itoa(podRestarts)
 		}
-		setConditionFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
+		setAnnotationsFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
 	}
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -294,9 +294,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cloneComplete)
 	}
 
-	if sourcePod != nil {
-		setAnnotationsFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
-	}
+	setAnnotationsFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {
 		return r.updatePVC(pvc)

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -294,7 +294,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cloneComplete)
 	}
 
-	setAnnotationsFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
+	setAnnotationsFromPodWithPrefix(pvc.Annotations, sourcePod, AnnSourceRunningCondition)
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {
 		return r.updatePVC(pvc)

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -294,14 +294,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cloneComplete)
 	}
 
-	if sourcePod != nil && sourcePod.Status.ContainerStatuses != nil {
-		// update pvc annotation tracking pod restarts only if the source pod restart count is greater
-		// see the same in upload-controller
-		annPodRestarts, _ := strconv.Atoi(pvc.Annotations[AnnPodRestarts])
-		podRestarts := int(sourcePod.Status.ContainerStatuses[0].RestartCount)
-		if podRestarts > annPodRestarts {
-			pvc.Annotations[AnnPodRestarts] = strconv.Itoa(podRestarts)
-		}
+	if sourcePod != nil {
 		setAnnotationsFromPodWithPrefix(pvc.Annotations, AnnSourceRunningCondition, sourcePod)
 	}
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -369,10 +369,6 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		}
 	}
 	if pod.Status.ContainerStatuses != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated.ExitCode == 0 {
-	}
-	if pod.Status.ContainerStatuses != nil &&
 		pod.Status.ContainerStatuses[0].State.Terminated != nil {
 		if getSource(pvc) == SourceVDDK {
 			r.saveVddkAnnotations(pvc, pod, log)

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -347,7 +347,7 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 
 	log.V(1).Info("Updating PVC from pod")
 	anno := pvc.GetAnnotations()
-	setAnnotationsFromPodWithPrefix(anno, AnnRunningCondition, pod)
+	setAnnotationsFromPodWithPrefix(anno, pod, AnnRunningCondition)
 
 	scratchExitCode := false
 	if pod.Status.ContainerStatuses != nil &&

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -379,10 +379,6 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		anno[AnnCurrentPodID] = string(pod.ObjectMeta.UID)
 	}
 
-	if pod.Status.ContainerStatuses != nil {
-		anno[AnnPodRestarts] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
-	}
-
 	anno[AnnImportPod] = string(pod.Name)
 	if !scratchExitCode {
 		// No scratch exit code, update the phase based on the pod. If we do have scratch exit code we don't want to update the

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -2,11 +2,9 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -93,10 +91,6 @@ const (
 
 	// ImportTargetInUse is reason for event created when an import pvc is in use
 	ImportTargetInUse = "ImportTargetInUse"
-)
-
-var (
-	vddkInfoMatch = regexp.MustCompile(`((.*; )|^)VDDK: (?P<info>{.*})`)
 )
 
 // ImportReconciler members
@@ -368,12 +362,6 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.Message)
 		}
 	}
-	if pod.Status.ContainerStatuses != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated != nil {
-		if getSource(pvc) == SourceVDDK {
-			r.saveVddkAnnotations(pvc, pod, log)
-		}
-	}
 
 	if anno[AnnCurrentCheckpoint] != "" {
 		anno[AnnCurrentPodID] = string(pod.ObjectMeta.UID)
@@ -424,31 +412,6 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		}
 	}
 	return nil
-}
-
-func (r *ImportReconciler) saveVddkAnnotations(pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod, log logr.Logger) {
-	terminationMessage := pod.Status.ContainerStatuses[0].State.Terminated.Message
-	log.V(1).Info("Saving VDDK annotations from pod status message: ", "message", terminationMessage)
-
-	var terminationInfo string
-	matches := vddkInfoMatch.FindAllStringSubmatch(terminationMessage, -1)
-	for index, matchName := range vddkInfoMatch.SubexpNames() {
-		if matchName == "info" && len(matches) > 0 {
-			terminationInfo = matches[0][index]
-			break
-		}
-	}
-
-	var vddkInfo util.VddkInfo
-	err := json.Unmarshal([]byte(terminationInfo), &vddkInfo)
-	if err == nil {
-		if vddkInfo.Host != "" {
-			pvc.Annotations[AnnVddkHostConnection] = vddkInfo.Host
-		}
-		if vddkInfo.Version != "" {
-			pvc.Annotations[AnnVddkVersion] = vddkInfo.Version
-		}
-	}
 }
 
 func (r *ImportReconciler) updatePVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -353,7 +353,7 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 
 	log.V(1).Info("Updating PVC from pod")
 	anno := pvc.GetAnnotations()
-	setConditionFromPodWithPrefix(anno, AnnRunningCondition, pod)
+	setAnnotationsFromPodWithPrefix(anno, AnnRunningCondition, pod)
 
 	scratchExitCode := false
 	if pod.Status.ContainerStatuses != nil &&

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -245,7 +245,7 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
 		}
 	}
-	setConditionFromPodWithPrefix(anno, AnnRunningCondition, pod)
+	setAnnotationsFromPodWithPrefix(anno, AnnRunningCondition, pod)
 
 	if !reflect.DeepEqual(pvc, pvcCopy) {
 		if err := r.updatePVC(pvcCopy); err != nil {

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -236,15 +236,6 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 	anno[AnnPodPhase] = string(podPhase)
 	anno[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
 
-	if pod.Status.ContainerStatuses != nil {
-		// update pvc annotation tracking pod restarts only if the source pod restart count is greater
-		// see the same in clone-controller
-		pvcAnnPodRestarts, _ := strconv.Atoi(anno[AnnPodRestarts])
-		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
-		if podRestarts > pvcAnnPodRestarts {
-			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
-		}
-	}
 	setAnnotationsFromPodWithPrefix(anno, AnnRunningCondition, pod)
 
 	if !reflect.DeepEqual(pvc, pvcCopy) {

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -236,7 +236,7 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 	anno[AnnPodPhase] = string(podPhase)
 	anno[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
 
-	setAnnotationsFromPodWithPrefix(anno, AnnRunningCondition, pod)
+	setAnnotationsFromPodWithPrefix(anno, pod, AnnRunningCondition)
 
 	if !reflect.DeepEqual(pvc, pvcCopy) {
 		if err := r.updatePVC(pvcCopy); err != nil {

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -244,10 +244,6 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 		if podRestarts > pvcAnnPodRestarts {
 			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
 		}
-
-		if pod.Status.ContainerStatuses[0].State.Terminated != nil &&
-			pod.Status.ContainerStatuses[0].State.Terminated.ExitCode == 0 {
-		}
 	}
 	setConditionFromPodWithPrefix(anno, AnnRunningCondition, pod)
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
+	"strconv"
 	"strings"
 
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -547,6 +548,11 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 func setAnnotationsFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
 	if pod.Status.ContainerStatuses != nil {
+		annPodRestarts, _ := strconv.Atoi(anno[AnnPodRestarts])
+		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
+		if podRestarts >= annPodRestarts {
+			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
+		}
 		if pod.Status.ContainerStatuses[0].State.Running != nil {
 			anno[prefix] = "true"
 			anno[prefix+".message"] = ""

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -553,7 +553,7 @@ func setConditionFromPodWithPrefix(anno map[string]string, prefix string, pod *v
 			anno[prefix+".reason"] = podRunningReason
 		} else {
 			anno[AnnRunningCondition] = "false"
-			if pod.Status.ContainerStatuses[0].State.Waiting != nil {
+			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason != "CrashLoopBackOff" {
 				anno[prefix+".message"] = pod.Status.ContainerStatuses[0].State.Waiting.Message
 				anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Waiting.Reason
 			} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -563,19 +563,20 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, prefix
 		anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
 	}
 	setVddkAnnotations(anno, pod)
-	if pod.Status.ContainerStatuses[0].State.Running != nil {
+	containerState := pod.Status.ContainerStatuses[0].State
+	if containerState.Running != nil {
 		anno[prefix] = "true"
 		anno[prefix+".message"] = ""
 		anno[prefix+".reason"] = podRunningReason
 	} else {
 		anno[AnnRunningCondition] = "false"
-		if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason != "CrashLoopBackOff" {
-			anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Waiting.Message)
-			anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Waiting.Reason
-		} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {
-			anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Terminated.Message)
-			anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Terminated.Reason
-			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, common.PreallocationApplied) {
+		if containerState.Waiting != nil && containerState.Waiting.Reason != "CrashLoopBackOff" {
+			anno[prefix+".message"] = simplifyKnownMessage(containerState.Waiting.Message)
+			anno[prefix+".reason"] = containerState.Waiting.Reason
+		} else if containerState.Terminated != nil {
+			anno[prefix+".message"] = simplifyKnownMessage(containerState.Terminated.Message)
+			anno[prefix+".reason"] = containerState.Terminated.Reason
+			if strings.Contains(containerState.Terminated.Message, common.PreallocationApplied) {
 				anno[AnnPreallocationApplied] = "true"
 			}
 		}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -610,13 +610,14 @@ func setVddkAnnotations(anno map[string]string, pod *corev1.Pod) {
 
 	var vddkInfo util.VddkInfo
 	err := json.Unmarshal([]byte(terminationInfo), &vddkInfo)
-	if err == nil {
-		if vddkInfo.Host != "" {
-			anno[AnnVddkHostConnection] = vddkInfo.Host
-		}
-		if vddkInfo.Version != "" {
-			anno[AnnVddkVersion] = vddkInfo.Version
-		}
+	if err != nil {
+		return
+	}
+	if vddkInfo.Host != "" {
+		anno[AnnVddkHostConnection] = vddkInfo.Host
+	}
+	if vddkInfo.Version != "" {
+		anno[AnnVddkVersion] = vddkInfo.Version
 	}
 }
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -547,27 +547,28 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 }
 
 func setAnnotationsFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
-	if pod.Status.ContainerStatuses != nil {
-		annPodRestarts, _ := strconv.Atoi(anno[AnnPodRestarts])
-		podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
-		if podRestarts >= annPodRestarts {
-			anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
-		}
-		if pod.Status.ContainerStatuses[0].State.Running != nil {
-			anno[prefix] = "true"
-			anno[prefix+".message"] = ""
-			anno[prefix+".reason"] = podRunningReason
-		} else {
-			anno[AnnRunningCondition] = "false"
-			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason != "CrashLoopBackOff" {
-				anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Waiting.Message)
-				anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Waiting.Reason
-			} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {
-				anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Terminated.Message)
-				anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Terminated.Reason
-				if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, common.PreallocationApplied) {
-					anno[AnnPreallocationApplied] = "true"
-				}
+	if pod.Status.ContainerStatuses == nil {
+		return
+	}
+	annPodRestarts, _ := strconv.Atoi(anno[AnnPodRestarts])
+	podRestarts := int(pod.Status.ContainerStatuses[0].RestartCount)
+	if podRestarts >= annPodRestarts {
+		anno[AnnPodRestarts] = strconv.Itoa(podRestarts)
+	}
+	if pod.Status.ContainerStatuses[0].State.Running != nil {
+		anno[prefix] = "true"
+		anno[prefix+".message"] = ""
+		anno[prefix+".reason"] = podRunningReason
+	} else {
+		anno[AnnRunningCondition] = "false"
+		if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason != "CrashLoopBackOff" {
+			anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Waiting.Message)
+			anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Waiting.Reason
+		} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {
+			anno[prefix+".message"] = simplifyKnownMessage(pod.Status.ContainerStatuses[0].State.Terminated.Message)
+			anno[prefix+".reason"] = pod.Status.ContainerStatuses[0].State.Terminated.Reason
+			if strings.Contains(pod.Status.ContainerStatuses[0].State.Terminated.Message, common.PreallocationApplied) {
+				anno[AnnPreallocationApplied] = "true"
 			}
 		}
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -545,7 +545,7 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 	return (podPhaseFromPVC(pvc) == v1.PodSucceeded)
 }
 
-func setConditionFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
+func setAnnotationsFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
 	if pod.Status.ContainerStatuses != nil {
 		if pod.Status.ContainerStatuses[0].State.Running != nil {
 			anno[prefix] = "true"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -553,7 +553,7 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 	return (podPhaseFromPVC(pvc) == v1.PodSucceeded)
 }
 
-func setAnnotationsFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
+func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, prefix string) {
 	if pod == nil || pod.Status.ContainerStatuses == nil {
 		return
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -547,7 +547,7 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 }
 
 func setAnnotationsFromPodWithPrefix(anno map[string]string, prefix string, pod *v1.Pod) {
-	if pod.Status.ContainerStatuses == nil {
+	if pod == nil || pod.Status.ContainerStatuses == nil {
 		return
 	}
 	annPodRestarts, _ := strconv.Atoi(anno[AnnPodRestarts])

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -199,7 +199,7 @@ var _ = Describe("DecodePublicKey", func() {
 	})
 })
 
-var _ = Describe("setConditionFromPod", func() {
+var _ = Describe("setAnnotationsFromPod", func() {
 	It("Should follow pod container status, running", func() {
 		result := make(map[string]string)
 		testPod := createImporterTestPod(createPvc("test", metav1.NamespaceDefault, nil, nil), "test", nil)
@@ -212,7 +212,7 @@ var _ = Describe("setConditionFromPod", func() {
 				},
 			},
 		}
-		setConditionFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
 		Expect(result[AnnRunningCondition]).To(Equal("true"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Pod is running"))
 	})
@@ -232,7 +232,7 @@ var _ = Describe("setConditionFromPod", func() {
 				},
 			},
 		}
-		setConditionFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
 		Expect(result[AnnRunningCondition]).To(Equal("false"))
 		Expect(result[AnnRunningConditionMessage]).To(Equal("The container completed"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Completed"))
@@ -253,7 +253,7 @@ var _ = Describe("setConditionFromPod", func() {
 				},
 			},
 		}
-		setConditionFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
 		Expect(result[AnnRunningCondition]).To(Equal("false"))
 		Expect(result[AnnRunningConditionMessage]).To(Equal("container is waiting"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Pending"))
@@ -274,7 +274,7 @@ var _ = Describe("setConditionFromPod", func() {
 				},
 			},
 		}
-		setConditionFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
 		Expect(result[AnnPreallocationApplied]).To(Equal("true"))
 	})
 })

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -212,7 +212,7 @@ var _ = Describe("setAnnotationsFromPod", func() {
 				},
 			},
 		}
-		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
 		Expect(result[AnnRunningCondition]).To(Equal("true"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Pod is running"))
 	})
@@ -232,7 +232,7 @@ var _ = Describe("setAnnotationsFromPod", func() {
 				},
 			},
 		}
-		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
 		Expect(result[AnnRunningCondition]).To(Equal("false"))
 		Expect(result[AnnRunningConditionMessage]).To(Equal("The container completed"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Completed"))
@@ -253,7 +253,7 @@ var _ = Describe("setAnnotationsFromPod", func() {
 				},
 			},
 		}
-		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
 		Expect(result[AnnRunningCondition]).To(Equal("false"))
 		Expect(result[AnnRunningConditionMessage]).To(Equal("container is waiting"))
 		Expect(result[AnnRunningConditionReason]).To(Equal("Pending"))
@@ -274,7 +274,7 @@ var _ = Describe("setAnnotationsFromPod", func() {
 				},
 			},
 		}
-		setAnnotationsFromPodWithPrefix(result, AnnRunningCondition, testPod)
+		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
 		Expect(result[AnnPreallocationApplied]).To(Equal("true"))
 	})
 })

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -240,10 +240,18 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 
 // Default nbdkit log watcher, just logs lines as nbdkit prints them.
 func watchNbdLog(output *bufio.Reader) {
+	f, err := os.Create("/tmp/nbdkit.log")
+	if err != nil {
+		klog.Errorf("Error writing nbdkit log to file: %v", err)
+	}
+	defer f.Close()
+
 	scanner := bufio.NewScanner(output)
 	for scanner.Scan() {
 		line := scanner.Text()
-		klog.Infof("Log line from nbdkit: %s", line)
+		logLine := fmt.Sprintf("Log line from nbdkit: %s", line)
+		klog.Info(logLine)
+		f.WriteString(logLine)
 	}
 	if err := scanner.Err(); err != nil {
 		klog.Errorf("Error watching nbdkit log: %v", err)

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -240,7 +240,8 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 	return nil
 }
 
-// Default nbdkit log watcher, just logs lines as nbdkit prints them.
+// Default nbdkit log watcher, logs lines as nbdkit prints them,
+// and appends them to the nbdkit log file.
 func watchNbdLog(output *bufio.Reader) {
 	f, err := os.Create(common.NbdkitLogPath)
 	if err != nil {

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 const (
@@ -240,7 +242,7 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 
 // Default nbdkit log watcher, just logs lines as nbdkit prints them.
 func watchNbdLog(output *bufio.Reader) {
-	f, err := os.Create("/tmp/nbdkit.log")
+	f, err := os.Create(common.NbdkitLogPath)
 	if err != nil {
 		klog.Errorf("Error writing nbdkit log to file: %v", err)
 	}

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -123,7 +123,7 @@ func convertToRaw(src, dest string, preallocate bool) error {
 	if err != nil {
 		os.Remove(dest)
 		errorMsg := "could not convert image to raw"
-		if nbdkitLog, err := ioutil.ReadFile("/tmp/nbdkit.log"); err == nil {
+		if nbdkitLog, err := ioutil.ReadFile(common.NbdkitLogPath); err == nil {
 			errorMsg += " " + string(nbdkitLog)
 		}
 		return errors.Wrap(err, errorMsg)
@@ -193,7 +193,7 @@ func (o *qemuOperations) Info(url *url.URL) (*ImgInfo, error) {
 	output, err := qemuExecFunction(qemuInfoLimits, nil, "qemu-img", "info", "--output=json", url.String())
 	if err != nil {
 		errorMsg := fmt.Sprintf("%s, %s", output, err.Error())
-		if nbdkitLog, err := ioutil.ReadFile("/tmp/nbdkit.log"); err == nil {
+		if nbdkitLog, err := ioutil.ReadFile(common.NbdkitLogPath); err == nil {
 			errorMsg += " " + string(nbdkitLog)
 		}
 		return nil, errors.Errorf(errorMsg)

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -19,6 +19,7 @@ package image
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -121,7 +122,11 @@ func convertToRaw(src, dest string, preallocate bool) error {
 	}
 	if err != nil {
 		os.Remove(dest)
-		return errors.Wrap(err, "could not convert image to raw")
+		errorMsg := "could not convert image to raw"
+		if nbdkitLog, err := ioutil.ReadFile("/tmp/nbdkit.log"); err == nil {
+			errorMsg += " " + string(nbdkitLog)
+		}
+		return errors.Wrap(err, errorMsg)
 	}
 
 	return nil
@@ -187,7 +192,11 @@ func (o *qemuOperations) Info(url *url.URL) (*ImgInfo, error) {
 	}
 	output, err := qemuExecFunction(qemuInfoLimits, nil, "qemu-img", "info", "--output=json", url.String())
 	if err != nil {
-		return nil, errors.Errorf("%s, %s", output, err.Error())
+		errorMsg := fmt.Sprintf("%s, %s", output, err.Error())
+		if nbdkitLog, err := ioutil.ReadFile("/tmp/nbdkit.log"); err == nil {
+			errorMsg += " " + string(nbdkitLog)
+		}
+		return nil, errors.Errorf(errorMsg)
 	}
 	return checkOutputQemuImgInfo(output, url.String())
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -232,6 +232,7 @@ func WriteTerminationMessage(message string) error {
 
 // WriteTerminationMessageToFile writes the passed in message to the passed in message file
 func WriteTerminationMessageToFile(file, message string) error {
+	message = strings.ReplaceAll(message, "\n", " ")
 	// Only write the first line of the message.
 	scanner := bufio.NewScanner(strings.NewReader(message))
 	if scanner.Scan() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -294,7 +294,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					// will not match if the pod hasn't failed and the backoff is not long enough yet
 					resultDv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 					Expect(dverr).ToNot(HaveOccurred())
-					return verifyConditions(resultDv.Status.Conditions, startTime, args.readyCondition, args.runningCondition, args.boundCondition)
+					return VerifyConditions(resultDv.Status.Conditions, startTime, args.readyCondition, args.runningCondition, args.boundCondition)
 				}, timeout, pollingInterval).Should(BeTrue())
 
 				// verify PVC was created
@@ -2279,38 +2279,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 	})
 })
-
-func verifyConditions(actualConditions []cdiv1.DataVolumeCondition, startTime time.Time, testConditions ...*cdiv1.DataVolumeCondition) bool {
-	for _, condition := range testConditions {
-		if condition != nil {
-			actualCondition := findConditionByType(condition.Type, actualConditions)
-			if actualCondition != nil {
-				if actualCondition.Status != condition.Status {
-					fmt.Fprintf(GinkgoWriter, "INFO: Condition.Status does not match for type: %s\n", condition.Type)
-					return false
-				}
-				if strings.Compare(actualCondition.Reason, condition.Reason) != 0 {
-					fmt.Fprintf(GinkgoWriter, "INFO: Condition.Reason does not match for type: %s, reason expected [%s], reason found: [%s]\n", condition.Type, condition.Reason, actualCondition.Reason)
-					return false
-				}
-				if !strings.Contains(actualCondition.Message, condition.Message) {
-					fmt.Fprintf(GinkgoWriter, "INFO: Condition.Message does not match for type: %s, message expected: [%s],  message found: [%s]\n", condition.Type, condition.Message, actualCondition.Message)
-					return false
-				}
-			}
-		}
-	}
-	return true
-}
-
-func findConditionByType(conditionType cdiv1.DataVolumeConditionType, conditions []cdiv1.DataVolumeCondition) *cdiv1.DataVolumeCondition {
-	for i, condition := range conditions {
-		if condition.Type == conditionType {
-			return &conditions[i]
-		}
-	}
-	return nil
-}
 
 func SetFilesystemOverhead(f *framework.Framework, globalOverhead, scOverhead string) {
 	defaultSCName := utils.DefaultStorageClass.GetName()


### PR DESCRIPTION
- Make sure that the nbdkit messages are in the terminating message, and appear at the exit.
- Avoid newlines in the terminating message, as they don't appear in the `kubectl get pod .. -o yaml` view.
- Avoid CrashLoopBackOff becoming a condition, we prefer to know why the crash had happened.
- If the message is a known long message about the image being too small, pass that stirng.
Tests are adjusted to take advantage of this condition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This is intended for [BZ #1893526](https://bugzilla.redhat.com/show_bug.cgi?id=1893526).
Makes it easier to tell that the DV failed because it's too small - for humans and programmers alike.

**Special notes for your reviewer**:
I haven't found out why the termination message doesn't show past newlines.
Perhaps that's just the kubectl get .. -o yaml view.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid "crashloopbackoff" becoming a datavolume condition message.
Make "DataVolume too small to contain image" a possible datavolume condition message, instead of dumping nbdkit logs.
Avoid the terminating message getting cut off, and improve it to include nbdkit logs when they exist.
```