### PR TITLE
BugId: 2038679 -  Clone with volume mode file system using Storage API fails

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -253,7 +253,7 @@ func createBlankImage(imageSize string, availableDestSpace int64, preallocation 
 
 	var err error
 	if volumeMode == v1.PersistentVolumeFilesystem {
-		quantityWithFSOverhead := importer.GetUsableSpace(filesystemOverhead, minSizeQuantity.Value())
+		quantityWithFSOverhead := util.GetUsableSpace(filesystemOverhead, minSizeQuantity.Value())
 		klog.Infof("Space adjusted for filesystem overhead: %d.\n", quantityWithFSOverhead)
 		err = image.CreateBlankImage(common.ImporterWritePath, *resource.NewScaledQuantity(quantityWithFSOverhead, 0), preallocation)
 	} else if volumeMode == v1.PersistentVolumeBlock && preallocation {

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1654,7 +1654,7 @@ func (r *DatavolumeReconciler) calculateUsableSpace(srcStorageClass *storagev1.S
 			return resource.Quantity{}, err
 		}
 		fsOverheadFloat, _ := strconv.ParseFloat(string(fsOverhead), 64)
-		usableSpace := GetUsableSpace(fsOverheadFloat, srcRequest.Value())
+		usableSpace := util.GetUsableSpace(fsOverheadFloat, srcRequest.Value())
 
 		return *resource.NewScaledQuantity(usableSpace, 0), nil
 	}
@@ -2509,13 +2509,4 @@ func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
 
 func newLongTermCloneTokenGenerator(key *rsa.PrivateKey) token.Generator {
 	return token.NewGenerator(common.ExtendedCloneTokenIssuer, key, 10*365*24*time.Hour)
-}
-
-// GetUsableSpace calculates space to use taking file system overhead into account
-func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	// +1 always rounds up.
-	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
-	// qemu-img will round up, making us use more than the usable space.
-	// This later conflicts with image size validation.
-	return util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
 }

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -174,6 +174,7 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 		}
 		if err = ValidateCanCloneSourceAndTargetSpec(&source.Spec, &pvc.Spec, contentType); err != nil {
 			log.Error(err, "Error validating clone spec, ignoring")
+			r.recorder.Eventf(pvc, corev1.EventTypeWarning, ErrIncompatiblePVC, err.Error())
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -214,6 +214,11 @@ func getRequestedImageSize(pvc *v1.PersistentVolumeClaim) (string, error) {
 	return pvcSize.String(), nil
 }
 
+// GetVolumeMode returns the volumeMode from PVC handling default empty value
+func GetVolumeMode(pvc *v1.PersistentVolumeClaim) v1.PersistentVolumeMode {
+	return getVolumeMode(pvc)
+}
+
 // returns the volumeMode from PVC handling default empty value
 func getVolumeMode(pvc *v1.PersistentVolumeClaim) v1.PersistentVolumeMode {
 	return resolveVolumeMode(pvc.Spec.VolumeMode)

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -18,7 +18,6 @@ package importer
 
 import (
 	"fmt"
-	"math"
 	"net/url"
 	"os"
 
@@ -412,16 +411,7 @@ func (dp *DataProcessor) PreallocationApplied() bool {
 }
 
 func (dp *DataProcessor) getUsableSpace() int64 {
-	return GetUsableSpace(dp.filesystemOverhead, dp.availableSpace)
-}
-
-// GetUsableSpace calculates space to use taking file system overhead into account
-func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	// +1 always rounds up.
-	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
-	// qemu-img will round up, making us use more than the usable space.
-	// This later conflicts with image size validation.
-	return util.RoundDown(spaceWithOverhead, util.DefaultAlignBlockSize)
+	return util.GetUsableSpace(dp.filesystemOverhead, dp.availableSpace)
 }
 
 // Rebase and commit a delta image to its backing file

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 
 	"kubevirt.io/containerized-data-importer/pkg/image"
-	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 type fakeInfoOpRetVal struct {
@@ -330,38 +329,6 @@ var _ = Describe("Data Processor", func() {
 		table.Entry("ImageIO base copy", &ImageioDataSource{currentSnapshot: "123", previousSnapshot: ""}, true),
 		table.Entry("VDDK delta copy", &VDDKDataSource{CurrentSnapshot: "123", PreviousSnapshot: "123"}, false),
 		table.Entry("VDDK base copy", &VDDKDataSource{CurrentSnapshot: "123", PreviousSnapshot: ""}, true),
-	)
-
-	const (
-		Mi              = int64(1024 * 1024)
-		Gi              = 1024 * Mi
-		noOverhead      = float64(0)
-		defaultOverhead = float64(0.055)
-		largeOverhead   = float64(0.75)
-	)
-	table.DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {
-		for i := int64(virtualSize - 1024); i < virtualSize+1024; i++ {
-			// Requested space is virtualSize rounded up to 1Mi alignment / (1 - overhead) rounded up
-			requestedSpace := int64(float64(util.RoundUp(i, util.DefaultAlignBlockSize)+1) / float64(1-overhead))
-			if i <= virtualSize {
-				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize))
-			} else {
-				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize + Mi))
-			}
-		}
-	},
-		table.Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
-		table.Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
-		table.Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
-		table.Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
-		table.Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
-		table.Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
-		table.Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
-		table.Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
-		table.Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
-		table.Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
-		table.Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
-		table.Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
 	)
 })
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -430,3 +430,12 @@ func AppendZeroWithWrite(outFile *os.File, start, length int64) error {
 	}
 	return nil
 }
+
+// GetUsableSpace calculates space to use taking file system overhead into account
+func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
+	// +1 always rounds up.
+	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
+	// qemu-img will round up, making us use more than the usable space.
+	// This later conflicts with image size validation.
+	return RoundDown(spaceWithOverhead, DefaultAlignBlockSize)
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -225,3 +225,37 @@ var _ = Describe("Zero out ranges in files", func() {
 		table.Entry("using write", AppendZeroWithWrite),
 	)
 })
+var _ = Describe("Usable Space calculation", func() {
+
+	const (
+		Mi              = int64(1024 * 1024)
+		Gi              = 1024 * Mi
+		noOverhead      = float64(0)
+		defaultOverhead = float64(0.055)
+		largeOverhead   = float64(0.75)
+	)
+	table.DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {
+		for i := int64(virtualSize - 1024); i < virtualSize+1024; i++ {
+			// Requested space is virtualSize rounded up to 1Mi alignment / (1 - overhead) rounded up
+			requestedSpace := int64(float64(RoundUp(i, DefaultAlignBlockSize)+1) / float64(1-overhead))
+			if i <= virtualSize {
+				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize))
+			} else {
+				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize + Mi))
+			}
+		}
+	},
+		table.Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
+		table.Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
+		table.Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
+		table.Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
+		table.Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
+		table.Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
+		table.Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
+		table.Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
+		table.Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
+		table.Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
+		table.Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
+		table.Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
+	)
+})

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -517,12 +517,11 @@ var _ = Describe("all clone tests", func() {
 			})
 
 			It("[rfe_id:1126][crit:High][vendor:cnv-qe@redhat.com][level:component] Should fail with Event when cloning into a smaller sized data volume", func() {
-				By("Creating a source from a real image") // todo fs....
+				By("Creating a source from a real image")
 				sourceDv := utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 				filesystem := v1.PersistentVolumeFilesystem
 				sourceDv.Spec.PVC.VolumeMode = &filesystem
 				sourceDv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
-				fmt.Fprintf(GinkgoWriter, "sourceDv %v", sourceDv)
 
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
@@ -536,7 +535,6 @@ var _ = Describe("all clone tests", func() {
 					sourceDv.Name,
 					sourceDv.Spec.PVC.StorageClassName,
 					sourceDv.Spec.PVC.VolumeMode)
-				fmt.Fprintf(GinkgoWriter, "targetDv %v", targetDv)
 
 				targetDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 				Expect(err).ToNot(HaveOccurred())
@@ -884,7 +882,7 @@ var _ = Describe("all clone tests", func() {
 		})
 
 		It("[rfe_id:1126][test_id:1896][crit:High][vendor:cnv-qe@redhat.com][level:component] Should not allow cloning into a smaller sized data volume", func() {
-			By("Creating a source from a real image") // todo fs....
+			By("Creating a source from a real image")
 			sourceDv = utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 			filesystem := v1.PersistentVolumeFilesystem
 			sourceDv.Spec.PVC.VolumeMode = &filesystem

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -61,7 +61,7 @@ func (f *Framework) ForceBindPvcIfDvIsWaitForFirstConsumer(dv *cdiv1.DataVolume)
 	fmt.Fprintf(ginkgo.GinkgoWriter, "verifying pvc was created for dv %s\n", dv.Name)
 	// FIXME: #1210, brybacki, tomob this code assumes dvname = pvcname needs to be fixed,
 	pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "PVC should exist")
 	if f.IsBindingModeWaitForFirstConsumer(pvc.Spec.StorageClassName) {
 		err = utils.WaitForDataVolumePhase(f.CdiClient, dv.Namespace, cdiv1.WaitForFirstConsumer, dv.Name)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -444,6 +444,41 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 	return dv
 }
 
+// NewDataVolumeForImageCloningAndStorageSpec initializes a DataVolume struct with spec.storage for cloning disk image
+func NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
+	storageSpec := &cdiv1.StorageSpec{
+		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+		Resources: k8sv1.ResourceRequirements{
+			Requests: k8sv1.ResourceList{
+				k8sv1.ResourceStorage: resource.MustParse(size),
+			},
+		},
+	}
+
+	dv := &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        dataVolumeName,
+			Annotations: map[string]string{},
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			Source: &cdiv1.DataVolumeSource{
+				PVC: &cdiv1.DataVolumeSourcePVC{
+					Namespace: namespace,
+					Name:      pvcName,
+				},
+			},
+			Storage: storageSpec,
+		},
+	}
+	if volumeMode != nil {
+		dv.Spec.Storage.VolumeMode = volumeMode
+	}
+	if storageClassName != nil {
+		dv.Spec.Storage.StorageClassName = storageClassName
+	}
+	return dv
+}
+
 // NewDataVolumeWithRegistryImport initializes a DataVolume struct with registry annotations
 func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registryURL string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -580,15 +580,18 @@ func WaitForDataVolumePhase(clientSet *cdiclientset.Clientset, namespace string,
 
 // WaitForDataVolumePhaseWithTimeout waits for DV's phase to be in a particular phase (Pending, Bound, or Lost) with a specified timeout
 func WaitForDataVolumePhaseWithTimeout(clientSet *cdiclientset.Clientset, namespace string, phase cdiv1.DataVolumePhase, dataVolumeName string, timeout time.Duration) error {
+	var actualPhase cdiv1.DataVolumePhase
+
 	err := wait.PollImmediate(dataVolumePollInterval, timeout, func() (bool, error) {
 		dataVolume, err := clientSet.CdiV1beta1().DataVolumes(namespace).Get(context.TODO(), dataVolumeName, metav1.GetOptions{})
 		if err != nil || dataVolume.Status.Phase != phase {
+			actualPhase = dataVolume.Status.Phase
 			return false, err
 		}
 		return true, nil
 	})
 	if err != nil {
-		return fmt.Errorf("DataVolume %s not in phase %s within %v", dataVolumeName, phase, timeout)
+		return fmt.Errorf("DataVolume %s not in phase %s within %v, actual phase=%s", dataVolumeName, phase, timeout, actualPhase)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a problem with validation webhook failing for a clone that should succeed.

Validation webhook compares real PVC size of source volume with the requested size on spec.storage. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2038679

**Special notes for your reviewer**:
Still experimenting 
**Release note**:

```release-note
NONE
```

