### PR TITLE
Move nfs-server images to quay.io

### DIFF
--- a/cluster-sync/nfs/nfs-server.yaml
+++ b/cluster-sync/nfs/nfs-server.yaml
@@ -29,7 +29,7 @@ spec:
         cdi.kubevirt.io/testing: ""
     spec:
       containers:
-      - image: itsthenetwork/nfs-server-alpine:12
+      - image: quay.io/awels/nfs-server-alpine:12
         imagePullPolicy: IfNotPresent
         name: nfs-server
         env:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
dockerhub rate limit strikes again. Move the nfs-server image to quay.io/awels so we don't run into that problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

