### PR TITLE
Add storageprofiles to RBAC

### DIFF
--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -60,21 +60,6 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"cdiconfigs",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"patch",
-				"update",
-			},
-		},
-		{
-			APIGroups: []string{
 				"upload.cdi.kubevirt.io",
 			},
 			Resources: []string{
@@ -117,19 +102,6 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"create",
-			},
-		},
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"cdiconfigs",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -24,7 +24,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 )
 
-func createAggregateClusterRoles(args *FactoryArgs) []client.Object {
+func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 	return []client.Object{
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
@@ -143,6 +143,7 @@ func createConfigReaderClusterRole(name string) *rbacv1.ClusterRole {
 			},
 			Resources: []string{
 				"cdiconfigs",
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -236,21 +236,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 		},
 		{
 			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"cdiconfigs",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"patch",
-				"update",
-			},
-		},
-		{
-			APIGroups: []string{
 				"upload.cdi.kubevirt.io",
 			},
 			Resources: []string{
@@ -287,19 +272,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 			},
 			Verbs: []string{
 				"create",
-			},
-		},
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"cdiconfigs",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
 			},
 		},
 	}

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -259,21 +260,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"*",
 			},
 		},
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"storageprofiles",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"patch",
-				"update",
-			},
-		},
 	}
 
 	var editRules = adminRules
@@ -316,19 +302,6 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"watch",
 			},
 		},
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"storageprofiles",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
 	}
 
 	f := framework.NewFramework("aggregated-role-definition-tests")
@@ -337,16 +310,16 @@ var _ = Describe("Aggregated role definition tests", func() {
 		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(context.TODO(), role, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		found := false
 		for _, expectedRule := range rules {
+			found := false
 			for _, r := range clusterRole.Rules {
 				if reflect.DeepEqual(expectedRule, r) {
 					found = true
 					break
 				}
 			}
+			Expect(found).To(BeTrue(), fmt.Sprintf("Rule for resources %v should exist", expectedRule.Resources))
 		}
-		Expect(found).To(BeTrue())
 	},
 		Entry("[test_id:3945]for admin", "admin", adminRules),
 		Entry("[test_id:3946]for edit", "edit", editRules),

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -130,6 +130,20 @@ var _ = Describe("Aggregated role in-action tests", func() {
 			config.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
 		})
 		Expect(err).To(HaveOccurred())
+
+		profiles, err := cdiClient.CdiV1beta1().StorageProfiles().List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(profiles.Items).ToNot(BeEmpty())
+
+		profileName := profiles.Items[0].Name
+		storageProfile, err := cdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), profileName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		spec := &storageProfile.Spec
+		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		spec.CloneStrategy = &cs
+		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
+		Expect(err).To(HaveOccurred())
 	},
 		Entry("[test_id:3948]can do everything with admin", "admin"),
 		Entry("[test_id:3949]can do everything with edit", "edit"),
@@ -177,6 +191,20 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		err = utils.UpdateCDIConfig(crClient, func(config *cdiv1.CDIConfigSpec) {
 			config.ScratchSpaceStorageClass = &[]string{"foobar"}[0]
 		})
+		Expect(err).To(HaveOccurred())
+
+		profiles, err := cdiClient.CdiV1beta1().StorageProfiles().List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(profiles.Items).ToNot(BeEmpty())
+
+		profileName := profiles.Items[0].Name
+		storageProfile, err := cdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), profileName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		spec := &storageProfile.Spec
+		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		spec.CloneStrategy = &cs
+		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -231,6 +259,21 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"storageprofiles",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"patch",
+				"update",
+			},
+		},
 	}
 
 	var editRules = adminRules
@@ -266,6 +309,19 @@ var _ = Describe("Aggregated role definition tests", func() {
 			},
 			Resources: []string{
 				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds RBAC rules for storageprofiles

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1992961

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix  access control for storageprofiles
```

