### PR TITLE
Attempt to mitigate flake #1989, 'io: read/write on closed pipe'

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -153,9 +153,14 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		}
 
 		By("Do upload")
-		Eventually(func() error {
-			return uploader(uploadProxyURL, token, expectedStatus)
-		}, timeout, pollingInterval).Should(BeNil(), "Upload should eventually succeed, even if initially pod is not ready")
+		Eventually(func() bool {
+			err = uploader(uploadProxyURL, token, expectedStatus)
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
+				return false
+			}
+			return true
+		}, timeout, 5*time.Second).Should(BeTrue(), "Upload should eventually succeed, even if initially pod is not ready")
 
 		if validToken {
 			By("Verify PVC status annotation says succeeded")
@@ -1265,9 +1270,14 @@ var _ = Describe("Preallocation", func() {
 		Expect(token).ToNot(BeEmpty())
 
 		By("Do upload")
-		Eventually(func() error {
-			return uploader(uploadProxyURL, token, http.StatusOK)
-		}, timeout, pollingInterval).Should(BeNil(), "Upload should eventually succeed, even if initially pod is not ready")
+		Eventually(func() bool {
+			err = uploader(uploadProxyURL, token, http.StatusOK)
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
+				return false
+			}
+			return true
+		}, timeout, 5*time.Second).Should(BeTrue(), "Upload should eventually succeed, even if initially pod is not ready")
 
 		phase = cdiv1.Succeeded
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
So the upload func being called in the eventually loop means we're going to be running
this:
https://github.com/kubevirt/containerized-data-importer/blob/main/tests/upload_test.go#L415-L428
a bunch of times, which leads to sometimes failing with
```bash
<*errors.errorString | 0xc000200140>: {
        s: "io: read/write on closed pipe",
    }
    io: read/write on closed pipe
occurred
/root/go/src/kubevirt.io/containerized-data-importer/tests/upload_test.go:424
```
Slightly incrementing the interval in which we call the upload func seems to mitigate this flake.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1989

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

