### PR TITLE
[release-v1.28] VDDK: Reduce read size when connecting to vCenter.

### DIFF
--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 
 	libnbd "github.com/mrnold/go-libnbd"
 	. "github.com/onsi/ginkgo"
@@ -321,6 +322,27 @@ var _ = Describe("VDDK data source", func() {
 		mockTerminationChannel <- os.Interrupt
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should reduce pread length for vCenter endpoints", func() {
+		newVddkDataSource = createVddkDataSource
+		diskName := "testdisk.vmdk"
+
+		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
+			switch out := result.(type) {
+			case *mo.VirtualMachine:
+				if property[0] == "config.hardware.device" {
+					out.Config = createVirtualDiskConfig(diskName, 12345)
+				}
+			}
+			return nil
+		}
+		_, err := NewVDDKDataSource("http://esx.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(MaxPreadLength).To(Equal(uint32(MaxPreadLengthESX)))
+		_, err = NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(MaxPreadLength).To(Equal(uint32(MaxPreadLengthVC)))
+	})
 })
 
 type mockNbdOperations struct{}
@@ -403,10 +425,16 @@ func createMockVddkDataSink(destinationFile string, size uint64, volumeMode v1.P
 	return sink, nil
 }
 
-type mockVMwareConnectionOperations struct{}
+type mockVMwareConnectionOperations struct {
+	Endpoint string
+}
 
 func (ops *mockVMwareConnectionOperations) Logout(context.Context) error {
 	return nil
+}
+
+func (ops *mockVMwareConnectionOperations) IsVC() bool {
+	return strings.Contains(ops.Endpoint, "vcenter")
 }
 
 type mockVMwareFunctions struct {
@@ -458,7 +486,7 @@ func createMockVMwareClient(endpoint string, accessKey string, secKey string, th
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &VMwareClient{
-		conn:       &mockVMwareConnectionOperations{},
+		conn:       &mockVMwareConnectionOperations{endpoint},
 		cancel:     cancel,
 		context:    ctx,
 		moref:      "vm-1",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of #1881 to v1.28.

**Which issue(s) this PR fixes**:
Fixes [RHBZ#2003691](https://bugzilla.redhat.com/show_bug.cgi?id=2003691)

**Release note**:

```release-note
Lower VDDK read size for vCenter connections to reduce incidence of allocation failures caused by simultaneous imports. 
```

