### PR TITLE
Avoid trying to get metrics from non-running pod.

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1399,7 +1399,7 @@ func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVol
 	if err == nil {
 		if pod.Status.Phase != corev1.PodRunning {
 			// Avoid long timeouts and error traces from HTTP get when pod is already gone
-			return reconcile.Result{}, errors.New("Pod is not running, can't get metrics")
+			return reconcile.Result{}, nil
 		}
 		if err := updateProgressUsingPod(datavolume, pod); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1397,6 +1397,10 @@ func (r *DatavolumeReconciler) reconcileProgressUpdate(datavolume *cdiv1.DataVol
 	}
 	pod, err := r.getPodFromPvc(podNamespace, pvcUID)
 	if err == nil {
+		if pod.Status.Phase != corev1.PodRunning {
+			// Avoid long timeouts and error traces from HTTP get when pod is already gone
+			return reconcile.Result{}, errors.New("Pod is not running, can't get metrics")
+		}
 		if err := updateProgressUsingPod(datavolume, pod); err != nil {
 			return reconcile.Result{}, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request avoids calling updateProgressUsingPod when the importer pod exists but is not running. This prevents a 30-second delay in the phase transition to Paused in multi-stage imports. 

**Which issue(s) this PR fixes**:
No issue or bug, just noticed this while working on #1903.

**Release note**:
```release-note
Avoid trying to get metrics from non-running pod. 
```

