### PR TITLE
VDDK: accept snapshot change IDs in previous checkpoint fields

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -254,6 +254,32 @@ spec:
          requests:
            storage: "32Gi"
 ```
+
+#### Change IDs
+For multi-stage VDDK imports, the `previous` field in the list of checkpoints can be specified as a snapshot ID or a change ID. A change ID persists after its associated snapshot has been deleted, so it can be used to implement a warm migration workflow that does not leave chains of snapshots that need to be cleaned (see [this VMware KB article](https://kb.vmware.com/s/article/76082)).
+
+Example: initiate a multi-stage VDDK import, specifying the initial snapshot as the first checkpoint.
+
+```yaml
+finalCheckpoint: false
+checkpoints:
+  - current: "snapshot-1"
+    previous: ""
+```
+
+After the snapshot has been copied and the Data Volume is `Paused`, save the snapshot's change ID, delete the snapshot, and let the VM run for some time so that the data on the disk changes somewhat. Take a new snapshot, and append the new checkpoint to the list using the new snapshot ID as `current` and the deleted snapshot's change ID as `previous`:
+
+```yaml
+finalCheckpoint: false
+checkpoints:
+  - current: "snapshot-1"
+    previous: ""
+  - current: "snapshot-2"
+    previous: "53 d0 ac 95 4f 09 f7 93-b1 21 e2 39 97 8a fa 63/4"
+```
+
+This process can be repeated until the VM can be shut down for a final snapshot copy with `finalCheckpoint` set to `true`.
+
 ## Target Storage/PVC
 
 There are two ways to request a storage - by using either the `pvc` or the `storage` section in the DataVolume resource yaml.

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -45,6 +45,8 @@ go_library(
             "//vendor/github.com/vmware/govmomi:go_default_library",
             "//vendor/github.com/vmware/govmomi/find:go_default_library",
             "//vendor/github.com/vmware/govmomi/object:go_default_library",
+            "//vendor/github.com/vmware/govmomi/vim25:go_default_library",
+            "//vendor/github.com/vmware/govmomi/vim25/methods:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -94,7 +94,9 @@ go_test(
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "//vendor/github.com/mrnold/go-libnbd:go_default_library",
+            "//vendor/github.com/vmware/govmomi/vim25:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
+            "//vendor/github.com/vmware/govmomi/vim25/soap:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
         ],

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -232,6 +232,9 @@ type VMwareVMOperations interface {
 	Client() *vim25.Client
 }
 
+// Mock underlying QueryChangedDiskAreas for unit test, distinct from the one in VMwareVMOperations
+var QueryChangedDiskAreas = methods.QueryChangedDiskAreas
+
 // VMwareClient holds a connection to the VMware API with pre-filled information about one VM
 type VMwareClient struct {
 	conn       VMwareConnectionOperations // *govmomi.Client
@@ -797,7 +800,7 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 				StartOffset: 0,
 				This:        vmware.vm.Reference(),
 			}
-			response, err := methods.QueryChangedDiskAreas(vmware.context, vmware.vm.Client(), &request)
+			response, err := QueryChangedDiskAreas(vmware.context, vmware.vm.Client(), &request)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -232,7 +232,7 @@ type VMwareVMOperations interface {
 	Client() *vim25.Client
 }
 
-// Mock underlying QueryChangedDiskAreas for unit test, distinct from the one in VMwareVMOperations
+// QueryChangedDiskAreas mocks the underlying QueryChangedDiskAreas for unit test, distinct from the one in VMwareVMOperations
 var QueryChangedDiskAreas = methods.QueryChangedDiskAreas
 
 // VMwareClient holds a connection to the VMware API with pre-filled information about one VM
@@ -791,8 +791,8 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 	if currentSnapshot != nil && previousCheckpoint != "" {
 		// Check if this is a snapshot or a change ID, and query disk areas as appropriate.
 		// Change IDs look like: 52 de c0 d9 b9 43 9d 10-61 d5 4c 1b e9 7b 65 63/81
-		changeIdPattern := `([0-9a-fA-F]{2}\s?)*-([0-9a-fA-F]{2}\s?)*\/([0-9a-fA-F]*)`
-		if matched, _ := regexp.MatchString(changeIdPattern, previousCheckpoint); matched {
+		changeIDPattern := `([0-9a-fA-F]{2}\s?)*-([0-9a-fA-F]{2}\s?)*\/([0-9a-fA-F]*)`
+		if matched, _ := regexp.MatchString(changeIDPattern, previousCheckpoint); matched {
 			request := types.QueryChangedDiskAreas{
 				ChangeId:    previousCheckpoint,
 				DeviceKey:   backingFileObject.Key,


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request allows the VDDK importer to accept snapshot change IDs in the "previous" fields of multi-stage checkpoint lists. This way, snapshots can be deleted as part of the process of a warm migration, instead of deleting multiple snapshots all at once after the migration is finished. This is the [recommended VMware workflow](https://kb.vmware.com/s/article/76082) and should help address [RHBZ#1942651](https://bugzilla.redhat.com/show_bug.cgi?id=1942651) in a nicer way.

**Which issue(s) this PR fixes**:
Fixes [RHBZ#2000298](https://bugzilla.redhat.com/show_bug.cgi?id=2000298)

**Special notes for your reviewer**:
I opted to try to preserve the existing support for snapshot IDs instead of replacing it with change IDs only, in case there are clients that depend on the existing behavior. The checkpoints are already specified as strings anyway, and the formats of change IDs and snapshot IDs are different enough that they will likely always be distinguishable. It's okay if we need something heavier-duty, but I didn't want to start with a huge change.

**Release note**:
```release-note
VDDK: accept snapshot change IDs in previous checkpoint fields
```

