### PR TITLE
Extend test for explicit storage class

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1570,9 +1570,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			requestedSize := resource.MustParse("100Mi")
 
 			spec := cdiv1.StorageSpec{
-				AccessModes:      nil,
-				VolumeMode:       nil,
-				StorageClassName: &defaultScName,
+				AccessModes: nil,
+				VolumeMode:  nil,
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
 						v1.ResourceStorage: requestedSize,
@@ -1583,10 +1582,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
 			dataVolume := createDataVolumeForImport(f, spec)
 
-			By("verifying pvc created with correct accessModes")
+			By("verifying pvc created with correct accessModes and storageclass name")
 			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+			Expect(*pvc.Spec.StorageClassName).To(And(Not(BeNil())), Equal(defaultScName))
 
 			By("Restore the profile")
 			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)


### PR DESCRIPTION

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Extend the functional test to check for explicit storage class (storage class name handling implemented here: https://github.com/kubevirt/containerized-data-importer/pull/1936).

Check that the CDI sets the storage class on the DV/PVC when it is
not specified in the spec.storage API but computed by CDI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

