### PR TITLE
Fix 2 common flakes

### DIFF
--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -488,25 +488,27 @@ var _ = Describe("CDI route config tests", func() {
 var _ = Describe("CDIConfig instance management", func() {
 	f := framework.NewFramework("cdiconfig-test")
 
-	It("[test_id:4952]Should re-create the object if deleted", func() {
-		By("Verifying the object exists")
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		// Save the UID, so we can check it against a new one.
-		orgUID := config.GetUID()
-		GinkgoWriter.Write([]byte(fmt.Sprintf("Original CDIConfig UID: %s\n", orgUID)))
-		By("Deleting the object")
-		err = f.CdiClient.CdiV1beta1().CDIConfigs().Delete(context.TODO(), config.Name, metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
+	Context("[Destructive]", func() {
+		It("[test_id:4952]Should re-create the object if deleted", func() {
+			By("Verifying the object exists")
+			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// Save the UID, so we can check it against a new one.
+			orgUID := config.GetUID()
+			GinkgoWriter.Write([]byte(fmt.Sprintf("Original CDIConfig UID: %s\n", orgUID)))
+			By("Deleting the object")
+			err = f.CdiClient.CdiV1beta1().CDIConfigs().Delete(context.TODO(), config.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
-			newConfig, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			GinkgoWriter.Write([]byte(fmt.Sprintf("New CDIConfig UID: %s\n", newConfig.GetUID())))
-			return orgUID != newConfig.GetUID()
-		}, time.Second*30, time.Second).Should(BeTrue())
+			Eventually(func() bool {
+				newConfig, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				GinkgoWriter.Write([]byte(fmt.Sprintf("New CDIConfig UID: %s\n", newConfig.GetUID())))
+				return orgUID != newConfig.GetUID() && !apiequality.Semantic.DeepEqual(newConfig.Status, cdiv1.CDIConfigStatus{})
+			}, time.Second*30, time.Second).Should(BeTrue())
+		})
 	})
 })
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -234,8 +234,10 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Expect(token).ToNot(BeEmpty())
 
 		By("Do upload")
-		err = uploadFileNameToPath(binaryRequestFunc, filename, uploadProxyURL, syncUploadPath, token, http.StatusOK)
-		Expect(err).To(HaveOccurred())
+		Eventually(func() bool {
+			err = uploadFileNameToPath(binaryRequestFunc, filename, uploadProxyURL, syncUploadPath, token, http.StatusOK)
+			return err != nil && strings.Contains(err.Error(), "Unexpected return value 500")
+		}, timeout, pollingInterval).Should(BeTrue())
 
 		uploadPod, err := utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, utils.UploadPodName(pvc), common.CDILabelSelector)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get uploader pod %q", f.Namespace.Name+"/"+utils.UploadPodName(pvc)))


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- `[test_id:4952]Should re-create the object if deleted`
This test deletes the CDIConfig and waits for it to recreate with a different UID.
However, this condition alone will not suffice as the CDIConfig status might still be empty for a few seconds,
causing havoc in following tests.
Will now wait for .status to not be empty, and marking test as destructive.

- `[test_id:2330]Verify failure on sync upload if virtual size > pvc size`
Test looks for **any** error after making the HTTP request for upload from the host, which doesn't cut it;
That could be an EOF (witnessed), port-forward, etc -> while the only error that would guarantee the upload process
actually got triggered is `Unexpected return value 500`.
Without seeing this error we can't continue testing the scenario (can't be sure any upload logic even triggered).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

