### PR TITLE
Fix cluster-sync PULL_POLICY usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,10 @@ cluster-clean-test-infra:
 	CDI_CLEAN="test-infra" ./cluster-sync/clean.sh
 
 cluster-sync-cdi: cluster-clean-cdi
-	./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
+	./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} PULL_POLICY=${PULL_POLICY}
 
 cluster-sync-test-infra: cluster-clean-test-infra
-	CDI_SYNC="test-infra" ./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG}
+	CDI_SYNC="test-infra" ./cluster-sync/sync.sh CDI_AVAILABLE_TIMEOUT=${CDI_AVAILABLE_TIMEOUT} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} PULL_POLICY=${PULL_POLICY}
 
 cluster-sync: cluster-sync-cdi cluster-sync-test-infra
 

--- a/cluster-sync/sync-os-ci.sh
+++ b/cluster-sync/sync-os-ci.sh
@@ -20,7 +20,7 @@ CDI_UPGRADE_RETRY_COUNT=${CDI_UPGRADE_RETRY_COUNT:-60}
 # Set controller verbosity to 3 for functional tests.
 export VERBOSITY=3
 
-PULL_POLICY=$(getTestPullPolicy)
+PULL_POLICY=${PULL_POLICY:-IfNotPresent}
 # The default DOCKER_PREFIX is set to kubevirt and used for builds, however we don't use that for cluster-sync
 # instead we use a local registry; so here we'll check for anything != "external"
 # wel also confuse this by swapping the setting of the DOCKER_PREFIX variable around based on it's context, for

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -21,7 +21,7 @@ CDI_UPGRADE_RETRY_COUNT=${CDI_UPGRADE_RETRY_COUNT:-60}
 # Set controller verbosity to 3 for functional tests.
 export VERBOSITY=3
 
-PULL_POLICY=$(getTestPullPolicy)
+PULL_POLICY=${PULL_POLICY:-IfNotPresent}
 # The default DOCKER_PREFIX is set to kubevirt and used for builds, however we don't use that for cluster-sync
 # instead we use a local registry; so here we'll check for anything != "external"
 # wel also confuse this by swapping the setting of the DOCKER_PREFIX variable around based on it's context, for
@@ -36,7 +36,7 @@ if [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
 fi
 
 # Need to set the DOCKER_PREFIX appropriately in the call to `make docker push`, otherwise make will just pass in the default `kubevirt`
-DOCKER_PREFIX=$MANIFEST_REGISTRY PULL_POLICY=$(getTestPullPolicy) make manifests
+DOCKER_PREFIX=$MANIFEST_REGISTRY PULL_POLICY=$PULL_POLICY make manifests
 DOCKER_PREFIX=$DOCKER_PREFIX make push
 
 function kill_running_operator {

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -86,19 +86,3 @@ function parseTestOpts() {
         esac
     done
 }
-
-function getTestPullPolicy() {
-    local pp
-    case "${KUBEVIRT_PROVIDER}" in
-    "k8s-1.13.3")
-        pp=$PULL_POLICY
-        ;;
-    "os-3.11.0")
-        pp=Always
-        ;;
-    "okd-4.1")
-        pp=Always
-        ;;
-    esac
-    echo "$pp"
-}


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
`make cluster-sync` was ignoring `PULL_POLICY`  and used the default `IfNotPresent`
This was found while cluster-sync'ing with `KUBEVIRT_PROVIDER=external` to an existing cluster. 

**Release note**:
```release-note
NONE
```

