### PR TITLE
[release-v1.38] Manual cherrypick 2082

### DIFF
--- a/cmd/cdi-controller/leaderelection.go
+++ b/cmd/cdi-controller/leaderelection.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	configMapName = "cdi-controller-leader-election-helper"
+	configMapName = common.CDIControllerLeaderElectionHelperName
 	componentName = "cdi-controller"
 )
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -212,6 +212,9 @@ const (
 
 	// PreallocationApplied is a string inserted into importer's/uploader's exit message
 	PreallocationApplied = "Preallocation applied"
+
+	// CDIControllerLeaderElectionHelperName is the name of the configmap that is used as a helper for controller leader election
+	CDIControllerLeaderElectionHelperName = "cdi-controller-leader-election-helper"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -250,6 +250,12 @@ func reconcileRemainingRelationshipLabels(args *callbacks.ReconcileCallbackArgs)
 				Namespace: namespace,
 			},
 		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.CDIControllerLeaderElectionHelperName,
+				Namespace: namespace,
+			},
+		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      apiserver.APISigningKeySecretName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual backport of #2082, we want this single (missed in #2018) resource to also get labeled on update in the previous release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2017478

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Some of the cdi resources are missing labels after upgrade
```

