### PR TITLE
Update DataSource Ready condition on DV update

### DIFF
--- a/pkg/controller/datasource-controller.go
+++ b/pkg/controller/datasource-controller.go
@@ -30,8 +30,10 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -126,39 +128,72 @@ func NewDataSourceController(mgr manager.Manager, log logr.Logger, installerLabe
 	if err != nil {
 		return nil, err
 	}
-	if err := addDataSourceControllerWatches(mgr, DataSourceController, log); err != nil {
+	if err := addDataSourceControllerWatches(mgr, DataSourceController); err != nil {
 		return nil, err
 	}
 	log.Info("Initialized DataSource controller")
 	return DataSourceController, nil
 }
 
-func addDataSourceControllerWatches(mgr manager.Manager, c controller.Controller, log logr.Logger) error {
+func addDataSourceControllerWatches(mgr manager.Manager, c controller.Controller) error {
 	if err := cdiv1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
-	if err := c.Watch(&source.Kind{Type: &cdiv1.DataSource{}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(&source.Kind{Type: &cdiv1.DataSource{}}, &handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool { return true },
+			DeleteFunc: func(e event.DeleteEvent) bool { return true },
+			UpdateFunc: func(e event.UpdateEvent) bool { return !sameDataSourcePvc(e.ObjectOld, e.ObjectNew) },
+		},
+	); err != nil {
 		return err
 	}
 
-	mapToDataSource := func(obj client.Object) []reconcile.Request {
-		var reqs []reconcile.Request
-		dsList := &cdiv1.DataSourceList{}
-		if err := mgr.GetClient().List(context.TODO(), dsList, &client.ListOptions{}); err != nil {
-			return nil
-		}
-		for _, ds := range dsList.Items {
-			pvc := ds.Spec.Source.PVC
-			if pvc != nil && pvc.Name == obj.GetName() && pvc.Namespace == obj.GetNamespace() {
-				reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}})
-			}
-		}
-		return reqs
+	const dataSourcePvcField = "spec.source.pvc"
+
+	getKey := func(namespace, name string) string {
+		return namespace + "." + name
 	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &cdiv1.DataSource{}, dataSourcePvcField, func(obj client.Object) []string {
+		if pvc := obj.(*cdiv1.DataSource).Spec.Source.PVC; pvc != nil {
+			return []string{getKey(pvc.Namespace, pvc.Name)}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	mapToDataSource := func(obj client.Object) (reqs []reconcile.Request) {
+		var dataSources cdiv1.DataSourceList
+		matchingFields := client.MatchingFields{dataSourcePvcField: getKey(obj.GetNamespace(), obj.GetName())}
+		mgr.GetClient().List(context.TODO(), &dataSources, matchingFields)
+		for _, ds := range dataSources.Items {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}})
+		}
+		return
+	}
+
 	if err := c.Watch(&source.Kind{Type: &cdiv1.DataVolume{}},
 		handler.EnqueueRequestsFromMapFunc(mapToDataSource),
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool { return true },
+			DeleteFunc: func(e event.DeleteEvent) bool { return true },
+			// Only DV status phase update is interesting to reconcile
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				dvOld, okOld := e.ObjectOld.(*cdiv1.DataVolume)
+				dvNew, okNew := e.ObjectNew.(*cdiv1.DataVolume)
+				return okOld && okNew && dvOld.Status.Phase != dvNew.Status.Phase
+			},
+		},
 	); err != nil {
 		return err
 	}
 	return nil
+}
+
+func sameDataSourcePvc(objOld, objNew client.Object) bool {
+	dsOld, okOld := objOld.(*cdiv1.DataSource)
+	dsNew, okNew := objNew.(*cdiv1.DataSource)
+	return okOld && okNew && reflect.DeepEqual(dsOld.Spec.Source.PVC, dsNew.Spec.Source.PVC)
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "cloner_test.go",
         "csiclone_test.go",
         "dataimportcron_test.go",
+        "datasource_test.go",
         "datavolume_test.go",
         "explain_test.go",
         "import_proxy_test.go",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//vendor/github.com/openshift/custom-resource-status/conditions/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -3,6 +3,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,12 +17,17 @@ import (
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
 
-var _ = FDescribe("DataSource", func() {
-	const dsName = "ds-test"
-	const pvcName = "pvc-test"
+var _ = Describe("DataSource", func() {
+	const (
+		ds1Name  = "ds1"
+		ds2Name  = "ds2"
+		pvc1Name = "pvc1"
+		pvc2Name = "pvc2"
+	)
+
 	f := framework.NewFramework("datasource-func-test")
 
-	newDataSource := func() *cdiv1.DataSource {
+	newDataSource := func(dsName string) *cdiv1.DataSource {
 		return &cdiv1.DataSource{
 			TypeMeta: metav1.TypeMeta{APIVersion: cdiv1.SchemeGroupVersion.String()},
 			ObjectMeta: metav1.ObjectMeta{
@@ -31,50 +37,96 @@ var _ = FDescribe("DataSource", func() {
 		}
 	}
 
-	waitForReadyCondition := func(status corev1.ConditionStatus, reason string) (ds *cdiv1.DataSource) {
-		By(fmt.Sprintf("wait for ready condition: %s, %s", status, reason))
+	waitForReadyCondition := func(ds *cdiv1.DataSource, status corev1.ConditionStatus, reason string) *cdiv1.DataSource {
+		By(fmt.Sprintf("wait for DataSource %s ready condition: %s, %s", ds.Name, status, reason))
 		Eventually(func() bool {
 			var err error
-			ds, err = f.CdiClient.CdiV1beta1().DataSources(f.Namespace.Name).Get(context.TODO(), dsName, metav1.GetOptions{})
+			ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Get(context.TODO(), ds.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			cond := controller.FindDataSourceConditionByType(ds, cdiv1.DataSourceReady)
 			if cond != nil {
 				By(fmt.Sprintf("condition state: %s, %s", cond.Status, cond.Reason))
 			}
 			return cond != nil && cond.Status == status && cond.Reason == reason
-		}, timeout, pollingInterval).Should(BeTrue())
-		return
+		}, 60*time.Second, pollingInterval).Should(BeTrue())
+		return ds
 	}
 
-	It("[test_id:8041]status conditions should be updated on pvc create/update/delete", func() {
-		By("creating datasource")
-		ds := newDataSource()
-		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		ds = waitForReadyCondition(corev1.ConditionFalse, "NoPvc")
-
-		dv := utils.NewDataVolumeWithHTTPImport(pvcName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
-		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvcName}
-		ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		ds = waitForReadyCondition(corev1.ConditionFalse, "NotFound")
-
-		By("creating datavolume")
-		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+	testUrl := func() string { return fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs) }
+	createDv := func(pvcName, url string) {
+		By(fmt.Sprintf("creating DataVolume %s %s", pvcName, url))
+		dv := utils.NewDataVolumeWithHTTPImport(pvcName, "1Gi", url)
+		dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
 		By("verifying pvc was created")
 		pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindIfWaitForFirstConsumer(pvc)
-		ds = waitForReadyCondition(corev1.ConditionTrue, "Ready")
+	}
 
-		err = utils.DeleteDataVolume(f.CdiClient, dv.Namespace, dv.Name)
+	It("[test_id:8041]status conditions should be updated on pvc create/update/delete", func() {
+		By("creating datasource")
+		ds := newDataSource(ds1Name)
+		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		ds = waitForReadyCondition(corev1.ConditionFalse, "NotFound")
+		ds = waitForReadyCondition(ds, corev1.ConditionFalse, "NoPvc")
+
+		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvc1Name}
+		ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(ds, corev1.ConditionFalse, "NotFound")
+
+		createDv(pvc1Name, testUrl())
+		ds = waitForReadyCondition(ds, corev1.ConditionTrue, "Ready")
+
+		err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, pvc1Name)
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(ds, corev1.ConditionFalse, "NotFound")
 
 		ds.Spec.Source.PVC = nil
 		ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		ds = waitForReadyCondition(corev1.ConditionFalse, "NoPvc")
+		ds = waitForReadyCondition(ds, corev1.ConditionFalse, "NoPvc")
+	})
+
+	createDs := func(dsName, pvcName string) *cdiv1.DataSource {
+		By(fmt.Sprintf("creating DataSource %s -> %s", dsName, pvcName))
+		ds := newDataSource(dsName)
+		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvcName}
+		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return waitForReadyCondition(ds, corev1.ConditionTrue, "Ready")
+	}
+
+	updateDsPvc := func(ds *cdiv1.DataSource, pvcName string) {
+		By(fmt.Sprintf("updating DataSource %s -> %s", ds.Name, pvcName))
+		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvcName}
+		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	It("[test_id:8067]status conditions should be updated when several DataSources refer the same pvc", func() {
+		createDv(pvc1Name, testUrl())
+		ds1 := createDs(ds1Name, pvc1Name)
+		ds2 := createDs(ds2Name, pvc1Name)
+
+		ds1 = waitForReadyCondition(ds1, corev1.ConditionTrue, "Ready")
+		ds2 = waitForReadyCondition(ds2, corev1.ConditionTrue, "Ready")
+
+		err := utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, pvc1Name)
+		Expect(err).ToNot(HaveOccurred())
+		ds1 = waitForReadyCondition(ds1, corev1.ConditionFalse, "NotFound")
+		ds2 = waitForReadyCondition(ds2, corev1.ConditionFalse, "NotFound")
+
+		createDv(pvc2Name, testUrl()+"bad")
+		updateDsPvc(ds1, pvc2Name)
+		updateDsPvc(ds2, pvc2Name)
+		ds1 = waitForReadyCondition(ds1, corev1.ConditionFalse, "ImportInProgress")
+		ds2 = waitForReadyCondition(ds2, corev1.ConditionFalse, "ImportInProgress")
+
+		err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, pvc2Name)
+		Expect(err).ToNot(HaveOccurred())
+		ds1 = waitForReadyCondition(ds1, corev1.ConditionFalse, "NotFound")
+		ds2 = waitForReadyCondition(ds2, corev1.ConditionFalse, "NotFound")
 	})
 })

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -1,0 +1,80 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var _ = FDescribe("DataSource", func() {
+	const dsName = "ds-test"
+	const pvcName = "pvc-test"
+	f := framework.NewFramework("datasource-func-test")
+
+	newDataSource := func() *cdiv1.DataSource {
+		return &cdiv1.DataSource{
+			TypeMeta: metav1.TypeMeta{APIVersion: cdiv1.SchemeGroupVersion.String()},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dsName,
+				Namespace: f.Namespace.Name,
+			},
+		}
+	}
+
+	waitForReadyCondition := func(status corev1.ConditionStatus, reason string) (ds *cdiv1.DataSource) {
+		By(fmt.Sprintf("wait for ready condition: %s, %s", status, reason))
+		Eventually(func() bool {
+			var err error
+			ds, err = f.CdiClient.CdiV1beta1().DataSources(f.Namespace.Name).Get(context.TODO(), dsName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			cond := controller.FindDataSourceConditionByType(ds, cdiv1.DataSourceReady)
+			if cond != nil {
+				By(fmt.Sprintf("condition state: %s, %s", cond.Status, cond.Reason))
+			}
+			return cond != nil && cond.Status == status && cond.Reason == reason
+		}, timeout, pollingInterval).Should(BeTrue())
+		return
+	}
+
+	It("[test_id:8041]status conditions should be updated on pvc create/update/delete", func() {
+		By("creating datasource")
+		ds := newDataSource()
+		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(corev1.ConditionFalse, "NoPvc")
+
+		dv := utils.NewDataVolumeWithHTTPImport(pvcName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
+		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvcName}
+		ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(corev1.ConditionFalse, "NotFound")
+
+		By("creating datavolume")
+		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+		Expect(err).ToNot(HaveOccurred())
+		By("verifying pvc was created")
+		pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
+		Expect(err).ToNot(HaveOccurred())
+		f.ForceBindIfWaitForFirstConsumer(pvc)
+		ds = waitForReadyCondition(corev1.ConditionTrue, "Ready")
+
+		err = utils.DeleteDataVolume(f.CdiClient, dv.Namespace, dv.Name)
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(corev1.ConditionFalse, "NotFound")
+
+		ds.Spec.Source.PVC = nil
+		ds, err = f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		ds = waitForReadyCondition(corev1.ConditionFalse, "NoPvc")
+	})
+})

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -100,7 +100,7 @@ var _ = Describe("DataSource", func() {
 
 	updateDsPvc := func(ds *cdiv1.DataSource, pvcName string) {
 		By(fmt.Sprintf("updating DataSource %s -> %s", ds.Name, pvcName))
-		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: f.Namespace.Name, Name: pvcName}
+		ds.Spec.Source.PVC = &cdiv1.DataVolumeSourcePVC{Namespace: "", Name: pvcName}
 		ds, err := f.CdiClient.CdiV1beta1().DataSources(ds.Namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Added the DataSource controller a DV watch, so whenever a DataSource
referred DV/PVC is created/updated/deleted, the DataSource Ready status
condition is updated accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

