### PR TITLE
Update builder push to align with kubevirt.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,7 +138,7 @@ http_archive(
 # Pull base image fedora33
 container_pull(
     name = "fedora",
-    digest = "sha256:bfcc10d2d2a3a52fe997daba311c3a5298b426b524ab2b012fa24730dd0eb763",
+    digest = "sha256:59a4488599eb5c28cfc1695c4d9956fb2734a08be94d86269375cb68fc3c2406",
     registry = "quay.io",
     repository = "fedora/fedora",
     tag = "33-x86_64",

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -26,10 +26,9 @@ FUNC_TEST_REGISTRY_POPULATE="cdi-func-test-registry-populate"
 FUNC_TEST_REGISTRY_INIT="cdi-func-test-registry-init"
 FUNC_TEST_BAD_WEBSERVER="cdi-func-test-bad-webserver"
 FUNC_TEST_PROXY="cdi-func-test-proxy"
-# update this whenever builder Dockerfile is updated
-BUILDER_TAG=${BUILDER_TAG:-0.0.13}
-BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder@sha256:dad7ca592f31b375803ed9f1c517734044e1bc925fde08dc7324d04f2e8ac053
-}
+
+# update this whenever new builder tag is created
+BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder:0.0.13}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER} tools/${FUNC_TEST_PROXY}"
 CDI_PKGS="cmd/ pkg/ test/"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of checking the digest, use a tag that is derived from
a date/time and git hash. Check if hack/build/docker has changed
before building a new builder image on merge of a PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

