### PR TITLE
Use scratch space for qcow2.gz files.

### DIFF
--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -135,7 +135,9 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 	if hs.contentType == cdiv1.DataVolumeArchive {
 		return ProcessingPhaseTransferDataDir, nil
 	}
-	if hs.brokenForQemuImg {
+	if hs.brokenForQemuImg || (hs.readers.ArchiveGz && hs.readers.Convert) {
+		// Either broken for qemu-img, so we have to download first OR we are converting
+		// a qcow2 that is gzipped (which means we have to download the image anyway)
 		return ProcessingPhaseTransferScratch, nil
 	}
 	if hs.customCA != "" {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are unable to directly convert using nbdkit with the gz filter because it has to download the entire file to get the info. This causes the PR limit to timeout on larger files. This forces us to use scratch space for qcow2.gz files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: large qcow2.gz files failed to import due to pr limit
```

