### PR TITLE
Speed up transfer cleanup in ImageIO functional tests.

### DIFF
--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -361,7 +361,7 @@ func cleanupTransfer(conn ConnectionInterface, it *ovirtsdk4.ImageTransfer) erro
 
 		imageTransferResponse, err := transferService.Get().Send()
 		if err != nil {
-			if strings.Contains(err.Error(), "404 Not Found") {
+			if strings.Contains(err.Error(), "404 Not Found") || strings.Contains(err.Error(), "404 page not found") {
 				klog.Info("Transfer ticket cleaned up.")
 				return nil
 			}

--- a/tests/imageio-inventory.go
+++ b/tests/imageio-inventory.go
@@ -72,8 +72,17 @@ func ResetImageIoInventory(f *framework.Framework, configurators ...string) {
 func CreateImageIoDefaultInventory(f *framework.Framework) {
 	ResetImageIoInventory(f)
 
-	// Final catch-all API response
 	responseSequences := []imageIoMockResponseSequence{
+		{
+			Path:   "/ovirt-engine/api/imagetransfers",
+			Method: "GET",
+			Responses: []imageIoMockResponse{
+				{
+					ResponseBody: "404 page not found",
+					ResponseCode: 404,
+				},
+			},
+		},
 		{
 			Path:   "/ovirt-engine/api",
 			Method: "GET",


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds a small change to the ImageIO importer to watch for the 404 request returned by fakeovirt when cleaning up an image transfer. This avoids a ~30-second delay when terminating ImageIO functional tests. At a minimum, this should speed up testing by a few minutes. It should also help improve pass rates for ImageIO warm migration tests, which have been showing up in failure logs with alarming frequency.

**Which issue(s) this PR fixes**:
Fixes: None

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

