### PR TITLE
Add DataSource as an optional sourceRef for DataVolumes

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -479,12 +479,12 @@ func (app *cdiAPIApp) healthzHandler(req *restful.Request, resp *restful.Respons
 }
 
 func (app *cdiAPIApp) createDataVolumeValidatingWebhook() error {
-	app.container.ServeMux.Handle(dvValidatePath, webhooks.NewDataVolumeValidatingWebhook(app.client))
+	app.container.ServeMux.Handle(dvValidatePath, webhooks.NewDataVolumeValidatingWebhook(app.client, app.cdiClient))
 	return nil
 }
 
 func (app *cdiAPIApp) createDataVolumeMutatingWebhook() error {
-	app.container.ServeMux.Handle(dvMutatePath, webhooks.NewDataVolumeMutatingWebhook(app.client, app.privateSigningKey))
+	app.container.ServeMux.Handle(dvMutatePath, webhooks.NewDataVolumeMutatingWebhook(app.client, app.cdiClient, app.privateSigningKey))
 	return nil
 }
 

--- a/pkg/apiserver/webhooks/datavolume-mutate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-mutate_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	cdiclientfake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
 
 	cdicorev1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
@@ -180,6 +181,7 @@ func mutateDVs(key *rsa.PrivateKey, ar *admissionv1.AdmissionReview, isAuthorize
 		}
 		return true, sar, nil
 	})
-	wh := NewDataVolumeMutatingWebhook(client, key)
+	cdiClient := cdiclientfake.NewSimpleClientset()
+	wh := NewDataVolumeMutatingWebhook(client, cdiClient, key)
 	return serve(ar, wh)
 }

--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -471,7 +471,7 @@ func (wh *dataVolumeValidatingWebhook) Admit(ar admissionv1.AdmissionReview) *ad
 
 	causes = wh.validateDataVolumeSpec(ar.Request, k8sfield.NewPath("spec"), &dv.Spec, &dv.Namespace)
 	if len(causes) > 0 {
-		klog.Infof("rejected DataVolume admission")
+		klog.Infof("rejected DataVolume admission %s", causes)
 		return toRejectedAdmissionResponse(causes)
 	}
 

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	cdiclientfake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 )
@@ -505,7 +506,8 @@ func newPVCSpec(sizeValue int64) *corev1.PersistentVolumeClaimSpec {
 
 func validateDataVolumeCreate(dv *cdiv1.DataVolume, objects ...runtime.Object) *admissionv1.AdmissionResponse {
 	client := fakeclient.NewSimpleClientset(objects...)
-	wh := NewDataVolumeValidatingWebhook(client)
+	cdiClient := cdiclientfake.NewSimpleClientset()
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient)
 
 	dvBytes, _ := json.Marshal(dv)
 	ar := &admissionv1.AdmissionReview{
@@ -527,7 +529,8 @@ func validateDataVolumeCreate(dv *cdiv1.DataVolume, objects ...runtime.Object) *
 
 func validateAdmissionReview(ar *admissionv1.AdmissionReview, objects ...runtime.Object) *admissionv1.AdmissionResponse {
 	client := fakeclient.NewSimpleClientset(objects...)
-	wh := NewDataVolumeValidatingWebhook(client)
+	cdiClient := cdiclientfake.NewSimpleClientset()
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient)
 	return serve(ar, wh)
 }
 

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -42,6 +42,11 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 )
 
+var (
+	testNamespace  = "testNamespace"
+	emptyNamespace = ""
+)
+
 var _ = Describe("Validating Webhook", func() {
 	Context("with DataVolume admission review", func() {
 		It("should accept DataVolume with HTTP source on create", func() {
@@ -355,6 +360,86 @@ var _ = Describe("Validating Webhook", func() {
 			Entry("reject a spec change on un-approved fields, even with identical non-empty multi-stage fields", false, []string{"stage-1"}, false, []string{"stage-1"}, func(newDV *cdiv1.DataVolume) { newDV.Spec.Source.VDDK.URL = "tesing123" }, false),
 		)
 	})
+
+	Context("with DataVolume (using sourceRef) admission review", func() {
+		DescribeTable("should", func(dataSourceNamespace *string) {
+			pvcName := "testPVC"
+			dataVolume := newDataSourceDataVolume("testDV", dataSourceNamespace, "test")
+			dataVolume.Namespace = testNamespace
+			dataSource := &cdiv1.DataSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Spec.SourceRef.Name,
+					Namespace: testNamespace,
+				},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Name:      pvcName,
+							Namespace: testNamespace,
+						},
+					},
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: testNamespace,
+				},
+				Spec: *newPVCSpec(pvcSizeDefault),
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, []runtime.Object{dataSource})
+			Expect(resp.Allowed).To(Equal(true))
+		},
+			Entry("accept DataVolume with PVC and sourceRef on create", &testNamespace),
+			Entry("accept DataVolume with PVC and sourceRef nil namespace on create", nil),
+			Entry("accept DataVolume with PVC and sourceRef missing namespace on create", &emptyNamespace),
+		)
+
+		It("should reject DataVolume with SourceRef on create if DataSource does not exist", func() {
+			ns := "testNamespace"
+			dataVolume := newDataSourceDataVolume("testDV", &ns, "test")
+			resp := validateDataVolumeCreate(dataVolume)
+			Expect(resp.Allowed).To(Equal(false))
+		})
+
+		It("should reject DataVolume with SourceRef on create if DataSource exists but PVC does not exist", func() {
+			dataVolume := newDataSourceDataVolume("testDV", &testNamespace, "test")
+			dataSource := &cdiv1.DataSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Spec.SourceRef.Name,
+					Namespace: testNamespace,
+				},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Name:      "testPVC",
+							Namespace: testNamespace,
+						},
+					},
+				},
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource})
+			Expect(resp.Allowed).To(Equal(false))
+		})
+
+		It("should reject DataVolume with empty SourceRef name on create", func() {
+			dataVolume := newDataSourceDataVolume("testDV", &testNamespace, "")
+			resp := validateDataVolumeCreate(dataVolume)
+			Expect(resp.Allowed).To(Equal(false))
+		})
+
+		It("should reject DataVolume with both source and sourceRef on create", func() {
+			dataVolume := newDataVolumeWithBothSourceAndSourceRef("testDV", "testNamespace", "test")
+			resp := validateDataVolumeCreate(dataVolume)
+			Expect(resp.Allowed).To(Equal(false))
+		})
+
+		It("should reject DataVolume with no source or sourceRef on create", func() {
+			dataVolume := newDataVolumeWithNoSourceOrSourceRef("testDV")
+			resp := validateDataVolumeCreate(dataVolume)
+			Expect(resp.Allowed).To(Equal(false))
+		})
+	})
 })
 
 func newMultistageDataVolume(name string, final bool, checkpoints []string) *cdiv1.DataVolume {
@@ -455,7 +540,6 @@ func newDataVolumeWithMultipleSources(name string) *cdiv1.DataVolume {
 }
 
 func newDataVolumeWithPVCSizeZero(name, url string) *cdiv1.DataVolume {
-
 	httpSource := cdiv1.DataVolumeSource{
 		HTTP: &cdiv1.DataVolumeSourceHTTP{URL: url},
 	}
@@ -464,7 +548,42 @@ func newDataVolumeWithPVCSizeZero(name, url string) *cdiv1.DataVolume {
 	return newDataVolume(name, httpSource, pvc)
 }
 
+func newDataSourceDataVolume(name string, sourceRefNamespace *string, sourceRefName string) *cdiv1.DataVolume {
+	sourceRef := cdiv1.DataVolumeSourceRef{
+		Kind:      cdiv1.DataVolumeDataSource,
+		Namespace: sourceRefNamespace,
+		Name:      sourceRefName,
+	}
+	pvc := newPVCSpec(pvcSizeDefault)
+	return newDataVolumeWithSourceRef(name, nil, &sourceRef, pvc)
+}
+
+func newDataVolumeWithBothSourceAndSourceRef(name string, pvcNamespace string, pvcName string) *cdiv1.DataVolume {
+	pvcSource := cdiv1.DataVolumeSource{
+		PVC: &cdiv1.DataVolumeSourcePVC{
+			Namespace: pvcNamespace,
+			Name:      pvcName,
+		},
+	}
+	sourceRef := cdiv1.DataVolumeSourceRef{
+		Kind:      cdiv1.DataVolumeDataSource,
+		Namespace: &pvcNamespace,
+		Name:      pvcName,
+	}
+	pvc := newPVCSpec(pvcSizeDefault)
+	return newDataVolumeWithSourceRef(name, &pvcSource, &sourceRef, pvc)
+}
+
+func newDataVolumeWithNoSourceOrSourceRef(name string) *cdiv1.DataVolume {
+	pvc := newPVCSpec(pvcSizeDefault)
+	return newDataVolumeWithSourceRef(name, nil, nil, pvc)
+}
+
 func newDataVolume(name string, source cdiv1.DataVolumeSource, pvc *corev1.PersistentVolumeClaimSpec) *cdiv1.DataVolume {
+	return newDataVolumeWithSourceRef(name, &source, nil, pvc)
+}
+
+func newDataVolumeWithSourceRef(name string, source *cdiv1.DataVolumeSource, sourceRef *cdiv1.DataVolumeSourceRef, pvc *corev1.PersistentVolumeClaimSpec) *cdiv1.DataVolume {
 	namespace := k8sv1.NamespaceDefault
 	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -478,13 +597,12 @@ func newDataVolume(name string, source cdiv1.DataVolumeSource, pvc *corev1.Persi
 		},
 		Status: cdiv1.DataVolumeStatus{},
 		Spec: cdiv1.DataVolumeSpec{
-			Source: &source,
-			PVC:    pvc,
+			Source:    source,
+			SourceRef: sourceRef,
+			PVC:       pvc,
 		},
 	}
-
 	return dv
-
 }
 
 const pvcSizeDefault = 5 << 20 // 5Mi
@@ -505,8 +623,12 @@ func newPVCSpec(sizeValue int64) *corev1.PersistentVolumeClaimSpec {
 }
 
 func validateDataVolumeCreate(dv *cdiv1.DataVolume, objects ...runtime.Object) *admissionv1.AdmissionResponse {
-	client := fakeclient.NewSimpleClientset(objects...)
-	cdiClient := cdiclientfake.NewSimpleClientset()
+	return validateDataVolumeCreateEx(dv, objects, nil)
+}
+
+func validateDataVolumeCreateEx(dv *cdiv1.DataVolume, k8sObjects, cdiObjects []runtime.Object) *admissionv1.AdmissionResponse {
+	client := fakeclient.NewSimpleClientset(k8sObjects...)
+	cdiClient := cdiclientfake.NewSimpleClientset(cdiObjects...)
 	wh := NewDataVolumeValidatingWebhook(client, cdiClient)
 
 	dvBytes, _ := json.Marshal(dv)

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -51,14 +51,14 @@ type admissionHandler struct {
 }
 
 // NewDataVolumeValidatingWebhook creates a new DataVolumeValidation webhook
-func NewDataVolumeValidatingWebhook(client kubernetes.Interface) http.Handler {
-	return newAdmissionHandler(&dataVolumeValidatingWebhook{client: client})
+func NewDataVolumeValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface) http.Handler {
+	return newAdmissionHandler(&dataVolumeValidatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient})
 }
 
 // NewDataVolumeMutatingWebhook creates a new DataVolumeMutation webhook
-func NewDataVolumeMutatingWebhook(client kubernetes.Interface, key *rsa.PrivateKey) http.Handler {
+func NewDataVolumeMutatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface, key *rsa.PrivateKey) http.Handler {
 	generator := newCloneTokenGenerator(key)
-	return newAdmissionHandler(&dataVolumeMutatingWebhook{client: client, tokenGenerator: generator, proxy: &sarProxy{client: client}})
+	return newAdmissionHandler(&dataVolumeMutatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient, tokenGenerator: generator, proxy: &sarProxy{client: k8sClient}})
 }
 
 // NewCDIValidatingWebhook creates a new CDI validating webhook

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -347,6 +347,24 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 		return reconcile.Result{}, nil
 	}
 
+	// If sourceRef is set, populate spec.Source with data from the DataSource
+	if datavolume.Spec.SourceRef != nil {
+		if datavolume.Spec.SourceRef.Kind != cdiv1.DataVolumeDataSource {
+			return reconcile.Result{}, errors.Errorf("Unsupported sourceRef kind %s, currently only %s is supported", datavolume.Spec.SourceRef.Kind, cdiv1.DataVolumeDataSource)
+		}
+		ns := datavolume.Namespace
+		if datavolume.Spec.SourceRef.Namespace != nil && *datavolume.Spec.SourceRef.Namespace != "" {
+			ns = *datavolume.Spec.SourceRef.Namespace
+		}
+		dataSource := &cdiv1.DataSource{}
+		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: datavolume.Spec.SourceRef.Name, Namespace: ns}, dataSource); err != nil {
+			return reconcile.Result{}, err
+		}
+		datavolume.Spec.Source = &cdiv1.DataVolumeSource{
+			PVC: dataSource.Spec.Source.PVC,
+		}
+	}
+
 	pvcExists := true
 	// Get the pvc with the name specified in DataVolume.spec
 	pvc := &corev1.PersistentVolumeClaim{}
@@ -507,46 +525,47 @@ func (r *DatavolumeReconciler) isCSIClonePossible(dataVolume *cdiv1.DataVolume, 
 }
 
 func (r *DatavolumeReconciler) selectCloneStrategy(datavolume *cdiv1.DataVolume, pvcSpec *corev1.PersistentVolumeClaimSpec) (cloneStrategy, error) {
+	if datavolume.Spec.Source.PVC == nil {
+		return NoClone, nil
+	}
 
-	if datavolume.Spec.Source.PVC != nil {
-		// The source and target PVCs share the same Storage Class
-		// get this the same way as for getSnapshotClassForSmartClone(datavolume, pvcSpec)
-		preferredCloneStrategy, err := r.getCloneStrategy(datavolume)
+	// The source and target PVCs share the same Storage Class
+	// get this the same way as for getSnapshotClassForSmartClone(datavolume, pvcSpec)
+	preferredCloneStrategy, err := r.getCloneStrategy(datavolume)
+	if err != nil {
+		return NoClone, err
+	}
+
+	bindingMode, err := r.getStorageClassBindingMode(pvcSpec.StorageClassName)
+	if err != nil {
+		return NoClone, err
+	}
+
+	if preferredCloneStrategy != nil && *preferredCloneStrategy == cdiv1.CloneStrategyCsiClone {
+		csiClonePossible, err := r.isCSIClonePossible(datavolume, pvcSpec)
 		if err != nil {
-			return 0, err
+			return NoClone, err
 		}
 
-		bindingMode, err := r.getStorageClassBindingMode(pvcSpec.StorageClassName)
+		if csiClonePossible &&
+			(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate) {
+			return CsiClone, nil
+		}
+	} else if preferredCloneStrategy != nil && *preferredCloneStrategy == cdiv1.CloneStrategySnapshot {
+		snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
 		if err != nil {
-			return 0, err
+			return NoClone, err
+		}
+		snapshotClassAvailable := snapshotClassName != ""
+
+		snapshotPossible, err := r.snapshotSmartClonePossible(datavolume, pvcSpec)
+		if err != nil {
+			return NoClone, err
 		}
 
-		if preferredCloneStrategy != nil && *preferredCloneStrategy == cdiv1.CloneStrategyCsiClone {
-			csiClonePossible, err := r.isCSIClonePossible(datavolume, pvcSpec)
-			if err != nil {
-				return 0, err
-			}
-
-			if csiClonePossible &&
-				(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate) {
-				return CsiClone, nil
-			}
-		} else if preferredCloneStrategy != nil && *preferredCloneStrategy == cdiv1.CloneStrategySnapshot {
-			snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
-			if err != nil {
-				return 0, err
-			}
-			snapshotClassAvailable := snapshotClassName != ""
-
-			snapshotPossible, err := r.snapshotSmartClonePossible(datavolume, pvcSpec)
-			if err != nil {
-				return 0, err
-			}
-
-			if snapshotClassAvailable && snapshotPossible &&
-				(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate) {
-				return SmartClone, nil
-			}
+		if snapshotClassAvailable && snapshotPossible &&
+			(!isCrossNamespaceClone(datavolume) || *bindingMode == storagev1.VolumeBindingImmediate) {
+			return SmartClone, nil
 		}
 	}
 
@@ -703,7 +722,7 @@ func (r *DatavolumeReconciler) getVddkAnnotations(dataVolume *cdiv1.DataVolume, 
 
 	// only update if something has changed
 	if !reflect.DeepEqual(dataVolume, dataVolumeCopy) {
-		return true, r.client.Update(context.TODO(), dataVolumeCopy)
+		return true, r.updateDataVolume(dataVolumeCopy)
 	}
 	return false, nil
 }
@@ -909,7 +928,7 @@ func (r *DatavolumeReconciler) initTransfer(log logr.Logger, dv *cdiv1.DataVolum
 
 	if !HasFinalizer(dv, crossNamespaceFinalizer) {
 		AddFinalizer(dv, crossNamespaceFinalizer)
-		if err := r.client.Update(context.TODO(), dv); err != nil {
+		if err := r.updateDataVolume(dv); err != nil {
 			return false, err
 		}
 
@@ -1026,7 +1045,7 @@ func (r *DatavolumeReconciler) cleanupTransfer(log logr.Logger, dv *cdiv1.DataVo
 	}
 
 	RemoveFinalizer(dv, crossNamespaceFinalizer)
-	if err := r.client.Update(context.TODO(), dv); dv != nil {
+	if err := r.updateDataVolume(dv); dv != nil {
 		return err
 	}
 
@@ -1485,40 +1504,41 @@ func newSnapshot(dataVolume *cdiv1.DataVolume, snapshotName, snapshotClassName s
 
 func (r *DatavolumeReconciler) updateImportStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *DataVolumeEvent) {
 	phase, ok := pvc.Annotations[AnnPodPhase]
-	if ok {
-		switch phase {
-		case string(corev1.PodPending):
-			// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
-			dataVolumeCopy.Status.Phase = cdiv1.ImportScheduled
+	if !ok {
+		return
+	}
+	switch phase {
+	case string(corev1.PodPending):
+		// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
+		dataVolumeCopy.Status.Phase = cdiv1.ImportScheduled
+		event.eventType = corev1.EventTypeNormal
+		event.reason = ImportScheduled
+		event.message = fmt.Sprintf(MessageImportScheduled, pvc.Name)
+	case string(corev1.PodRunning):
+		// TODO: Use a more generic In Progess, like maybe TransferInProgress.
+		dataVolumeCopy.Status.Phase = cdiv1.ImportInProgress
+		event.eventType = corev1.EventTypeNormal
+		event.reason = ImportInProgress
+		event.message = fmt.Sprintf(MessageImportInProgress, pvc.Name)
+	case string(corev1.PodFailed):
+		dataVolumeCopy.Status.Phase = cdiv1.Failed
+		event.eventType = corev1.EventTypeWarning
+		event.reason = ImportFailed
+		event.message = fmt.Sprintf(MessageImportFailed, pvc.Name)
+	case string(corev1.PodSucceeded):
+		_, ok := pvc.Annotations[AnnCurrentCheckpoint]
+		if ok {
+			// this is a multistage import, set the datavolume status to paused
+			dataVolumeCopy.Status.Phase = cdiv1.Paused
 			event.eventType = corev1.EventTypeNormal
-			event.reason = ImportScheduled
-			event.message = fmt.Sprintf(MessageImportScheduled, pvc.Name)
-		case string(corev1.PodRunning):
-			// TODO: Use a more generic In Progess, like maybe TransferInProgress.
-			dataVolumeCopy.Status.Phase = cdiv1.ImportInProgress
+			event.reason = ImportPaused
+			event.message = fmt.Sprintf(MessageImportPaused, pvc.Name)
+		} else {
+			dataVolumeCopy.Status.Phase = cdiv1.Succeeded
+			dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress("100.0%")
 			event.eventType = corev1.EventTypeNormal
-			event.reason = ImportInProgress
-			event.message = fmt.Sprintf(MessageImportInProgress, pvc.Name)
-		case string(corev1.PodFailed):
-			dataVolumeCopy.Status.Phase = cdiv1.Failed
-			event.eventType = corev1.EventTypeWarning
-			event.reason = ImportFailed
-			event.message = fmt.Sprintf(MessageImportFailed, pvc.Name)
-		case string(corev1.PodSucceeded):
-			_, ok := pvc.Annotations[AnnCurrentCheckpoint]
-			if ok {
-				// this is a multistage import, set the datavolume status to paused
-				dataVolumeCopy.Status.Phase = cdiv1.Paused
-				event.eventType = corev1.EventTypeNormal
-				event.reason = ImportPaused
-				event.message = fmt.Sprintf(MessageImportPaused, pvc.Name)
-			} else {
-				dataVolumeCopy.Status.Phase = cdiv1.Succeeded
-				dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress("100.0%")
-				event.eventType = corev1.EventTypeNormal
-				event.reason = ImportSucceeded
-				event.message = fmt.Sprintf(MessageImportSucceeded, pvc.Name)
-			}
+			event.reason = ImportSucceeded
+			event.message = fmt.Sprintf(MessageImportSucceeded, pvc.Name)
 		}
 	}
 }
@@ -1566,66 +1586,67 @@ func (r *DatavolumeReconciler) updateSmartCloneStatusPhase(phase cdiv1.DataVolum
 
 func (r *DatavolumeReconciler) updateCloneStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *DataVolumeEvent) {
 	phase, ok := pvc.Annotations[AnnPodPhase]
-	if ok {
-		switch phase {
-		case string(corev1.PodPending):
-			// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
-			dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled
-			event.eventType = corev1.EventTypeNormal
-			event.reason = CloneScheduled
-			event.message = fmt.Sprintf(MessageCloneScheduled, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
-		case string(corev1.PodRunning):
-			// TODO: Use a more generic In Progess, like maybe TransferInProgress.
-			dataVolumeCopy.Status.Phase = cdiv1.CloneInProgress
-			event.eventType = corev1.EventTypeNormal
-			event.reason = CloneInProgress
-			event.message = fmt.Sprintf(MessageCloneInProgress, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
-		case string(corev1.PodFailed):
-			dataVolumeCopy.Status.Phase = cdiv1.Failed
-			event.eventType = corev1.EventTypeWarning
-			event.reason = CloneFailed
-			event.message = fmt.Sprintf(MessageCloneFailed, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
-		case string(corev1.PodSucceeded):
-			dataVolumeCopy.Status.Phase = cdiv1.Succeeded
-			dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress("100.0%")
-			event.eventType = corev1.EventTypeNormal
-			event.reason = CloneSucceeded
-			event.message = fmt.Sprintf(MessageCloneSucceeded, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
-		}
-
+	if !ok {
+		return
+	}
+	switch phase {
+	case string(corev1.PodPending):
+		// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
+		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled
+		event.eventType = corev1.EventTypeNormal
+		event.reason = CloneScheduled
+		event.message = fmt.Sprintf(MessageCloneScheduled, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
+	case string(corev1.PodRunning):
+		// TODO: Use a more generic In Progess, like maybe TransferInProgress.
+		dataVolumeCopy.Status.Phase = cdiv1.CloneInProgress
+		event.eventType = corev1.EventTypeNormal
+		event.reason = CloneInProgress
+		event.message = fmt.Sprintf(MessageCloneInProgress, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
+	case string(corev1.PodFailed):
+		dataVolumeCopy.Status.Phase = cdiv1.Failed
+		event.eventType = corev1.EventTypeWarning
+		event.reason = CloneFailed
+		event.message = fmt.Sprintf(MessageCloneFailed, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
+	case string(corev1.PodSucceeded):
+		dataVolumeCopy.Status.Phase = cdiv1.Succeeded
+		dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress("100.0%")
+		event.eventType = corev1.EventTypeNormal
+		event.reason = CloneSucceeded
+		event.message = fmt.Sprintf(MessageCloneSucceeded, dataVolumeCopy.Spec.Source.PVC.Namespace, dataVolumeCopy.Spec.Source.PVC.Name, pvc.Namespace, pvc.Name)
 	}
 }
 
 func (r *DatavolumeReconciler) updateUploadStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *DataVolumeEvent) {
 	phase, ok := pvc.Annotations[AnnPodPhase]
-	if ok {
-		switch phase {
-		case string(corev1.PodPending):
-			// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
-			dataVolumeCopy.Status.Phase = cdiv1.UploadScheduled
+	if !ok {
+		return
+	}
+	switch phase {
+	case string(corev1.PodPending):
+		// TODO: Use a more generic Scheduled, like maybe TransferScheduled.
+		dataVolumeCopy.Status.Phase = cdiv1.UploadScheduled
+		event.eventType = corev1.EventTypeNormal
+		event.reason = UploadScheduled
+		event.message = fmt.Sprintf(MessageUploadScheduled, pvc.Name)
+	case string(corev1.PodRunning):
+		running := pvc.Annotations[AnnPodReady]
+		if running == "true" {
+			// TODO: Use a more generic In Progess, like maybe TransferInProgress.
+			dataVolumeCopy.Status.Phase = cdiv1.UploadReady
 			event.eventType = corev1.EventTypeNormal
-			event.reason = UploadScheduled
-			event.message = fmt.Sprintf(MessageUploadScheduled, pvc.Name)
-		case string(corev1.PodRunning):
-			running := pvc.Annotations[AnnPodReady]
-			if running == "true" {
-				// TODO: Use a more generic In Progess, like maybe TransferInProgress.
-				dataVolumeCopy.Status.Phase = cdiv1.UploadReady
-				event.eventType = corev1.EventTypeNormal
-				event.reason = UploadReady
-				event.message = fmt.Sprintf(MessageUploadReady, pvc.Name)
-			}
-		case string(corev1.PodFailed):
-			dataVolumeCopy.Status.Phase = cdiv1.Failed
-			event.eventType = corev1.EventTypeWarning
-			event.reason = UploadFailed
-			event.message = fmt.Sprintf(MessageUploadFailed, pvc.Name)
-		case string(corev1.PodSucceeded):
-			dataVolumeCopy.Status.Phase = cdiv1.Succeeded
-			event.eventType = corev1.EventTypeNormal
-			event.reason = UploadSucceeded
-			event.message = fmt.Sprintf(MessageUploadSucceeded, pvc.Name)
+			event.reason = UploadReady
+			event.message = fmt.Sprintf(MessageUploadReady, pvc.Name)
 		}
+	case string(corev1.PodFailed):
+		dataVolumeCopy.Status.Phase = cdiv1.Failed
+		event.eventType = corev1.EventTypeWarning
+		event.reason = UploadFailed
+		event.message = fmt.Sprintf(MessageUploadFailed, pvc.Name)
+	case string(corev1.PodSucceeded):
+		dataVolumeCopy.Status.Phase = cdiv1.Succeeded
+		event.eventType = corev1.EventTypeNormal
+		event.reason = UploadSucceeded
+		event.message = fmt.Sprintf(MessageUploadSucceeded, pvc.Name)
 	}
 }
 
@@ -1832,7 +1853,7 @@ func (r *DatavolumeReconciler) emitFailureConditionEvent(dataVolume *cdiv1.DataV
 func (r *DatavolumeReconciler) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, event *DataVolumeEvent) error {
 	// Only update the object if something actually changed in the status.
 	if !reflect.DeepEqual(dataVolume, dataVolumeCopy) {
-		if err := r.client.Update(context.TODO(), dataVolumeCopy); err != nil {
+		if err := r.updateDataVolume(dataVolumeCopy); err != nil {
 			r.log.Error(err, "Unable to update datavolume", "name", dataVolumeCopy.Name)
 			return err
 		}
@@ -2059,6 +2080,14 @@ func (r *DatavolumeReconciler) newPersistentVolumeClaim(dataVolume *cdiv1.DataVo
 	}
 
 	return pvc, nil
+}
+
+// Whenever the controller updates a DV, we must make sure to nil out spec.source when spec.sourceRef is set
+func (r *DatavolumeReconciler) updateDataVolume(dataVolume *cdiv1.DataVolume) error {
+	if dataVolume.Spec.SourceRef != nil {
+		dataVolume.Spec.Source = nil
+	}
+	return r.client.Update(context.TODO(), dataVolume)
 }
 
 // RenderPvcSpec creates a new PVC Spec based on either the dv.spec.pvc or dv.spec.storage section

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -111,6 +111,18 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"datasources",
+			},
+			Verbs: []string{
+				"list",
+				"get",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
 				"cdis",
 			},
 			Verbs: []string{

--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -138,10 +138,10 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 				}, timeout, pollingInterval).Should(BeTrue())
 
 			},
-				table.Entry("[test_id:XXXX]fail with empty kind", "", "test", "test-pvc"),
-				table.Entry("[test_id:XXXX]fail with unsupported kind", "no-such-kind", "test", "test-pvc"),
-				table.Entry("[test_id:XXXX]fail with empty sourceRef name", "DataSource", "test", ""),
-				table.Entry("[test_id:XXXX]fail with sourceRef DataSource doesn't exist", "DataSource", "test", "test-pvc"),
+				table.Entry("[test_id:6780]fail with empty kind", "", "test", "test-pvc"),
+				table.Entry("[test_id:6781]fail with unsupported kind", "no-such-kind", "test", "test-pvc"),
+				table.Entry("[test_id:6782]fail with empty sourceRef name", "DataSource", "test", ""),
+				table.Entry("[test_id:6783]fail with sourceRef DataSource doesn't exist", "DataSource", "test", "test-pvc"),
 			)
 
 			table.DescribeTable("with Datavolume PVC size should", func(size string) {
@@ -320,7 +320,7 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 			// k8s < 1.15 return Required value: name or generateName is required, >= 1.15 return error validating data: unknown object type "nil" in DataVolume.metadata
 			table.Entry("[test_id:1857]fail without datavolume name", "manifests/dvNoName.yaml", true, "Required value: name or generateName is required", "error validating data: unknown object type \"nil\" in DataVolume.metadata"),
 			table.Entry("[test_id:1856]fail without meta data", "manifests/dvNoMetaData.yaml", true, "Required value: name or generateName is required"),
-			table.Entry("[test_id:XXXX]fail with both source and sourceRef", "manifests/dvBothSourceAndSourceRef.yaml", true, "Data volume should have either Source or SourceRef"),
+			table.Entry("[test_id:6786]fail with both source and sourceRef", "manifests/dvBothSourceAndSourceRef.yaml", true, "Data volume should have either Source or SourceRef"),
 		)
 
 		It("[test_id:4895][posneg:positive]report progress while importing 1024Mi PVC", func() {

--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -113,6 +113,37 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 				table.Entry("[test_id:3928]fail with empty VDDK source thumbprint", "vddk", validURL, "secret", "uuid", "backingfile", ""),
 			)
 
+			table.DescribeTable("with DataVolume sourceRef validation should", func(kind, namespace, name string) {
+				By("Reading yaml file from: " + datavolumeTestFile)
+				err := yamlFiletoStruct(datavolumeTestFile, &dv)
+				Expect(err).ToNot(HaveOccurred())
+
+				delete(dv["spec"].(map[string]interface{}), "source")
+				dv["spec"].(map[string]interface{})["sourceRef"] = map[string]interface{}{
+					"kind":      kind,
+					"namespace": &namespace,
+					"name":      name}
+
+				err = structToYamlFile(destinationFile, dv)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying kubectl create")
+				Eventually(func() bool {
+					out, err := RunKubectlCommand(f, "create", "-f", destinationFile, "-n", f.Namespace.Name)
+					By("out: " + out)
+					if err != nil {
+						return true
+					}
+					return false
+				}, timeout, pollingInterval).Should(BeTrue())
+
+			},
+				table.Entry("[test_id:XXXX]fail with empty kind", "", "test", "test-pvc"),
+				table.Entry("[test_id:XXXX]fail with unsupported kind", "no-such-kind", "test", "test-pvc"),
+				table.Entry("[test_id:XXXX]fail with empty sourceRef name", "DataSource", "test", ""),
+				table.Entry("[test_id:XXXX]fail with sourceRef DataSource doesn't exist", "DataSource", "test", "test-pvc"),
+			)
+
 			table.DescribeTable("with Datavolume PVC size should", func(size string) {
 
 				By("Reading yaml file from: " + datavolumeTestFile)
@@ -267,8 +298,7 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 		},
 			table.Entry("[test_id:1760]fail with blank image source and contentType archive", "manifests/dvBlankArchive.yaml", true, "SourceType cannot be blank and the contentType be archive"),
 			table.Entry("[test_id:1761]fail with invalid contentType", "manifests/dvInvalidContentType.yaml", true, "ContentType not one of: kubevirt, archive", "Unsupported value: \"invalid\": supported values: \"kubevirt\", \"archive\""),
-			//FIXME: Data volume source is now optional, so test should be added for missing both source and sourceRef
-			//table.Entry("[test_id:1762]fail with missing source", "manifests/dvMissingSource.yaml", true, "Missing Data volume source", "spec.source in body must be of type object", "missing required field \"source\" in io.kubevirt.cdi.v1beta1.DataVolume.spec"),
+			table.Entry("[test_id:1762]fail with missing both source and sourceRef", "manifests/dvMissingSource.yaml", true, "Data volume should have either Source or SourceRef", "spec.source in body must be of type object", "spec.sourceRef in body must be of type object"),
 			table.Entry("[test_id:1763]fail with multiple sources", "manifests/dvMultiSource.yaml", true, "Multiple Data volume sources"),
 			table.Entry("[test_id:1764]fail with invalid URL for http source", "manifests/dvInvalidURL.yaml", true, "spec.source Invalid source URL"),
 			table.Entry("[test_id:1765]fail with invalid source PVC", "manifests/dvInvalidSourcePVC.yaml", true, "spec.source.pvc.name in body is required", "spec.source.pvc.name: Required value", "missing required field \"name\" in io.kubevirt.cdi.v1beta1.DataVolume.spec.source.pvc"),
@@ -284,13 +314,13 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 			table.Entry("[test_id:1923]fail with missing storage size", "manifests/dvMissingRequestSpec.yaml", true, "PVC size is missing", "spec.pvc.resources in body must be of type object"),
 			table.Entry("[test_id:1915]fail with invalid access modes", "manifests/dvInvalidAccessModes.yaml", true, "supported values: \"ReadOnlyMany\", \"ReadWriteMany\", \"ReadWriteOnce\""),
 			table.Entry("[test_id:3922]fail with multiple access modes", "manifests/dvMultipleAccessModes.yaml", true, "PVC multiple accessModes"),
-			//FIXME: Data volume source is now optional, so test should be added for missing both source and sourceRef
-			//table.Entry("[test_id:1861]fail with missing source (but source key)", "manifests/dvMissingSource2.yaml", true, "Missing Data volume source", "missing required field \"source\" in io.kubevirt.cdi.v1beta1.DataVolume.spec", "invalid: spec.source: Required value"),
+			table.Entry("[test_id:1861]fail with missing both source and sourceRef (but having both keys)", "manifests/dvMissingSource2.yaml", true, "Data volume should have either Source or SourceRef"),
 			table.Entry("[test_id:1860]fail with missing http url key", "manifests/dvMissingSourceHttp.yaml", true, "Missing Data volume source", "spec.source.http in body must be of type object"),
 			table.Entry("[test_id:1858]fail with missing datavolume spec", "manifests/dvMissingCompleteSpec.yaml", true, "Missing Data volume source", "missing required field \"spec\" in io.kubevirt.cdi.v1beta1.DataVolume", " invalid: spec: Required value"),
 			// k8s < 1.15 return Required value: name or generateName is required, >= 1.15 return error validating data: unknown object type "nil" in DataVolume.metadata
 			table.Entry("[test_id:1857]fail without datavolume name", "manifests/dvNoName.yaml", true, "Required value: name or generateName is required", "error validating data: unknown object type \"nil\" in DataVolume.metadata"),
 			table.Entry("[test_id:1856]fail without meta data", "manifests/dvNoMetaData.yaml", true, "Required value: name or generateName is required"),
+			table.Entry("[test_id:XXXX]fail with both source and sourceRef", "manifests/dvBothSourceAndSourceRef.yaml", true, "Data volume should have either Source or SourceRef"),
 		)
 
 		It("[test_id:4895][posneg:positive]report progress while importing 1024Mi PVC", func() {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -108,7 +108,7 @@ var _ = Describe("all clone tests", func() {
 			completeClone(f, f.Namespace, targetPvc, diskImagePath, sourceMD5, sourcePvcDiskGroup)
 		})
 
-		It("[test_id:XXXX]Should clone imported data from SourceRef PVC DataSource", func() {
+		It("[test_id:6784]Should clone imported data from SourceRef PVC DataSource", func() {
 			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 			By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)

--- a/tests/manifests/dvBothSourceAndSourceRef.yaml
+++ b/tests/manifests/dvBothSourceAndSourceRef.yaml
@@ -4,7 +4,11 @@ metadata:
   name: test-dv
 spec:
   source:
+      http:
+         url: "http://cdi-file-host.cdi:82/tinyCore.qcow2"
   sourceRef:
+      kind: DataSource
+      name: fedora
   pvc:
     accessModes:
       - ReadWriteOnce

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -115,6 +115,51 @@ func NewCloningDataVolume(dataVolumeName, size string, sourcePvc *k8sv1.Persiste
 	return NewDataVolumeForImageCloning(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 }
 
+// NewDataVolumeWithSourceRef initializes a DataVolume struct with DataSource SourceRef
+func NewDataVolumeWithSourceRef(dataVolumeName string, size, sourceRefNamespace, sourceRefName string) *cdiv1.DataVolume {
+	claimSpec := &k8sv1.PersistentVolumeClaimSpec{
+		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+		Resources: k8sv1.ResourceRequirements{
+			Requests: k8sv1.ResourceList{
+				k8sv1.ResourceStorage: resource.MustParse(size),
+			},
+		},
+	}
+
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        dataVolumeName,
+			Annotations: map[string]string{},
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			SourceRef: &cdiv1.DataVolumeSourceRef{
+				Kind:      cdiv1.DataVolumeDataSource,
+				Namespace: &sourceRefNamespace,
+				Name:      sourceRefName,
+			},
+			PVC: claimSpec,
+		},
+	}
+}
+
+// NewDataSource initializes a DataSource struct with PVC source
+func NewDataSource(dataSourceName, dataSourceNamespace, pvcName, pvcNamespace string) *cdiv1.DataSource {
+	return &cdiv1.DataSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dataSourceName,
+			Namespace: dataSourceNamespace,
+		},
+		Spec: cdiv1.DataSourceSpec{
+			Source: cdiv1.DataSourceSource{
+				PVC: &cdiv1.DataVolumeSourcePVC{
+					Name:      pvcName,
+					Namespace: pvcNamespace,
+				},
+			},
+		},
+	}
+}
+
 // NewDataVolumeWithHTTPImport initializes a DataVolume struct with HTTP annotations
 func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
 	claimSpec := &k8sv1.PersistentVolumeClaimSpec{


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
A `DataSource` is an abstraction that points to the place we'd like to import/clone from. A `DataVolume` can either have an inlined `dataVolume.Spec.Source` as it exists today, or reference a `DataSource` object via `dataVolume.Spec.SourceRef` to perform the same action. The latter allows us to decouple the inlined source from a DataVolume so we can have a static link that points to a DataSource which is mutable.

For more details, view the [design document](https://github.com/kubevirt/community/blob/master/design-proposals/golden-image-delivery-and-update-pipeline.md).

**Special notes for your reviewer**:
- currently only DataSource sourceRef kind is supported
- currently only PVC DataSource source is supported

**Release note**:
```release-note
Add DataSource as an optional source reference for DataVolumes
```