### PR TITLE
Commit write to disk in source-pvc filler pod

### DIFF
--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -135,7 +135,7 @@ func (f *Framework) CreateAndPopulateSourcePVC(pvcDef *k8sv1.PersistentVolumeCla
 	// Create the source PVC and populate it with a file, so we can verify the clone.
 	sourcePvc, err := f.CreatePVCFromDefinition(pvcDef)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	pod, err := f.CreatePod(f.NewPodWithPVC(podName, fillCommand, sourcePvc))
+	pod, err := f.CreatePod(f.NewPodWithPVC(podName, fillCommand+"&& sync", sourcePvc))
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	err = f.WaitTimeoutForPodStatus(pod.Name, k8sv1.PodSucceeded, utils.PodWaitForTime)


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Addresses a flake where the clone target DV is "Succeeded" and empty:
```bash
[WARN] error executing command ["/bin/sh" "-c" "md5sum /pvc/disk.img"], error: command terminated with exit code 1
INFO: stderr: [md5sum: /pvc/disk.img: No such file or directory]
```
What I believe happens here is that the filler pod is not committing writes and directly exiting after the `echo 1245 > disk.img`,
resulting in us cloning an empty pvc and doing a successfull job at it.
Did not see it fail at all with the `&& sync` addition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

