### PR TITLE
Add alert for DataImportCron not being up to date

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -336,5 +336,5 @@ func getTokenPrivateKey() *rsa.PrivateKey {
 
 func registerMetrics() {
 	metrics.Registry.MustRegister(controller.IncompleteProfileGauge)
-	metrics.Registry.MustRegister(controller.DataImportCronNotUpToDateGauge)
+	metrics.Registry.MustRegister(controller.DataImportCronOutdatedGauge)
 }

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -336,4 +336,5 @@ func getTokenPrivateKey() *rsa.PrivateKey {
 
 func registerMetrics() {
 	metrics.Registry.MustRegister(controller.IncompleteProfileGauge)
+	metrics.Registry.MustRegister(controller.DataImportCronNotUpToDateGauge)
 }

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -88,15 +88,14 @@ func updateConditionState(condition *cdiv1.ConditionState, status corev1.Conditi
 	}
 }
 
-func updateDataImportCronFailingMetric(cron *cdiv1.DataImportCron, increment bool) {
-	upToDateCondition := FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
+func updateDataImportCronOutdatedMetric(upToDateCondition *cdiv1.DataImportCronCondition, increment bool) {
 	if increment {
 		if upToDateCondition == nil || upToDateCondition.ConditionState.Status != corev1.ConditionFalse {
-			DataImportCronNotUpToDateGauge.Inc()
+			DataImportCronOutdatedGauge.Inc()
 		}
 	} else {
 		if upToDateCondition.ConditionState.Status != corev1.ConditionTrue {
-			DataImportCronNotUpToDateGauge.Dec()
+			DataImportCronOutdatedGauge.Dec()
 		}
 	}
 }

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -87,3 +87,16 @@ func updateConditionState(condition *cdiv1.ConditionState, status corev1.Conditi
 		condition.Message = message
 	}
 }
+
+func updateDataImportCronFailingMetric(cron *cdiv1.DataImportCron, increment bool) {
+	upToDateCondition := FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
+	if increment {
+		if upToDateCondition == nil || upToDateCondition.ConditionState.Status != corev1.ConditionFalse {
+			DataImportCronNotUpToDateGauge.Inc()
+		}
+	} else {
+		if upToDateCondition.ConditionState.Status != corev1.ConditionTrue {
+			DataImportCronNotUpToDateGauge.Dec()
+		}
+	}
+}

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -88,13 +88,13 @@ func updateConditionState(condition *cdiv1.ConditionState, status corev1.Conditi
 	}
 }
 
-func updateDataImportCronOutdatedMetric(upToDateCondition *cdiv1.DataImportCronCondition, increment bool) {
+func updateDataImportCronOutdatedMetric(prevUpToDateCondition *cdiv1.DataImportCronCondition, increment bool) {
 	if increment {
-		if upToDateCondition == nil || upToDateCondition.ConditionState.Status != corev1.ConditionFalse {
+		if prevUpToDateCondition == nil || prevUpToDateCondition.ConditionState.Status != corev1.ConditionFalse {
 			DataImportCronOutdatedGauge.Inc()
 		}
 	} else {
-		if upToDateCondition.ConditionState.Status != corev1.ConditionTrue {
+		if prevUpToDateCondition.ConditionState.Status != corev1.ConditionTrue {
 			DataImportCronOutdatedGauge.Dec()
 		}
 	}

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -214,13 +214,17 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
+						generateRecordRule(
+							"kubevirt_cdi_dataimportcron_outdated_total",
+							"sum(kubevirt_cdi_dataimportcron_outdated or vector(0))",
+						),
 						generateAlertRule(
-							"CDIDataImportCronNotUpToDate",
-							"kubevirt_cdi_dataimportcron_not_up_to_date_total > 0",
+							"CDIDataImportCronOutdated",
+							"kubevirt_cdi_dataimportcron_outdated_total > 0",
 							"15m",
 							map[string]string{
 								"summary":     "DataImportCron latest imports are outdated",
-								"runbook_url": runbookURLBasePath + "CDIDataImportCronNotUpToDate",
+								"runbook_url": runbookURLBasePath + "CDIDataImportCronOutdated",
 							},
 							map[string]string{
 								severityAlertLabelKey:  "info",

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -214,6 +214,20 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
+						generateAlertRule(
+							"CDIDataImportCronNotUpToDate",
+							"kubevirt_cdi_dataimportcron_not_up_to_date_total > 0",
+							"15m",
+							map[string]string{
+								"summary":     "DataImportCron PVCs do not hold the latest OS image, disk might not contain latest OS version",
+								"runbook_url": runbookURLBasePath + "CDIDataImportCronNotUpToDate",
+							},
+							map[string]string{
+								severityAlertLabelKey:  "info",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
+							},
+						),
 					},
 				},
 			},

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -219,7 +219,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 							"kubevirt_cdi_dataimportcron_not_up_to_date_total > 0",
 							"15m",
 							map[string]string{
-								"summary":     "DataImportCron PVCs do not hold the latest OS image, disk might not contain latest OS version",
+								"summary":     "DataImportCron latest imports are outdated",
 								"runbook_url": runbookURLBasePath + "CDIDataImportCronNotUpToDate",
 							},
 							map[string]string{

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -22,25 +22,23 @@ import (
 
 const (
 	dataImportCronTimeout = 4 * time.Minute
+	scheduleEveryMinute   = "* * * * *"
+	scheduleOnceAYear     = "0 0 1 1 *"
 )
 
 var (
-	importsToKeep int32 = 1
+	importsToKeep       int32 = 1
+	registryPullNode          = cdiv1.RegistryPullNode
+	externalRegistryURL       = "docker://quay.io/kubevirt/cirros-container-disk-demo"
 )
 
 var _ = Describe("DataImportCron", func() {
-	const (
-		scheduleEveryMinute = "* * * * *"
-		scheduleOnceAYear   = "0 0 1 1 *"
-	)
 	var (
-		f                   = framework.NewFramework(namespacePrefix)
-		registryPullNode    = cdiv1.RegistryPullNode
-		trustedRegistryURL  = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
-		externalRegistryURL = "docker://quay.io/kubevirt/cirros-container-disk-demo"
-		dataSourceName      = "datasource-test"
-		cron                *cdiv1.DataImportCron
-		err                 error
+		f                  = framework.NewFramework(namespacePrefix)
+		trustedRegistryURL = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
+		dataSourceName     = "datasource-test"
+		cron               *cdiv1.DataImportCron
+		err                error
 	)
 
 	table.DescribeTable("should", func(schedule string, retentionPolicy cdiv1.DataImportCronRetentionPolicy, repeat int, checkGarbageCollection bool) {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -883,7 +883,7 @@ var _ = Describe("ALL Operator tests", func() {
 				numCrons := 2
 				retentionPolicy := cdiv1.DataImportCronRetainAll
 				trustedRegistryURL := fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix)
-				originalMetricVal := getMetricValue("kubevirt_cdi_dataimportcron_not_up_to_date_total")
+				originalMetricVal := getMetricValue("kubevirt_cdi_dataimportcron_outdated_total")
 				expectedFailingCrons := originalMetricVal + numCrons
 				if utils.IsOpenshift(f.K8sClient) {
 					url = externalRegistryURL
@@ -905,10 +905,7 @@ var _ = Describe("ALL Operator tests", func() {
 						cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Get(context.TODO(), cron.Name, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 						upToDateCondition := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
-						if upToDateCondition != nil && upToDateCondition.ConditionState.Status == corev1.ConditionTrue {
-							return true
-						}
-						return false
+						return upToDateCondition != nil && upToDateCondition.ConditionState.Status == corev1.ConditionTrue
 					}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 					Eventually(func() error {
 						cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Get(context.TODO(), cron.Name, metav1.GetOptions{})
@@ -923,16 +920,16 @@ var _ = Describe("ALL Operator tests", func() {
 					}, dataImportCronTimeout, pollingInterval).Should(BeNil())
 					By(fmt.Sprintf("Ensuring metric value incremented to %d", originalMetricVal+i))
 					Eventually(func() int {
-						return getMetricValue("kubevirt_cdi_dataimportcron_not_up_to_date_total")
-					}, 2*time.Minute, 1*time.Second).Should(BeNumerically("==", originalMetricVal+i))
+						return getMetricValue("kubevirt_cdi_dataimportcron_outdated_total")
+					}, 3*time.Minute, 1*time.Second).Should(BeNumerically("==", originalMetricVal+i))
 				}
 				By("Ensure metric value decrements when crons are cleaned up")
 				for i := 1; i < numCrons+1; i++ {
 					err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Delete(context.TODO(), fmt.Sprintf("cron-test-%d", i), metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() int {
-						return getMetricValue("kubevirt_cdi_dataimportcron_not_up_to_date_total")
-					}, 2*time.Minute, 1*time.Second).Should(BeNumerically("==", expectedFailingCrons-i))
+						return getMetricValue("kubevirt_cdi_dataimportcron_outdated_total")
+					}, 3*time.Minute, 1*time.Second).Should(BeNumerically("==", expectedFailingCrons-i))
 				}
 			})
 		})


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
DataImportCrons now have conditions (particularly UpToDate) that tell us if
things are going as planned. We can utilize those to alert whenever were not UpToDate for a while.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Alert about a DataImportCron not being up to date; possibly not using a PVC that holds latest OS
```

