### PR TITLE
Replace the priorityClass to kubevirt-cluster-critical

### DIFF
--- a/pkg/operator/controller/cr-manager.go
+++ b/pkg/operator/controller/cr-manager.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 
 	cdicluster "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
 	cdinamespaced "kubevirt.io/containerized-data-importer/pkg/operator/resources/namespaced"
@@ -84,7 +85,7 @@ func (r *ReconcileCDI) getNamespacedArgs(cr *cdiv1.CDI) *cdinamespaced.FactoryAr
 		if cr.Spec.PriorityClass != nil && string(*cr.Spec.PriorityClass) != "" {
 			result.PriorityClassName = string(*cr.Spec.PriorityClass)
 		} else {
-			result.PriorityClassName = "openshift-user-critical"
+			result.PriorityClassName = utils.CDIPriorityClass
 		}
 		// Verify the priority class name exists.
 		priorityClass := &schedulingv1.PriorityClass{}

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -420,7 +420,7 @@ _The CDI Operator does not support updates yet._
 		data.Verbosity,
 		data.ImagePullPolicy)
 
-	deployment.Spec.Template.Spec.PriorityClassName = "openshift-user-critical"
+	deployment.Spec.Template.Spec.PriorityClassName = utils.CDIPriorityClass
 
 	strategySpec := csvStrategySpec{
 		Permissions: []csvPermissions{

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -28,6 +28,8 @@ import (
 const (
 	// CDILabel is the labe applied to all non operator resources
 	CDILabel = "cdi.kubevirt.io"
+	// CDIPriorityClass is the priority class for all CDI pods.
+	CDIPriorityClass = "kubevirt-cluster-critical"
 )
 
 var commonLabels = map[string]string{

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -28,6 +28,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	resourcesutils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 	"kubevirt.io/containerized-data-importer/tests"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -892,7 +893,7 @@ var _ = Describe("ALL Operator tests", func() {
 				systemClusterCritical = cdiv1.CDIPriorityClass("system-cluster-critical")
 				osUserCrit            = &schedulev1.PriorityClass{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "openshift-user-critical",
+						Name: resourcesutils.CDIPriorityClass,
 					},
 					Value: 10000,
 				}


### PR DESCRIPTION
The current priority class for the operator is `openshift-user-critical`. This priority class does not exist in Kubernetes.

Instead, use the `kubevirt-cluster-critical` priority class that is created by HCO.

Fixes #2010 

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
use the `kubevirt-cluster-critical` priority class for CDI pods.
```

