### PR TITLE
VDDK: Reduce read size when connecting to vCenter.

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -218,6 +218,7 @@ func dumpLogs(ringEntry interface{}) {
 // VMwareConnectionOperations provides a mockable interface for the things needed from VMware client objects.
 type VMwareConnectionOperations interface {
 	Logout(context.Context) error
+	IsVC() bool
 }
 
 // VMwareVMOperations provides a mockable interface for the things needed from VMware VM objects.
@@ -430,8 +431,22 @@ func FindVM(context context.Context, conn *govmomi.Client, uuid string) (string,
 // MaxBlockStatusLength limits the maximum block status request size to 2GB
 const MaxBlockStatusLength = (2 << 30)
 
-// MaxPreadLength limits individual data block transfers to 23MB, larger block sizes fail
-const MaxPreadLength = (23 << 20)
+// MaxPreadLengthESX limits individual VDDK data block transfers to 23MB.
+// Larger block sizes fail immediately.
+const MaxPreadLengthESX = (23 << 20)
+
+// MaxPreadLengthVC limits indidivual VDDK data block transfers to 2MB only when
+// connecting to vCenter. With vCenter endpoints, multiple simultaneous importer
+// pods with larger read sizes cause allocation failures on the server, and the
+// imports start to fail:
+//         "NfcFssrvrProcessErrorMsg: received NFC error 5 from server:
+//          Failed to allocate the requested 24117272 bytes"
+const MaxPreadLengthVC = (2 << 20)
+
+// MaxPreadLength is the maxmimum read size to request from VMware. Default to
+// the larger option, and reduce it in createVddkDataSource when connecting to
+// vCenter endpoints.
+var MaxPreadLength uint32 = MaxPreadLengthESX
 
 // NbdOperations provides a mockable interface for the things needed from libnbd.
 type NbdOperations interface {
@@ -558,7 +573,7 @@ func CopyRange(handle NbdOperations, sink VDDKDataSink, block *BlockStatusData, 
 		return err
 	}
 
-	buffer := bytes.Repeat([]byte{0}, MaxPreadLength)
+	buffer := bytes.Repeat([]byte{0}, int(MaxPreadLength))
 	count := uint32(0)
 	for count < block.Length {
 		if block.Length-count < MaxPreadLength {
@@ -816,6 +831,12 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 			klog.Errorf("Unable to get source disk size: %v", err)
 			return nil, err
 		}
+	}
+
+	MaxPreadLength = MaxPreadLengthESX
+	if vmware.conn.IsVC() {
+		klog.Infof("Connected to vCenter, restricting read request size to %d.", MaxPreadLengthVC)
+		MaxPreadLength = MaxPreadLengthVC
 	}
 
 	source := &VDDKDataSource{


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request checks if the VDDK endpoint is vCenter or a direct connection to ESX. When the endpoint is vCenter, reduce the read request size to 2MB. This reduces the frequency of the "Failed to allocate the requested 24117272 bytes" errors that interfere with migrations running multiple imports in parallel. It is still possible to hit, but less likely - 2MB matches the previous qemu-img implementation.

For direct ESX connections, this pull request does nothing different. That should leave the door open for users to try for faster transfers with direct connections, if needed.

**Which issue(s) this PR fixes**
Fixes [RHBZ#1984775](https://bugzilla.redhat.com/show_bug.cgi?id=1984775)

**Special notes for your reviewer**:

**Release note**:
```release-note
Lower VDDK read size for vCenter connections to reduce incidence of allocation failures caused by simultaneous imports.  
```

