### PR TITLE
Removing cdi-prometheus-metrics service for CDI installation

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -31,8 +31,6 @@ const (
 
 	// PrometheusLabel provides the label to indicate prometheus metrics are available in the pods.
 	PrometheusLabel = "prometheus.cdi.kubevirt.io"
-	// PrometheusServiceName is the name of the prometheus service created by the operator.
-	PrometheusServiceName = "cdi-prometheus-metrics"
 
 	// UploadTargetLabel has the UID of upload target PVC
 	UploadTargetLabel = CDIComponentLabel + "/uploadTarget"

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -188,18 +188,6 @@ var _ = Describe("Controller", func() {
 				validateEvents(args.reconciler, createNotReadyEventValidationMap())
 			})
 
-			It("should create prometheus service", func() {
-				args := createArgs()
-				doReconcile(args)
-
-				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: cdiNamespace, Name: common.PrometheusServiceName}}
-				obj, err := getObject(args.client, svc)
-				Expect(err).ToNot(HaveOccurred())
-
-				svc = obj.(*corev1.Service)
-				Expect(svc.OwnerReferences[0].UID).Should(Equal(args.cdi.UID))
-			})
-
 			It("should create requeue when configmap exists with another owner", func() {
 				cm := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1666,7 +1654,6 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.Secret cdi-uploadserver-client-signer"] = false
 	match[normalCreateSuccess+" *v1.ConfigMap cdi-uploadserver-client-signer-bundle"] = false
 	match[normalCreateSuccess+" *v1.Secret cdi-uploadserver-client-cert"] = false
-	match[normalCreateSuccess+" *v1.Service cdi-prometheus-metrics"] = false
 	match[normalCreateEnsured+" SecurityContextConstraint exists"] = false
 	return match
 }

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,7 +34,6 @@ import (
 const (
 	controllerResourceName = "cdi-deployment"
 	prometheusLabel        = common.PrometheusLabel
-	prometheusServiceName  = common.PrometheusServiceName
 )
 
 func createControllerResources(args *FactoryArgs) []client.Object {
@@ -51,7 +49,6 @@ func createControllerResources(args *FactoryArgs) []client.Object {
 			args.PullPolicy,
 			args.InfraNodePlacement),
 		createInsecureRegConfigMap(),
-		createPrometheusService(),
 	}
 }
 
@@ -275,20 +272,4 @@ func createInsecureRegConfigMap() *corev1.ConfigMap {
 			Labels: utils.ResourceBuilder.WithCommonLabels(nil),
 		},
 	}
-}
-
-func createPrometheusService() *corev1.Service {
-	service := utils.ResourceBuilder.CreateService(prometheusServiceName, prometheusLabel, "", nil)
-	service.Spec.Ports = []corev1.ServicePort{
-		{
-			Name: "metrics",
-			Port: 443,
-			TargetPort: intstr.IntOrString{
-				Type:   intstr.String,
-				StrVal: "metrics",
-			},
-			Protocol: corev1.ProtocolTCP,
-		},
-	}
-	return service
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -50,28 +50,6 @@ var _ = Describe("ALL Operator tests", func() {
 				Expect(r.Spec.TLS.Termination).To(Equal(routev1.TLSTerminationReencrypt))
 			})
 
-			It("[test_id:4351]should create a prometheus service in cdi namespace", func() {
-				promService, err := f.K8sClient.CoreV1().Services(f.CdiInstallNs).Get(context.TODO(), common.PrometheusServiceName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(promService.Spec.Ports[0].Name).To(Equal("metrics"))
-				Expect(promService.Spec.Selector[common.PrometheusLabel]).To(Equal(""))
-				originalTimeStamp := promService.ObjectMeta.CreationTimestamp
-
-				By("Deleting the service")
-				err = f.K8sClient.CoreV1().Services(f.CdiInstallNs).Delete(context.TODO(), common.PrometheusServiceName, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				By("Verifying the operator has re-created the service")
-				Eventually(func() bool {
-					promService, err = f.K8sClient.CoreV1().Services(f.CdiInstallNs).Get(context.TODO(), common.PrometheusServiceName, metav1.GetOptions{})
-					if err == nil {
-						return originalTimeStamp.Before(&promService.ObjectMeta.CreationTimestamp)
-					}
-					return false
-				}, 1*time.Minute, 2*time.Second).Should(BeTrue())
-				Expect(promService.Spec.Ports[0].Name).To(Equal("metrics"))
-				Expect(promService.Spec.Selector[common.PrometheusLabel]).To(Equal(""))
-			})
-
 			It("[test_id:3952]add cdi-sa to containerized-data-importer scc", func() {
 				if !utils.IsOpenshift(f.K8sClient) {
 					Skip("This test is OpenShift specific")


### PR DESCRIPTION
Signed-off-by: Vishesh Ajay Tanksale <vtanksale@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The service cdi-prometheus-metrics is not used anywhere. It is being removed from the CDI installation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubevirt/containerized-data-importer/issues/1890
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed cdi-prometheus-metrics service
```

