### PR TITLE
Explicitly set the storage class name

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -2374,6 +2374,7 @@ func pvcFromStorage(client client.Client, recorder record.EventRecorder, log log
 
 		return pvcSpec, nil
 	}
+	pvcSpec.StorageClassName = &storageClass.Name
 
 	// given storageClass we can apply defaults if needed
 	if len(pvcSpec.AccessModes) == 0 {


### PR DESCRIPTION


Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Explicitly set that storage class name

When the storage request is specified using the 'storage' API in
a DataVolume, CDI uses Storage Profiles to look up any missing
values that would be required to create the underlying PVC.
If the user omits the storage class parameter in their DV,
CDI assumes the cluster's default storage class will be used.

Since CDI calculates the storage class that should be used in
this case, it should explicitly set that storage class name
in the PVC it creates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set the calculated storage class name on PVC 
```

