### PR TITLE
Retry clone kill which is flaky

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1317,9 +1317,11 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Kill upload pod to force error")
-			// exit code 137 = 128 + 9, it means parent process issued kill -9, in our case it is not a problem
-			_, _, err = f.ExecShellInPod(utils.UploadPodName(targetPvc), targetNs.Name, "kill 1")
-			Expect(err).To(Or(
+			Eventually(func() error {
+				// exit code 137 = 128 + 9, it means parent process issued kill -9, in our case it is not a problem
+				_, _, err = f.ExecShellInPod(utils.UploadPodName(targetPvc), targetNs.Name, "kill 1")
+				return err
+			}, shortTimeout, fastPollingInterval).Should(Or(
 				BeNil(),
 				WithTransform(errAsString, ContainSubstring("137"))))
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1316,7 +1316,7 @@ var _ = Describe("all clone tests", func() {
 			utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, targetNs.Name, v1.ClaimBound, targetPvc.Name)
 
 			By("Wait for upload pod")
-			err = utils.WaitTimeoutForPodReady(f.K8sClient, utils.UploadPodName(targetPvc), targetNs.Name, utils.PodWaitForTime)
+			err = utils.WaitTimeoutForPodReadyPollPeriod(f.K8sClient, utils.UploadPodName(targetPvc), targetNs.Name, utils.PodWaitIntervalFast, utils.PodWaitForTime)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Kill upload pod to force error")

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -19,6 +19,10 @@ import (
 const (
 	// PodWaitForTime is the time to wait for Pod operations to complete
 	PodWaitForTime = defaultPollPeriod
+	// PodWaitForTimeFast is the fast time to wait for Pod operations to complete (30 sec)
+	PodWaitForTimeFast = defaultPollPeriodFast
+	// PodWaitIntervalFast is the fast polling interval (250ms)
+	PodWaitIntervalFast = 250 * time.Millisecond
 
 	podCreateTime = defaultPollPeriod
 	podDeleteTime = defaultPollPeriod
@@ -131,7 +135,12 @@ func findPodByCompFuncOnce(clientSet *kubernetes.Clientset, namespace, prefix, l
 
 // WaitTimeoutForPodReady waits for the given pod to be created and ready
 func WaitTimeoutForPodReady(clientSet *kubernetes.Clientset, podName, namespace string, timeout time.Duration) error {
-	return WaitTimeoutForPodCondition(clientSet, podName, namespace, k8sv1.PodReady, timeout)
+	return WaitTimeoutForPodCondition(clientSet, podName, namespace, k8sv1.PodReady, 2*time.Second, timeout)
+}
+
+// WaitTimeoutForPodReadyPollPeriod waits for the given pod to be created and ready using the passed in poll period
+func WaitTimeoutForPodReadyPollPeriod(clientSet *kubernetes.Clientset, podName, namespace string, pollperiod, timeout time.Duration) error {
+	return WaitTimeoutForPodCondition(clientSet, podName, namespace, k8sv1.PodReady, pollperiod, timeout)
 }
 
 // WaitTimeoutForPodSucceeded waits for pod to succeed
@@ -150,8 +159,8 @@ func WaitTimeoutForPodStatus(clientSet *kubernetes.Clientset, podName, namespace
 }
 
 // WaitTimeoutForPodCondition waits for the given pod to be created and have an expected condition
-func WaitTimeoutForPodCondition(clientSet *kubernetes.Clientset, podName, namespace string, conditionType k8sv1.PodConditionType, timeout time.Duration) error {
-	return wait.PollImmediate(2*time.Second, timeout, podCondition(clientSet, podName, namespace, conditionType))
+func WaitTimeoutForPodCondition(clientSet *kubernetes.Clientset, podName, namespace string, conditionType k8sv1.PodConditionType, pollperiod, timeout time.Duration) error {
+	return wait.PollImmediate(pollperiod, timeout, podCondition(clientSet, podName, namespace, conditionType))
 }
 
 func podStatus(clientSet *kubernetes.Clientset, podName, namespace string, status k8sv1.PodPhase) wait.ConditionFunc {

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	defaultPollInterval = 2 * time.Second
-	defaultPollPeriod   = 270 * time.Second
+	defaultPollInterval   = 2 * time.Second
+	defaultPollPeriod     = 270 * time.Second
+	defaultPollPeriodFast = 30 * time.Second
 
 	// DefaultPvcMountPath is the default mount path used
 	DefaultPvcMountPath = "/pvc"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
[test_id:4000] Create a data volume and then clone it while killing the
container and verify retry count was pretty flaky lately. The likely culprit was the small amount of data being cloned. This causes the pods to be removed before we have a chance to connect issue the kill command.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

