### PR TITLE
Allow http in s3 datasource

### DIFF
--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -68,7 +68,6 @@ var _ = Describe("S3 data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
-		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = file
 		result, err := sd.Info()
 		Expect(err).To(HaveOccurred())
@@ -81,7 +80,6 @@ var _ = Describe("S3 data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
-		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = file
 		result, err := sd.Info()
 		Expect(err).NotTo(HaveOccurred())
@@ -94,7 +92,6 @@ var _ = Describe("S3 data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
-		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = file
 		result, err := sd.Info()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are using the AWS s3 client, and if the URL we pass in starts with http, the AddScheme function in the AWS S3 client replaces the scheme with https. This checks the URL scheme and if it is http, it disables TLS, which causes the AWS S3 client to set the scheme internally as http.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2067 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Allow http endpoints with s3 import.
```

