### PR TITLE
Removing 'all' alias for objecttransfers.cdi.kubevirt.io CRD

### DIFF
--- a/pkg/apis/core/v1beta1/types_transfer.go
+++ b/pkg/apis/core/v1beta1/types_transfer.go
@@ -30,7 +30,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:shortName=ot;ots,categories=all,scope=Cluster
+// +kubebuilder:resource:shortName=ot;ots,scope=Cluster
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The phase of the ObjectTransfer"
 // +kubebuilder:subresource:status

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -3291,8 +3291,6 @@ metadata:
 spec:
   group: cdi.kubevirt.io
   names:
-    categories:
-    - all
     kind: ObjectTransfer
     listKind: ObjectTransferList
     plural: objecttransfers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It removes 'all' alias for objecttransfers.cdi.kubevirt.io CRD. Based on [this](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-cli/kubectl-conventions.md#rules-for-extending-special-resource-alias---all) cluster scoped resources should not be part of the `kubectl get all` output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

