### PR TITLE
update builder golang to 1.17 remove kubebuilder

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -36,5 +36,3 @@ if ! git diff-index --quiet HEAD~1 hack/build/docker; then
 
   docker push ${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG}
 fi
-
-

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -1,14 +1,20 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.fedoraproject.org/fedora-minimal:33
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
-RUN 	dnf -y install dnf-plugins-core && \
-	dnf config-manager --set-enable crb && dnf update -y && \
-	dnf install -y \
+COPY fedora.repo /tmp/fedora_ci.dnf.repo
+
+RUN sed -i 's/proxy = None//gI' /tmp/fedora_ci.dnf.repo && \
+	cat /tmp/fedora_ci.dnf.repo && \
+	mkdir /etc/yum.repos.d/old && \
+	mv /etc/yum.repos.d/*.repo /etc/yum.repos.d/old  && \
+	mv /tmp/fedora_ci.dnf.repo /etc/yum.repos.d/fedora.repo && \
+	microdnf update -y && microdnf install -y \
 	cpio \
 	diffutils \
 	git \
 	python3-pip \
 	python3-devel \
+	mercurial \
 	gcc \
 	gcc-c++ \
 	glibc-devel \
@@ -24,41 +30,35 @@ RUN 	dnf -y install dnf-plugins-core && \
 	nbdkit-devel \
 	unzip \
 	java-11-openjdk-devel \
-	&& dnf clean all
-
-# Necessary for Bazel to find Python inside the container
-#
-# https://github.com/bazelbuild/bazel/issues/8665
-# https://github.com/bazelbuild/bazel/issues/11554
-RUN ln -s /usr/bin/python3 /usr/bin/python
+	btrfs-progs-devel \
+	device-mapper-devel \
+	&& microdnf clean all && \
+	mv /etc/yum.repos.d/old/* /etc/yum.repos.d/ && \
+	rmdir /etc/yum.repos.d/old
 
 RUN pip3 install --upgrade j2cli operator-courier==2.1.11 && \
-    curl -sL https://services.gradle.org/distributions/gradle-6.6-bin.zip -o gradle-6.6-bin.zip && \
-    mkdir /opt/gradle && \
-    unzip -d /opt/gradle gradle-6.6-bin.zip && \
-    ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
-    rm gradle-6.6-bin.zip
+	curl -sL https://services.gradle.org/distributions/gradle-6.6-bin.zip -o gradle-6.6-bin.zip && \
+	mkdir /opt/gradle && \
+	unzip -d /opt/gradle gradle-6.6-bin.zip && \
+	ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
+	rm gradle-6.6-bin.zip
 
-ENV GIMME_GO_VERSION=1.16.6 GOPATH="/go" KUBEBUILDER_VERSION="2.3.2" ARCH="amd64" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.17.5 GOPATH="/go" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 
 RUN \
-    source /etc/profile.d/gimme.sh && \
-    eval $(go env) && \
-    go get github.com/onsi/ginkgo/ginkgo && \
-    go get golang.org/x/tools/cmd/goimports && \
-    go get mvdan.cc/sh/cmd/shfmt && \
-    go get github.com/mattn/goveralls && \
-    go get -u golang.org/x/lint/golint && \
-    go get github.com/rmohr/go-swagger-utils/swagger-doc && \
-    go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 && \
-    go get github.com/securego/gosec/v2/cmd/gosec@0ce48a5 && \
-    rm -rf "${GOPATH}/pkg" && \
-    (curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz" && \
-     tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz && \
-     mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH} /usr/local/kubebuilder && \
-     rm kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz )
+	source /etc/profile.d/gimme.sh && \
+	eval $(go env) && \
+	go install github.com/onsi/ginkgo/ginkgo@v1.14.1 && \
+	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install mvdan.cc/sh/cmd/shfmt@latest && \
+	go install github.com/mattn/goveralls@latest && \
+	go install golang.org/x/lint/golint@latest && \
+	go install github.com/rmohr/go-swagger-utils/swagger-doc@latest && \
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 && \
+	go install github.com/securego/gosec/v2/cmd/gosec@0ce48a5 && \
+	rm -rf "${GOPATH}/pkg"
 
 ENV BAZEL_VERSION 3.7.2
 

--- a/hack/build/docker/builder/fedora.repo
+++ b/hack/build/docker/builder/fedora.repo
@@ -1,0 +1,40 @@
+[fedora-base-fc31]
+clean_requirements_on_remove=True
+tsflags=nodocs
+name=Fedora $releasever - $basearch
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-updates-fc31]
+clean_requirements_on_remove=True
+tsflags=nodocs
+name=Fedora $releasever - $basearch - Updates
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[copr:copr.fedorainfracloud.org:vbatts:bazel]
+name=Copr repo for bazel owned by vbatts
+baseurl=https://copr-be.cloud.fedoraproject.org/results/vbatts/bazel/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/vbatts/bazel/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

1.17 needed for k8s 1.23 libs.  kubebuilder binaries removed because they were changed and IMO not needed for unit tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update golang in builder image
```

