### PR TITLE
Update default storage to use CSI hpp driver

### DIFF
--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -46,7 +46,8 @@ function configure_hpp() {
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/operator.yaml -n hostpath-provisioner
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc.yaml
-  _kubectl patch storageclass hostpath-provisioner -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc-csi.yaml
+  _kubectl patch storageclass hostpath-csi -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 }
 
 function configure_ceph() {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1655,7 +1655,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 	Expect(err).To(BeNil())
 	Expect(md5Match).To(BeTrue())
 
-	if utils.DefaultStorageCSI && sourcePvcDiskGroup != "" {
+	if utils.DefaultStorageCSIRespectsFsGroup && sourcePvcDiskGroup != "" {
 		// CSI storage class, it should respect fsGroup
 		By("Checking that disk image group is qemu")
 		Expect(f.GetDiskGroup(targetNs, targetPvc, false)).To(Equal(sourcePvcDiskGroup))

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -75,6 +76,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 	It("[posneg:negative][test_id:6655] Support for CSI Clone strategy in storage profile with SC HPP - negative", func() {
 		if f.IsCSIVolumeCloneStorageClassAvailable() {
 			Skip("Test should only run on non-csi storage")
+		}
+		if utils.DefaultStorageClassCsiDriver != nil {
+			Skip("default storage class has CSI Driver, cannot run test")
 		}
 
 		By(fmt.Sprintf("configure storage profile %s", cloneStorageClassName))

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 		By("Verifying permissions are 660")
 		Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")
-		if utils.DefaultStorageCSI {
+		if utils.DefaultStorageCSIRespectsFsGroup {
 			// CSI storage class, it should respect fsGroup
 			By("Checking that disk image group is qemu")
 			Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(same).To(BeTrue())
 			By("Verifying the image is sparse")
 			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
-			if utils.DefaultStorageCSI {
+			if utils.DefaultStorageCSIRespectsFsGroup {
 				// CSI storage class, it should respect fsGroup
 				By("Checking that disk image group is qemu")
 				Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -61,7 +61,7 @@ var (
 	// NfsService is the service in the cdi namespace that will be created if KUBEVIRT_STORAGE=nfs
 	NfsService *corev1.Service
 	nfsChecked bool
-	// DefaultStorageCSIRespectsFsGroup is true if the default storage class is CSI, false other wise.
+	// DefaultStorageCSIRespectsFsGroup is true if the default storage class is CSI and respects fsGroup, false other wise.
 	DefaultStorageCSIRespectsFsGroup bool
 )
 

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -52,13 +53,16 @@ const (
 )
 
 var (
-	// DefaultStorageClass the defauld storage class used in tests
+	// DefaultStorageClass the default storage class used in tests
 	DefaultStorageClass *storagev1.StorageClass
+	// DefaultStorageClassCsiDriver the default storage class CSI driver if it exists.
+	DefaultStorageClassCsiDriver *storagev1.CSIDriver
+
 	// NfsService is the service in the cdi namespace that will be created if KUBEVIRT_STORAGE=nfs
 	NfsService *corev1.Service
 	nfsChecked bool
-	// DefaultStorageCSI is true if the default storage class is CSI, false other wise.
-	DefaultStorageCSI bool
+	// DefaultStorageCSIRespectsFsGroup is true if the default storage class is CSI, false other wise.
+	DefaultStorageCSIRespectsFsGroup bool
 )
 
 func getDefaultStorageClass(client *kubernetes.Clientset) *storagev1.StorageClass {
@@ -76,15 +80,23 @@ func getDefaultStorageClass(client *kubernetes.Clientset) *storagev1.StorageClas
 	return nil
 }
 
-func isDefaultStorageClassCSI(client *kubernetes.Clientset) bool {
+func getDefaultStorageClassCsiDriver(client *kubernetes.Clientset) *storagev1.CSIDriver {
 	if DefaultStorageClass != nil {
-		_, err := client.StorageV1().CSIDrivers().Get(context.TODO(), DefaultStorageClass.Provisioner, metav1.GetOptions{})
+		csidrivers, err := client.StorageV1().CSIDrivers().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return false
+			ginkgo.Fail(fmt.Sprintf("Unable to get csi driver: %v", err))
 		}
-		return true
+		for _, driver := range csidrivers.Items {
+			if driver.Name == DefaultStorageClass.Provisioner {
+				return &driver
+			}
+		}
 	}
-	return false
+	return nil
+}
+
+func isDefaultStorageClassCSIRespectsFsGroup() bool {
+	return DefaultStorageClassCsiDriver != nil && DefaultStorageClassCsiDriver.Spec.FSGroupPolicy != nil && *DefaultStorageClassCsiDriver.Spec.FSGroupPolicy != storagev1.NoneFSGroupPolicy
 }
 
 // IsHostpathProvisioner returns true if hostpath-provisioner is the default storage class
@@ -108,7 +120,9 @@ func CacheTestsData(client *kubernetes.Clientset, cdiNs string) {
 	if DefaultStorageClass == nil {
 		DefaultStorageClass = getDefaultStorageClass(client)
 	}
-	DefaultStorageCSI = isDefaultStorageClassCSI(client)
+	DefaultStorageClassCsiDriver = getDefaultStorageClassCsiDriver(client)
+	DefaultStorageCSIRespectsFsGroup = isDefaultStorageClassCSIRespectsFsGroup()
+
 	if !nfsChecked {
 		NfsService = getNfsService(client, cdiNs)
 		nfsChecked = true


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the default storage for hpp lanes to be the csi driver instead of the legacy driver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

