### PR TITLE
[release-v1.28] Default disk alignment to 1Mi instead of 512 bytes

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -286,7 +286,7 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 		// Change permissions to 0660
 		err := os.Chmod(dp.dataFile, 0660)
 		if err != nil {
-			err = errors.Wrap(err, "Unable to change permissions of target file")
+			return ProcessingPhaseError, errors.Wrap(err, "Unable to change permissions of target file")
 		}
 	}
 
@@ -362,10 +362,9 @@ func (dp *DataProcessor) getUsableSpace() int64 {
 
 // GetUsableSpace calculates space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	blockSize := int64(512)
 	spaceWithOverhead := int64((1 - filesystemOverhead) * float64(availableSpace))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
-	qemuImgCorrection := util.RoundDown(spaceWithOverhead, blockSize)
+	qemuImgCorrection := util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
 	return qemuImgCorrection
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,8 @@ import (
 
 const (
 	blockdevFileName = "/usr/sbin/blockdev"
+	// DefaultAlignBlockSize is the alignment size we use to align disk images, its a multiple of all known hardware block sizes 512/4k/8k/32k/64k.
+	DefaultAlignBlockSize = 1024 * 1024
 )
 
 // CountingReader is a reader that keeps track of how much has been read

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,10 +17,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const pattern = "^[a-zA-Z0-9]+$"
-const TestImagesDir = "../../tests/images"
+const (
+	pattern       = "^[a-zA-Z0-9]+$"
+	TestImagesDir = "../../tests/images"
+)
 
-var fileDir, _ = filepath.Abs(TestImagesDir)
+var (
+	fileDir, _ = filepath.Abs(TestImagesDir)
+)
 
 var _ = Describe("Util", func() {
 	It("Should match RandAlphaNum", func() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1011,7 +1011,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		It("[test_id:5353]Importer pod should have specific datavolume annotations passed but not others", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs))
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 			By(fmt.Sprintf("creating new datavolume %s with annotations", dataVolume.Name))
 			dataVolume.Annotations[controller.AnnPodNetwork] = "net1"
 			dataVolume.Annotations["annot1"] = "value1"
@@ -1023,18 +1023,14 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-			By("verifying the Datavolume is not complete yet")
-			foundDv, err := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if foundDv.Status.Phase != cdiv1.Succeeded {
-				By("find importer pod")
-				var sourcePod *v1.Pod
-				Eventually(func() bool {
-					sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
-					return err == nil
-				}, timeout, pollingInterval).Should(BeTrue())
-				verifyAnnotations(sourcePod)
-			}
+			By("find importer pod")
+			var sourcePod *v1.Pod
+			Eventually(func() bool {
+				sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
+				return err == nil
+			}, timeout, pollingInterval).Should(BeTrue())
+			By(fmt.Sprintf("Verifying pod %s has correct annotation", sourcePod.Name))
+			verifyAnnotations(sourcePod)
 		})
 
 		It("[test_id:5365]Uploader pod should have specific datavolume annotations passed but not others", func() {
@@ -1050,18 +1046,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-			By("verifying the Datavolume is not complete yet")
-			foundDv, err := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if foundDv.Status.Phase != cdiv1.Succeeded {
-				By("find uploader pod")
-				var sourcePod *v1.Pod
-				Eventually(func() bool {
-					sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)
-					return err == nil
-				}, timeout, pollingInterval).Should(BeTrue())
-				verifyAnnotations(sourcePod)
-			}
+			By("find uploader pod")
+			var sourcePod *v1.Pod
+			Eventually(func() bool {
+				sourcePod, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, "cdi-upload", common.CDILabelSelector)
+				return err == nil
+			}, timeout, pollingInterval).Should(BeTrue())
+			verifyAnnotations(sourcePod)
 		})
 
 		It("[test_id:5366]Cloner pod should have specific datavolume annotations passed but not others", func() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
backport of #1873

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Align disk image size to 1Mi instead of 512 bytes.
```

