### PR TITLE
Overhead on profile and usable space toghether

### DIFF
--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1429,6 +1429,45 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(dv.Status.Progress).To(BeEquivalentTo("2.3%"))
 		})
 	})
+
+	const (
+		Mi              = int64(1024 * 1024)
+		Gi              = 1024 * Mi
+		noOverhead      = float64(0)
+		defaultOverhead = float64(0.055)
+		largeOverhead   = float64(0.75)
+	)
+	DescribeTable("GetRequiredSpace should return properly enlarged sizes,", func(imageSize int64, overhead float64) {
+		for testedSize := int64(imageSize - 1024); testedSize < imageSize+1024; testedSize++ {
+			alignedImageSpace := imageSize
+			if testedSize > imageSize {
+				alignedImageSpace = imageSize + Mi
+			}
+
+			// TEST
+			actualRequiredSpace := GetRequiredSpace(overhead, testedSize)
+
+			// ASSERT results
+			// check that the resulting space includes overhead over the `aligned image size`
+			overheadSpace := actualRequiredSpace - alignedImageSpace
+			actualOverhead := float64(overheadSpace) / float64(actualRequiredSpace)
+
+			Expect(actualOverhead).To(BeNumerically("~", overhead, 0.01))
+		}
+	},
+		Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
+		Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
+		Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
+		Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
+		Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
+		Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
+		Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
+		Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
+		Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
+		Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
+		Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
+		Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
+	)
 })
 
 func podUsingCloneSource(dv *cdiv1.DataVolume, readOnly bool) *corev1.Pod {

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -18,6 +18,7 @@ package importer
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 
@@ -324,6 +325,11 @@ func ResizeImage(dataFile, imageSize string, totalTargetSpace int64, preallocati
 			klog.V(1).Infof("No need to resize image. Requested size: %s, Image size: %d.\n", imageSize, info.VirtualSize)
 			return nil
 		}
+		// Check if calculated size is < imageSize, and return error if so.
+		if currentImageSizeQuantity.Cmp(minSizeQuantity) == 1 {
+			klog.V(1).Infof("Calculated new size is < than current size, not resizing: requested size %s, virtual size: %d.\n", minSizeQuantity.String(), info.VirtualSize)
+			return nil
+		}
 		klog.V(1).Infof("Expanding image size to: %s\n", minSizeQuantity.String())
 		return qemuOperations.Resize(dataFile, minSizeQuantity, preallocation)
 	}
@@ -372,11 +378,11 @@ func (dp *DataProcessor) getUsableSpace() int64 {
 
 // GetUsableSpace calculates space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	spaceWithOverhead := int64((1 - filesystemOverhead) * float64(availableSpace))
+	// +1 always rounds up.
+	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
-	qemuImgCorrection := util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
-	return qemuImgCorrection
+	return util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
 }
 
 // Rebase and commit a delta image to its backing file

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -254,6 +254,9 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			if strings.Contains(log, "qemu-img execution failed") {
 				return true
 			}
+			if strings.Contains(log, "calculated new size is < than current size, not resizing") {
+				return true
+			}
 			By("Failed to find error messages about a too large image in log:")
 			By(log)
 			return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Bugfix: Fix fsoverhead calculation.


**Special notes for your reviewer**:
AS it looks  #1924 depends on #1923, this PR joins them together.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix fsoverhead calculation

```

