### PR TITLE
Add common labels into alert definitions

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -345,7 +345,9 @@ var _ = Describe("Controller", func() {
 						"runbook_url": runbookURLBasePath + "CDIOperatorDown",
 					},
 					Labels: map[string]string{
-						"severity": "warning",
+						"severity":                      "warning",
+						"kubernetes_operator_part_of":   "kubevirt",
+						"kubernetes_operator_component": "containerized-data-importer",
 					},
 				}
 

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -41,11 +41,16 @@ import (
 )
 
 const (
-	ruleName            = "prometheus-cdi-rules"
-	rbacName            = "cdi-monitoring"
-	monitorName         = "service-monitor-cdi"
-	defaultMonitoringNs = "monitoring"
-	runbookURLBasePath  = "https://kubevirt.io/monitoring/runbooks/"
+	ruleName                 = "prometheus-cdi-rules"
+	rbacName                 = "cdi-monitoring"
+	monitorName              = "service-monitor-cdi"
+	defaultMonitoringNs      = "monitoring"
+	runbookURLBasePath       = "https://kubevirt.io/monitoring/runbooks/"
+	severityAlertLabelKey    = "severity"
+	partOfAlertLabelKey      = "kubernetes_operator_part_of"
+	partOfAlertLabelValue    = "kubevirt"
+	componentAlertLabelKey   = "kubernetes_operator_component"
+	componentAlertLabelValue = common.CDILabelValue
 )
 
 func ensurePrometheusResourcesExist(c client.Client, scheme *runtime.Scheme, owner metav1.Object) error {
@@ -150,7 +155,9 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": runbookURLBasePath + "CDIOperatorDown",
 							},
 							map[string]string{
-								"severity": "warning",
+								severityAlertLabelKey:  "warning",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 						generateAlertRule(
@@ -162,7 +169,9 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": runbookURLBasePath + "CDINotReady",
 							},
 							map[string]string{
-								"severity": "warning",
+								severityAlertLabelKey:  "warning",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 						generateRecordRule(
@@ -186,7 +195,9 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": runbookURLBasePath + "CDIDataVolumeUnusualRestartCount",
 							},
 							map[string]string{
-								"severity": "warning",
+								severityAlertLabelKey:  "warning",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 						generateAlertRule(
@@ -198,7 +209,9 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": runbookURLBasePath + "CDIStorageProfilesIncomplete",
 							},
 							map[string]string{
-								"severity": "info",
+								severityAlertLabelKey:  "info",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 					},


### PR DESCRIPTION
We want to be able to list all kubevirt alerts so we added labels to
differentiate them.

Signed-off-by: assafad <aadmi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added common labels into alert definitions
```

