### PR TITLE
Set some reasonable requests/limits for workloads

### DIFF
--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -672,7 +672,7 @@ func createCloneReconciler(objects ...runtime.Object) *CloneReconciler {
 	objs = append(objs, MakeEmptyCDICR())
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
 	cdiConfig.Status = cdiv1.CDIConfigStatus{
-		DefaultPodResourceRequirements: createDefaultPodResourceRequirements(int64(0), int64(0), int64(0), int64(0)),
+		DefaultPodResourceRequirements: createDefaultPodResourceRequirements("", "", "", ""),
 	}
 	objs = append(objs, cdiConfig)
 

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -223,13 +223,19 @@ func (r *CDIConfigReconciler) reconcileStorageClass(config *cdiv1.CDIConfig) err
 }
 
 func (r *CDIConfigReconciler) reconcileDefaultPodResourceRequirements(config *cdiv1.CDIConfig) error {
+	cpuLimit, _ := resource.ParseQuantity("750m")
+	memLimit, _ := resource.ParseQuantity("600M")
+	cpuRequest, _ := resource.ParseQuantity("100m")
+	memRequest, _ := resource.ParseQuantity("60M")
 	config.Status.DefaultPodResourceRequirements = &v1.ResourceRequirements{
 		Limits: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceCPU:    *resource.NewQuantity(0, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(0, resource.DecimalSI)},
+			v1.ResourceCPU:    cpuLimit,
+			v1.ResourceMemory: memLimit,
+		},
 		Requests: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceCPU:    *resource.NewQuantity(0, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(0, resource.DecimalSI)},
+			v1.ResourceCPU:    cpuRequest,
+			v1.ResourceMemory: memRequest,
+		},
 	}
 
 	if config.Spec.PodResourceRequirements != nil {

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -36,6 +36,10 @@ import (
 // AnnConfigAuthority is the annotation specifying a resource as the CDIConfig authority
 const (
 	AnnConfigAuthority = "cdi.kubevirt.io/configAuthority"
+	defaultCPULimit    = "750m"
+	defaultMemLimit    = "600M"
+	defaultCPURequest  = "100m"
+	defaultMemRequest  = "60M"
 )
 
 // CDIConfigReconciler members
@@ -223,10 +227,10 @@ func (r *CDIConfigReconciler) reconcileStorageClass(config *cdiv1.CDIConfig) err
 }
 
 func (r *CDIConfigReconciler) reconcileDefaultPodResourceRequirements(config *cdiv1.CDIConfig) error {
-	cpuLimit, _ := resource.ParseQuantity("750m")
-	memLimit, _ := resource.ParseQuantity("600M")
-	cpuRequest, _ := resource.ParseQuantity("100m")
-	memRequest, _ := resource.ParseQuantity("60M")
+	cpuLimit, _ := resource.ParseQuantity(defaultCPULimit)
+	memLimit, _ := resource.ParseQuantity(defaultMemLimit)
+	cpuRequest, _ := resource.ParseQuantity(defaultCPURequest)
+	memRequest, _ := resource.ParseQuantity(defaultMemRequest)
 	config.Status.DefaultPodResourceRequirements = &v1.ResourceRequirements{
 		Limits: map[v1.ResourceName]resource.Quantity{
 			v1.ResourceCPU:    cpuLimit,

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -626,10 +626,15 @@ var _ = Describe("getUrlFromRoute", func() {
 })
 
 var _ = Describe("Controller default pod resource requirements reconcile loop", func() {
-	var testValue int64 = 1
+	var (
+		testValueCPULimit   = "10"
+		testValueCPURequest = "4"
+		testValueMemLimit   = "10M"
+		testValueMemRequest = "4M"
+	)
 
 	It("Should set the defaultPodResourceRequirements to the override value", func() {
-		defaultResourceRequirements := createDefaultPodResourceRequirements(1, 2, 3, 4)
+		defaultResourceRequirements := createDefaultPodResourceRequirements("1", "2", "3000M", "4000M")
 
 		reconciler, cdiConfig := createConfigReconciler()
 		cdiConfig.Spec.PodResourceRequirements = defaultResourceRequirements
@@ -650,75 +655,79 @@ var _ = Describe("Controller default pod resource requirements reconcile loop", 
 
 		err := reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(0, 0, 0, 0)))
+		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements("", "", "", "")))
 	})
 
 	It("Should set the defaultPodResourceRequirements to the default if all fields are null except ResourceRequirements.Limits.cpu", func() {
+		var err error
 		defaultResourceRequirements := &corev1.ResourceRequirements{
 			Limits:   corev1.ResourceList{},
 			Requests: nil,
 		}
-
-		defaultResourceRequirements.Limits[corev1.ResourceCPU] = *resource.NewQuantity(testValue, resource.DecimalSI)
-		fmt.Println(defaultResourceRequirements)
-
+		defaultResourceRequirements.Limits[corev1.ResourceCPU], err = resource.ParseQuantity(testValueCPULimit)
+		Expect(err).ToNot(HaveOccurred())
 		reconciler, cdiConfig := createConfigReconciler()
 		cdiConfig.Spec.PodResourceRequirements = defaultResourceRequirements
 
-		err := reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
+		err = reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(testValue, 0, 0, 0)))
+		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(testValueCPULimit, "", "", "")))
 	})
 
 	It("Should set the defaultPodResourceRequirements to the default if all fields are null except ResourceRequirements.Limits.memory", func() {
+		var err error
 		defaultResourceRequirements := &corev1.ResourceRequirements{
 			Limits:   corev1.ResourceList{},
 			Requests: nil,
 		}
 
-		defaultResourceRequirements.Limits[corev1.ResourceMemory] = *resource.NewQuantity(testValue, resource.DecimalSI)
-		fmt.Println(defaultResourceRequirements)
+		defaultResourceRequirements.Limits[corev1.ResourceMemory], err = resource.ParseQuantity(testValueMemLimit)
+		Expect(err).ToNot(HaveOccurred())
 
 		reconciler, cdiConfig := createConfigReconciler()
 		cdiConfig.Spec.PodResourceRequirements = defaultResourceRequirements
 
-		err := reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
+		err = reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(0, testValue, 0, 0)))
+		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements("", testValueMemLimit, "", "")))
 	})
 
 	It("Should set the defaultPodResourceRequirements to the default if all fields are null except ResourceRequirements.Requests.cpu", func() {
+		var err error
 		defaultResourceRequirements := &corev1.ResourceRequirements{
 			Limits:   nil,
 			Requests: corev1.ResourceList{},
 		}
 
-		defaultResourceRequirements.Requests[corev1.ResourceCPU] = *resource.NewQuantity(testValue, resource.DecimalSI)
+		defaultResourceRequirements.Requests[corev1.ResourceCPU], err = resource.ParseQuantity(testValueCPURequest)
+		Expect(err).ToNot(HaveOccurred())
 		fmt.Println(defaultResourceRequirements)
 
 		reconciler, cdiConfig := createConfigReconciler()
 		cdiConfig.Spec.PodResourceRequirements = defaultResourceRequirements
 
-		err := reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
+		err = reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(0, 0, testValue, 0)))
+		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements("", "", testValueCPURequest, "")))
 	})
 
 	It("Should set the defaultPodResourceRequirements to the default if all fields are null except ResourceRequirements.Requests.memory", func() {
+		var err error
 		defaultResourceRequirements := &corev1.ResourceRequirements{
 			Limits:   nil,
 			Requests: corev1.ResourceList{},
 		}
 
-		defaultResourceRequirements.Requests[corev1.ResourceMemory] = *resource.NewQuantity(testValue, resource.DecimalSI)
+		defaultResourceRequirements.Requests[corev1.ResourceMemory], err = resource.ParseQuantity(testValueMemRequest)
+		Expect(err).ToNot(HaveOccurred())
 		fmt.Println(defaultResourceRequirements)
 
 		reconciler, cdiConfig := createConfigReconciler()
 		cdiConfig.Spec.PodResourceRequirements = defaultResourceRequirements
 
-		err := reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
+		err = reconciler.reconcileDefaultPodResourceRequirements(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements(0, 0, 0, testValue)))
+		Expect(cdiConfig.Status.DefaultPodResourceRequirements).To(Equal(createDefaultPodResourceRequirements("", "", "", testValueMemRequest)))
 	})
 })
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -512,7 +512,7 @@ func createUploadReconciler(objects ...runtime.Object) *UploadReconciler {
 	// Append empty CDIConfig object that normally is created by the reconcile loop
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
 	cdiConfig.Status = cdiv1.CDIConfigStatus{
-		DefaultPodResourceRequirements: createDefaultPodResourceRequirements(int64(0), int64(0), int64(0), int64(0)),
+		DefaultPodResourceRequirements: createDefaultPodResourceRequirements("", "", "", ""),
 	}
 	cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -783,14 +783,34 @@ func createVolumeSnapshotCrd() *extv1.CustomResourceDefinition {
 	}
 }
 
-func createDefaultPodResourceRequirements(limitCPUValue int64, limitMemoryValue int64, requestCPUValue int64, requestMemoryValue int64) *corev1.ResourceRequirements {
+func createDefaultPodResourceRequirements(limitCPUValue string, limitMemoryValue string, requestCPUValue string, requestMemoryValue string) *corev1.ResourceRequirements {
+	if limitCPUValue == "" {
+		limitCPUValue = defaultCPULimit
+	}
+	cpuLimit, err := resource.ParseQuantity(limitCPUValue)
+	Expect(err).ToNot(HaveOccurred())
+	if limitMemoryValue == "" {
+		limitMemoryValue = defaultMemLimit
+	}
+	memLimit, err := resource.ParseQuantity(limitMemoryValue)
+	Expect(err).ToNot(HaveOccurred())
+	if requestCPUValue == "" {
+		requestCPUValue = defaultCPURequest
+	}
+	cpuRequest, err := resource.ParseQuantity(requestCPUValue)
+	Expect(err).ToNot(HaveOccurred())
+	if requestMemoryValue == "" {
+		requestMemoryValue = defaultMemRequest
+	}
+	memRequest, err := resource.ParseQuantity(requestMemoryValue)
+	Expect(err).ToNot(HaveOccurred())
 	return &corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceCPU:    *resource.NewQuantity(limitCPUValue, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(limitMemoryValue, resource.DecimalSI)},
+			corev1.ResourceCPU:    cpuLimit,
+			corev1.ResourceMemory: memLimit},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceCPU:    *resource.NewQuantity(requestCPUValue, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(requestMemoryValue, resource.DecimalSI)},
+			corev1.ResourceCPU:    cpuRequest,
+			corev1.ResourceMemory: memRequest},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of setting 0/0 for cpu/mem request and limits, set something reasonable in case we have an incomplete LimitRange in the namespace. This would cause pods to not get created due to invalid resource request values. With this change we should have something reasonable that always works.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1666

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Set reasonable default values for request/limits of workload pods.
```

