### PR TITLE
Allow increasing DV storage request size

### DIFF
--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -331,40 +331,6 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(Equal(true))
 		})
 
-		It("should reject DataVolume spec PVC size update", func() {
-			blankSource := cdiv1.DataVolumeSource{
-				Blank: &cdiv1.DataVolumeBlankImage{},
-			}
-			pvc := newPVCSpec(pvcSizeDefault)
-			newDataVolume := newDataVolume("testDv", blankSource, pvc)
-			newBytes, _ := json.Marshal(&newDataVolume)
-
-			oldDataVolume := newDataVolume.DeepCopy()
-			oldDataVolume.Spec.PVC.Resources.Requests["storage"] =
-				*resource.NewQuantity(pvcSizeDefault+1, resource.BinarySI)
-			oldBytes, _ := json.Marshal(oldDataVolume)
-
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Operation: admissionv1.Update,
-					Resource: metav1.GroupVersionResource{
-						Group:    cdiv1.SchemeGroupVersion.Group,
-						Version:  cdiv1.SchemeGroupVersion.Version,
-						Resource: "datavolumes",
-					},
-					Object: runtime.RawExtension{
-						Raw: newBytes,
-					},
-					OldObject: runtime.RawExtension{
-						Raw: oldBytes,
-					},
-				},
-			}
-
-			resp := validateAdmissionReview(ar)
-			Expect(resp.Allowed).To(Equal(false))
-		})
-
 		It("should accept DataVolume spec PVC size format update", func() {
 			blankSource := cdiv1.DataVolumeSource{
 				Blank: &cdiv1.DataVolumeBlankImage{},

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -92,6 +92,7 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"get",
+				"update",
 			},
 		},
 		{


### PR DESCRIPTION
Check with a dryrun attempt to increase the PVC size if it exists.
Removes some unit tests testing that storage size is immutable, in
favour of functional tests that it can be increased.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate datavolume size updates to the PVC
```

