### PR TITLE
[release-v1.38] Revert "Backport fix hpp tests (#2047)"

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1602,7 +1602,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 	Expect(err).To(BeNil())
 	Expect(md5Match).To(BeTrue())
 
-	if utils.DefaultStorageCSIRespectsFsGroup && sourcePvcDiskGroup != "" {
+	if utils.DefaultStorageCSI && sourcePvcDiskGroup != "" {
 		// CSI storage class, it should respect fsGroup
 		By("Checking that disk image group is qemu")
 		Expect(f.GetDiskGroup(targetNs, targetPvc, false)).To(Equal(sourcePvcDiskGroup))

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -72,4 +71,5 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high] CSI Vol
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, expectedMd5)
 	})
+
 })

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
 		By("Verifying permissions are 660")
 		Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")
-		if utils.DefaultStorageCSIRespectsFsGroup {
+		if utils.DefaultStorageCSI {
 			// CSI storage class, it should respect fsGroup
 			By("Checking that disk image group is qemu")
 			Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -130,7 +130,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(same).To(BeTrue())
 			By("Verifying the image is sparse")
 			Expect(f.VerifySparse(f.Namespace, pvc)).To(BeTrue())
-			if utils.DefaultStorageCSIRespectsFsGroup {
+			if utils.DefaultStorageCSI {
 				// CSI storage class, it should respect fsGroup
 				By("Checking that disk image group is qemu")
 				Expect(f.GetDiskGroup(f.Namespace, pvc, false)).To(Equal("107"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reverts the usage of the hpp CSI driver for this branch. The lanes in this branch have kubernetes that is older than the minimum version required by hpp with CSI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Note I hardcoded the version to 0.9.0 in ephemeral.sh since that is the last release without CSI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

