### PR TITLE
Use NodePort instead of kubectl port-forward for upload tests

### DIFF
--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -17,7 +17,7 @@ LABELS=("operator.cdi.kubevirt.io" "cdi.kubevirt.io" "prometheus.cdi.kubevirt.io
 NAMESPACES=(default kube-system cdi)
 
 set +e
-_kubectl patch cdi cdi --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
+_kubectl patch cdi ${CR_NAME} --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
 set -e
 
 _kubectl get ot --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep objectTransfer | while read p; do

--- a/manifests/templates/uploadproxy-nodeport.yaml.in
+++ b/manifests/templates/uploadproxy-nodeport.yaml.in
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cdi-uploadproxy-nodeport
+  namespace: {{ .Namespace }}
+  labels:
+    cdi.kubevirt.io/testing: ""
+spec:
+  type: NodePort
+  selector:
+    cdi.kubevirt.io: cdi-uploadproxy
+  ports:
+    - port: 443
+      targetPort: 8443
+      nodePort: 31001


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Follow up for #1886, we now have a kubevirtci version that gives us a free port.
We can use that to make the switch from `kubectl port-forward` which has been known to cause many flakes in our CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
We are only going to fall back to `kubectl port-forward` when override is not set:
https://github.com/kubevirt/containerized-data-importer/blob/main/tests/upload_test.go#L74-L78

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

