### PR TITLE
Fix ingress test with no service to test right ingress

### DIFF
--- a/pkg/apiserver/BUILD.bazel
+++ b/pkg/apiserver/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     deps = [
         "//pkg/apis/upload/v1beta1:go_default_library",
         "//pkg/client/clientset/versioned/fake:go_default_library",
+        "//pkg/common:go_default_library",
         "//pkg/keys/keystest:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/cert:go_default_library",

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -453,16 +453,20 @@ var _ = Describe("CDI ingress config tests", func() {
 	})
 
 	It("Should not crash and uploadProxy empty, if ingress defined without service", func() {
-		ingress = createIngress("test-ingress", f.CdiInstallNs, "cdi-uploadproxy", ingressUrl)
+		ingress = createNoServiceIngress("test-ingress", f.CdiInstallNs)
 		// The cdi controller will not process this ingress because it doesn't have the url we are looking for.
 		_, err := f.K8sClient.NetworkingV1().Ingresses(f.CdiInstallNs).Create(context.TODO(), ingress, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		By("Expecting uploadproxy url to be blank")
-		Eventually(func() bool {
+		By("Expecting uploadproxy url to be the default url")
+		Eventually(func() string {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return config.Status.UploadProxyURL == nil
-		}, time.Second*30, time.Second).Should(BeTrue())
+			proxyUrl := ""
+			if config.Status.UploadProxyURL != nil {
+				proxyUrl = *config.Status.UploadProxyURL
+			}
+			return proxyUrl
+		}, time.Second*30, time.Second).Should(Equal(defaultUrl))
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The test was not testing against an ingress with no service. Also it would fail if a route exists, it would return the value of the route instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

