### PR TITLE
Improve directory detection on containerdisk imports

### DIFF
--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -110,8 +110,8 @@ func isWhiteout(path string) bool {
 	return strings.HasPrefix(filepath.Base(path), whFilePrefix)
 }
 
-func isDir(path string) bool {
-	return strings.HasSuffix(path, "/")
+func isDir(hdr *tar.Header) bool {
+	return hdr.Typeflag == tar.TypeDir
 }
 
 func processLayer(ctx context.Context,
@@ -147,7 +147,7 @@ func processLayer(ctx context.Context,
 			return false, errors.Wrap(err, "Error reading layer")
 		}
 
-		if hasPrefix(hdr.Name, pathPrefix) && !isWhiteout(hdr.Name) && !isDir(hdr.Name) {
+		if hasPrefix(hdr.Name, pathPrefix) && !isWhiteout(hdr.Name) && !isDir(hdr) {
 			klog.Infof("File '%v' found in the layer", hdr.Name)
 			destFile := filepath.Join(destDir, hdr.Name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Check the tar header metadata if a tar entry is a directory instead of
checking if it has a `/` suffix.

This solves the following issue:

While most applications write a `/` at the end of a directory entry in a
tar header, it is not necessarily there. If it is missing, the directory
will be treated as the target file and CDI tries and fails to import the
`disk` directory itself:

```
iI1203 12:02:26.740362       1 transport.go:149] File 'disk' found in the layer
I1203 12:02:26.740461       1 util.go:172] Writing data...
E1203 12:02:26.742269       1 registry-datasource.go:123] Error reading directory
E1203 12:02:26.742319       1 data-processor.go:229] readdirent: not a directory
image file does not exist in image directory
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

