### PR TITLE
Run imageio test deployment as root

### DIFF
--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -17,6 +17,8 @@ spec:
         app: imageio
         cdi.kubevirt.io/testing: ""
     spec:
+      securityContext:
+        runAsUser: 0
       serviceAccountName: cdi-testing-sa
       initContainers:
       - name: init


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We see an error starting the deployment's server d/s:
```bash
[cnv-qe-jenkins@alex48-451-xzjsk-executor ocs-test]$ oc logs -f -n openshift-cnv imageio-deployment-f9bfff68-clbs2 imageiotest
Using configuration from /etc/pki/tls/openssl.cnf
...
  File "/ovirt-imageio/daemon/ovirt_imageio/uhttp.py", line 80, in server_bind
    self.socket.bind(self.server_address)
PermissionError: [Errno 13] Permission denied
curl: (7) Couldn't connect to server
```
Running as root seems to solve it, and doesn't harm test integrity since it's a test-helper.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

