### PR TITLE
Default disk alignment to 1Mi instead of 512 bytes

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -2285,11 +2285,10 @@ func getDefaultAccessModes(c client.Client, storageClass *storagev1.StorageClass
 
 // GetRequiredSpace calculates space required taking file system overhead into account
 func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
-	blockSize := int64(512)
 	// count overhead as a percentage of the whole/new size
 	spaceWithOverhead := int64(float64(requestedSpace) / (1 - filesystemOverhead))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
-	qemuImgCorrection := util.RoundUp(spaceWithOverhead, blockSize)
+	qemuImgCorrection := util.RoundUp(spaceWithOverhead, util.DefaultAlignBlockSize)
 	return qemuImgCorrection
 }

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -285,7 +285,7 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 		// Change permissions to 0660
 		err := os.Chmod(dp.dataFile, 0660)
 		if err != nil {
-			err = errors.Wrap(err, "Unable to change permissions of target file")
+			return ProcessingPhaseError, errors.Wrap(err, "Unable to change permissions of target file")
 		}
 	}
 
@@ -361,10 +361,9 @@ func (dp *DataProcessor) getUsableSpace() int64 {
 
 // GetUsableSpace calculates space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	blockSize := int64(512)
 	spaceWithOverhead := int64((1 - filesystemOverhead) * float64(availableSpace))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
-	qemuImgCorrection := util.RoundDown(spaceWithOverhead, blockSize)
+	qemuImgCorrection := util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
 	return qemuImgCorrection
 }

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -242,9 +242,11 @@ var _ = Describe("Data Processor", func() {
 			transferResponse: ProcessingPhaseConvert,
 			url:              url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", tmpDir, "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.055, false)
 		dp.availableSpace = int64(1500)
-		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(dp.getUsableSpace(), 0))
+		usableSpace := dp.getUsableSpace()
+
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(usableSpace, 0))
 		replaceQEMUOperations(qemuOperations, func() {
 			err = dp.ProcessData()
 			Expect(err).ToNot(HaveOccurred())
@@ -305,12 +307,14 @@ var _ = Describe("Convert", func() {
 
 var _ = Describe("Resize", func() {
 	It("Should not resize and return complete, when requestedSize is blank", func() {
+		tempDir, err := ioutil.TempDir(os.TempDir(), "dest")
+		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false)
+		dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "", 0.055, false)
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -320,8 +324,11 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should not resize and return complete, when requestedSize is valid, but datadir doesn't exist (block device)", func() {
+		tempDir, err := ioutil.TempDir(os.TempDir(), "dest")
+		Expect(err).ToNot(HaveOccurred())
+
 		replaceAvailableSpaceBlockFunc(func(dataDir string) (int64, error) {
-			Expect("dest").To(Equal(dataDir))
+			Expect(tempDir).To(Equal(dataDir))
 			return int64(100000), nil
 		}, func() {
 			url, err := url.Parse("http://fakeurl-notreal.fake")
@@ -329,7 +336,7 @@ var _ = Describe("Resize", func() {
 			mdp := &MockDataProvider{
 				url: url,
 			}
-			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+			dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "1G", 0.055, false)
 			qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 			replaceQEMUOperations(qemuOperations, func() {
 				nextPhase, err := dp.resize()
@@ -340,14 +347,14 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should resize and return complete, when requestedSize is valid, and datadir exists", func() {
-		tmpDir, err := ioutil.TempDir("", "data")
+		tmpDir, err := ioutil.TempDir(os.TempDir(), "data")
 		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, tmpDir, tmpDir, "scratchDataDir", "1G", 0.055, false)
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -357,7 +364,7 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should not resize and return error, when ResizeImage fails", func() {
-		tmpDir, err := ioutil.TempDir("", "data")
+		tmpDir, err := ioutil.TempDir(os.TempDir(), "data")
 		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	blockdevFileName = "/usr/sbin/blockdev"
+	// DefaultAlignBlockSize is the alignment size we use to align disk images, its a multiple of all known hardware block sizes 512/4k/8k/32k/64k.
+	DefaultAlignBlockSize = 1024 * 1024
 )
 
 // CountingReader is a reader that keeps track of how much has been read

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,10 +17,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const pattern = "^[a-zA-Z0-9]+$"
-const TestImagesDir = "../../tests/images"
+const (
+	pattern       = "^[a-zA-Z0-9]+$"
+	TestImagesDir = "../../tests/images"
+)
 
-var fileDir, _ = filepath.Abs(TestImagesDir)
+var (
+	fileDir, _ = filepath.Abs(TestImagesDir)
+)
 
 var _ = Describe("Util", func() {
 	It("Should match RandAlphaNum", func() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1052,7 +1052,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		It("[test_id:5353]Importer pod should have specific datavolume annotations passed but not others", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs))
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 			By(fmt.Sprintf("creating new datavolume %s with annotations", dataVolume.Name))
 			dataVolume.Annotations[controller.AnnPodNetwork] = "net1"
 			dataVolume.Annotations["annot1"] = "value1"
@@ -1065,18 +1065,14 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-			By("verifying the Datavolume is not complete yet")
-			foundDv, err := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if foundDv.Status.Phase != cdiv1.Succeeded {
-				By("find importer pod")
-				var sourcePod *v1.Pod
-				Eventually(func() bool {
-					sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
-					return err == nil
-				}, timeout, pollingInterval).Should(BeTrue())
-				verifyAnnotations(sourcePod)
-			}
+			By("find importer pod")
+			var sourcePod *v1.Pod
+			Eventually(func() bool {
+				sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
+				return err == nil
+			}, timeout, pollingInterval).Should(BeTrue())
+			By(fmt.Sprintf("Verifying pod %s has correct annotation", sourcePod.Name))
+			verifyAnnotations(sourcePod)
 		})
 
 		It("[test_id:5365]Uploader pod should have specific datavolume annotations passed but not others", func() {
@@ -1093,18 +1089,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-			By("verifying the Datavolume is not complete yet")
-			foundDv, err := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if foundDv.Status.Phase != cdiv1.Succeeded {
-				By("find uploader pod")
-				var sourcePod *v1.Pod
-				Eventually(func() bool {
-					sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)
-					return err == nil
-				}, timeout, pollingInterval).Should(BeTrue())
-				verifyAnnotations(sourcePod)
-			}
+			By("find uploader pod")
+			var sourcePod *v1.Pod
+			Eventually(func() bool {
+				sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)
+				return err == nil
+			}, timeout, pollingInterval).Should(BeTrue())
+			verifyAnnotations(sourcePod)
 		})
 
 		It("[test_id:5366]Cloner pod should have specific datavolume annotations passed but not others", func() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We had hardcoded the block size at 512 bytes, which can cause alignment issues when the hardware is a 4k block device. This will manifest itself as
```
{"component":"virt-launcher","level":"error","msg":"internal error: qemu unexpectedly closed the monitor: 2021-06-15T15:16:06.788431Z qemu-kvm: -device virtio-blk-pci-non-transitional,bus=pci.6,addr=0x0,drive=li
bvirt-1-format,id=ua-disk-0,write-cache=on: Cannot get 'write' permission without 'resize': Image size is not a multiple of request alignment","pos":"qemuProcessReportLogError:2111","subcomponent":"libvirt","thread":"290","timestamp":"2021-06-15T15:16:06.811000Z"}
```
in KubeVirt as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1976730

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Align disk image size to 1Mi instead of 512 bytes.
```

