### PR TITLE
Allow admin user to set CDI control plane priority class via CDI cr.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3635,6 +3635,10 @@
       "default": {},
       "$ref": "#/definitions/api.NodePlacement"
      },
+     "priorityClass": {
+      "description": "PriorityClass of the CDI control plane",
+      "type": "string"
+     },
      "uninstallStrategy": {
       "description": "CDIUninstallStrategy defines the state to leave CDI on uninstall",
       "type": "string"

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.2
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.20.2
 	k8s.io/sample-controller => k8s.io/sample-controller v0.20.2
+	k8s.io/schedule => k8s.io/schedule v0.20.2
 
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.0
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -14682,6 +14682,13 @@ func schema_pkg_apis_core_v1beta1_CDISpec(ref common.ReferenceCallback) common.O
 							Ref:         ref("kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1.CDICertConfig"),
 						},
 					},
+					"priorityClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PriorityClass of the CDI control plane",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -567,7 +567,12 @@ type CDISpec struct {
 	Config *CDIConfigSpec `json:"config,omitempty"`
 	// certificate configuration
 	CertConfig *CDICertConfig `json:"certConfig,omitempty"`
+	// PriorityClass of the CDI control plane
+	PriorityClass *CDIPriorityClass `json:"priorityClass,omitempty"`
 }
+
+// CDIPriorityClass defines the priority class of the CDI control plane.
+type CDIPriorityClass string
 
 // CDICloneStrategy defines the preferred method for performing a CDI clone (override snapshot?)
 type CDICloneStrategy string

--- a/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -302,6 +302,7 @@ func (CDISpec) SwaggerDoc() map[string]string {
 		"cloneStrategyOverride": "Clone strategy override: should we use a host-assisted copy even if snapshots are available?\n+kubebuilder:validation:Enum=\"copy\";\"snapshot\"",
 		"config":                "CDIConfig at CDI level",
 		"certConfig":            "certificate configuration",
+		"priorityClass":         "PriorityClass of the CDI control plane",
 	}
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -291,6 +291,11 @@ func (in *CDISpec) DeepCopyInto(out *CDISpec) {
 		*out = new(CDICertConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PriorityClass != nil {
+		in, out := &in.PriorityClass, &out.PriorityClass
+		*out = new(CDIPriorityClass)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -197,6 +197,19 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"scheduling.k8s.io",
+			},
+			Resources: []string{
+				"priorityclasses",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
 }
 

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -1466,6 +1466,9 @@ spec:
                       type: object
                     type: array
                 type: object
+              priorityClass:
+                description: PriorityClass of the CDI control plane
+                type: string
               uninstallStrategy:
                 description: CDIUninstallStrategy defines the state to leave CDI on uninstall
                 enum:

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -42,7 +42,7 @@ func createAPIServerResources(args *FactoryArgs) []client.Object {
 		createAPIServerRoleBinding(),
 		createAPIServerRole(),
 		createAPIServerService(),
-		createAPIServerDeployment(args.APIServerImage, args.Verbosity, args.PullPolicy, args.InfraNodePlacement),
+		createAPIServerDeployment(args.APIServerImage, args.Verbosity, args.PullPolicy, args.PriorityClassName, args.InfraNodePlacement),
 	}
 }
 
@@ -87,9 +87,12 @@ func createAPIServerService() *corev1.Service {
 	return service
 }
 
-func createAPIServerDeployment(image, verbosity, pullPolicy string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
+func createAPIServerDeployment(image, verbosity, pullPolicy, priorityClassName string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
 	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(apiServerRessouceName, cdiLabel, apiServerRessouceName, apiServerRessouceName, 1, infraNodePlacement)
+	if priorityClassName != "" {
+		deployment.Spec.Template.Spec.PriorityClassName = priorityClassName
+	}
 	container := utils.CreateContainer(apiServerRessouceName, image, verbosity, pullPolicy)
 	container.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -47,6 +47,7 @@ func createControllerResources(args *FactoryArgs) []client.Object {
 			args.UploadServerImage,
 			args.Verbosity,
 			args.PullPolicy,
+			args.PriorityClassName,
 			args.InfraNodePlacement),
 		createInsecureRegConfigMap(),
 	}
@@ -90,9 +91,12 @@ func createControllerServiceAccount() *corev1.ServiceAccount {
 	return utils.ResourceBuilder.CreateServiceAccount(common.ControllerServiceAccountName)
 }
 
-func createControllerDeployment(controllerImage, importerImage, clonerImage, uploadServerImage, verbosity, pullPolicy string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
+func createControllerDeployment(controllerImage, importerImage, clonerImage, uploadServerImage, verbosity, pullPolicy, priorityClassName string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
 	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(controllerResourceName, "app", "containerized-data-importer", common.ControllerServiceAccountName, int32(1), infraNodePlacement)
+	if priorityClassName != "" {
+		deployment.Spec.Template.Spec.PriorityClassName = priorityClassName
+	}
 	container := utils.CreateContainer("cdi-controller", controllerImage, verbosity, pullPolicy)
 	container.Env = []corev1.EnvVar{
 		{

--- a/pkg/operator/resources/namespaced/factory.go
+++ b/pkg/operator/resources/namespaced/factory.go
@@ -38,6 +38,7 @@ type FactoryArgs struct {
 	UploadServerImage      string `required:"true" split_words:"true"`
 	Verbosity              string `required:"true"`
 	PullPolicy             string `required:"true" split_words:"true"`
+	PriorityClassName      string
 	Namespace              string
 	InfraNodePlacement     *sdkapi.NodePlacement
 }

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -37,7 +37,7 @@ func createUploadProxyResources(args *FactoryArgs) []client.Object {
 		createUploadProxyService(),
 		createUploadProxyRoleBinding(),
 		createUploadProxyRole(),
-		createUploadProxyDeployment(args.UploadProxyImage, args.Verbosity, args.PullPolicy, args.InfraNodePlacement),
+		createUploadProxyDeployment(args.UploadProxyImage, args.Verbosity, args.PullPolicy, args.PriorityClassName, args.InfraNodePlacement),
 	}
 }
 
@@ -82,9 +82,12 @@ func createUploadProxyRole() *rbacv1.Role {
 	return utils.ResourceBuilder.CreateRole(uploadProxyResourceName, rules)
 }
 
-func createUploadProxyDeployment(image, verbosity, pullPolicy string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
+func createUploadProxyDeployment(image, verbosity, pullPolicy, priorityClassName string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {
 	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils.CreateDeployment(uploadProxyResourceName, cdiLabel, uploadProxyResourceName, uploadProxyResourceName, int32(1), infraNodePlacement)
+	if priorityClassName != "" {
+		deployment.Spec.Template.Spec.PriorityClassName = priorityClassName
+	}
 	container := utils.CreateContainer(uploadProxyResourceName, image, verbosity, pullPolicy)
 	container.Env = []corev1.EnvVar{
 		{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -293,7 +293,7 @@ var _ = Describe("CDI ingress config tests, using manifests", func() {
 
 	It("[test_id:4950]Keep current value on no http rule ingress", func() {
 		manifestFile = "manifests/ingressNoHttp.yaml"
-		controllerPod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, "app=containerized-data-importer")
+		controllerPod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, common.CDILabelSelector)
 		Expect(err).ToNot(HaveOccurred())
 		currentRestarts := controllerPod.Status.ContainerStatuses[0].RestartCount
 		fmt.Fprintf(GinkgoWriter, "INFO: Current number of restarts: %d\n", currentRestarts)
@@ -311,7 +311,7 @@ var _ = Describe("CDI ingress config tests, using manifests", func() {
 		for i := 0; i < 10; i++ {
 			// Check for 20 seconds if the deployment pod crashed.
 			time.Sleep(2 * time.Second)
-			controllerPod, err = utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, "app=containerized-data-importer")
+			controllerPod, err = utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, common.CDILabelSelector)
 			Expect(err).ToNot(HaveOccurred())
 			// Restarts will increase if we crashed due to null pointer.
 			Expect(currentRestarts).To(Equal(controllerPod.Status.ContainerStatuses[0].RestartCount))

--- a/tests/leaderelection_test.go
+++ b/tests/leaderelection_test.go
@@ -22,11 +22,13 @@ import (
 )
 
 const (
-	cdiDeploymentName      = "cdi-deployment"
-	cdiDeploymentPodPrefix = "cdi-deployment-"
-	cdiOperatorName        = "cdi-operator"
-	cdiOperatorPodPrefix   = "cdi-operator-"
-	newDeploymentName      = "cdi-new-deployment"
+	cdiDeploymentName       = "cdi-deployment"
+	cdiDeploymentPodPrefix  = "cdi-deployment-"
+	cdiApiServerPodPrefix   = "cdi-apiserver-"
+	cdiUploadProxyPodPrefix = "cdi-uploadproxy-"
+	cdiOperatorName         = "cdi-operator"
+	cdiOperatorPodPrefix    = "cdi-operator-"
+	newDeploymentName       = "cdi-new-deployment"
 
 	pollingInterval = 2 * time.Second
 	timeout         = 360 * time.Second
@@ -248,7 +250,7 @@ func cleanupTest(f *framework.Framework, newDeployment *appsv1.Deployment) {
 }
 
 func getDeployments(f *framework.Framework) *appsv1.DeploymentList {
-	deployments, err := f.K8sClient.AppsV1().Deployments(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=containerized-data-importer"})
+	deployments, err := f.K8sClient.AppsV1().Deployments(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{LabelSelector: common.CDILabelSelector})
 	Expect(err).ToNot(HaveOccurred())
 	return deployments
 }
@@ -260,7 +262,7 @@ func getOperatorDeployment(f *framework.Framework) *appsv1.Deployment {
 }
 
 func getPods(f *framework.Framework) *v1.PodList {
-	pods, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=containerized-data-importer"})
+	pods, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{LabelSelector: common.CDILabelSelector})
 	Expect(err).ToNot(HaveOccurred())
 	return pods
 }

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -115,7 +115,7 @@ func findPodByCompFuncOnce(clientSet *kubernetes.Clientset, namespace, prefix, l
 	for _, pod := range podList.Items {
 		if compFunc(pod.Name, prefix) {
 			if result == nil {
-				result = &pod
+				result = pod.DeepCopy()
 			} else {
 				fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: First pod name %s in namespace %s\n", result.Name, result.Namespace)
 				fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Second pod name %s in namespace %s\n", pod.Name, pod.Namespace)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1085,5 +1085,6 @@ sigs.k8s.io/yaml
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.2
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.20.2
 # k8s.io/sample-controller => k8s.io/sample-controller v0.20.2
+# k8s.io/schedule => k8s.io/schedule v0.20.2
 # sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.0
 # vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow users to specify the priority class of the CDI control
plane using the CDI CR. Verifies that the set value is valid
before passing to the deployments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1953484

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Allow admin user to specify priority class of CDI control plane
```

