### PR TITLE
Fix fieldRef apiVersion spam

### DIFF
--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -122,7 +122,8 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 			Name: common.InstallerPartOfLabel,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesPartOfLabel),
+					APIVersion: "v1",
+					FieldPath:  fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesPartOfLabel),
 				},
 			},
 		},
@@ -130,7 +131,8 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 			Name: common.InstallerVersionLabel,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesVersionLabel),
+					APIVersion: "v1",
+					FieldPath:  fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesVersionLabel),
 				},
 			},
 		},


### PR DESCRIPTION
Since #1864 we're seeing spam in the operator logs:
`[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/env/6/valueFrom/fieldRef/apiVersion\"},`

This happens because we don't specify the fieldRef's apiVersion explicitly when creating the controller,
so k8s populates it for us -> causing us to reconcile it back.

Will now set the apiVersion explicitly to avoid this spam.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

