### PR TITLE
Revert "cdi-api-reference default branch is master, add an exception for it"

### DIFF
--- a/hack/ci/language.sh
+++ b/hack/ci/language.sh
@@ -15,7 +15,6 @@ VIOLATIONS=$(git grep -iI -E $PHRASES -- \
 	':!cluster-sync' \
 	':!*generated*' \
 	':!*swagger.json*' \
-	':!hack/gen-swagger-doc/deploy.sh' \
 	':!hack/ci/language.sh' \
 		"${CDI_DIR}" \
 		| grep -v \

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -30,7 +30,7 @@ Content of this repository is generated from OpenAPI specification of
 
 ## KubeVirt Containerized Data Importer API References
 
-* [master](${GITHUB_IO_FQDN}/master/index.html)
+* [main](${GITHUB_IO_FQDN}/main/index.html)
 __EOF__
 find * -type d -regex "^v[0-9.]*" \
     -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" \; >>README.md
@@ -43,7 +43,7 @@ if git status --porcelain | grep -v "index[.]html" | grep --quiet "^ [AM]"; then
     git add -A README.md "${TARGET_DIR}"/*.html
     git commit --message "API Reference update by KubeVirt Prow build ${BUILD_ID}"
 
-    git push origin master >/dev/null 2>&1
+    git push origin main >/dev/null 2>&1
     echo "API Reference updated for ${TARGET_DIR}."
 else
     echo "API Reference hasn't changed."


### PR DESCRIPTION
Now that the default branch is main.

**Special notes for your reviewer**:
Actually waiting on @aglitke to do the change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

