### PR TITLE
Remove DataImportCron CDI labeling

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -122,7 +122,6 @@ func (r *DataImportCronReconciler) Reconcile(ctx context.Context, req reconcile.
 func (r *DataImportCronReconciler) initCron(ctx context.Context, dataImportCron *cdiv1.DataImportCron) error {
 	AddFinalizer(dataImportCron, dataImportCronFinalizer)
 	if isURLSource(dataImportCron) && !r.cronJobExists(ctx, dataImportCron) {
-		util.SetRecommendedLabels(dataImportCron, r.installerLabels, common.CDIControllerName)
 		cronJob, err := r.newCronJob(dataImportCron)
 		if err != nil {
 			return err
@@ -134,7 +133,6 @@ func (r *DataImportCronReconciler) initCron(ctx context.Context, dataImportCron 
 			return err
 		}
 	} else if isImageStreamSource(dataImportCron) && dataImportCron.Annotations[AnnNextCronTime] == "" {
-		util.SetRecommendedLabels(dataImportCron, r.installerLabels, common.CDIControllerName)
 		addAnnotation(dataImportCron, AnnNextCronTime, time.Now().Format(time.RFC3339))
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
The following labels should be set by the operator that creates the resource, and not by the DataImportCron controller, otherwise it may result an unnecessary reconciliation and a race-condition.

```
app.kubernetes.io/component
app.kubernetes.io/managed-by
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

