### PR TITLE
Fix cdi-containerimage-server readiness sync in cdi-importer

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -128,13 +128,13 @@ func main() {
 			errorEmptyDiskWithContentTypeArchive()
 		}
 	} else {
+		waitForReadyFile()
 		klog.V(1).Infoln("begin import process")
 
 		ds = newDataSource(source, contentType, volumeMode)
 		defer ds.Close()
 
 		processor := newDataProcessor(contentType, volumeMode, ds, imageSize, filesystemOverhead, preallocation)
-		waitForReadyFile()
 		err = processor.ProcessData()
 
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently importer connects too early, so it gets restarted and successfully connects only on the second try.

```
$ k logs importer-registry-image-datavolume importer
I1130 12:27:49.884684       1 importer.go:77] Starting importer
I1130 12:27:49.884791       1 importer.go:131] begin import process
I1130 12:27:49.884857       1 http-datasource.go:387] Attempting to HEAD "http://localhost:8100/disk.img" via http client
I1130 12:27:49.885995       1 http-datasource.go:322] Attempting to get object "http://localhost:8100/disk.img" via http client
E1130 12:27:49.886382       1 importer.go:276] Get "http://localhost:8100/disk.img": dial tcp [::1]:8100: connect: connection refused
HTTP request errored
kubevirt.io/containerized-data-importer/pkg/importer.createHTTPReader
        pkg/importer/http-datasource.go:325
kubevirt.io/containerized-data-importer/pkg/importer.NewHTTPDataSource
        pkg/importer/http-datasource.go:99
main.newDataSource
        cmd/cdi-importer/importer.go:207
main.main
        cmd/cdi-importer/importer.go:133
runtime.main
        GOROOT/src/runtime/proc.go:225
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1371
```

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**Release note**:
```release-note
NONE
```

