### PR TITLE
Add missing relationship labels on cdi-api-signing-key secret

### DIFF
--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apiserver:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/common:go_default_library",
         "//pkg/util/cert/watcher:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor/github.com/kelseyhightower/envconfig:go_default_library",

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -100,6 +100,8 @@ type cdiAPIApp struct {
 	certWarcher CertWatcher
 
 	tokenGenerator token.Generator
+
+	installerLabels map[string]string
 }
 
 // UploadTokenRequestAPI returns web service for swagger generation
@@ -117,7 +119,8 @@ func NewCdiAPIServer(bindAddress string,
 	cdiClient cdiclient.Interface,
 	authorizor CdiAPIAuthorizer,
 	authConfigWatcher AuthConfigWatcher,
-	certWatcher CertWatcher) (CdiAPIServer, error) {
+	certWatcher CertWatcher,
+	installerLabels map[string]string) (CdiAPIServer, error) {
 	var err error
 	app := &cdiAPIApp{
 		bindAddress:       bindAddress,
@@ -128,6 +131,7 @@ func NewCdiAPIServer(bindAddress string,
 		authorizer:        authorizor,
 		authConfigWatcher: authConfigWatcher,
 		certWarcher:       certWatcher,
+		installerLabels:   installerLabels,
 	}
 
 	err = app.getKeysAndCerts()
@@ -192,7 +196,7 @@ func (app *cdiAPIApp) Start(ch <-chan struct{}) error {
 func (app *cdiAPIApp) getKeysAndCerts() error {
 	namespace := util.GetNamespace()
 
-	privateKey, err := keys.GetOrCreatePrivateKey(app.client, namespace, apiSigningKeySecretName)
+	privateKey, err := keys.GetOrCreatePrivateKey(app.client, namespace, apiSigningKeySecretName, app.installerLabels)
 	if err != nil {
 		return errors.Wrap(err, "Error getting/creating signing key")
 	}

--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/operator:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/cert:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/keys/keystest/keystest.go
+++ b/pkg/keys/keystest/keystest.go
@@ -49,7 +49,9 @@ func newSecret(namespace, secretName string, data map[string][]byte, owner *meta
 			Name:      secretName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				common.CDIComponentLabel: "keystore",
+				common.CDIComponentLabel:           "keystore",
+				common.AppKubernetesComponentLabel: "storage",
+				common.AppKubernetesManagedByLabel: "cdi-apiserver",
 			},
 		},
 		Type: "Opaque",

--- a/pkg/keys/keystore.go
+++ b/pkg/keys/keystore.go
@@ -29,6 +29,7 @@ import (
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/operator"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 )
 
@@ -41,7 +42,7 @@ const (
 )
 
 // GetOrCreatePrivateKey gets or creates a private key secret
-func GetOrCreatePrivateKey(client kubernetes.Interface, namespace, secretName string) (*rsa.PrivateKey, error) {
+func GetOrCreatePrivateKey(client kubernetes.Interface, namespace, secretName string, installerLabels map[string]string) (*rsa.PrivateKey, error) {
 	secret, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -58,6 +59,7 @@ func GetOrCreatePrivateKey(client kubernetes.Interface, namespace, secretName st
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating prvate key secret")
 		}
+		util.SetRecommendedLabels(secret, installerLabels, "cdi-apiserver")
 
 		secret, err = client.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 		if err != nil {

--- a/pkg/keys/keystore_test.go
+++ b/pkg/keys/keystore_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Create Private Key", func() {
 	It("Should create a Private Key", func() {
 		client := k8sfake.NewSimpleClientset()
 
-		privateKey, err := GetOrCreatePrivateKey(client, namespace, secret)
+		privateKey, err := GetOrCreatePrivateKey(client, namespace, secret, map[string]string{})
 		Expect(err).NotTo(HaveOccurred())
 
 		actions := []core.Action{}
@@ -154,7 +154,7 @@ var _ = Describe("Create Private Key", func() {
 
 		client := k8sfake.NewSimpleClientset(kubeobjects...)
 
-		returnedPrivateKey, err := GetOrCreatePrivateKey(client, namespace, secret)
+		returnedPrivateKey, err := GetOrCreatePrivateKey(client, namespace, secret, map[string]string{})
 		Expect(err).NotTo(HaveOccurred())
 
 		actions := []core.Action{}

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package namespaced
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -94,6 +96,26 @@ func createAPIServerDeployment(image, verbosity, pullPolicy, priorityClassName s
 		deployment.Spec.Template.Spec.PriorityClassName = priorityClassName
 	}
 	container := utils.CreateContainer(apiServerRessouceName, image, verbosity, pullPolicy)
+	container.Env = []corev1.EnvVar{
+		{
+			Name: common.InstallerPartOfLabel,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesPartOfLabel),
+				},
+			},
+		},
+		{
+			Name: common.InstallerVersionLabel,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  fmt.Sprintf("metadata.labels['%s']", common.AppKubernetesVersionLabel),
+				},
+			},
+		},
+	}
 	container.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`cdi-api-signing-key` Secret is not being labeled currently, this PR handles that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1994389

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Some of the cdi resources missing app labels
```

