### PR TITLE
Add test for ratelimited qcow2.gz

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1675,8 +1675,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 	})
 
 	Describe("Progress reporting on import datavolume", func() {
-		It("[test_id:3934]Should report progress while importing", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs))
+		table.DescribeTable("Should report progress while importing", func(url string) {
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(url, f.CdiInstallNs))
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -1704,7 +1704,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				progress := dv.Status.Progress
 				return progressRegExp.MatchString(string(progress))
 			}, timeout, pollingInterval).Should(BeTrue())
-		})
+		},
+			table.Entry("[test_id:3934]when image is qcow2", utils.TinyCoreQcow2URLRateLimit),
+			table.Entry("[test_id:6902]when image is qcow2.gz", utils.TinyCoreQcow2GzURLRateLimit),
+		)
 	})
 
 	Describe("[rfe_id:4223][crit:high] DataVolume - WaitForFirstConsumer", func() {

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -41,6 +41,8 @@ const (
 	HTTPSTinyCoreQcow2URL = "https://cdi-file-host.%s/tinyCore.qcow2"
 	// TinyCoreQcow2URLRateLimit provides a test url for the tineyCore qcow2 image via rate-limiting proxy
 	TinyCoreQcow2URLRateLimit = "http://cdi-file-host.%s:82/tinyCore.qcow2"
+	// TinyCoreQcow2GzURLRateLimit provides a test url for the tineyCore qcow2.gz image via rate-limiting proxy
+	TinyCoreQcow2GzURLRateLimit = "http://cdi-file-host.%s:82/tinyCore.qcow2.gz"
 	// HTTPSTinyCoreVmdkURL provides a test url for the tineyCore qcow2 image
 	HTTPSTinyCoreVmdkURL = "https://cdi-file-host.%s/tinyCore.vmdk"
 	// HTTPSTinyCoreVdiURL provides a test url for the tineyCore qcow2 image


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Verifies https://bugzilla.redhat.com/show_bug.cgi?id=1989170 which was fixed by https://github.com/kubevirt/containerized-data-importer/pull/1878.
Reverted the fix to ensure we hit the problem:
```bash
I0823 15:07:03.730128       1 http-datasource.go:296] Attempting to get object "http://cdi-file-host.cdi:82/tinyCore.qcow2.gz" via http client
I0823 15:07:03.730503       1 data-processor.go:323] Calculating available size
...
...
...
I0823 15:07:04.233156       1 prlimit.go:128] Setting CPU limit to 30
I0823 15:07:04.233931       1 prlimit.go:159] Setting Address space limit to 1073741824
E0823 15:07:34.234196       1 prlimit.go:174] qemu-img failed output is:
E0823 15:07:34.234240       1 prlimit.go:175]
E0823 15:07:34.234249       1 prlimit.go:176]
E0823 15:07:34.234359       1 data-processor.go:228] , qemu-img execution failed: signal: killed
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

