### PR TITLE
Stop qemu-img writing with cache=none

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -113,13 +113,15 @@ func NewQEMUOperations() QEMUOperations {
 }
 
 func convertToRaw(src, dest string, preallocate bool) error {
-	args := []string{"convert", "-t", "none", "-p", "-O", "raw", src, dest}
+	args := []string{"convert", "-t", "writeback", "-p", "-O", "raw", src, dest}
 	var err error
+
 	if preallocate {
 		err = addPreallocation(args, convertPreallocationMethods, func(args []string) ([]byte, error) {
 			return qemuExecFunction(nil, reportProgress, "qemu-img", args...)
 		})
 	} else {
+		klog.V(3).Infof("Running qemu-img convert with args: %v", args)
 		_, err = qemuExecFunction(nil, reportProgress, "qemu-img", args...)
 	}
 	if err != nil {
@@ -130,6 +132,18 @@ func convertToRaw(src, dest string, preallocate bool) error {
 		}
 		return errors.Wrap(err, errorMsg)
 	}
+
+	// With writeback cache mode it's possible that the process will exit before all writes have been commited to storage.
+	// To guarantee that our write was commited to storage, we make a fsync syscall and ensure success.
+	file, err := os.Open(dest)
+	if err != nil {
+		return errors.Wrap(err, "could not get file descriptor for fsync call following qemu-img writing")
+	}
+	if err := file.Sync(); err != nil {
+		return errors.Wrap(err, "could not fsync following qemu-img writing")
+	}
+	klog.V(3).Infof("Successfully completed fsync(%s) syscall, qemu-img convert write is commited to disk", dest)
+	file.Close()
 
 	return nil
 }
@@ -313,6 +327,7 @@ func addPreallocation(args []string, preallocationMethods [][]string, qemuFn fun
 		// For some subcommands (e.g. resize), preallocation optinos must come before other options
 		argsToTry := append([]string{args[0]}, preallocationMethod...)
 		argsToTry = append(argsToTry, args[1:]...)
+		klog.V(3).Infof("Attempting preallocation method, qemu-img convert args: %v", argsToTry)
 
 		output, err = qemuFn(argsToTry)
 		if err != nil && strings.Contains(string(output), "Unsupported preallocation mode") {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -496,8 +496,11 @@ func startPrometheusPortForward(f *framework.Framework) (string, *exec.Cmd, erro
 
 var _ = Describe("Importer Test Suite-Block_device", func() {
 	f := framework.NewFramework(namespacePrefix)
-	var pvc *v1.PersistentVolumeClaim
-	var err error
+	var (
+		pvc            *v1.PersistentVolumeClaim
+		err            error
+		tinyCoreIsoURL = func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
+	)
 
 	AfterEach(func() {
 		if pvc != nil {
@@ -563,6 +566,56 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 			Expect(err).NotTo(HaveOccurred())
 			return strings.Contains(log, "attempting to create blank disk for block mode")
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should perform fsync syscall after qemu-img convert to raw", func() {
+		if !f.IsBlockVolumeStorageClassAvailable() {
+			Skip("Storage Class for block volume is not available")
+		}
+		dataVolume := utils.NewDataVolumeWithHTTPImportToBlockPV("qemu-img-convert-fsync-test", "4Gi", tinyCoreIsoURL(), f.BlockSCName)
+		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
+		dataVolume.SetAnnotations(map[string]string{})
+		dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
+
+		var importer *v1.Pod
+		By("Find importer pod")
+		Eventually(func() bool {
+			importer, err = utils.FindPodByPrefix(f.K8sClient, dataVolume.Namespace, common.ImporterPodName, common.CDILabelSelector)
+			return err == nil
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		By("Verify fsync() syscall was made")
+		Eventually(func() bool {
+			log, err := tests.RunKubectlCommand(f, "logs", importer.Name, "-n", importer.Namespace)
+			if err != nil {
+				return false
+			}
+			for _, line := range strings.Split(strings.TrimSuffix(log, "\n"), "\n") {
+				if strings.Contains(line, fmt.Sprintf("Successfully completed fsync(%s) syscall", common.WriteBlockPath)) {
+					return true
+				}
+			}
+			return false
+		}, 3*time.Minute, pollingInterval).Should(BeTrue())
+
+		phase := cdiv1.Succeeded
+		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))
+		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, phase, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		zero := int64(0)
+		err = utils.DeletePodByName(f.K8sClient, fmt.Sprintf("%s-%s", common.ImporterPodName, dataVolume.Name), f.Namespace.Name, &zero)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify content")
+		same, err := f.VerifyTargetPVCContentMD5(f.Namespace, utils.PersistentVolumeClaimFromDataVolume(dataVolume), utils.DefaultPvcMountPath, utils.UploadFileMD5, utils.UploadFileSize)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(same).To(BeTrue())
+
+		By("Delete DV")
+		err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since #1102 our `qemu-img convert` writes use the "none" cache mode;
This is because with [default](https://github.com/qemu/qemu/blob/master/qemu-img.c#L151) "unsafe" cache mode its possible that the process can exit before all writes have
reached storage (lazily flushed). Also note "unsafe" [ignores flushes](https://documentation.suse.com/sles/11-SP4/html/SLES-kvm4zseries/cha-qemu-cachemodes.html#id-1.10.6.6.5).
This might be an expensive approach to fix the problem since "none" bypasses the host cache.

We can instead tackle this situation differently by sticking to "writeback" cache mode,
along with ensuring the write was committed (fsync syscall).

Looks like we were already leaning in this direction in the past:
https://github.com/kubevirt/containerized-data-importer/issues/1414#issuecomment-706992460

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: our qemu-img convert cmd writes with cache=none (bypassing cache)
```

