### PR TITLE
Fix operator not reconciling changing of service type

### DIFF
--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -53,6 +53,7 @@ func createUploadProxyService() *corev1.Service {
 			Protocol: corev1.ProtocolTCP,
 		},
 	}
+	service.Spec.Type = corev1.ServiceTypeClusterIP
 	return service
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If someone edited the upload service owned by the operator to type NodePort, the operator would not fix it back to cluster ip. This PR specifies we want the service to be clusterIp only, and that ensures the operator reconciles the service back to clusterIp

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1871 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

