### PR TITLE
Whitespace change to builder to trigger postsubmit job

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -26,7 +26,6 @@ RUN 	dnf -y install dnf-plugins-core && \
 	java-11-openjdk-devel \
 	&& dnf clean all
 
-
 # Necessary for Bazel to find Python inside the container
 #
 # https://github.com/bazelbuild/bazel/issues/8665


### PR DESCRIPTION
**What this PR does / why we need it**:
we failed to push an updated builder for #1982, doing a no-op change will trigger the post-submit job.
-->
```release-note
NONE
```

