### PR TITLE
update go to 1.16.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,7 +43,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.16.1",
+    go_version = "1.16.6",
 )
 
 http_archive(

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -27,7 +27,7 @@ FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 FUNC_TEST_PROXY="cdi-func-test-proxy"
 # update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.12}
+BUILDER_TAG=${BUILDER_TAG:-0.0.13}
 BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder@sha256:45ff791390bcd3902781e0f790083f30bba8553d2568e34e75675228c5d4bfb5
 }
 

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install --upgrade j2cli operator-courier==2.1.11 && \
     ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
     rm gradle-6.6-bin.zip
 
-ENV GIMME_GO_VERSION=1.16.1 GOPATH="/go" KUBEBUILDER_VERSION="2.3.2" ARCH="amd64" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.16.6 GOPATH="/go" KUBEBUILDER_VERSION="2.3.2" ARCH="amd64" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 


### PR DESCRIPTION
consistent with kubevirt and will be required if we update k8s libraries

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

