### PR TITLE
Add DataImportCron initial import before cron schedule

### DIFF
--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -101,6 +101,18 @@ func createControllerRole() *rbacv1.Role {
 				"delete",
 			},
 		},
+
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
 	}
 	return utils.ResourceBuilder.CreateRole(controllerResourceName, rules)
 }

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -86,7 +86,7 @@ var _ = Describe("DataImportCron", func() {
 
 		var lastImportDv, currentImportDv string
 		for i := 0; i < repeat; i++ {
-			if repeat > 1 {
+			if i > 0 {
 				// Emulate source update using digests from https://quay.io/repository/kubevirt/cirros-container-disk-demo?tab=tags
 				digest := []string{
 					"sha256:68b44fc891f3fae6703d4b74bcc9b5f24df8d23f12e642805d1420cbe7a4be70",


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Currently, the DataImportCron polls and imports are handled by the controller according to the cron schedule. We would like to add an initial import on DataImportCron creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

