### PR TITLE
Fix blank block preallocation import

### DIFF
--- a/pkg/image/BUILD.bazel
+++ b/pkg/image/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/common:go_default_library",
         "//pkg/system:go_default_library",
         "//pkg/util:go_default_library",
+        "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -339,6 +339,40 @@ var _ = Describe("Create blank image", func() {
 	})
 })
 
+var _ = Describe("Create preallocated blank block", func() {
+	It("Should complete successfully if preallocation succeeds", func() {
+		quantity, err := resource.ParseQuantity("10Gi")
+		Expect(err).NotTo(HaveOccurred())
+		dest := "cdi-block-volume"
+		replaceExecFunction(mockExecFunction("", "", nil, "if=/dev/zero", "of="+dest, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes"), func() {
+			err = PreallocateBlankBlock(dest, quantity)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("Should complete successfully with value not aligned to 1MiB", func() {
+		quantity, err := resource.ParseQuantity("5243392Ki")
+		Expect(err).NotTo(HaveOccurred())
+		dest := "cdi-block-volume"
+		firstCallArgs := []string{"if=/dev/zero", "of=" + dest, "bs=1048576", "count=5120", "seek=0", "oflag=seek_bytes"}
+		secondCallArgs := []string{"if=/dev/zero", "of=" + dest, "bs=524288", "count=1", "seek=5368709120", "oflag=seek_bytes"}
+		replaceExecFunction(mockExecFunctionTwoCalls("", "", nil, firstCallArgs, secondCallArgs), func() {
+			err = PreallocateBlankBlock(dest, quantity)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("Should fail if preallocation fails", func() {
+		quantity, err := resource.ParseQuantity("10Gi")
+		Expect(err).NotTo(HaveOccurred())
+		dest := "cdi-block-volume"
+		replaceExecFunction(mockExecFunction("", "exit 1", nil, "if=/dev/zero", "of="+dest, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes"), func() {
+			err = PreallocateBlankBlock(dest, quantity)
+			Expect(strings.Contains(err.Error(), "Could not preallocate blank block volume at")).To(BeTrue())
+		})
+	})
+})
+
 var _ = Describe("Try different preallocation modes", func() {
 	It("Should try falloc first", func() {
 		calledCount := 0
@@ -426,7 +460,10 @@ func mockExecFunction(output, errString string, expectedLimits *system.ProcessLi
 					break
 				}
 			}
-			Expect(found).To(BeTrue())
+			// if not found will fail and show the diff in the args
+			if found != true {
+				Expect(checkArgs).To(Equal(args))
+			}
 		}
 
 		if output != "" {
@@ -445,6 +482,29 @@ func mockExecFunctionStrict(output, errString string, expectedLimits *system.Pro
 		Expect(reflect.DeepEqual(expectedLimits, limits)).To(BeTrue())
 
 		Expect(checkArgs).To(Equal(args))
+
+		if output != "" {
+			bytes = []byte(output)
+		}
+		if errString != "" {
+			err = errors.New(errString)
+		}
+
+		return
+	}
+}
+
+func mockExecFunctionTwoCalls(output, errString string, expectedLimits *system.ProcessLimitValues, firstCallArgs []string, secondCallArgs []string) execFunctionType {
+	firstCall := true
+	return func(limits *system.ProcessLimitValues, f func(string), cmd string, args ...string) (bytes []byte, err error) {
+		Expect(reflect.DeepEqual(expectedLimits, limits)).To(BeTrue())
+
+		if firstCall {
+			Expect(firstCallArgs).To(Equal(args))
+			firstCall = false
+		} else {
+			Expect(secondCallArgs).To(Equal(args))
+		}
 
 		if output != "" {
 			bytes = []byte(output)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1345,7 +1345,7 @@ var _ = Describe("Preallocation", func() {
 				Skip("Storage Class for block volume is not available")
 			}
 
-			return utils.NewDataVolumeForBlankRawImageBlock("import-dv", "100Mi", f.BlockSCName)
+			return utils.NewDataVolumeForBlankRawImageBlock("import-dv", "1Gi", f.BlockSCName)
 		}),
 	)
 


### PR DESCRIPTION
When trying to preallocate big size such as 1Gi
the preallocation failed since the dd occupied too
much memory and OOMKiller killed the process.
To fix it the dd will write in 1Mi block size the
requested size (will write the extra reminder if the
size is not aligned to 1Mi)
There was a test which checked blank block preallocation
but the size was only 100Mi which didnt fail, changed to 1Gi.

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # BZ#2017613
https://bugzilla.redhat.com/show_bug.cgi?id=2017613

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

