### PR TITLE
Enable DataImportCron garbageCollect by default

### DIFF
--- a/doc/os-image-poll-and-update.md
+++ b/doc/os-image-poll-and-update.md
@@ -1,6 +1,6 @@
 # Automated OS image import, poll and update
 
-CDI supports automating OS image import, poll and update, keeping OS images up-to-date. On the first time a `DataImportCron` is scheduled, the controller will import the source image. On any following scheduled poll, if the source image digest (sha256) has updated, the controller will import it to a new `PVC` in the `DataImportCron` namespace, and update the managed `DataSource` to point that `PVC`. A garbage collector is responsible to keep the last 3 imported `PVCs` per `DataImportCron`, and delete older ones. 
+CDI supports automating OS image import, poll and update, keeping OS images up-to-date according to the given `schedule`. On the first time a `DataImportCron` is scheduled, the controller will import the source image. On any following scheduled poll, if the source image digest (sha256) has updated, the controller will import it to a new `PVC` in the `DataImportCron` namespace, and update the managed `DataSource` to point that `PVC`. A garbage collector (`garbageCollect: Outdated` enabled by default) is responsible to keep the last `importsToKeep` (3 by default) imported `PVCs` per `DataImportCron`, and delete older ones.
 
 See design doc [here](https://github.com/kubevirt/community/blob/main/design-proposals/golden-image-delivery-and-update-pipeline.md)
 
@@ -25,6 +25,7 @@ spec:
         storageClassName: hostpath-provisioner
   schedule: "30 1 * * 1"
   garbageCollect: Outdated
+  importsToKeep: 2
   managedDataSource: fedora
 ```
 
@@ -68,8 +69,8 @@ spec:
           requests:
             storage: 5Gi
         storageClassName: hostpath-provisioner
-  schedule: "30 1 * * 1"
-  garbageCollect: Outdated
+  schedule: "0 0 * * 5"
+  importsToKeep: 4
   managedDataSource: rhel8
 ```
 

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -14991,7 +14991,7 @@ func schema_pkg_apis_core_v1beta1_DataImportCronSpec(ref common.ReferenceCallbac
 					},
 					"garbageCollect": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported. Options are currently \"Never\" and \"Outdated\", defaults to \"Never\".",
+							Description: "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported. Options are currently \"Outdated\" and \"Never\", defaults to \"Outdated\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -351,7 +351,7 @@ func (r *DataImportCronReconciler) createImportDataVolume(ctx context.Context, d
 
 func (r *DataImportCronReconciler) garbageCollectOldImports(ctx context.Context, dataImportCron *cdiv1.DataImportCron) error {
 	log := r.log.WithName("garbageCollectOldImports")
-	if dataImportCron.Spec.GarbageCollect == nil || *dataImportCron.Spec.GarbageCollect != cdiv1.DataImportCronGarbageCollectOutdated {
+	if dataImportCron.Spec.GarbageCollect != nil && *dataImportCron.Spec.GarbageCollect != cdiv1.DataImportCronGarbageCollectOutdated {
 		return nil
 	}
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -3743,8 +3743,8 @@ spec:
             properties:
               garbageCollect:
                 description: GarbageCollect specifies whether old PVCs should be cleaned
-                  up after a new PVC is imported. Options are currently "Never" and
-                  "Outdated", defaults to "Never".
+                  up after a new PVC is imported. Options are currently "Outdated"
+                  and "Never", defaults to "Outdated".
                 type: string
               importsToKeep:
                 description: Number of import PVCs to keep when garbage collecting.

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -483,7 +483,7 @@ type DataImportCronSpec struct {
 	// Schedule specifies in cron format when and how often to look for new imports
 	Schedule string `json:"schedule"`
 	// GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.
-	// Options are currently "Never" and "Outdated", defaults to "Never".
+	// Options are currently "Outdated" and "Never", defaults to "Outdated".
 	// +optional
 	GarbageCollect *DataImportCronGarbageCollect `json:"garbageCollect,omitempty"`
 	// Number of import PVCs to keep when garbage collecting. Default is 3.

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -241,7 +241,7 @@ func (DataImportCronSpec) SwaggerDoc() map[string]string {
 		"":                  "DataImportCronSpec defines specification for DataImportCron",
 		"template":          "Template specifies template for the DVs to be created",
 		"schedule":          "Schedule specifies in cron format when and how often to look for new imports",
-		"garbageCollect":    "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.\nOptions are currently \"Never\" and \"Outdated\", defaults to \"Never\".\n+optional",
+		"garbageCollect":    "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.\nOptions are currently \"Outdated\" and \"Never\", defaults to \"Outdated\".\n+optional",
 		"importsToKeep":     "Number of import PVCs to keep when garbage collecting. Default is 3.\n+optional",
 		"managedDataSource": "ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.\nDataSource has to be in the same namespace.",
 	}


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Enable DataImportCron garbageCollect by default, so we won't have tons of dusty pvcs left around. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

