### PR TITLE
always preallocate for block imports

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -93,6 +93,8 @@ func main() {
 	volumeMode := v1.PersistentVolumeBlock
 	if _, err := os.Stat(common.WriteBlockPath); os.IsNotExist(err) {
 		volumeMode = v1.PersistentVolumeFilesystem
+	} else {
+		preallocation = true
 	}
 
 	availableDestSpace, err := util.GetAvailableSpaceByVolumeMode(volumeMode)


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Sometimes importing a raw image to a block PVC fails.  This seems to fix that case because `-S 0` will be passed to `qemu-img convert`.  Is this masking over a bug in qemu-img?  Maybe.  But I still think it is nice to explicitly zero ranges in block PVCs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1980

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Always preallocate for imports to block PVCs
```

