### PR TITLE
add script that is called from prow for pushing images

### DIFF
--- a/automation/prow_periodic_push.sh
+++ b/automation/prow_periodic_push.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+build_date="$(date +%Y%m%d)"
+cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+export DOCKER_TAG="${build_date}_$(git show -s --format=%h)-arm64"
+make manifests
+make bazel-push-images
+bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/${build_date}"
+gsutil cp ./_out/manifests/release/cdi-operator.yaml gs://$bucket_dir/cdi-operator-arm64.yaml
+gsutil cp ./_out/manifests/release/cdi-cr.yaml gs://$bucket_dir/cdi-cr-arm64.yaml


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Combine commands we run in prow for periodic pushes into a single script so we can manage it from cdi repo instead of project-infra.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

