### PR TITLE
Trigger Host Assisted Cloning for encrypted ocs sc.

### DIFF
--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -153,6 +154,30 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(len(updatedSp.Status.ClaimPropertySets)).To(Equal(0))
 		Expect(updatedSp.Spec.ClaimPropertySets).To(Equal(claimPropertySets))
 	})
+
+	table.DescribeTable("should create clone strategy", func(cloneStrategy cdiv1.CDICloneStrategy) {
+		storageClass := createStorageClass(storageClassName, map[string]string{AnnDefaultStorageClass: "true"})
+
+		storageClass.Annotations["cdi.kubevirt.io/clone-strategy"] = string(cloneStrategy)
+		reconciler := createStorageProfileReconciler(storageClass)
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
+		Expect(err).ToNot(HaveOccurred())
+
+		storageProfileList := &cdiv1.StorageProfileList{}
+		err = reconciler.client.List(context.TODO(), storageProfileList, &client.ListOptions{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(storageProfileList.Items)).To(Equal(1))
+
+		sp := storageProfileList.Items[0]
+		Expect(*sp.Status.StorageClass).To(Equal(storageClassName))
+		Expect(*sp.Status.CloneStrategy).To(Equal(cloneStrategy))
+	},
+		table.Entry("None", cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
+		table.Entry("Snapshot", cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
+		table.Entry("Clone", cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)),
+	)
+
 })
 
 func createStorageProfileReconciler(objects ...runtime.Object) *StorageProfileReconciler {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->




**What this PR does / why we need it**:
This PR allows storage classes to set the preferred clone method with an annotation on the storage class. This is helpful for known provisioners that want different behavior for certain configurations in the storage class. For instance rook-ceph with encryption enabled, will want to a host assisted clone instead of smart clone.

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

