### PR TITLE
Adding support to specify externally managed certs

### DIFF
--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/util/cert/watcher:go_default_library",
         "//pkg/version/verflag:go_default_library",
+        "//vendor/github.com/kelseyhightower/envconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/cmd/cdi-apiserver/apiserver.go
+++ b/cmd/cdi-apiserver/apiserver.go
@@ -44,21 +44,25 @@ const (
 	// Default address api listens on.
 	defaultHost = "0.0.0.0"
 
-	certDir  = "/var/run/certs/cdi-apiserver-server-cert/"
-	certFile = certDir + "tls.crt"
-	keyFile  = certDir + "tls.key"
+	defaultCertDir  = "/var/run/certs/cdi-apiserver-server-cert/"
+	defaultCertFile = defaultCertDir + "tls.crt"
+	defaultKeyFile  = defaultCertDir + "tls.key"
 )
 
 var (
 	configPath string
 	masterURL  string
 	verbose    string
+	certFile string
+	keyFile string
 )
 
 func init() {
 	// flags
 	flag.StringVar(&configPath, "kubeconfig", os.Getenv("KUBECONFIG"), "(Optional) Overrides $KUBECONFIG")
 	flag.StringVar(&masterURL, "server", "", "(Optional) URL address of a remote api server.  Do not set for local clusters.")
+	flag.StringVar(&certFile, "cert-file", defaultCertFile, "(Optional) API Server Certificate ")
+	flag.StringVar(&keyFile, "key-file", defaultKeyFile, "(Optional) API Server private key for the certificate")
 	klog.InitFlags(nil)
 	flag.Parse()
 

--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/cert/fetcher:go_default_library",
         "//pkg/util/cert/generator:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
+        "//vendor/github.com/kelseyhightower/envconfig:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/cdi-uploadproxy/BUILD.bazel
+++ b/cmd/cdi-uploadproxy/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/util/cert/fetcher:go_default_library",
         "//pkg/util/cert/watcher:go_default_library",
+        "//vendor/github.com/kelseyhightower/envconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/pkg/util/cert/fetcher/certfetcher.go
+++ b/pkg/util/cert/fetcher/certfetcher.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"path"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -22,17 +20,18 @@ type CertFetcher interface {
 
 // FileCertFetcher reads certs from files
 type FileCertFetcher struct {
-	Name string
+	KeyFileName  string
+	CertFileName string
 }
 
 // KeyBytes returns key bytes
 func (f *FileCertFetcher) KeyBytes() ([]byte, error) {
-	return ioutil.ReadFile(path.Join(baseCertPath, f.Name, "tls.key"))
+	return ioutil.ReadFile(f.KeyFileName)
 }
 
 // CertBytes returns cert bytes
 func (f *FileCertFetcher) CertBytes() ([]byte, error) {
-	return ioutil.ReadFile(path.Join(baseCertPath, f.Name, "tls.crt"))
+	return ioutil.ReadFile(f.CertFileName)
 }
 
 // MemCertFetcher reads certs from files


### PR DESCRIPTION
Signed-off-by: Vishesh Ajay Tanksale <vtanksale@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Add flags to API Server, Controller and upload proxy to specify custom certificate paths. Custom certs path can be used to populate externally managed certs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

