### PR TITLE
Fix smartclone sometimes not triggering due to capicity not being reported.

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1209,9 +1209,8 @@ func (r *DatavolumeReconciler) snapshotSmartClonePossible(dataVolume *cdiv1.Data
 	}
 
 	srcStorageClass := &storagev1.StorageClass{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: *targetPvcStorageClassName}, srcStorageClass); err != nil {
-		log.Info("Unable to retrieve storage class, falling back to host assisted clone", "storage class", *targetPvcStorageClassName)
-		return false, nil
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: *targetPvcStorageClassName}, srcStorageClass); IgnoreNotFound(err) != nil {
+		return false, err
 	}
 	srcCapacity, hasSrcCapacity := pvc.Status.Capacity[corev1.ResourceStorage]
 	targetRequest, hasTargetRequest := targetStorageSpec.Resources.Requests[corev1.ResourceStorage]

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -384,6 +384,9 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 	}
 
 	snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	doSmartClone := err == nil &&
 		cloneStrategy == cdiv1.CloneStrategySnapshot &&
 		(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -387,7 +387,11 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	doSmartClone := err == nil &&
+	snapshotPossible, err := r.snapshotSmartClonePossible(datavolume, pvcSpec)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	doSmartClone := snapshotClassName != "" && snapshotPossible &&
 		cloneStrategy == cdiv1.CloneStrategySnapshot &&
 		(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate)
 
@@ -1103,17 +1107,59 @@ func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVol
 }
 
 func (r *DatavolumeReconciler) getSnapshotClassForSmartClone(dataVolume *cdiv1.DataVolume, targetStorageSpec *corev1.PersistentVolumeClaimSpec) (string, error) {
-	// TODO: Figure out if this belongs somewhere else, seems like something for the smart clone controller.
-	// Check if clone is requested
-	sourcePvcSpec := dataVolume.Spec.Source.PVC
-	if sourcePvcSpec == nil {
-		return "", errors.New("no source PVC provided")
-	}
-
+	log := r.log.WithName("getSnapshotClassForSmartClone").V(3)
 	// Check if relevant CRDs are available
 	if !IsCsiCrdsDeployed(r.extClientSet) {
-		r.log.V(3).Info("Missing CSI snapshotter CRDs, falling back to host assisted clone")
-		return "", errors.New("CSI snapshot CRDs not found")
+		log.Info("Missing CSI snapshotter CRDs, falling back to host assisted clone")
+		return "", nil
+	}
+
+	targetPvcStorageClassName := targetStorageSpec.StorageClassName
+	targetStorageClass, err := GetStorageClassByName(r.client, targetPvcStorageClassName)
+	if err != nil {
+		return "", err
+	}
+	if targetStorageClass == nil {
+		log.Info("Target PVC's Storage Class not found")
+		return "", nil
+	}
+	targetPvcStorageClassName = &targetStorageClass.Name
+	// Fetch the source storage class
+	srcStorageClass := &storagev1.StorageClass{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: *targetPvcStorageClassName}, srcStorageClass); err != nil {
+		log.Info("Unable to retrieve storage class, falling back to host assisted clone", "storage class", *targetPvcStorageClassName)
+		return "", err
+	}
+
+	// List the snapshot classes
+	scs := &snapshotv1.VolumeSnapshotClassList{}
+	if err := r.client.List(context.TODO(), scs); err != nil {
+		log.Info("Cannot list snapshot classes, falling back to host assisted clone")
+		return "", err
+	}
+	for _, snapshotClass := range scs.Items {
+		// Validate association between snapshot class and storage class
+		if snapshotClass.Driver == srcStorageClass.Provisioner {
+			log.Info("smart-clone is applicable for datavolume", "datavolume",
+				dataVolume.Name, "snapshot class", snapshotClass.Name)
+			return snapshotClass.Name, nil
+		}
+	}
+
+	log.Info("Could not match snapshotter with storage class, falling back to host assisted clone")
+	return "", nil
+
+}
+
+func (r *DatavolumeReconciler) snapshotSmartClonePossible(dataVolume *cdiv1.DataVolume, targetStorageSpec *corev1.PersistentVolumeClaimSpec) (bool, error) {
+	// TODO: Figure out if this belongs somewhere else, seems like something for the smart clone controller.
+	// Check if clone is requested
+	log := r.log.WithName("SnapshotSmartCloneAllowed").V(3)
+
+	sourcePvcSpec := dataVolume.Spec.Source.PVC
+	if sourcePvcSpec == nil {
+		log.Info("no source PVC provided")
+		return false, nil
 	}
 
 	// Find source PVC
@@ -1125,73 +1171,56 @@ func (r *DatavolumeReconciler) getSnapshotClassForSmartClone(dataVolume *cdiv1.D
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: sourcePvcNs, Name: sourcePvcSpec.Name}, pvc); err != nil {
 		if k8serrors.IsNotFound(err) {
-			r.log.V(3).Info("Source PVC is missing", "source namespace", sourcePvcSpec.Namespace, "source name", sourcePvcSpec.Name)
+			log.Info("Source PVC is missing", "source namespace", sourcePvcSpec.Namespace, "source name", sourcePvcSpec.Name)
+			return false, nil
 		}
-		return "", errors.New("source PVC not found")
+		return false, err
 	}
 
 	targetPvcStorageClassName := targetStorageSpec.StorageClassName
 	targetStorageClass, err := GetStorageClassByName(r.client, targetPvcStorageClassName)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 	if targetStorageClass == nil {
-		r.log.V(3).Info("Target PVC's Storage Class not found")
-		return "", errors.New("Target PVC storage class not found")
+		log.Info("Target PVC's Storage Class not found")
+		return false, nil
 	}
 	targetPvcStorageClassName = &targetStorageClass.Name
 	sourcePvcStorageClassName := pvc.Spec.StorageClassName
 
 	// Compare source and target storage classess
 	if *sourcePvcStorageClassName != *targetPvcStorageClassName {
-		r.log.V(3).Info("Source PVC and target PVC belong to different storage classes", "source storage class",
+		log.Info("Source PVC and target PVC belong to different storage classes", "source storage class",
 			*sourcePvcStorageClassName, "target storage class", *targetPvcStorageClassName)
-		return "", errors.New("source PVC and target PVC belong to different storage classes")
+		return false, nil
 	}
 
 	sourceVolumeMode := resolveVolumeMode(pvc.Spec.VolumeMode)
 	targetSpecVolumeMode, err := getStorageVolumeMode(r.client, dataVolume, targetStorageClass)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 	targetVolumeMode := resolveVolumeMode(targetSpecVolumeMode)
 	if sourceVolumeMode != targetVolumeMode {
-		r.log.V(3).Info("Source PVC and target PVC have different volume modes, falling back to host assisted clone", "source volume mode",
+		log.Info("Source PVC and target PVC have different volume modes, falling back to host assisted clone", "source volume mode",
 			sourceVolumeMode, "target volume mode", targetVolumeMode)
-		return "", errors.New("Source PVC and target PVC have different volume modes, falling back to host assisted clone")
+		return false, nil
 	}
 
-	// Fetch the source storage class
 	srcStorageClass := &storagev1.StorageClass{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: *sourcePvcStorageClassName}, srcStorageClass); err != nil {
-		r.log.V(3).Info("Unable to retrieve storage class, falling back to host assisted clone", "storage class", *sourcePvcStorageClassName)
-		return "", errors.New("unable to retrieve storage class, falling back to host assisted clone")
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: *targetPvcStorageClassName}, srcStorageClass); err != nil {
+		log.Info("Unable to retrieve storage class, falling back to host assisted clone", "storage class", *targetPvcStorageClassName)
+		return false, nil
 	}
-
 	srcCapacity, hasSrcCapacity := pvc.Status.Capacity[corev1.ResourceStorage]
 	targetRequest, hasTargetRequest := targetStorageSpec.Resources.Requests[corev1.ResourceStorage]
 	allowExpansion := srcStorageClass.AllowVolumeExpansion != nil && *srcStorageClass.AllowVolumeExpansion
 	if !hasSrcCapacity || !hasTargetRequest || (srcCapacity.Cmp(targetRequest) < 0 && !allowExpansion) {
-		return "", errors.New("source/target sizes not compatible")
+		// return error so we retry the reconcile
+		return false, errors.New("source/target sizes not compatible")
 	}
-
-	// List the snapshot classes
-	scs := &snapshotv1.VolumeSnapshotClassList{}
-	if err := r.client.List(context.TODO(), scs); err != nil {
-		r.log.V(3).Info("Cannot list snapshot classes, falling back to host assisted clone")
-		return "", errors.New("cannot list snapshot classes, falling back to host assisted clone")
-	}
-	for _, snapshotClass := range scs.Items {
-		// Validate association between snapshot class and storage class
-		if snapshotClass.Driver == srcStorageClass.Provisioner {
-			r.log.V(3).Info("smart-clone is applicable for datavolume", "datavolume",
-				dataVolume.Name, "snapshot class", snapshotClass.Name)
-			return snapshotClass.Name, nil
-		}
-	}
-
-	r.log.V(3).Info("Could not match snapshotter with storage class, falling back to host assisted clone")
-	return "", errors.New("could not match snapshotter with storage class, falling back to host assisted clone")
+	return true, nil
 }
 
 func (r *DatavolumeReconciler) getCloneStrategy() (cdiv1.CDICloneStrategy, error) {

--- a/tests/alpha_test.go
+++ b/tests/alpha_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Alpha API tests", func() {
 			pvcDef := utils.NewPVCDefinition("source-pvc", "1G", nil, nil)
 			source, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(context.TODO(), pvcDef, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindIfWaitForFirstConsumer(source)
 
 			By("create target namespace")
 			targetNs, err := f.CreateNamespace(f.NsPrefix, map[string]string{

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -155,7 +155,6 @@ func (f *Framework) VerifyTargetPVCContentMD5(namespace *k8sv1.Namespace, pvc *k
 	if err != nil {
 		return false, err
 	}
-
 	return expectedHash == md5, nil
 }
 

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -198,6 +198,7 @@ func createAndPopulateSourcePVC(dataVolumeName string, volumeMode v1.PersistentV
 	}
 	pvc, err := f.CreatePVCFromDefinition(pvcDef)
 	Expect(err).ToNot(HaveOccurred())
+	f.ForceBindIfWaitForFirstConsumer(pvc)
 	return pvc
 }
 

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -24,10 +22,6 @@ import (
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests that modify CDI CR", func() {
 	var cdiCr cdiv1.CDI
 	var cdiCrSpec *cdiv1.CDISpec
-
-	fillData := "123456789012345678901234567890123456789012345678901234567890"
-	testFile := utils.DefaultPvcMountPath + "/source.txt"
-	fillCommandFilesystem := "echo -n \"" + fillData + "\" >> " + testFile
 
 	f := framework.NewFramework("dv-func-test")
 
@@ -62,13 +56,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests th
 		_, err := f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &cdiCr, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		dataVolume := createDataVolume("dv-smart-clone-test-1", fillCommandFilesystem, v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
+		dataVolume := createDataVolume("dv-smart-clone-test-1", v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
 		verifyEvent(controller.CloneInProgress, dataVolume.Namespace, f)
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
 		// Verify PVC's content
-		verifyPVC(dataVolume, f, testFile, fillData)
+		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, utils.TinyCoreBlockMD5)
 
 		events, err := RunKubectlCommand(f, "get", "events", "-n", dataVolume.Namespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -82,46 +76,41 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests th
 })
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", func() {
-	fillData := "123456789012345678901234567890123456789012345678901234567890"
-	testFile := utils.DefaultPvcMountPath + "/source.txt"
-	fillCommandFilesystem := "echo -n \"" + fillData + "\" >> " + testFile
-	fillCommandBlock := "echo -n \"" + fillData + "\" | dd of=" + utils.DefaultPvcMountPath
-
 	f := framework.NewFramework("dv-func-test")
 
 	It("[rfe_id:1106][test_id:3494][crit:high][vendor:cnv-qe@redhat.com][level:component] Verify DataVolume Smart Cloning - volumeMode filesystem - Positive flow", func() {
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
-		dataVolume := createDataVolume("dv-smart-clone-test-1", fillCommandFilesystem, v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
+		dataVolume := createDataVolume("dv-smart-clone-test-1", v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
 		verifyEvent(controller.SnapshotForSmartCloneInProgress, dataVolume.Namespace, f)
 		verifyEvent(controller.SmartClonePVCInProgress, dataVolume.Namespace, f)
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
 		// Verify PVC's content
-		verifyPVC(dataVolume, f, testFile, fillData)
+		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, utils.TinyCoreBlockMD5)
 	})
 
 	It("[rfe_id:1106][test_id:3495][crit:high][vendor:cnv-qe@redhat.com][level:component] Verify DataVolume Smart Cloning - volumeMode block - Positive flow", func() {
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
-		dataVolume := createDataVolume("dv-smart-clone-test-1", fillCommandBlock, v1.PersistentVolumeBlock, f.SnapshotSCName, f)
+		dataVolume := createDataVolume("dv-smart-clone-test-1", v1.PersistentVolumeBlock, f.SnapshotSCName, f)
 		verifyEvent(controller.SnapshotForSmartCloneInProgress, dataVolume.Namespace, f)
 		verifyEvent(controller.SmartClonePVCInProgress, dataVolume.Namespace, f)
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
 		// Verify PVC's content
-		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, fillData)
+		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, utils.TinyCoreBlockMD5)
 	})
 
 	It("[test_id:4987]Verify DataVolume Smart Cloning - volumeMode filesystem - Waits for source to be available", func() {
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
-		sourcePvc := createAndPopulateSourcePVC("dv-smart-clone-test-1", fillCommandFilesystem, v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
+		sourcePvc := createAndPopulateSourcePVC("dv-smart-clone-test-1", v1.PersistentVolumeFilesystem, f.SnapshotSCName, f)
 		pod, err := f.CreateExecutorPodWithPVC("temp-pod", f.Namespace.Name, sourcePvc)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -151,7 +140,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
 		// Verify PVC's content
-		verifyPVC(dataVolume, f, testFile, fillData)
+		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, utils.TinyCoreBlockMD5)
 	})
 
 	It("[rfe_id:1106][test_id:3496][crit:high][vendor:cnv-qe@redhat.com][level:component] Verify DataVolume Smart Cloning - Check regular clone works", func() {
@@ -164,7 +153,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 			}
 		}
 
-		dataVolume := createDataVolume("dv-smart-clone-test-negative", fillCommandFilesystem, v1.PersistentVolumeFilesystem, "", f)
+		dataVolume := createDataVolume("dv-smart-clone-test-negative", v1.PersistentVolumeFilesystem, "", f)
 
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
@@ -175,15 +164,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 	})
 })
 
-func verifyPVC(dataVolume *cdiv1.DataVolume, f *framework.Framework, testPath string, expectedData string) {
-	hash := md5.Sum([]byte(expectedData))
-	md5sum := hex.EncodeToString(hash[:])
+func verifyPVC(dataVolume *cdiv1.DataVolume, f *framework.Framework, testPath string, md5sum string) {
 	By("verifying pvc was created")
 	targetPvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprint("Verifying target PVC content"))
-	Expect(f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, testPath, md5sum, int64(len(expectedData)))).To(BeTrue())
+	Expect(f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, testPath, md5sum, 18874368)).To(BeTrue())
 }
 
 func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f *framework.Framework) {
@@ -198,20 +185,24 @@ func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f
 	}
 }
 
-func createAndPopulateSourcePVC(dataVolumeName, command string, volumeMode v1.PersistentVolumeMode, scName string, f *framework.Framework) *v1.PersistentVolumeClaim {
+func createAndPopulateSourcePVC(dataVolumeName string, volumeMode v1.PersistentVolumeMode, scName string, f *framework.Framework) *v1.PersistentVolumeClaim {
 	By(fmt.Sprintf("Storage Class name: %s", scName))
-	sourcePVCName := fmt.Sprintf("%s-src-pvc", dataVolumeName)
-	sourcePodFillerName := fmt.Sprintf("%s-filler-pod", dataVolumeName)
-	pvcDef := utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
+	httpEp := fmt.Sprintf("http://%s:%d", utils.FileHostName+"."+f.CdiInstallNs, utils.HTTPNoAuthPort)
+	pvcAnn := map[string]string{
+		controller.AnnEndpoint: httpEp + "/tinyCore.iso",
+	}
+	pvcDef := utils.NewPVCDefinition(fmt.Sprintf("%s-src-pvc", dataVolumeName), "1Gi", pvcAnn, nil)
 	pvcDef.Spec.VolumeMode = &volumeMode
 	if scName != "" {
 		pvcDef.Spec.StorageClassName = &scName
 	}
-	return f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
+	pvc, err := f.CreatePVCFromDefinition(pvcDef)
+	Expect(err).ToNot(HaveOccurred())
+	return pvc
 }
 
-func createDataVolume(dataVolumeName, command string, volumeMode v1.PersistentVolumeMode, scName string, f *framework.Framework) *cdiv1.DataVolume {
-	sourcePvc := createAndPopulateSourcePVC(dataVolumeName, command, volumeMode, scName, f)
+func createDataVolume(dataVolumeName string, volumeMode v1.PersistentVolumeMode, scName string, f *framework.Framework) *cdiv1.DataVolume {
+	sourcePvc := createAndPopulateSourcePVC(dataVolumeName, volumeMode, scName, f)
 
 	By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
 	dataVolume := utils.NewCloningDataVolume(dataVolumeName, "1Gi", sourcePvc)

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -170,7 +170,7 @@ func verifyPVC(dataVolume *cdiv1.DataVolume, f *framework.Framework, testPath st
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprint("Verifying target PVC content"))
-	Expect(f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, testPath, md5sum, 18874368)).To(BeTrue())
+	Expect(f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, testPath, md5sum, utils.UploadFileSize)).To(BeTrue())
 }
 
 func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f *framework.Framework) {

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Transport Tests", func() {
 			case controller.SourceHTTP, controller.SourceRegistry:
 				if file != targetFile {
 					By("Verify content")
-					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, 18874368)
+					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, utils.UploadFileSize)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(same).To(BeTrue())
 				}


### PR DESCRIPTION
Updated tests to use a real image instead of data that is filled.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Smart clone was not always used if the provisioner was slow to allocate the PV.
```

