### PR TITLE
Fix leader election test that is failing.

### DIFF
--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -179,6 +179,7 @@ func getLeaderAndNewDeployment(f *framework.Framework) (string, *appsv1.Deployme
 	leaderPodName := pods.Items[0].Name
 
 	log := getLog(f, leaderPodName)
+	fmt.Fprintf(GinkgoWriter, "Log: %s", log)
 	Expect(checkLogForRegEx(logIsLeaderRegex, log)).To(BeTrue())
 
 	newDeployment := deployments.Items[0].DeepCopy()

--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -64,28 +64,30 @@ var _ = Describe("[rfe_id:1250][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		cleanupTest(f, newDeployment)
 	})
 
-	It("[test_id:1365]Should only ever be one controller as leader", func() {
-		Expect(leaderPodName).ShouldNot(BeEmpty())
+	Context("[Destructive]", func() {
+		It("[test_id:1365]Should only ever be one controller as leader", func() {
+			Expect(leaderPodName).ShouldNot(BeEmpty())
 
-		newPodName := locateNewPod(f, leaderPodName)
-		Expect(newPodName).ShouldNot(BeEmpty())
+			newPodName := locateNewPod(f, leaderPodName)
+			Expect(newPodName).ShouldNot(BeEmpty())
 
-		By("Check that new pod is attempting to become leader")
-		Eventually(func() bool {
+			By("Check that new pod is attempting to become leader")
+			Eventually(func() bool {
+				log := getLog(f, newPodName)
+				return checkLogForRegEx(logCheckLeaderRegEx, log)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			// have to prove new pod won't become leader in period longer than lease duration
+			time.Sleep(20 * time.Second)
+
+			By("Confirm pod did not become leader")
 			log := getLog(f, newPodName)
-			return checkLogForRegEx(logCheckLeaderRegEx, log)
-		}, timeout, pollingInterval).Should(BeTrue())
-
-		// have to prove new pod won't become leader in period longer than lease duration
-		time.Sleep(20 * time.Second)
-
-		By("Confirm pod did not become leader")
-		log := getLog(f, newPodName)
-		logMatched := checkLogForRegEx(logIsLeaderRegex, log)
-		if logMatched {
-			fmt.Fprintf(GinkgoWriter, "Log: %s", log)
-		}
-		Expect(logMatched).To(BeFalse())
+			logMatched := checkLogForRegEx(logIsLeaderRegex, log)
+			if logMatched {
+				fmt.Fprintf(GinkgoWriter, "Log: %s", log)
+			}
+			Expect(logMatched).To(BeFalse())
+		})
 	})
 })
 
@@ -104,69 +106,70 @@ var _ = Describe("[rfe_id:1250][crit:high][test_id:1889][vendor:cnv-qe@redhat.co
 		cleanupTest(f, newDeployment)
 	})
 
-	It("Should not not interrupt an import while switching leaders", func() {
-		Expect(leaderPodName).ShouldNot(BeEmpty())
-		var importer *v1.Pod
+	Context("[Destructive]", func() {
+		It("Should not not interrupt an import while switching leaders", func() {
+			Expect(leaderPodName).ShouldNot(BeEmpty())
+			var importer *v1.Pod
 
-		newPodName := locateNewPod(f, leaderPodName)
-		Expect(newPodName).ShouldNot(BeEmpty())
+			newPodName := locateNewPod(f, leaderPodName)
+			Expect(newPodName).ShouldNot(BeEmpty())
 
-		By("Starting slow import, we can monitor if it gets interrupted during leader changes")
-		httpEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPRateLimitPort)
-		pvcAnn := map[string]string{
-			controller.AnnEndpoint: httpEp + "/tinyCore.iso",
-			controller.AnnSecret:   "",
-		}
-
-		pvc, err := utils.CreatePVCFromDefinition(f.K8sClient, f.Namespace.Name, utils.NewPVCDefinition("import-e2e", "40Mi", pvcAnn, nil))
-		Expect(err).NotTo(HaveOccurred())
-		f.ForceBindIfWaitForFirstConsumer(pvc)
-
-		Eventually(func() bool {
-			importer, err = utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, common.ImporterPodName, common.CDILabelSelector)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", f.Namespace.Name+"/"+common.ImporterPodName))
-			return importer.Status.Phase == v1.PodRunning || importer.Status.Phase == v1.PodSucceeded
-		}, timeout, pollingInterval).Should(BeTrue())
-
-		Eventually(func() bool {
-			log, err := tests.RunKubectlCommand(f, "logs", importer.Name, "-n", f.Namespace.Name)
-			Expect(err).NotTo(HaveOccurred())
-			return checkLogForRegEx(logImporterStarting, log)
-		}, timeout, pollingInterval).Should(BeTrue())
-
-		// The import is starting, and the transfer is about to happen. Now kill the leader
-		By("Killing leader, we should have a new leader elected")
-		err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).Delete(context.TODO(), leaderPodName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to kill leader: %v", err))
-
-		By("Verifying that the original leader pod is gone.")
-		Eventually(func() bool {
-			_, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).Get(context.TODO(), leaderPodName, metav1.GetOptions{})
-			return err != nil && k8serrors.IsNotFound(err)
-		}, timeout, pollingInterval).Should(BeTrue())
-
-		Eventually(func() bool {
-			newDeploymentPodName := locateNewPod(f, newPodName)
-			newDeploymentLog := ""
-			if newDeploymentPodName != "" {
-				newDeploymentLog = getLog(f, newDeploymentPodName)
+			By("Starting slow import, we can monitor if it gets interrupted during leader changes")
+			httpEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPRateLimitPort)
+			pvcAnn := map[string]string{
+				controller.AnnEndpoint: httpEp + "/tinyCore.iso",
+				controller.AnnSecret:   "",
 			}
-			log := getLog(f, newPodName)
-			fmt.Fprintf(GinkgoWriter, "INFO: Lookin for: %s\n", logIsLeaderRegex)
-			fmt.Fprintf(GinkgoWriter, "INFO: In new deployment pod log: %s\n", log)
-			if newDeploymentLog != "" {
-				fmt.Fprintf(GinkgoWriter, "INFO: In original leader pod log: %s\n", newDeploymentLog)
-			}
-			return checkLogForRegEx(logIsLeaderRegex, log) || checkLogForRegEx(logIsLeaderRegex, newDeploymentLog)
-		}, timeout, pollingInterval).Should(BeTrue())
 
-		By("Verifying imported pod has progressed without issue")
-		Eventually(func() bool {
-			log, err := tests.RunKubectlCommand(f, "logs", importer.Name, "-n", f.Namespace.Name)
+			pvc, err := utils.CreatePVCFromDefinition(f.K8sClient, f.Namespace.Name, utils.NewPVCDefinition("import-e2e", "40Mi", pvcAnn, nil))
 			Expect(err).NotTo(HaveOccurred())
-			return checkLogForRegEx(logImporterCompleted, log)
-		}, timeout, pollingInterval).Should(BeTrue())
+			f.ForceBindIfWaitForFirstConsumer(pvc)
 
+			Eventually(func() bool {
+				importer, err = utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, common.ImporterPodName, common.CDILabelSelector)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get importer pod %q", f.Namespace.Name+"/"+common.ImporterPodName))
+				return importer.Status.Phase == v1.PodRunning || importer.Status.Phase == v1.PodSucceeded
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Eventually(func() bool {
+				log, err := tests.RunKubectlCommand(f, "logs", importer.Name, "-n", f.Namespace.Name)
+				Expect(err).NotTo(HaveOccurred())
+				return checkLogForRegEx(logImporterStarting, log)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			// The import is starting, and the transfer is about to happen. Now kill the leader
+			By("Killing leader, we should have a new leader elected")
+			err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).Delete(context.TODO(), leaderPodName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to kill leader: %v", err))
+
+			By("Verifying that the original leader pod is gone.")
+			Eventually(func() bool {
+				_, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).Get(context.TODO(), leaderPodName, metav1.GetOptions{})
+				return err != nil && k8serrors.IsNotFound(err)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Eventually(func() bool {
+				newDeploymentPodName := locateNewPod(f, newPodName)
+				newDeploymentLog := ""
+				if newDeploymentPodName != "" {
+					newDeploymentLog = getLog(f, newDeploymentPodName)
+				}
+				log := getLog(f, newPodName)
+				fmt.Fprintf(GinkgoWriter, "INFO: Lookin for: %s\n", logIsLeaderRegex)
+				fmt.Fprintf(GinkgoWriter, "INFO: In new deployment pod log: %s\n", log)
+				if newDeploymentLog != "" {
+					fmt.Fprintf(GinkgoWriter, "INFO: In original leader pod log: %s\n", newDeploymentLog)
+				}
+				return checkLogForRegEx(logIsLeaderRegex, log) || checkLogForRegEx(logIsLeaderRegex, newDeploymentLog)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			By("Verifying imported pod has progressed without issue")
+			Eventually(func() bool {
+				log, err := tests.RunKubectlCommand(f, "logs", importer.Name, "-n", f.Namespace.Name)
+				Expect(err).NotTo(HaveOccurred())
+				return checkLogForRegEx(logImporterCompleted, log)
+			}, timeout, pollingInterval).Should(BeTrue())
+		})
 	})
 })
 


### PR DESCRIPTION
Add some logging to figure out what is in the log why it is not being matched

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The leader election tests are failing often, and it appears to fail in some log matching and I am guessing a new k8s version logs something different. This PR attempts to fix the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

