### PR TITLE
Correct md5sum verification in tests

### DIFF
--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -1,48 +1,38 @@
 package tests
 
 import (
-	"context"
 	"fmt"
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 )
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high] CSI Volume cloning tests", func() {
 	var originalProfileSpec *cdiv1.StorageProfileSpec
-
-	fillData := "123456789012345678901234567890123456789012345678901234567890"
-	testFile := utils.DefaultPvcMountPath + "/source.txt"
-	fillCommandFilesystem := "echo -n \"" + fillData + "\" >> " + testFile
+	var cloneStorageClassName string
 
 	f := framework.NewFramework("dv-func-test")
 
 	BeforeEach(func() {
+		cloneStorageClassName = utils.DefaultStorageClass.GetName()
 		if f.IsCSIVolumeCloneStorageClassAvailable() {
-
-			cloneStorageClassName := f.CsiCloneSCName
-			By(fmt.Sprintf("Get original storage profile: %s", cloneStorageClassName))
-
-			spec, err := utils.GetStorageProfileSpec(f.CdiClient, cloneStorageClassName)
-			originalProfileSpec = spec
-			Expect(err).ToNot(HaveOccurred())
-			By(fmt.Sprintf("Got original storage profile: %v", originalProfileSpec))
+			cloneStorageClassName = f.CsiCloneSCName
 		}
 
+		By(fmt.Sprintf("Get original storage profile: %s", cloneStorageClassName))
+
+		spec, err := utils.GetStorageProfileSpec(f.CdiClient, cloneStorageClassName)
+		originalProfileSpec = spec
+		Expect(err).ToNot(HaveOccurred())
+		By(fmt.Sprintf("Got original storage profile: %v", originalProfileSpec))
 	})
 
 	AfterEach(func() {
 		if originalProfileSpec != nil {
-			cloneStorageClassName := f.CsiCloneSCName
 			By("Restore the profile")
 			utils.UpdateStorageProfile(f.CrClient, cloneStorageClassName, *originalProfileSpec)
 		}
@@ -56,13 +46,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high] CSI Vol
 		By(fmt.Sprintf("configure storage profile %s", f.CsiCloneSCName))
 		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
 
-		dataVolume, md5 := createDataVolume("dv-csi-clone-test-1", fillCommandFilesystem, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
+		dataVolume, md5 := createDataVolume("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
 		verifyEvent(string(cdiv1.CSICloneInProgress), dataVolume.Namespace, f)
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
 		// Verify PVC's content
-		verifyPVC(dataVolume, f, testFile, md5)
+		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 	})
 
 	It("Verify DataVolume CSI Cloning - volumeMode block - Positive flow", func() {
@@ -82,42 +72,4 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high] CSI Vol
 		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, expectedMd5)
 	})
 
-	It("Verify DataVolume CSI Cloning - volumeMode filesystem - Waits for source to be available", func() {
-		if !f.IsCSIVolumeCloneStorageClassAvailable() {
-			Skip("CSI Volume Clone is not applicable")
-		}
-
-		By(fmt.Sprintf("configure storage profile %s", f.CsiCloneSCName))
-		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
-		sourcePvc := createAndPopulateSourcePVC("dv-smart-clone-test-1", v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
-		pod, err := f.CreateExecutorPodWithPVC("temp-pod", f.Namespace.Name, sourcePvc)
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func() bool {
-			pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return pod.Status.Phase == v1.PodRunning
-		}, 90*time.Second, 2*time.Second).Should(BeTrue())
-
-		By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
-		dataVolume := utils.NewCloningDataVolume(dataVolumeName, "1Gi", sourcePvc)
-		if f.CsiCloneSCName != "" {
-			dataVolume.Spec.PVC.StorageClassName = &f.CsiCloneSCName
-		}
-
-		By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
-		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyEvent(controller.CSICloneSourceInUse, dataVolume.Namespace, f)
-		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyEvent(controller.CSICloneInProgress, dataVolume.Namespace, f)
-		// Wait for operation Succeeded
-		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
-		// Verify PVC's content
-		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, utils.TinyCoreBlockMD5)
-	})
 })

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -168,7 +168,7 @@ func (f *Framework) GetMD5(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolu
 
 	cmd := "md5sum " + fileName
 	if numBytes > 0 {
-		cmd = fmt.Sprintf("head -c %d %s | md5sum", numBytes, fileName)
+		cmd = fmt.Sprintf("head -c %d %s 1> null && head -c %d %s | md5sum", numBytes, fileName, numBytes, fileName)
 	}
 
 	output, stderr, err := f.ExecShellInPod(executorPod.Name, namespace.Name, cmd)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Namespace with quota", func() {
 		By(fmt.Sprintf("Creating PVC with endpoint annotation %q", httpEp+"/tinyCore.iso"))
 
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition(
-			"import-image-to-block-pvc",
+			"import-image-to-pvc",
 			"500Mi",
 			pvcAnn,
 			nil))
@@ -686,7 +686,7 @@ var _ = Describe("Namespace with quota", func() {
 		}, CompletionTimeout, assertionPollInterval).Should(BeEquivalentTo(v1.PodSucceeded))
 
 		By("Verify content")
-		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, utils.UploadFileSize)
+		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(same).To(BeTrue())
 		By("Verifying permissions are 660")
@@ -763,7 +763,7 @@ var _ = Describe("Namespace with quota", func() {
 		}, CompletionTimeout, assertionPollInterval).Should(BeEquivalentTo(v1.PodSucceeded))
 
 		By("Verify content")
-		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, utils.UploadFileSize)
+		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(same).To(BeTrue())
 		By("Verifying permissions are 660")
@@ -799,7 +799,7 @@ var _ = Describe("Namespace with quota", func() {
 		}, CompletionTimeout, assertionPollInterval).Should(BeEquivalentTo(v1.PodSucceeded))
 
 		By("Verify content")
-		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, "/pvc", utils.TinyCoreBlockMD5, utils.UploadFileSize)
+		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(same).To(BeTrue())
 		By("Verifying permissions are 660")
@@ -1088,7 +1088,7 @@ var _ = Describe("Preallocation", func() {
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
 
 		By("Verify content")
-		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		md5, err := f.GetMD5(f.Namespace, pvc, utils.DefaultImagePath, md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.TinyCoreMD5))
 
@@ -1120,7 +1120,7 @@ var _ = Describe("Preallocation", func() {
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Equal("true"))
 
 		By("Verify content")
-		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		md5, err := f.GetMD5(f.Namespace, pvc, utils.DefaultImagePath, md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.TinyCoreMD5))
 
@@ -1178,40 +1178,40 @@ var _ = Describe("Preallocation", func() {
 			Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).ShouldNot(Equal("true"))
 		}
 	},
-		Entry("HTTP import (ISO image)", true, utils.TinyCoreMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP import (ISO image)", true, utils.TinyCoreMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreIsoURL())
 		}),
-		Entry("HTTP import (QCOW2 image)", true, utils.TinyCoreMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP import (QCOW2 image)", true, utils.TinyCoreMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreQcow2URL())
 		}),
-		Entry("HTTP import (TAR image)", true, utils.TinyCoreTarMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP import (TAR image)", true, utils.TinyCoreTarMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeWithHTTPImport("import-dv", "100Mi", tinyCoreTarURL())
 		}),
 		Entry("HTTP import (archive content)", false, "", "", func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeWithArchiveContent("import-dv", "100Mi", tinyCoreTarURL())
 		}),
-		Entry("HTTP Import (TAR image, block DataVolume)", true, utils.TinyCoreBlockMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP Import (TAR image, block DataVolume)", true, utils.TinyCoreTarMD5, utils.DefaultPvcMountPath, func() *cdiv1.DataVolume {
 			if !f.IsBlockVolumeStorageClassAvailable() {
 				Skip("Storage Class for block volume is not available")
 			}
 
 			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreTarURL(), f.BlockSCName)
 		}),
-		Entry("HTTP Import (ISO image, block DataVolume)", true, utils.TinyCoreBlockMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP Import (ISO image, block DataVolume)", true, utils.TinyCoreMD5, utils.DefaultPvcMountPath, func() *cdiv1.DataVolume {
 			if !f.IsBlockVolumeStorageClassAvailable() {
 				Skip("Storage Class for block volume is not available")
 			}
 
 			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreIsoURL(), f.BlockSCName)
 		}),
-		Entry("HTTP Import (QCOW2 image, block DataVolume)", true, utils.TinyCoreBlockMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("HTTP Import (QCOW2 image, block DataVolume)", true, utils.TinyCoreMD5, utils.DefaultPvcMountPath, func() *cdiv1.DataVolume {
 			if !f.IsBlockVolumeStorageClassAvailable() {
 				Skip("Storage Class for block volume is not available")
 			}
 
 			return utils.NewDataVolumeWithHTTPImportToBlockPV("import-dv", "4Gi", tinyCoreQcow2URL(), f.BlockSCName)
 		}),
-		Entry("ImageIO import", true, utils.ImageioMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("ImageIO import", true, utils.ImageioMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			cm, err := utils.CopyImageIOCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
 			Expect(err).To(BeNil())
 			stringData := map[string]string{
@@ -1221,14 +1221,14 @@ var _ = Describe("Preallocation", func() {
 			s, _ := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, stringData, nil, f.Namespace.Name, "mysecret"))
 			return utils.NewDataVolumeWithImageioImport("import-dv", "100Mi", imageioURL(), s.Name, cm, "123")
 		}),
-		Entry("Registry import", true, utils.TinyCoreMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("Registry import", true, utils.TinyCoreMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			dataVolume = utils.NewDataVolumeWithRegistryImport("import-dv", "100Mi", tinyCoreRegistryURL())
 			cm, err := utils.CopyRegistryCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
 			Expect(err).To(BeNil())
 			dataVolume.Spec.Source.Registry.CertConfigMap = cm
 			return dataVolume
 		}),
-		Entry("VddkImport", true, utils.VcenterMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("VddkImport", true, utils.VcenterMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			// Find vcenter-simulator pod
 			pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, "vcenter-deployment", "app=vcenter")
 			Expect(err).ToNot(HaveOccurred())
@@ -1258,7 +1258,7 @@ var _ = Describe("Preallocation", func() {
 
 			return utils.NewDataVolumeWithVddkImport("import-dv", "100Mi", backingFile, s.Name, thumbprint, vcenterURL(), vmid.String())
 		}),
-		Entry("Blank image", true, utils.BlankMD5, "/pvc/disk.img", func() *cdiv1.DataVolume {
+		Entry("Blank image", true, utils.BlankMD5, utils.DefaultImagePath, func() *cdiv1.DataVolume {
 			return utils.NewDataVolumeForBlankRawImage("import-dv", "100Mi")
 		}),
 		Entry("Blank block DataVolume", true, utils.BlankMD5, "/pvc", func() *cdiv1.DataVolume {
@@ -1295,7 +1295,7 @@ var _ = Describe("Preallocation", func() {
 		Expect(pvc.GetAnnotations()[controller.AnnPreallocationApplied]).Should(Equal("true"))
 
 		By("Verify content")
-		md5, err := f.GetMD5(f.Namespace, pvc, "/pvc/disk.img", md5PrefixSize)
+		md5, err := f.GetMD5(f.Namespace, pvc, utils.DefaultImagePath, md5PrefixSize)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(utils.BlankMD5))
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -73,7 +73,7 @@ const (
 	// TinyCoreTarMD5 is the MD5 hash of first 100k bytes of tinyCore tar image
 	TinyCoreTarMD5 = "aec1a39d753b4b7cc81ee02bc625a342"
 	// TinyCoreBlockMD5 is the MD5 hash of first 100k bytes of tinyCore image on block device
-	TinyCoreBlockMD5 = "d41d8cd98f00b204e9800998ecf8427e"
+	TinyCoreBlockMD5 = "2a7a52285c846314d1dbd79e9818270d"
 	// ImageioMD5 is the MD5 hash of first 100k bytes of imageio image
 	ImageioMD5 = "91150be031835ccfac458744da57d4f6"
 	// VcenterMD5 is the MD5 hash of first 100k bytes of Vcenter image

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -72,8 +72,6 @@ const (
 	TinyCoreMD5 = "3710416a680523c7d07538cb1026c60c"
 	// TinyCoreTarMD5 is the MD5 hash of first 100k bytes of tinyCore tar image
 	TinyCoreTarMD5 = "aec1a39d753b4b7cc81ee02bc625a342"
-	// TinyCoreBlockMD5 is the MD5 hash of first 100k bytes of tinyCore image on block device
-	TinyCoreBlockMD5 = "2a7a52285c846314d1dbd79e9818270d"
 	// ImageioMD5 is the MD5 hash of first 100k bytes of imageio image
 	ImageioMD5 = "91150be031835ccfac458744da57d4f6"
 	// VcenterMD5 is the MD5 hash of first 100k bytes of Vcenter image


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
A problem was found with the way verification command is run. 

```
head -c [numBytes] [fileName] | md5sum

```
This command fails when the file path is bad, but the empty output is piped to md5 and the result is success with md5 of empty input.

In effect some tests were always passing. This was corrected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

