### PR TITLE
[release-v1.28] Add "AwaitingVDDK" back to condition reason.

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -159,6 +159,8 @@ const (
 	VddkConfigMap = "v2v-vmware"
 	// VddkConfigDataKey is the name of the ConfigMap key of the VDDK image reference
 	VddkConfigDataKey = "vddk-init-image"
+	// AwaitingVDDK is a Pending condition reason that indicates the PVC is waiting for a VDDK image
+	AwaitingVDDK = "AwaitingVDDK"
 
 	// UploadContentTypeHeader is the header upload clients may use to set the content type explicitly
 	UploadContentTypeHeader = "x-cdi-content-type"

--- a/pkg/controller/datavolume-conditions.go
+++ b/pkg/controller/datavolume-conditions.go
@@ -137,7 +137,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending", pvc.Name), pvcPending)
 				conditions = updateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
-				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcPending)
+				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcCondition.Reason)
 				conditions = updateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			}
 		case corev1.ClaimLost:

--- a/pkg/controller/datavolume-conditions_test.go
+++ b/pkg/controller/datavolume-conditions_test.go
@@ -224,15 +224,16 @@ var _ = Describe("updateBoundCondition", func() {
 	})
 
 	It("should be pending if PVC pending, if scratch PVC is not bound, message should be combined", func() {
+		reason := "not bound"
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
-		pvc := createPvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: "not bound", AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
+		pvc := createPvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: reason, AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
 		pvc.Status.Phase = corev1.ClaimPending
 		conditions = updateBoundCondition(conditions, pvc)
 		Expect(len(conditions)).To(Equal(2))
 		condition := findConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
 		Expect(condition.Message).To(Equal("target PVC test Pending and scratch PVC not bound"))
-		Expect(condition.Reason).To(Equal(pvcPending))
+		Expect(condition.Reason).To(Equal(reason))
 		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 		condition = findConditionByType(cdiv1.DataVolumeReady, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeReady))

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -90,9 +90,6 @@ const (
 	// creatingScratch provides a const to indicate scratch is being created.
 	creatingScratch = "CreatingScratchSpace"
 
-	// awaitingVddk provides a const to indicate the PVC is waiting for a VDDK image
-	awaitingVddk = "AwaitingVDDK"
-
 	// ImportTargetInUse is reason for event created when an import pvc is in use
 	ImportTargetInUse = "ImportTargetInUse"
 
@@ -457,7 +454,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 			anno := pvc.GetAnnotations()
 			anno[AnnBoundCondition] = "false"
 			anno[AnnBoundConditionMessage] = fmt.Sprintf("waiting for %s configmap for VDDK image", common.VddkConfigMap)
-			anno[AnnBoundConditionReason] = awaitingVddk
+			anno[AnnBoundConditionReason] = common.AwaitingVDDK
 			if updateErr := r.updatePVC(pvc, r.log); updateErr != nil {
 				return updateErr
 			}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -90,6 +90,9 @@ const (
 	// creatingScratch provides a const to indicate scratch is being created.
 	creatingScratch = "CreatingScratchSpace"
 
+	// awaitingVddk provides a const to indicate the PVC is waiting for a VDDK image
+	awaitingVddk = "AwaitingVDDK"
+
 	// ImportTargetInUse is reason for event created when an import pvc is in use
 	ImportTargetInUse = "ImportTargetInUse"
 
@@ -451,6 +454,13 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 		r.log.V(1).Info("Pod requires VDDK sidecar for VMware transfer")
 		vddkImageName, err = r.getVddkImageName()
 		if err != nil {
+			anno := pvc.GetAnnotations()
+			anno[AnnBoundCondition] = "false"
+			anno[AnnBoundConditionMessage] = fmt.Sprintf("waiting for %s configmap for VDDK image", common.VddkConfigMap)
+			anno[AnnBoundConditionReason] = awaitingVddk
+			if updateErr := r.updatePVC(pvc, r.log); updateErr != nil {
+				return updateErr
+			}
 			return err
 		}
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -570,6 +570,51 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(resPvc.GetAnnotations()[AnnRunningConditionMessage]).To(Equal("I went poof"))
 		Expect(resPvc.GetAnnotations()[AnnRunningConditionReason]).To(Equal("Explosion"))
 	})
+
+	It("Should mark PVC as waiting for VDDK configmap, if not already present", func() {
+		pvc := createPvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{AnnEndpoint: testEndPoint, AnnImportPod: "testpod", AnnSource: SourceVDDK}, nil, corev1.ClaimPending)
+		reconciler = createImportReconciler(pvc)
+		err := reconciler.createImporterPod(pvc)
+		By("Checking importer pod creation returned an error")
+		Expect(err).To(HaveOccurred())
+		By("Checking pvc annotations have been updated")
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.GetAnnotations()[AnnBoundCondition]).To(Equal("false"))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal("waiting for v2v-vmware configmap for VDDK image"))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(awaitingVddk))
+
+		By("Checking again after creating configmap")
+		configmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.VddkConfigMap,
+				Namespace: "cdi",
+			},
+			Data: map[string]string{
+				common.VddkConfigDataKey: "test",
+			},
+		}
+		reconciler.client.Create(context.TODO(), configmap)
+		err = reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should not mark PVC as waiting for VDDK configmap, if already present", func() {
+		configmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.VddkConfigMap,
+				Namespace: "cdi",
+			},
+			Data: map[string]string{
+				common.VddkConfigDataKey: "test",
+			},
+		}
+		pvc := createPvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{AnnEndpoint: testEndPoint, AnnImportPod: "testpod", AnnSource: SourceVDDK}, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(configmap, pvc)
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 var _ = Describe("Create Importer Pod", func() {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -583,7 +583,7 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resPvc.GetAnnotations()[AnnBoundCondition]).To(Equal("false"))
 		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal("waiting for v2v-vmware configmap for VDDK image"))
-		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(awaitingVddk))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(common.AwaitingVDDK))
 
 		By("Checking again after creating configmap")
 		configmap := &corev1.ConfigMap{

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -249,7 +249,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			return utils.NewDataVolumeForUpload(dataVolumeName, size)
 		}
 
-		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+		testDataVolume := func(args dataVolumeTestArguments) {
 			// Have to call the function in here, to make sure the BeforeEach in the Framework has run.
 			dataVolume := args.dvFunc(args.name, args.size, args.url())
 			startTime := time.Now()
@@ -319,7 +319,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					return false
 				}, timeout, pollingInterval).Should(BeTrue())
 			}
-		},
+		}
+
+		table.DescribeTable("should", testDataVolume,
 			table.Entry("[rfe_id:1115][crit:high][test_id:1357]succeed creating import dv with given valid url", dataVolumeTestArguments{
 				name:             "dv-http-import",
 				size:             "1Gi",
@@ -774,6 +776,47 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Status:  v1.ConditionFalse,
 					Message: "Import Complete",
 					Reason:  "Completed",
+				}}),
+		)
+
+		// Similar to previous table, but with additional cleanup steps
+		table.DescribeTable("should", func(args dataVolumeTestArguments) {
+			configMap, err := RunKubectlCommand(f, "get", "configmap", "-o", "yaml", "-n", f.CdiInstallNs, common.VddkConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = RunKubectlCommand(f, "delete", "configmap", "-n", f.CdiInstallNs, common.VddkConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			defer func() {
+				command := CreateKubectlCommand(f, "create", "-n", f.CdiInstallNs, "-f", "-")
+				command.Stdin = strings.NewReader(configMap)
+				err := command.Run()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			testDataVolume(args)
+		},
+			table.Entry("[test_id:5079]should fail with \"AwaitingVDDK\" reason when VDDK credentials config map is not present", dataVolumeTestArguments{
+				name:             "dv-awaiting-vddk",
+				size:             "1Gi",
+				url:              vcenterURL,
+				dvFunc:           createVddkDataVolume,
+				eventReason:      common.AwaitingVDDK,
+				phase:            cdiv1.ImportScheduled,
+				checkPermissions: false,
+				readyCondition: &cdiv1.DataVolumeCondition{
+					Type:   cdiv1.DataVolumeReady,
+					Status: v1.ConditionFalse,
+				},
+				boundCondition: &cdiv1.DataVolumeCondition{
+					Type:    cdiv1.DataVolumeBound,
+					Status:  v1.ConditionFalse,
+					Message: fmt.Sprintf("waiting for %s configmap for VDDK image", common.VddkConfigMap),
+					Reason:  common.AwaitingVDDK,
+				},
+				runningCondition: &cdiv1.DataVolumeCondition{
+					Type:   cdiv1.DataVolumeRunning,
+					Status: v1.ConditionFalse,
 				}}),
 		)
 


### PR DESCRIPTION
This is a cherry pick of #1627 and #1816 to the 1.28 release branch.

Addresses [RHBZ#1965181](https://bugzilla.redhat.com/show_bug.cgi?id=1965181).

```release-note
Add AwaitingVDDK condition reason to data volume when v2v-vmware ConfigMap is missing.
```