### PR TITLE
[release-v1.38] Overhead on profile and usable space toghether (#1926)

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -2472,10 +2473,12 @@ func getDefaultAccessModes(c client.Client, storageClass *storagev1.StorageClass
 
 // GetRequiredSpace calculates space required taking file system overhead into account
 func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
-	// count overhead as a percentage of the whole/new size
-	spaceWithOverhead := int64(float64(requestedSpace) / (1 - filesystemOverhead))
-	// qemu-img will round up, making us use more than the usable space.
-	// This later conflicts with image size validation.
-	qemuImgCorrection := util.RoundUp(spaceWithOverhead, util.DefaultAlignBlockSize)
-	return qemuImgCorrection
+	// the `image` has to be aligned correctly, so the space requested has to be aligned to
+	// next value that is a multiple of a block size
+	alignedSize := util.RoundUp(requestedSpace, util.DefaultAlignBlockSize)
+
+	// count overhead as a percentage of the whole/new size, including aligned image
+	// and the space required by filesystem metadata
+	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - filesystemOverhead)))
+	return spaceWithOverhead
 }

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1429,6 +1429,45 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(dv.Status.Progress).To(BeEquivalentTo("2.3%"))
 		})
 	})
+
+	const (
+		Mi              = int64(1024 * 1024)
+		Gi              = 1024 * Mi
+		noOverhead      = float64(0)
+		defaultOverhead = float64(0.055)
+		largeOverhead   = float64(0.75)
+	)
+	DescribeTable("GetRequiredSpace should return properly enlarged sizes,", func(imageSize int64, overhead float64) {
+		for testedSize := int64(imageSize - 1024); testedSize < imageSize+1024; testedSize++ {
+			alignedImageSpace := imageSize
+			if testedSize > imageSize {
+				alignedImageSpace = imageSize + Mi
+			}
+
+			// TEST
+			actualRequiredSpace := GetRequiredSpace(overhead, testedSize)
+
+			// ASSERT results
+			// check that the resulting space includes overhead over the `aligned image size`
+			overheadSpace := actualRequiredSpace - alignedImageSpace
+			actualOverhead := float64(overheadSpace) / float64(actualRequiredSpace)
+
+			Expect(actualOverhead).To(BeNumerically("~", overhead, 0.01))
+		}
+	},
+		Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
+		Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
+		Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
+		Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
+		Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
+		Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
+		Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
+		Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
+		Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
+		Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
+		Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
+		Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
+	)
 })
 
 func podUsingCloneSource(dv *cdiv1.DataVolume, readOnly bool) *corev1.Pod {

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"kubevirt.io/containerized-data-importer/pkg/image"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 type fakeInfoOpRetVal struct {
@@ -24,8 +25,8 @@ type fakeInfoOpRetVal struct {
 const TestImagesDir = "../../tests/images"
 
 const (
-	SmallActualSize  = 1024
-	SmallVirtualSize = 1024
+	SmallActualSize  = 1024 * 1024
+	SmallVirtualSize = 1024 * 1024
 )
 
 var (
@@ -243,10 +244,10 @@ var _ = Describe("Data Processor", func() {
 			url:              url,
 		}
 		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.055, false)
-		dp.availableSpace = int64(1500)
+		dp.availableSpace = int64(1536000)
 		usableSpace := dp.getUsableSpace()
 
-		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(usableSpace, 0))
+		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(usableSpace, 1024*1024))
 		replaceQEMUOperations(qemuOperations, func() {
 			err = dp.ProcessData()
 			Expect(err).ToNot(HaveOccurred())
@@ -256,6 +257,38 @@ var _ = Describe("Data Processor", func() {
 			Expect(tmpDir).To(Equal(mdp.transferPath))
 		})
 	})
+
+	const (
+		Mi              = int64(1024 * 1024)
+		Gi              = 1024 * Mi
+		noOverhead      = float64(0)
+		defaultOverhead = float64(0.055)
+		largeOverhead   = float64(0.75)
+	)
+	table.DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {
+		for i := int64(virtualSize - 1024); i < virtualSize+1024; i++ {
+			// Requested space is virtualSize rounded up to 1Mi alignment / (1 - overhead) rounded up
+			requestedSpace := int64(float64(util.RoundUp(i, util.DefaultAlignBlockSize)+1) / float64(1-overhead))
+			if i <= virtualSize {
+				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize))
+			} else {
+				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize + Mi))
+			}
+		}
+	},
+		table.Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
+		table.Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
+		table.Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
+		table.Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
+		table.Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
+		table.Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
+		table.Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
+		table.Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
+		table.Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
+		table.Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
+		table.Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
+		table.Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
+	)
 })
 
 var _ = Describe("Convert", func() {
@@ -415,9 +448,9 @@ var _ = Describe("ResizeImage", func() {
 			}
 		})
 	},
-		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500), 0)), "1500", int64(2048), false),
-		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "2500", int64(2048), false),
-		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024), 0)), "1024", int64(1024), false),
+		table.Entry("successfully resize to imageSize when imageSize > info.VirtualSize and < totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1500*1024), 0)), "1536000", int64(2048*1024), false),
+		table.Entry("successfully resize to totalSize when imageSize > info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048*1024), 0)), "2560000", int64(2048*1024), false),
+		table.Entry("successfully do nothing when imageSize = info.VirtualSize and > totalSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(1024*1024), 0)), "1048576", int64(1024*1024), false),
 		table.Entry("fail to resize to with blank imageSize", NewFakeQEMUOperations(nil, nil, fakeInfoRet, nil, nil, resource.NewScaledQuantity(int64(2048), 0)), "", int64(2048), true),
 		table.Entry("fail to resize to with blank imageSize", NewQEMUAllErrors(), "", int64(2048), true),
 	)
@@ -464,7 +497,7 @@ func (o *fakeQEMUOperations) Validate(*url.URL, int64, float64) error {
 
 func (o *fakeQEMUOperations) Resize(dest string, size resource.Quantity, preallocate bool) error {
 	if o.resizeQuantity != nil {
-		Expect(o.resizeQuantity.Cmp(size)).To(Equal(0))
+		Expect(o.resizeQuantity.Cmp(size)).To(Equal(0), "sizes don't match %v, %v", o.resizeQuantity.String(), size.String())
 	}
 	return o.e3
 }

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -254,6 +254,9 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			if strings.Contains(log, "qemu-img execution failed") {
 				return true
 			}
+			if strings.Contains(log, "calculated new size is < than current size, not resizing") {
+				return true
+			}
 			By("Failed to find error messages about a too large image in log:")
 			By(log)
 			return false


### PR DESCRIPTION
Manual cherry-pick of #1926

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix fsoverhead calculation
```

