### PR TITLE
Bump timeout in DataImportCron test suite

### DIFF
--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	dataImportCronTimeout = 90 * time.Second
+	dataImportCronTimeout = 4 * time.Minute
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Locally see 90 seconds is not enough for ensuring PVCs were cleaned up in `[test_id:7406]`,
bumping the timeout to avoid flake.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

