### PR TITLE
Set priority class name on operator csv

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -400,6 +400,8 @@ _The CDI Operator does not support updates yet._
 		data.Verbosity,
 		data.ImagePullPolicy)
 
+	deployment.Spec.Template.Spec.PriorityClassName = "openshift-user-critical"
+
 	strategySpec := csvStrategySpec{
 		Permissions: []csvPermissions{
 			{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Set the priority class name of the operator in the csv generator, so HCO can properly set the priority class name of the operator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

