### PR TITLE
Fix crash on ingress without default backend service.

### DIFF
--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -596,7 +596,7 @@ func watchClusterProxy(mgr manager.Manager, configController controller.Controll
 }
 
 func getURLFromIngress(ing *networkingv1.Ingress, uploadProxyServiceName string) string {
-	if ing.Spec.DefaultBackend != nil {
+	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
 		if ing.Spec.DefaultBackend.Service.Name != uploadProxyServiceName {
 			return ""
 		}
@@ -607,7 +607,7 @@ func getURLFromIngress(ing *networkingv1.Ingress, uploadProxyServiceName string)
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
-			if path.Backend.Service.Name == uploadProxyServiceName {
+			if path.Backend.Service != nil && path.Backend.Service.Name == uploadProxyServiceName {
 				if rule.Host != "" {
 					return rule.Host
 				}
@@ -615,7 +615,6 @@ func getURLFromIngress(ing *networkingv1.Ingress, uploadProxyServiceName string)
 		}
 	}
 	return ""
-
 }
 
 func getURLFromRoute(route *routev1.Route, uploadProxyServiceName string) string {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It was possible to create a npe on an Ingress without a default backend service due to missing check for nil. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1868 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed controller crash with ingress without default backend service.
```

