### PR TITLE
On CDI delete validation ignore DVs labeled with DataImportCron

### DIFF
--- a/pkg/apiserver/webhooks/cdi-validate.go
+++ b/pkg/apiserver/webhooks/cdi-validate.go
@@ -32,6 +32,7 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiclient "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 const uninstallErrorMsg = "Rejecting the uninstall request, since there are still DataVolumes present. Either delete all DataVolumes or change the uninstall strategy before uninstalling CDI."
@@ -64,7 +65,7 @@ func (wh *cdiValidatingWebhook) Admit(ar admissionv1.AdmissionReview) *admission
 	}
 
 	if cdi.Spec.UninstallStrategy != nil && *cdi.Spec.UninstallStrategy == cdiv1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist {
-		dvs, err := wh.client.CdiV1beta1().DataVolumes(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{Limit: 2})
+		dvs, err := wh.client.CdiV1beta1().DataVolumes(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{Limit: 2, LabelSelector: "!" + common.DataImportCronLabel})
 		if err != nil {
 			return toAdmissionResponseError(err)
 		}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -41,6 +41,9 @@ const (
 	// UploadTargetLabel has the UID of upload target PVC
 	UploadTargetLabel = CDIComponentLabel + "/uploadTarget"
 
+	// DataImportCronLabel has the name of the DataImportCron responsible for the labeled DataSource or DataVolume
+	DataImportCronLabel = CDIComponentLabel + "/dataImportCron"
+
 	// ImporterVolumePath provides a constant for the directory where the PV is mounted.
 	ImporterVolumePath = "/data"
 	// DiskImageName provides a constant for our importer/datastream_ginkgo_test and to build ImporterWritePath

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -75,7 +75,6 @@ const (
 	dataImportCronFinalizer = "cdi.kubevirt.io/dataImportCronFinalizer"
 
 	dataImportControllerName    = "dataimportcron-controller"
-	labelDataImportCronName     = "dataimportcron-name"
 	digestPrefix                = "sha256:"
 	digestDvNameSuffixLength    = 12
 	cronJobUIDSuffixLength      = 8
@@ -318,7 +317,7 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 	}
 	dataSourceCopy := dataSource.DeepCopy()
 	util.SetRecommendedLabels(dataSource, r.installerLabels, common.CDIControllerName)
-	dataSource.Labels[labelDataImportCronName] = dataImportCron.Name
+	dataSource.Labels[common.DataImportCronLabel] = dataImportCron.Name
 
 	sourcePVC := dataImportCron.Status.LastImportedPVC
 	if sourcePVC != nil {
@@ -394,7 +393,7 @@ func (r *DataImportCronReconciler) deleteOldImports(ctx context.Context, dataImp
 	log := r.log.WithName("deleteOldImports")
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			labelDataImportCronName: dataImportCron.Name,
+			common.DataImportCronLabel: dataImportCron.Name,
 		},
 	})
 	if err != nil {
@@ -493,7 +492,7 @@ func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Contro
 	}
 
 	getCronName := func(obj client.Object) string {
-		return obj.GetLabels()[labelDataImportCronName]
+		return obj.GetLabels()[common.DataImportCronLabel]
 	}
 	mapToCron := func(obj client.Object) []reconcile.Request {
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: getCronName(obj), Namespace: obj.GetNamespace()}}}
@@ -677,7 +676,7 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	dv.Name = dataVolumeName
 	dv.Namespace = cron.Namespace
 	util.SetRecommendedLabels(dv, r.installerLabels, common.CDIControllerName)
-	dv.Labels[labelDataImportCronName] = cron.Name
+	dv.Labels[common.DataImportCronLabel] = cron.Name
 	passCronAnnotationToDv(cron, dv, AnnImmediateBinding)
 	passCronAnnotationToDv(cron, dv, AnnPodRetainAfterCompletion)
 	return dv

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -417,12 +417,20 @@ var _ = Describe("ALL Operator tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
 
+				By("Creating datavolume with DataImportCron label")
+				dv = utils.NewDataVolumeForUpload("retain-me", "1Gi")
+				dv.Labels = map[string]string{common.DataImportCronLabel: "dic"}
+				dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+				Expect(err).ToNot(HaveOccurred())
+				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
+
 				By("Cannot delete CDI")
 				err = f.CdiClient.CdiV1beta1().CDIs().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("there are still DataVolumes present"))
 
-				err = f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Delete(context.TODO(), dv.Name, metav1.DeleteOptions{})
+				By("Delete the unlabeled datavolume")
+				err = f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Delete(context.TODO(), "delete-me", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Can delete CDI")


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
`DataImportCron` `RetentionPolicy` specifies whether the created `DataVolumes` and `DataSources` are retained when their `DataImportCron` is deleted. Default is `RetainAll`. However, when CDI delete validation finds existing DVs, it fails (if `UninstallStrategy` is `cdiv1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist`). Therefore, on CDI delete validation we are now ignoring DVs labeled with `DataImportCron` so it won't fail if they are the only existing DVs.

**Release note**:
```release-note
NONE
```

