### PR TITLE
Add long term token to pvcs when host assisted cloning cross namespaces

### DIFF
--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/controller/transfer:go_default_library",
         "//pkg/operator:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cert:go_default_library",
         "//pkg/util/cert/fetcher:go_default_library",
         "//pkg/util/cert/generator:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -176,6 +176,9 @@ const (
 	// CloneTokenIssuer is the JWT issuer for clone tokens
 	CloneTokenIssuer = "cdi-apiserver"
 
+	// ExtendedCloneTokenIssuer is the JWT issuer for clone tokens
+	ExtendedCloneTokenIssuer = "cdi-deployment"
+
 	// QemuSubGid is the gid used as the qemu group in fsGroup
 	QemuSubGid = int64(107)
 

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -255,7 +255,7 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 			return 0, err
 		}
 		if !sourcePopulated {
-			return 0, nil
+			return 2 * time.Second, nil
 		}
 
 		if err := r.validateSourceAndTarget(sourcePvc, targetPvc); err != nil {

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -73,6 +73,14 @@ type FakeValidator struct {
 	Params    map[string]string
 }
 
+type FakeGenerator struct {
+	token string
+}
+
+func (g *FakeGenerator) Generate(*token.Payload) (string, error) {
+	return g.token, nil
+}
+
 var _ = Describe("Clone controller reconcile loop", func() {
 	var (
 		reconciler *CloneReconciler
@@ -129,11 +137,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			AnnUploadClientName: "uploadclient"}, nil)
 		reconciler = createCloneReconciler(testPvc, createPvc("source", "default", map[string]string{}, nil))
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -159,17 +167,17 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		sourcePvc := createPvc("source", "default", map[string]string{}, nil)
 		reconciler = createCloneReconciler(testPvc, sourcePvc, podFunc(sourcePvc))
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
 		result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Requeue).To(BeTrue())
+		Expect(result.RequeueAfter).ToNot(BeZero())
 		By("Verifying source pod does not exist")
 		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
 		Expect(err).ToNot(HaveOccurred())
@@ -206,11 +214,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		}
 		reconciler = createCloneReconciler(objs...)
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -266,11 +274,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			AnnCloneRequest: "default/source", AnnPodReady: "true", AnnCloneToken: "foobaz", AnnCloneSourcePod: "default-testPvc1-source-pod"}, nil)
 		reconciler = createCloneReconciler(testPvc, createPvc("source", "default", map[string]string{}, nil))
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -284,11 +292,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			AnnCloneRequest: "default/source", AnnPodReady: "true", AnnCloneToken: "foobaz", AnnUploadClientName: "uploadclient", AnnCloneSourcePod: "default-testPvc1-source-pod"}, nil)
 		reconciler = createCloneReconciler(testPvc, createPvc("source", "default", map[string]string{}, nil))
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -304,11 +312,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		testPvc := createTargetPvcFunc()
 		reconciler = createCloneReconciler(testPvc, createSourcePvcFunc())
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -405,11 +413,11 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		testPvc := createTargetPvcFunc()
 		reconciler = createCloneReconciler(testPvc, createSourcePvcFunc())
 		By("Setting up the match token")
-		reconciler.tokenValidator.(*FakeValidator).match = "foobaz"
-		reconciler.tokenValidator.(*FakeValidator).Name = "source"
-		reconciler.tokenValidator.(*FakeValidator).Namespace = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
-		reconciler.tokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
+		reconciler.shortTokenValidator.(*FakeValidator).match = "foobaz"
+		reconciler.shortTokenValidator.(*FakeValidator).Name = "source"
+		reconciler.shortTokenValidator.(*FakeValidator).Namespace = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetNamespace"] = "default"
+		reconciler.shortTokenValidator.(*FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
@@ -587,7 +595,7 @@ var _ = Describe("Update PVC", func() {
 
 var _ = Describe("TokenValidation", func() {
 	g := token.NewGenerator(common.CloneTokenIssuer, getAPIServerKey(), 5*time.Minute)
-	v := newCloneTokenValidator(&getAPIServerKey().PublicKey)
+	v := newCloneTokenValidator(common.CloneTokenIssuer, &getAPIServerKey().PublicKey)
 
 	goodTokenData := func() *token.Payload {
 		return &token.Payload{
@@ -647,7 +655,7 @@ var _ = Describe("TokenValidation", func() {
 				},
 			},
 		}
-		err = validateCloneTokenPVC(v, source, target)
+		err = validateCloneTokenPVC(tokenString, v, source, target)
 		if expectedSuccess {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reflect.DeepEqual(p, goodTokenData())).To(BeTrue())
@@ -690,7 +698,7 @@ func createCloneReconciler(objects ...runtime.Object) *CloneReconciler {
 		scheme:   s,
 		log:      cloneLog,
 		recorder: rec,
-		tokenValidator: &FakeValidator{
+		shortTokenValidator: &FakeValidator{
 			Params: make(map[string]string, 0),
 		},
 		image:               testImage,

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -466,13 +466,14 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 			return reconcile.Result{}, err
 		}
 	case CsiClone:
-		if pvc.Status.Phase == corev1.ClaimBound {
+		switch pvc.Status.Phase {
+		case corev1.ClaimBound:
 			if err := r.setCloneOfOnPvc(pvc); err != nil {
 				return reconcile.Result{}, err
 			}
-		} else if pvc.Status.Phase == corev1.ClaimPending {
+		case corev1.ClaimPending:
 			return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CSICloneInProgress, datavolume, pvc, selectedCloneStrategy)
-		} else if pvc.Status.Phase == corev1.ClaimLost {
+		case corev1.ClaimLost:
 			return reconcile.Result{},
 				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Failed, datavolume, pvc, selectedCloneStrategy,
 					DataVolumeEvent{

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -212,6 +212,7 @@ type DatavolumeReconciler struct {
 	image           string
 	pullPolicy      string
 	tokenValidator  token.Validator
+	tokenGenerator  token.Generator
 	installerLabels map[string]string
 }
 
@@ -260,20 +261,23 @@ func NewDatavolumeController(
 	extClientSet extclientset.Interface,
 	log logr.Logger,
 	image, pullPolicy string,
-	apiServerKey *rsa.PublicKey,
+	tokenPublicKey *rsa.PublicKey,
+	tokenPrivateKey *rsa.PrivateKey,
 	installerLabels map[string]string,
 ) (controller.Controller, error) {
 	client := mgr.GetClient()
 	reconciler := &DatavolumeReconciler{
-		client:          client,
-		scheme:          mgr.GetScheme(),
-		extClientSet:    extClientSet,
-		log:             log.WithName("datavolume-controller"),
-		recorder:        mgr.GetEventRecorderFor("datavolume-controller"),
-		featureGates:    featuregates.NewFeatureGates(client),
-		image:           image,
-		pullPolicy:      pullPolicy,
-		tokenValidator:  newCloneTokenValidator(apiServerKey),
+		client:         client,
+		scheme:         mgr.GetScheme(),
+		extClientSet:   extClientSet,
+		log:            log.WithName("datavolume-controller"),
+		recorder:       mgr.GetEventRecorderFor("datavolume-controller"),
+		featureGates:   featuregates.NewFeatureGates(client),
+		image:          image,
+		pullPolicy:     pullPolicy,
+		tokenValidator: newCloneTokenValidator(common.CloneTokenIssuer, tokenPublicKey),
+		// for long term tokens to handle cross namespace dumb clones
+		tokenGenerator:  newLongTermCloneTokenGenerator(tokenPrivateKey),
 		installerLabels: installerLabels,
 	}
 	datavolumeController, err := controller.New("datavolume-controller", mgr, controller.Options{
@@ -456,31 +460,70 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 		}
 	}
 
-	if selectedCloneStrategy == SmartClone || selectedCloneStrategy == CsiClone {
-		if selectedCloneStrategy == CsiClone {
-			if pvc.Status.Phase == corev1.ClaimBound {
-				if err := r.setCloneOfOnPvc(pvc); err != nil {
-					return reconcile.Result{}, err
-				}
-			} else if pvc.Status.Phase == corev1.ClaimPending {
-				return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CSICloneInProgress, datavolume, pvc, selectedCloneStrategy)
-			} else if pvc.Status.Phase == corev1.ClaimLost {
-				return reconcile.Result{},
-					r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Failed, datavolume, pvc, selectedCloneStrategy,
-						DataVolumeEvent{
-							eventType: corev1.EventTypeWarning,
-							reason:    ErrClaimLost,
-							message:   fmt.Sprintf(MessageErrClaimLost, pvc.Name),
-						})
-			}
+	switch selectedCloneStrategy {
+	case HostAssistedClone:
+		if err := r.ensureExtendedToken(pvc); err != nil {
+			return reconcile.Result{}, err
 		}
-
+	case CsiClone:
+		if pvc.Status.Phase == corev1.ClaimBound {
+			if err := r.setCloneOfOnPvc(pvc); err != nil {
+				return reconcile.Result{}, err
+			}
+		} else if pvc.Status.Phase == corev1.ClaimPending {
+			return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CSICloneInProgress, datavolume, pvc, selectedCloneStrategy)
+		} else if pvc.Status.Phase == corev1.ClaimLost {
+			return reconcile.Result{},
+				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Failed, datavolume, pvc, selectedCloneStrategy,
+					DataVolumeEvent{
+						eventType: corev1.EventTypeWarning,
+						reason:    ErrClaimLost,
+						message:   fmt.Sprintf(MessageErrClaimLost, pvc.Name),
+					})
+		}
+		fallthrough
+	case SmartClone:
 		return r.finishClone(log, datavolume, pvc, pvcSpec, transferName, selectedCloneStrategy)
 	}
 
 	// Finally, we update the status block of the DataVolume resource to reflect the
 	// current state of the world
 	return r.reconcileDataVolumeStatus(datavolume, pvc)
+}
+
+func (r *DatavolumeReconciler) ensureExtendedToken(pvc *corev1.PersistentVolumeClaim) error {
+	_, ok := pvc.Annotations[AnnExtendedCloneToken]
+	if ok {
+		return nil
+	}
+
+	token, ok := pvc.Annotations[AnnCloneToken]
+	if !ok {
+		return fmt.Errorf("token missing")
+	}
+
+	payload, err := r.tokenValidator.Validate(token)
+	if err != nil {
+		return err
+	}
+
+	if payload.Params == nil {
+		payload.Params = make(map[string]string)
+	}
+	payload.Params["uid"] = string(pvc.UID)
+
+	newToken, err := r.tokenGenerator.Generate(payload)
+	if err != nil {
+		return err
+	}
+
+	pvc.Annotations[AnnExtendedCloneToken] = newToken
+
+	if err := r.client.Update(context.TODO(), pvc); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *DatavolumeReconciler) selectCloneStrategy(datavolume *cdiv1.DataVolume, pvcSpec *corev1.PersistentVolumeClaimSpec) (cloneStrategy, error) {
@@ -526,7 +569,7 @@ func (r *DatavolumeReconciler) selectCloneStrategy(datavolume *cdiv1.DataVolume,
 		}
 	}
 
-	return NoClone, nil
+	return HostAssistedClone, nil
 }
 
 func (r *DatavolumeReconciler) createPvcForDatavolume(log logr.Logger, datavolume *cdiv1.DataVolume, pvcSpec *corev1.PersistentVolumeClaimSpec) (*corev1.PersistentVolumeClaim, error) {
@@ -2521,4 +2564,8 @@ func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
 	// and the space required by filesystem metadata
 	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - filesystemOverhead)))
 	return spaceWithOverhead
+}
+
+func newLongTermCloneTokenGenerator(key *rsa.PrivateKey) token.Generator {
+	return token.NewGenerator(common.ExtendedCloneTokenIssuer, key, 10*365*24*time.Hour)
 }

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1559,12 +1559,14 @@ func createDatavolumeReconcilerWithoutConfig(objects ...runtime.Object) *Datavol
 	rec := record.NewFakeRecorder(10)
 	// Create a ReconcileMemcached object with the scheme and fake client.
 	r := &DatavolumeReconciler{
-		client:       cl,
-		scheme:       s,
-		log:          dvLog,
-		recorder:     rec,
-		extClientSet: extfakeclientset,
-		featureGates: featuregates.NewFeatureGates(cl),
+		client:         cl,
+		scheme:         s,
+		log:            dvLog,
+		recorder:       rec,
+		extClientSet:   extfakeclientset,
+		featureGates:   featuregates.NewFeatureGates(cl),
+		tokenValidator: &FakeValidator{match: "foobar"},
+		tokenGenerator: &FakeGenerator{token: "foobar"},
 		installerLabels: map[string]string{
 			common.AppKubernetesPartOfLabel:  "testing",
 			common.AppKubernetesVersionLabel: "v0.0.0-tests",

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -153,7 +153,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      "cdi-api-signing-key",
-			MountPath: controller.APIServerPublicKeyDir,
+			MountPath: controller.TokenKeyDir,
 		},
 		{
 			Name:      "uploadserver-ca-cert",
@@ -183,6 +183,10 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 						{
 							Key:  "id_rsa.pub",
 							Path: "id_rsa.pub",
+						},
+						{
+							Key:  "id_rsa",
+							Path: "id_rsa",
 						},
 					},
 					DefaultMode: &defaultMode,

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -56,6 +56,8 @@ go_test(
         "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/feature-gates:go_default_library",
+        "//pkg/token:go_default_library",
+        "//pkg/util/cert:go_default_library",
         "//pkg/util/naming:go_default_library",
         "//tests/framework:go_default_library",
         "//tests/reporters:go_default_library",

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"crypto/rsa"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -22,6 +23,8 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
+	"kubevirt.io/containerized-data-importer/pkg/token"
+	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
@@ -1602,7 +1605,8 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 
 	validateCloneType(f, dv)
 
-	if utils.GetCloneType(f.CdiClient, dv) == "snapshot" {
+	switch utils.GetCloneType(f.CdiClient, dv) {
+	case "snapshot":
 		sns := dv.Spec.Source.PVC.Namespace
 		if sns == "" {
 			sns = dv.Namespace
@@ -1614,6 +1618,28 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 		for _, s := range snapshots.Items {
 			Expect(s.DeletionTimestamp).ToNot(BeNil())
 		}
+	case "network":
+		s, err := f.K8sClient.CoreV1().Secrets(f.CdiInstallNs).Get(context.TODO(), "cdi-api-signing-key", metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		bytes, ok := s.Data["id_rsa.pub"]
+		Expect(ok).To(BeTrue())
+		objs, err := cert.ParsePublicKeysPEM(bytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(objs).To(HaveLen(1))
+		v := token.NewValidator("cdi-deployment", objs[0].(*rsa.PublicKey), time.Minute)
+
+		By("checking long token added")
+		Eventually(func() bool {
+			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(targetNs.Name).Get(context.TODO(), targetPvc.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			t, ok := pvc.Annotations[controller.AnnExtendedCloneToken]
+			if !ok {
+				return false
+			}
+			_, err = v.Validate(t)
+			Expect(err).ToNot(HaveOccurred())
+			return true
+		}, 10*time.Second, assertionPollInterval).Should(BeTrue())
 	}
 }
 


### PR DESCRIPTION
See bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1855182

When dumb cloning across namespaces, and a source in use (pod mounting source PVC) then it is possible for the token to time out (5 min).  To address that, the datavolume controller will add a "forever" token to the PVC.  This should be safe because the forever token includes the pvc UID.

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BufFix: BZ 1855182 - clone token timing out
```

