### PR TITLE
Use ImageIO extents API to copy raw images more efficiently.

### DIFF
--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/ulikunitz/xz:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ] + select({
@@ -52,7 +53,6 @@ go_library(
             "//vendor/github.com/vmware/govmomi/vim25/methods:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
-            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:arm64": [

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/ulikunitz/xz:go_default_library",
-        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ] + select({
@@ -53,6 +52,7 @@ go_library(
             "//vendor/github.com/vmware/govmomi/vim25/methods:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:arm64": [

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -885,6 +885,13 @@ func loadCA(certDir string) (*x509.CertPool, error) {
 	return caCertPool, nil
 }
 
+type ImageioImageOptions struct {
+	UnixSocket string   `json:"unix_socket"`
+	Features   []string `json:"features"`
+	MaxReaders int      `json:"max_readers"`
+	MaxWriters int      `json:"max_writers"`
+}
+
 // checkExtentsFeature sends OPTIONS to check for ImageIO extents API feature
 func checkExtentsFeature(ctx context.Context, httpClient *http.Client, transferURL string) (bool, error) {
 	request, err := http.NewRequest(http.MethodOptions, transferURL, nil)
@@ -898,13 +905,7 @@ func checkExtentsFeature(ctx context.Context, httpClient *http.Client, transferU
 		return false, errors.Wrap(err, "error sending options request")
 	}
 
-	type imageOptions struct {
-		UnixSocket string   `json:"unix_socket"`
-		Features   []string `json:"features"`
-		MaxReaders int      `json:"max_readers"`
-		MaxWriters int      `json:"max_writers"`
-	}
-	options := &imageOptions{}
+	options := &ImageioImageOptions{}
 	err = json.NewDecoder(response.Body).Decode(options)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to decode options response")

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -280,7 +280,7 @@ func (is *ImageioDataSource) StreamExtents(extentsReader *extentReader, fileName
 	preallocated := info.Size() >= int64(is.contentLength)
 
 	// Choose seek for regular files, and hole punching for block devices and pre-allocated files
-	zeroRange := util.SeekOffset
+	zeroRange := util.AppendZeroWithTruncate
 	if isBlock || preallocated {
 		zeroRange = util.PunchHole
 	}
@@ -290,8 +290,8 @@ func (is *ImageioDataSource) StreamExtents(extentsReader *extentReader, fileName
 		if extent.Zero {
 			err = zeroRange(outFile, extent.Start, extent.Length)
 			if err != nil {
-				klog.Infof("Initial zero method failed, trying WriteZeroBlock instead. Error was: %v", err)
-				zeroRange = util.WriteZeroBlock // If the initial choice fails, fall back to regular file writing
+				klog.Infof("Initial zero method failed, trying AppendZeroWithWrite instead. Error was: %v", err)
+				zeroRange = util.AppendZeroWithWrite // If the initial choice fails, fall back to regular file writing
 				err = zeroRange(outFile, extent.Start, extent.Length)
 				if err != nil {
 					return errors.Wrap(err, "failed to zero range on destination")

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -469,20 +469,8 @@ func (reader *extentReader) GetRange(start, end int64) (io.ReadCloser, error) {
 	// Validate the returned length, and return an error if it does not match the expected range size
 	expectedLength := end - start + 1
 	if length != expectedLength {
-		contentRange := response.Header.Get("Content-Range")
-		parts := strings.Split(contentRange, "*/")
-		if len(parts) > 1 {
-			if rangeLength, err := strconv.ParseInt(parts[1], 10, 64); err != nil {
-				response.Body.Close()
-				return nil, errors.Wrap(err, "failed to parse total length of image from range response")
-			} else if rangeLength != expectedLength {
-				response.Body.Close()
-				return nil, errors.Wrap(err, "parse incorrect total length of image from range response")
-			}
-		} else {
-			response.Body.Close()
-			return nil, errors.New(fmt.Sprintf("wrong length returned: %d vs expected %d", length, expectedLength))
-		}
+		response.Body.Close()
+		return nil, errors.New(fmt.Sprintf("wrong length returned: %d vs expected %d", length, expectedLength))
 	}
 
 	return response.Body, nil

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -545,11 +545,9 @@ var _ = Describe("Imageio extents", func() {
 		Expect(err).ToNot(HaveOccurred())
 		extentsReader, err := source.getExtentsReader()
 		Expect(err).ToNot(HaveOccurred())
-		offset := extentsReader.offset
 		ticketTime := time.Now()
 		time.Sleep(1 * time.Millisecond)
 		err = source.renewExtentsTicket(it.MustId(), extentsReader)
-		Expect(extentsReader.offset > offset).To(BeTrue())
 		Expect(renewalTime.Equal(ticketTime)).To(BeFalse())
 	})
 
@@ -563,7 +561,6 @@ var _ = Describe("Imageio extents", func() {
 		Expect(err).ToNot(HaveOccurred())
 		extentsReader, err := source.getExtentsReader()
 		Expect(err).ToNot(HaveOccurred())
-		offset := extentsReader.offset
 		ticketTime := time.Now()
 		renewalTime = ticketTime
 		doneChannel := make(chan struct{}, 1)
@@ -573,7 +570,6 @@ var _ = Describe("Imageio extents", func() {
 		Expect(phase).To(Equal(ProcessingPhaseTransferDataFile))
 		go source.monitorExtentsProgress(it.MustId(), extentsReader, 1*time.Millisecond, doneChannel)
 		time.Sleep(time.Duration(pollCount) * time.Millisecond)
-		Expect(extentsReader.offset > offset).To(BeTrue())
 		Expect(renewalTime.Equal(ticketTime)).To(BeFalse())
 	})
 
@@ -582,7 +578,6 @@ var _ = Describe("Imageio extents", func() {
 		Expect(err).ToNot(HaveOccurred())
 		extentsReader, err := source.getExtentsReader()
 		Expect(err).ToNot(HaveOccurred())
-		offset := extentsReader.offset
 		ticketTime := time.Now()
 		renewalTime = ticketTime
 		doneChannel := make(chan struct{}, 1)
@@ -592,7 +587,6 @@ var _ = Describe("Imageio extents", func() {
 		Expect(phase).To(Equal(ProcessingPhaseTransferDataFile))
 		go source.monitorExtentsProgress(it.MustId(), extentsReader, 10*time.Millisecond, doneChannel)
 		source.readers.progressReader.Current++
-		Expect(extentsReader.offset > offset).To(BeTrue())
 		Expect(renewalTime.Equal(ticketTime)).To(BeTrue())
 	})
 

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/common:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/util/prometheus/BUILD.bazel
+++ b/pkg/util/prometheus/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/util:go_default_library",
         "//tests/reporters:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -207,6 +207,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		return utils.NewDataVolumeWithImageioImport(dataVolumeName, size, url, s.Name, cm, "123")
 	}
 
+	createImageIoDataVolumeNoExtents := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
+		dataVolume := createImageIoDataVolume(dataVolumeName, size, url)
+		CreateImageIoInventoryNoExtents(f)
+		return dataVolume
+	}
+
 	createImageIoWarmImportDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
 		cm, err := utils.CopyImageIOCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
 		Expect(err).To(BeNil())
@@ -812,6 +818,30 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				size:             "1Gi",
 				url:              imageioURL,
 				dvFunc:           createImageIoWarmImportDataVolume,
+				eventReason:      controller.ImportSucceeded,
+				phase:            cdiv1.Succeeded,
+				checkPermissions: true,
+				readyCondition: &cdiv1.DataVolumeCondition{
+					Type:   cdiv1.DataVolumeReady,
+					Status: v1.ConditionTrue,
+				},
+				boundCondition: &cdiv1.DataVolumeCondition{
+					Type:    cdiv1.DataVolumeBound,
+					Status:  v1.ConditionTrue,
+					Message: "PVC dv-imageio-test Bound",
+					Reason:  "Bound",
+				},
+				runningCondition: &cdiv1.DataVolumeCondition{
+					Type:    cdiv1.DataVolumeRunning,
+					Status:  v1.ConditionFalse,
+					Message: "Import Complete",
+					Reason:  "Completed",
+				}}),
+			table.Entry("[test_id:3945]succeed creating dv from imageio source that does not support extents query", dataVolumeTestArguments{
+				name:             "dv-imageio-test",
+				size:             "1Gi",
+				url:              imageioURL,
+				dvFunc:           createImageIoDataVolumeNoExtents,
 				eventReason:      controller.ImportSucceeded,
 				phase:            cdiv1.Succeeded,
 				checkPermissions: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request checks for the "extents" feature when connecting to an ImageIO data source. If the feature is available, the importer uses the ImageIO extents API to avoid copying large blocks of all-zero bytes. This should reduce raw format transfer times closer to QCOW format times, and it avoids the need to convert from a QCOW in scratch space to a raw final destination. It also attempts to punch holes in the destination to avoid writing blocks of all-zero bytes. 

**Which issue(s) this PR fixes**:
Fixes [RHBZ#1993454](https://bugzilla.redhat.com/show_bug.cgi?id=1993454)

**Special notes for your reviewer**:
Looping through extents does not really mesh well with the existing stack of readers approach, so this works by creating a new reader for each extent and adjusting the progress reader as it moves along.

**Release note**:
```release-note
Use ImageIO extents API to transfer raw images efficiently.
```

