### PR TITLE
Update relationship labels on missed ConfigMap

### DIFF
--- a/cmd/cdi-controller/leaderelection.go
+++ b/cmd/cdi-controller/leaderelection.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	configMapName = "cdi-controller-leader-election-helper"
+	configMapName = common.CDIControllerLeaderElectionHelperName
 	componentName = "cdi-controller"
 )
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -246,6 +246,9 @@ const (
 
 	// UnusualRestartCountThreshold is the number of pod restarts that we consider unusual and would like to alert about
 	UnusualRestartCountThreshold = 3
+
+	// CDIControllerLeaderElectionHelperName is the name of the configmap that is used as a helper for controller leader election
+	CDIControllerLeaderElectionHelperName = "cdi-controller-leader-election-helper"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -250,6 +250,12 @@ func reconcileRemainingRelationshipLabels(args *callbacks.ReconcileCallbackArgs)
 				Namespace: namespace,
 			},
 		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.CDIControllerLeaderElectionHelperName,
+				Namespace: namespace,
+			},
+		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      apiserver.APISigningKeySecretName,


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This one was missed in #2018, we want to maintain its label values on update as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

