### PR TITLE
Add DataVolume annotation to retain the transfer pods after completion

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -317,6 +317,7 @@ The running and ready conditions are mutually exclusive, if running is true, the
 
 ## Annotations
 Specific [DV annotations](datavolume-annotations.md) are passed to the transfer pods to control their behavior.
+Other [annotations](debug.md) help debugging and testing by retaining the transfer pods after completion.
 
 ## Priority Class
 You can specify priority class name on the Data Volume Object. The corresponding pod created for the data volume will be assigned the priority class on the data volume. Following is an example of specifying the priority class on Data Volume 

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,0 +1,30 @@
+# Debugging CDI
+
+## Introduction
+
+There are various instrumentations available for developers debugging CDI. We will keep expanding this document to make our life easier.
+
+## DataVolume annotation to retain the transfer pods after completion
+
+Adding the annotation `cdi.kubevirt.io/storage.pod.retainAfterCompletion: "true"` will cause CDI transfer pods (importer, uploader, cloner) to be retained after a successful or failed completion. This makes debugging and testing easier, as developers can get the pod state and logs after completion. The pods will be deleted when their dv/pvc is deleted, otherwise the user is responsible for deleting them.
+
+For example:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: dv-pod-retain
+  annotations:
+      cdi.kubevirt.io/storage.pod.retainAfterCompletion: "true"
+spec:
+  source:
+      http:
+         url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+```

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -179,7 +179,7 @@ func (r *CloneReconciler) Reconcile(_ context.Context, req reconcile.Request) (r
 	}
 	log := r.log.WithValues("PVC", req.NamespacedName)
 	log.V(1).Info("reconciling Clone PVCs")
-	if pvc.DeletionTimestamp != nil || !r.shouldReconcile(pvc, log) {
+	if pvc.DeletionTimestamp != nil || (!r.shouldReconcile(pvc, log) && !isPodRetainAfterCompletion(pvc)) {
 		log.V(1).Info("Should not reconcile this PVC",
 			"checkPVC(AnnCloneRequest)", checkPVC(pvc, AnnCloneRequest, log),
 			"NOT has annotation(AnnCloneOf)", !metav1.HasAnnotation(pvc.ObjectMeta, AnnCloneOf),

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -126,7 +126,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 	// force cleanup if PVC pending delete and pod running or the upload/clone annotation was removed
-	if !shouldReconcile || podSucceededFromPVC(pvc) || pvc.DeletionTimestamp != nil {
+	if !shouldReconcile || (podSucceededFromPVC(pvc) && !isPodRetainAfterCompletion(pvc)) || pvc.DeletionTimestamp != nil {
 		log.V(1).Info("not doing anything with PVC",
 			"isUpload", isUpload,
 			"isCloneTarget", isCloneTarget,

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -126,7 +126,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 	// force cleanup if PVC pending delete and pod running or the upload/clone annotation was removed
-	if !shouldReconcile || (podSucceededFromPVC(pvc) && !isPodRetainAfterCompletion(pvc)) || pvc.DeletionTimestamp != nil {
+	if !shouldReconcile || podSucceededFromPVC(pvc) || pvc.DeletionTimestamp != nil {
 		log.V(1).Info("not doing anything with PVC",
 			"isUpload", isUpload,
 			"isCloneTarget", isCloneTarget,
@@ -334,7 +334,7 @@ func (r *UploadReconciler) cleanup(pvc *v1.PersistentVolumeClaim) error {
 		}
 		return err
 	}
-	if pod.DeletionTimestamp == nil {
+	if pod.DeletionTimestamp == nil && shouldDeletePod(pvc) {
 		if err := r.client.Delete(context.TODO(), pod); IgnoreNotFound(err) != nil {
 			return err
 		}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -764,9 +764,8 @@ func getPriorityClass(pvc *v1.PersistentVolumeClaim) string {
 	return anno[AnnPriorityClassName]
 }
 
-func isPodRetainAfterCompletion(pvc *corev1.PersistentVolumeClaim) bool {
-	retain, exists := pvc.ObjectMeta.Annotations[AnnPodRetainAfterCompletion]
-	return exists && retain == "true"
+func shouldDeletePod(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc.GetAnnotations()[AnnPodRetainAfterCompletion] != "true" || pvc.DeletionTimestamp != nil
 }
 
 // AddFinalizer adds a finalizer to a resource

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -65,6 +65,8 @@ const (
 	AnnPrePopulated = AnnAPIGroup + "/storage.prePopulated"
 	// AnnPriorityClassName is PVC annotation to indicate the priority class name for importer, cloner and uploader pod
 	AnnPriorityClassName = AnnAPIGroup + "/storage.pod.priorityclassname"
+	// AnnPodRetainAfterCompletion is PVC annotation for retaining transfer pods after completion)
+	AnnPodRetainAfterCompletion = AnnAPIGroup + "/storage.pod.retainAfterCompletion"
 
 	// AnnPreviousCheckpoint provides a const to indicate the previous snapshot for a multistage import
 	AnnPreviousCheckpoint = AnnAPIGroup + "/storage.checkpoint.previous"
@@ -760,6 +762,11 @@ func GetImportProxyConfig(config *cdiv1.CDIConfig, field string) (string, error)
 func getPriorityClass(pvc *v1.PersistentVolumeClaim) string {
 	anno := pvc.GetAnnotations()
 	return anno[AnnPriorityClassName]
+}
+
+func isPodRetainAfterCompletion(pvc *corev1.PersistentVolumeClaim) bool {
+	retain, exists := pvc.ObjectMeta.Annotations[AnnPodRetainAfterCompletion]
+	return exists && retain == "true"
 }
 
 // AddFinalizer adds a finalizer to a resource

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1104,7 +1104,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 				By("Trying to catch the pods...")
 				err = wait.PollImmediate(fastPollingInterval, 10*time.Second, func() (bool, error) {
-					sourcePod, err = utils.FindPodBysuffix(f.K8sClient, dataVolume.Namespace, "source-pod", common.CDILabelSelector)
+					sourcePod, err = utils.FindPodBySuffix(f.K8sClient, dataVolume.Namespace, "source-pod", common.CDILabelSelector)
 					if err != nil {
 						return false, err
 					}
@@ -2281,7 +2281,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				var uploadPod *v1.Pod
 				Eventually(func() bool {
 					if sourcePod == nil {
-						sourcePod, _ = utils.FindPodBysuffix(f.K8sClient, dataVolume.Namespace, "source-pod", common.CDILabelSelector)
+						sourcePod, _ = utils.FindPodBySuffix(f.K8sClient, dataVolume.Namespace, "source-pod", common.CDILabelSelector)
 					}
 					if uploadPod == nil {
 						uploadPod, _ = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)

--- a/tests/framework/pod.go
+++ b/tests/framework/pod.go
@@ -38,7 +38,7 @@ func (f *Framework) FindPodByPrefix(prefix string) (*k8sv1.Pod, error) {
 	return utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, prefix, common.CDILabelSelector)
 }
 
-// FindPodBySuffix is a wrapper around utils.FindPodByPostFix
-func (f *Framework) FindPodBySuffix(prefix string) (*k8sv1.Pod, error) {
-	return utils.FindPodBysuffix(f.K8sClient, f.Namespace.Name, prefix, common.CDILabelSelector)
+// FindPodBySuffix is a wrapper around utils.FindPodBySuffix
+func (f *Framework) FindPodBySuffix(suffix string) (*k8sv1.Pod, error) {
+	return utils.FindPodBySuffix(f.K8sClient, f.Namespace.Name, suffix, common.CDILabelSelector)
 }

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -156,12 +156,10 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		err = utils.WaitForDataVolumePhase(f.CdiClient, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
 
-		By("Sleep for a while")
-		time.Sleep(time.Second * 3)
-
 		By("Find importer pod after completion")
-		_, err = utils.FindPodByPrefixOnce(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
+		importer, err := utils.FindPodByPrefixOnce(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(importer.DeletionTimestamp).To(BeNil())
 	})
 })
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -139,6 +139,30 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))
 		}
 	})
+
+	It("[test_id:6687] Should retain the importer pod after completion with dv annotation cdi.kubevirt.io/storage.pod.retainAfterCompletion=true", func() {
+		dataVolume := utils.NewDataVolumeWithHTTPImport("import-pod-retain-test", "100Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
+		dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify pvc was created")
+		pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		f.ForceBindIfWaitForFirstConsumer(pvc)
+
+		By("Wait for import to be completed")
+		err = utils.WaitForDataVolumePhase(f.CdiClient, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
+
+		By("Sleep for a while")
+		time.Sleep(time.Second * 3)
+
+		By("Find importer pod after completion")
+		_, err = utils.FindPodByPrefixOnce(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
+		Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 var _ = Describe("[Istio] Namespace sidecar injection", func() {

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -70,14 +70,27 @@ func DeletePod(clientSet *kubernetes.Clientset, pod *k8sv1.Pod, namespace string
 	return DeletePodByName(clientSet, pod.Name, namespace, nil)
 }
 
-// FindPodBysuffix finds the first pod which has the passed in postfix. Returns error if multiple pods with the same prefix are found.
-func FindPodBysuffix(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string) (*k8sv1.Pod, error) {
-	return findPodByCompFunc(clientSet, namespace, prefix, labelSelector, strings.HasSuffix)
+// FindPodBySuffix finds the first pod which has the passed in suffix. Returns error if multiple pods with the same suffix are found.
+func FindPodBySuffix(clientSet *kubernetes.Clientset, namespace, suffix, labelSelector string) (*k8sv1.Pod, error) {
+	return findPodByCompFunc(clientSet, namespace, suffix, labelSelector, strings.HasSuffix)
 }
 
 // FindPodByPrefix finds the first pod which has the passed in prefix. Returns error if multiple pods with the same prefix are found.
 func FindPodByPrefix(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string) (*k8sv1.Pod, error) {
 	return findPodByCompFunc(clientSet, namespace, prefix, labelSelector, strings.HasPrefix)
+}
+
+// FindPodBySuffixOnce finds once (no polling) the first pod which has the passed in suffix. Returns error if multiple pods with the same suffix are found.
+func FindPodBySuffixOnce(clientSet *kubernetes.Clientset, namespace, suffix, labelSelector string) (*k8sv1.Pod, error) {
+	var result k8sv1.Pod
+	foundPod, err := findPodByCompFuncOnce(clientSet, namespace, suffix, labelSelector, strings.HasSuffix, &result)
+	if foundPod {
+		return &result, err
+	}
+	if err == nil {
+		return nil, fmt.Errorf("Unable to find pod containing %s", suffix)
+	}
+	return nil, err
 }
 
 // FindPodByPrefixOnce finds once (no polling) the first pod which has the passed in prefix. Returns error if multiple pods with the same prefix are found.

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -82,65 +82,51 @@ func FindPodByPrefix(clientSet *kubernetes.Clientset, namespace, prefix, labelSe
 
 // FindPodBySuffixOnce finds once (no polling) the first pod which has the passed in suffix. Returns error if multiple pods with the same suffix are found.
 func FindPodBySuffixOnce(clientSet *kubernetes.Clientset, namespace, suffix, labelSelector string) (*k8sv1.Pod, error) {
-	var result k8sv1.Pod
-	foundPod, err := findPodByCompFuncOnce(clientSet, namespace, suffix, labelSelector, strings.HasSuffix, &result)
-	if foundPod {
-		return &result, err
-	}
-	if err == nil {
-		return nil, fmt.Errorf("Unable to find pod containing %s", suffix)
-	}
-	return nil, err
+	return findPodByCompFuncOnce(clientSet, namespace, suffix, labelSelector, strings.HasSuffix)
 }
 
 // FindPodByPrefixOnce finds once (no polling) the first pod which has the passed in prefix. Returns error if multiple pods with the same prefix are found.
 func FindPodByPrefixOnce(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string) (*k8sv1.Pod, error) {
-	var result k8sv1.Pod
-	foundPod, err := findPodByCompFuncOnce(clientSet, namespace, prefix, labelSelector, strings.HasPrefix, &result)
-	if foundPod {
-		return &result, err
-	}
-	if err == nil {
-		return nil, fmt.Errorf("Unable to find pod containing %s", prefix)
-	}
-	return nil, err
+	return findPodByCompFuncOnce(clientSet, namespace, prefix, labelSelector, strings.HasPrefix)
 }
 
 func findPodByCompFunc(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string, compFunc func(string, string) bool) (*k8sv1.Pod, error) {
-	var result k8sv1.Pod
-	var foundPod bool
-	err := wait.PollImmediate(2*time.Second, podCreateTime, func() (bool, error) {
-		var err error
-		foundPod, err = findPodByCompFuncOnce(clientSet, namespace, prefix, labelSelector, compFunc, &result)
-		return foundPod, err
+	var result *k8sv1.Pod
+	var err error
+	wait.PollImmediate(2*time.Second, podCreateTime, func() (bool, error) {
+		result, err = findPodByCompFuncOnce(clientSet, namespace, prefix, labelSelector, compFunc)
+		if result != nil {
+			return true, err
+		}
+		// If no result yet, continue polling even if there is an error
+		return false, nil
 	})
-	if !foundPod {
-		return nil, fmt.Errorf("Unable to find pod containing %s", prefix)
-	}
-	return &result, err
+	return result, err
 }
 
-func findPodByCompFuncOnce(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string, compFunc func(string, string) bool, result *k8sv1.Pod) (bool, error) {
-	var foundPod bool
+func findPodByCompFuncOnce(clientSet *kubernetes.Clientset, namespace, prefix, labelSelector string, compFunc func(string, string) bool) (*k8sv1.Pod, error) {
+	var result *k8sv1.Pod
 	podList, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	for _, pod := range podList.Items {
 		if compFunc(pod.Name, prefix) {
-			if !foundPod {
-				foundPod = true
-				*result = pod
+			if result == nil {
+				result = &pod
 			} else {
 				fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: First pod name %s in namespace %s\n", result.Name, result.Namespace)
 				fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Second pod name %s in namespace %s\n", pod.Name, pod.Namespace)
-				return true, fmt.Errorf("Multiple pods starting with prefix %q in namespace %q", prefix, namespace)
+				return result, fmt.Errorf("Multiple pods starting with prefix %q in namespace %q", prefix, namespace)
 			}
 		}
 	}
-	return foundPod, nil
+	if result == nil {
+		return nil, fmt.Errorf("Unable to find pod containing %s", prefix)
+	}
+	return result, nil
 }
 
 // WaitTimeoutForPodReady waits for the given pod to be created and ready


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Add DV annotation which if set will cause CDI transfer pods to be retained after a failed/successful completion. This will make debugging and testing easier, as developers an get the pod logs etc.
- Annotation: `cdi.kubevirt.io/storage.pod.retainAfterCompletion=true`
- Pod will be retained after both successful and failed completion.
- User is responsible to delete the pods. They will be deleted anyway when their dv is deleted.

**Release note**:
```release-note
Add optional DataVolume annotation to retain the transfer pods after completion
```

