### PR TITLE
URL-encode special characters in VDDK credentials.

### DIFF
--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -248,18 +248,24 @@ func createVMwareClient(endpoint string, accessKey string, secKey string, thumbp
 	}
 
 	// Construct VMware SDK URL and get MOref
-	sdkURL := vmwURL.Scheme + "://" + accessKey + ":" + secKey + "@" + vmwURL.Host + "/sdk"
+	sdkURL := vmwURL.Scheme + "://" + url.PathEscape(accessKey) + ":" + url.PathEscape(secKey) + "@" + vmwURL.Host + "/sdk"
+	redacted := vmwURL.Scheme + "://" + url.PathEscape(accessKey) + ":" + "*****" + "@" + vmwURL.Host + "/sdk"
 	vmwURL, err = url.Parse(sdkURL)
 	if err != nil {
-		klog.Errorf("Unable to create VMware URL: %v", err)
-		return nil, err
+		return nil, errors.New("unable to create VMware URL from: " + redacted)
 	}
 
 	// Log in to vCenter
 	ctx, cancel := context.WithCancel(context.Background())
 	conn, err := govmomi.NewClient(ctx, vmwURL, true)
 	if err != nil {
-		klog.Errorf("Unable to connect to vCenter: %v", err)
+		if secKey != "" {
+			wrap := url.PathEscape(accessKey) + ":%s@"
+			target := fmt.Sprintf(wrap, url.PathEscape(secKey))
+			redacted = fmt.Sprintf(wrap, "*****")
+			redacted = strings.ReplaceAll(err.Error(), target, redacted)
+			err = errors.New("unable to connect to vCenter: " + redacted)
+		}
 		cancel()
 		return nil, err
 	}

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -254,6 +254,7 @@ func createVMwareClient(endpoint string, accessKey string, secKey string, thumbp
 	ctx, cancel := context.WithCancel(context.Background())
 	conn, err := govmomi.NewClient(ctx, vmwURL, true)
 	if err != nil {
+		klog.Errorf("Unable to connect to vCenter: %v", err)
 		cancel()
 		return nil, err
 	}

--- a/pkg/importer/vddk-datasource.go
+++ b/pkg/importer/vddk-datasource.go
@@ -247,25 +247,13 @@ func createVMwareClient(endpoint string, accessKey string, secKey string, thumbp
 		return nil, err
 	}
 
-	// Construct VMware SDK URL and get MOref
-	sdkURL := vmwURL.Scheme + "://" + url.PathEscape(accessKey) + ":" + url.PathEscape(secKey) + "@" + vmwURL.Host + "/sdk"
-	redacted := vmwURL.Scheme + "://" + url.PathEscape(accessKey) + ":" + "*****" + "@" + vmwURL.Host + "/sdk"
-	vmwURL, err = url.Parse(sdkURL)
-	if err != nil {
-		return nil, errors.New("unable to create VMware URL from: " + redacted)
-	}
+	vmwURL.User = url.UserPassword(accessKey, secKey)
+	vmwURL.Path = "sdk"
 
 	// Log in to vCenter
 	ctx, cancel := context.WithCancel(context.Background())
 	conn, err := govmomi.NewClient(ctx, vmwURL, true)
 	if err != nil {
-		if secKey != "" {
-			wrap := url.PathEscape(accessKey) + ":%s@"
-			target := fmt.Sprintf(wrap, url.PathEscape(secKey))
-			redacted = fmt.Sprintf(wrap, "*****")
-			redacted = strings.ReplaceAll(err.Error(), target, redacted)
-			err = errors.New("unable to connect to vCenter: " + redacted)
-		}
 		cancel()
 		return nil, err
 	}

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -64,15 +64,14 @@ var _ = Describe("VDDK data source", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("NewVDDKDataSource should not fail to parse credentials with special characters", func() {
+	It("NewVDDKDataSource should not fail on credentials with special characters", func() {
 		newVddkDataSource = createVddkDataSource
 		newVMwareClient = createVMwareClient
 		_, err := NewVDDKDataSource("http://--------", "test#user@vsphere.local", "Test#password", "", "", "", "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).ToNot(ContainSubstring("unable to create VMware URL"))
+		Expect(err.Error()).To(ContainSubstring("no such host"))
 		Expect(err.Error()).ToNot(ContainSubstring("Test#password"))
 		Expect(err.Error()).ToNot(ContainSubstring(url.PathEscape("Test#password")))
-		Expect(err.Error()).To(ContainSubstring("unable to connect to vCenter"))
 	})
 
 	It("VDDK data source GetURL should pass through NBD socket information", func() {

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -64,6 +64,17 @@ var _ = Describe("VDDK data source", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("NewVDDKDataSource should not fail to parse credentials with special characters", func() {
+		newVddkDataSource = createVddkDataSource
+		newVMwareClient = createVMwareClient
+		_, err := NewVDDKDataSource("http://--------", "test#user@vsphere.local", "Test#password", "", "", "", "", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).ToNot(ContainSubstring("unable to create VMware URL"))
+		Expect(err.Error()).ToNot(ContainSubstring("Test#password"))
+		Expect(err.Error()).ToNot(ContainSubstring(url.PathEscape("Test#password")))
+		Expect(err.Error()).To(ContainSubstring("unable to connect to vCenter"))
+	})
+
 	It("VDDK data source GetURL should pass through NBD socket information", func() {
 		dp, err := NewVDDKDataSource("", "", "", "", "", "", "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
For VDDK data sources, this pull request encodes the login credentials so that they can be used in VMware login URLs. Without this, special characters in the username or password can cause immediate importer failures.

This also tries to avoid printing passwords in related error messages.

**Which issue(s) this PR fixes**
Fixes [RHBZ#1972895](https://bugzilla.redhat.com/show_bug.cgi?id=1972895)

**Release note**:
```release-note
VDDK: handle special characters in login credentials.
```

