### PR TITLE
Remove skopeo binary dependency - use containers/image instead

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -908,21 +908,3 @@ http_file(
         "https://storage.googleapis.com/builddeps/ab5a824d402c717bfe8e01cfb216a70fd4a7e1d66d2d7baa80ac6ad6581081c9",
     ],
 )
-
-http_file(
-    name = "skopeo",
-    sha256 = "69d782e6796682205cab2264330cc87e8c9fce0adcb39b91be6b292fb49a0407",
-    urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/33/Everything/x86_64/os/Packages/s/skopeo-1.2.0-3.fc33.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/69d782e6796682205cab2264330cc87e8c9fce0adcb39b91be6b292fb49a0407",
-    ],
-)
-
-http_file(
-    name = "skopeo-aarch64",
-    sha256 = "34797f853fa66bab3d020fd5b2a35fa993dd19db0c0ce0d0be1cf02eab7f3146",
-    urls = [
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/33/Everything/aarch64/os/Packages/s/skopeo-1.2.0-3.fc33.aarch64.rpm",
-        "https://storage.googleapis.com/builddeps/34797f853fa66bab3d020fd5b2a35fa993dd19db0c0ce0d0be1cf02eab7f3146",
-    ],
-)

--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -23,8 +23,6 @@ rpm_image(
             "@capstone-aarch64//file",
             "@ostree-libs-aarch64//file",
             "@containers-common-aarch64//file",
-            "@skopeo-aarch64//file",
-            "@device-mapper-libs-aarch64//file",
         ],
         "//conditions:default": [
             "@liburing//file",
@@ -42,8 +40,6 @@ rpm_image(
             "@capstone//file",
             "@ostree-libs//file",
             "@containers-common//file",
-            "@skopeo//file",
-            "@device-mapper-libs//file",
         ],
     }),
 )

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",
         "//vendor/github.com/containers/image/v5/docker:go_default_library",
         "//vendor/github.com/containers/image/v5/image:go_default_library",
+        "//vendor/github.com/containers/image/v5/manifest:go_default_library",
         "//vendor/github.com/containers/image/v5/oci/archive:go_default_library",
         "//vendor/github.com/containers/image/v5/pkg/blobinfocache:go_default_library",
         "//vendor/github.com/containers/image/v5/types:go_default_library",

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/importer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,19 +44,6 @@ func init() {
 	accessKey, _ = util.ParseEnvVar(common.ImporterAccessKeyID, false)
 	secretKey, _ = util.ParseEnvVar(common.ImporterSecretKey, false)
 	insecureTLS, _ = strconv.ParseBool(os.Getenv(common.InsecureTLSVar))
-}
-
-func cmdRun(cmd string) (outStr string, err error) {
-	var out, stderr bytes.Buffer
-	command := exec.Command("sh", "-c", cmd)
-	command.Stdout = &out
-	command.Stderr = &stderr
-	err = command.Run()
-	if err != nil {
-		log.Printf("Failed to exec command \"%s\": %v: %s", cmd, err, stderr.String())
-	}
-	outStr = out.String()
-	return
 }
 
 func main() {


### PR DESCRIPTION
Depending on a Go binary from the package manager is undesirable
as whenever Go notifies us of a vulnerability and we need to
rebuild, we depend on the package to be updated, which may take
a while (especially in the case of, say, centos stream).

With a library, updates are a matter of rebuilding CDI itself,
and that's it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

