### PR TITLE
[release-v1.38] Backport fix hpp tests

### DIFF
--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -43,10 +43,20 @@ function configure_hpp() {
   done
   HPP_RELEASE=$(curl -s https://github.com/kubevirt/hostpath-provisioner-operator/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/namespace.yaml
+  #install cert-manager
+  _kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+  _kubectl wait --for=condition=available -n cert-manager --timeout=120s --all deployments
+  _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/webhook.yaml -n hostpath-provisioner
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/operator.yaml -n hostpath-provisioner
-  _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner
+  echo "Waiting for it to be ready"
+  _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
+
+  _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_legacy_cr.yaml -n hostpath-provisioner
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc.yaml
-  _kubectl patch storageclass hostpath-provisioner -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc-legacy-csi.yaml
+  echo "Waiting for hostpath provisioner to be available"
+  _kubectl wait hostpathprovisioners.hostpathprovisioner.kubevirt.io/hostpath-provisioner --for=condition=Available --timeout=480s
+  _kubectl patch storageclass hostpath-csi -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 }
 
 function configure_ceph() {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1602,7 +1602,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 	Expect(err).To(BeNil())
 	Expect(md5Match).To(BeTrue())
 
-	if utils.DefaultStorageCSI && sourcePvcDiskGroup != "" {
+	if utils.DefaultStorageCSIRespectsFsGroup && sourcePvcDiskGroup != "" {
 		// CSI storage class, it should respect fsGroup
 		By("Checking that disk image group is qemu")
 		Expect(f.GetDiskGroup(targetNs, targetPvc, false)).To(Equal(sourcePvcDiskGroup))

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -71,5 +72,4 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high] CSI Vol
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, expectedMd5)
 	})
-
 })

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 		By("Verifying permissions are 660")
 		Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")
-		if utils.DefaultStorageCSI {
+		if utils.DefaultStorageCSIRespectsFsGroup {
 			// CSI storage class, it should respect fsGroup
 			By("Checking that disk image group is qemu")
 			Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(same).To(BeTrue())
 			By("Verifying the image is sparse")
 			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
-			if utils.DefaultStorageCSI {
+			if utils.DefaultStorageCSIRespectsFsGroup {
 				// CSI storage class, it should respect fsGroup
 				By("Checking that disk image group is qemu")
 				Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))


### PR DESCRIPTION
With hpp operator at v0.11.0 it now requires cert-manager, and webhook
This PR modifies the hpp setup to include setting up those items.
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #2046 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

