### PR TITLE
Delete CRDs & check finalizers in operator delete

### DIFF
--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -82,11 +82,11 @@ func reconcileDeleteControllerDeployment(args *callbacks.ReconcileCallbackArgs) 
 	args.Logger.Info("Deleting CRDs and verifing no finalizers")
 
 	crd := &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "dataimportcrons.cdi.kubevirt.io"}}
-	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); cdicontroller.IgnoreNotFound(err) != nil {
 		return err
 	}
 	dics := &cdiv1.DataImportCronList{}
-	if err := args.Client.List(context.TODO(), dics, &client.ListOptions{}); err != nil && !errors.IsNotFound(err) {
+	if err := args.Client.List(context.TODO(), dics, &client.ListOptions{}); cdicontroller.IgnoreIsNoMatchError(err) != nil {
 		return err
 	}
 	for _, dic := range dics.Items {
@@ -96,11 +96,11 @@ func reconcileDeleteControllerDeployment(args *callbacks.ReconcileCallbackArgs) 
 	}
 
 	crd = &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "datavolumes.cdi.kubevirt.io"}}
-	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); cdicontroller.IgnoreNotFound(err) != nil {
 		return err
 	}
 	dvs := &cdiv1.DataVolumeList{}
-	if err := args.Client.List(context.TODO(), dvs, &client.ListOptions{}); err != nil && !errors.IsNotFound(err) {
+	if err := args.Client.List(context.TODO(), dvs, &client.ListOptions{}); cdicontroller.IgnoreIsNoMatchError(err) != nil {
 		return err
 	}
 	for _, dv := range dvs.Items {

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -79,6 +79,36 @@ func reconcileDeleteControllerDeployment(args *callbacks.ReconcileCallbackArgs) 
 		return nil
 	}
 
+	args.Logger.Info("Deleting CRDs and verifing no finalizers")
+
+	crd := &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "dataimportcrons.cdi.kubevirt.io"}}
+	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	dics := &cdiv1.DataImportCronList{}
+	if err := args.Client.List(context.TODO(), dics, &client.ListOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	for _, dic := range dics.Items {
+		if len(dic.Finalizers) > 0 {
+			return fmt.Errorf("DataImportCron %s has Finalizers %v", dic.Name, dic.Finalizers)
+		}
+	}
+
+	crd = &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "datavolumes.cdi.kubevirt.io"}}
+	if err := args.Client.Delete(context.TODO(), crd, &client.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	dvs := &cdiv1.DataVolumeList{}
+	if err := args.Client.List(context.TODO(), dvs, &client.ListOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	for _, dv := range dvs.Items {
+		if len(dv.Finalizers) > 0 {
+			return fmt.Errorf("DataVolume %s has Finalizers %v", dv.Name, dv.Finalizers)
+		}
+	}
+
 	args.Logger.Info("Deleting CDI deployment and all import/upload/clone pods/services")
 
 	err := args.Client.Delete(context.TODO(), deployment, &client.DeleteOptions{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
         "//vendor/github.com/openshift/custom-resource-status/conditions/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
`reconcileDeleteControllerDeployment` deletes the CRDs of `DataImportCron` and `DataVolume`, and returns error if any DIC/DV has a finalizer. It will get retried and controller will eventually remove the finalizers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

