### PR TITLE
Allow optional per-DataVolume VDDK image.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4046,6 +4046,10 @@
       "description": "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
       "type": "string"
      },
+     "initImageURL": {
+      "description": "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
+      "type": "string"
+     },
      "secretRef": {
       "description": "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
       "type": "string"

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -222,7 +222,7 @@ spec:
 [Get certificate example](../manifests/example/cert-configmap.yaml)
 
 ### VDDK Data Volume
-VDDK sources come from VMware vCenter or ESX endpoints. You will need a secret containing administrative credentials for the API provided by the VMware endpoint, as well as a special sidecar image containing the non-redistributable VDDK library folder. Instructions for creating a VDDK image can be found [here](https://docs.openshift.com/container-platform/4.3/cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.html#cnv-creating-vddk-image_cnv-importing-vmware-vm), with the addendum that the ConfigMap should exist in the current CDI namespace and not 'openshift-cnv'.
+VDDK sources come from VMware vCenter or ESX endpoints. You will need a secret containing administrative credentials for the API provided by the VMware endpoint, as well as a special sidecar image containing the non-redistributable VDDK library folder. Instructions for creating a VDDK image can be found [here](https://docs.openshift.com/container-platform/4.3/cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.html#cnv-creating-vddk-image_cnv-importing-vmware-vm), with the addendum that the ConfigMap should exist in the current CDI namespace and not 'openshift-cnv'. The image URL may also be specified in an optional `initImageURL` field as show below. This field will override the previous ConfigMap.
 
 ```yaml
 apiVersion: cdi.kubevirt.io/v1beta1
@@ -237,6 +237,7 @@ spec:
            uuid: "52260566-b032-36cb-55b1-79bf29e30490"
            thumbprint: "20:6C:8A:5D:44:40:B3:79:4B:28:EA:76:13:60:90:6E:49:D9:D9:A3" # SSL fingerprint of vCenter/ESX host
            secretRef: "vddk-credentials"
+           initImageURL: "http://registry:5000/vddk-init:latest"
     pvc:
        accessModes:
          - ReadWriteOnce

--- a/pkg/apis/core/v1alpha1/openapi_generated.go
+++ b/pkg/apis/core/v1alpha1/openapi_generated.go
@@ -15506,6 +15506,13 @@ func schema_pkg_apis_core_v1alpha1_DataVolumeSourceVDDK(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"initImageURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -16165,6 +16165,13 @@ func schema_pkg_apis_core_v1beta1_DataVolumeSourceVDDK(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"initImageURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -2374,6 +2374,9 @@ func (r *DatavolumeReconciler) newPersistentVolumeClaim(dataVolume *cdiv1.DataVo
 		annotations[AnnBackingFile] = dataVolume.Spec.Source.VDDK.BackingFile
 		annotations[AnnUUID] = dataVolume.Spec.Source.VDDK.UUID
 		annotations[AnnThumbprint] = dataVolume.Spec.Source.VDDK.Thumbprint
+		if dataVolume.Spec.Source.VDDK.InitImageURL != "" {
+			annotations[AnnVddkInitImageURL] = dataVolume.Spec.Source.VDDK.InitImageURL
+		}
 	} else {
 		return nil, errors.Errorf("no source set for datavolume")
 	}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -499,12 +499,14 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 			}
 		}
 		if vddkImageName == nil {
+			message := fmt.Sprintf("waiting for %s configmap or %s annotation for VDDK image", common.VddkConfigMap, AnnVddkInitImageURL)
 			anno[AnnBoundCondition] = "false"
-			anno[AnnBoundConditionMessage] = fmt.Sprintf("waiting for %s configmap or %s annotation for VDDK image", common.VddkConfigMap, AnnVddkInitImageURL)
+			anno[AnnBoundConditionMessage] = message
 			anno[AnnBoundConditionReason] = common.AwaitingVDDK
 			if err := r.updatePVC(pvc, r.log); err != nil {
 				return err
 			}
+			return errors.New(message)
 		}
 	}
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -604,7 +604,7 @@ var _ = Describe("Update PVC from POD", func() {
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resPvc.GetAnnotations()[AnnBoundCondition]).To(Equal("false"))
-		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal("waiting for v2v-vmware configmap for VDDK image"))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal(fmt.Sprintf("waiting for v2v-vmware configmap or %s annotation for VDDK image", AnnVddkInitImageURL)))
 		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal(common.AwaitingVDDK))
 
 		By("Checking again after creating configmap")
@@ -636,6 +636,17 @@ var _ = Describe("Update PVC from POD", func() {
 		reconciler = createImportReconciler(configmap, pvc)
 		err := reconciler.createImporterPod(pvc)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should not mark PVC as waiting for VDDK configmap, if image URL annotation is present", func() {
+		pvc := createPvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{AnnEndpoint: testEndPoint, AnnImportPod: "testpod", AnnSource: SourceVDDK, AnnVddkInitImageURL: "test://image"}, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc)
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.GetAnnotations()[AnnVddkInitImageURL]).To(Equal("test://image"))
 	})
 
 	It("Should copy VDDK connection information to annotations on PVC", func() {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -647,6 +647,7 @@ var _ = Describe("Update PVC from POD", func() {
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resPvc.GetAnnotations()[AnnVddkInitImageURL]).To(Equal("test://image"))
+		Expect(common.AwaitingVDDK).ToNot(Equal(resPvc.GetAnnotations()[AnnBoundConditionReason]))
 	})
 
 	It("Should copy VDDK connection information to annotations on PVC", func() {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -114,6 +114,8 @@ const (
 	AnnVddkVersion = AnnAPIGroup + "/storage.pod.vddk.version"
 	// AnnVddkHostConnection shows the last ESX host that serviced a DV's importer pod
 	AnnVddkHostConnection = AnnAPIGroup + "/storage.pod.vddk.host"
+	// AnnVddkInitImageURL saves a per-DV VDDK image URL on the PVC
+	AnnVddkInitImageURL = AnnAPIGroup + "/storage.pod.vddk.initimageurl"
 
 	// PodRunningReason is const that defines the pod was started as a reason
 	podRunningReason = "Pod is running"

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5121,6 +5121,11 @@ spec:
                                 description: BackingFile is the path to the virtual
                                   hard disk to migrate from vCenter/ESXi
                                 type: string
+                              initImageURL:
+                                description: InitImageURL is an optional URL to an
+                                  image containing an extracted VDDK library, overrides
+                                  v2v-vmware config map
+                                type: string
                               secretRef:
                                 description: SecretRef provides a reference to a secret
                                   containing the username and password needed to access
@@ -5907,6 +5912,10 @@ spec:
                         description: BackingFile is the path to the virtual hard disk
                           to migrate from vCenter/ESXi
                         type: string
+                      initImageURL:
+                        description: InitImageURL is an optional URL to an image containing
+                          an extracted VDDK library, overrides v2v-vmware config map
+                        type: string
                       secretRef:
                         description: SecretRef provides a reference to a secret containing
                           the username and password needed to access the vCenter or
@@ -6467,6 +6476,10 @@ spec:
                       backingFile:
                         description: BackingFile is the path to the virtual hard disk
                           to migrate from vCenter/ESXi
+                        type: string
+                      initImageURL:
+                        description: InitImageURL is an optional URL to an image containing
+                          an extracted VDDK library, overrides v2v-vmware config map
                         type: string
                       secretRef:
                         description: SecretRef provides a reference to a secret containing

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/types.go
@@ -197,6 +197,8 @@ type DataVolumeSourceVDDK struct {
 	Thumbprint string `json:"thumbprint,omitempty"`
 	// SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host
 	SecretRef string `json:"secretRef,omitempty"`
+	// InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map
+	InitImageURL string `json:"initImageURL,omitempty"`
 }
 
 // DataVolumeStatus contains the current status of the DataVolume

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/types_swagger_generated.go
@@ -110,12 +110,13 @@ func (DataVolumeSourceImageIO) SwaggerDoc() map[string]string {
 
 func (DataVolumeSourceVDDK) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":            "DataVolumeSourceVDDK provides the parameters to create a Data Volume from a Vmware source",
-		"url":         "URL is the URL of the vCenter or ESXi host with the VM to migrate",
-		"uuid":        "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
-		"backingFile": "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
-		"thumbprint":  "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
-		"secretRef":   "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
+		"":             "DataVolumeSourceVDDK provides the parameters to create a Data Volume from a Vmware source",
+		"url":          "URL is the URL of the vCenter or ESXi host with the VM to migrate",
+		"uuid":         "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
+		"backingFile":  "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
+		"thumbprint":   "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
+		"secretRef":    "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
+		"initImageURL": "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -228,6 +228,8 @@ type DataVolumeSourceVDDK struct {
 	Thumbprint string `json:"thumbprint,omitempty"`
 	// SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host
 	SecretRef string `json:"secretRef,omitempty"`
+	// InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map
+	InitImageURL string `json:"initImageURL,omitempty"`
 }
 
 // DataVolumeSourceRef defines an indirect reference to the source of data for the DataVolume

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -113,12 +113,13 @@ func (DataVolumeSourceImageIO) SwaggerDoc() map[string]string {
 
 func (DataVolumeSourceVDDK) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":            "DataVolumeSourceVDDK provides the parameters to create a Data Volume from a Vmware source",
-		"url":         "URL is the URL of the vCenter or ESXi host with the VM to migrate",
-		"uuid":        "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
-		"backingFile": "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
-		"thumbprint":  "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
-		"secretRef":   "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
+		"":             "DataVolumeSourceVDDK provides the parameters to create a Data Volume from a Vmware source",
+		"url":          "URL is the URL of the vCenter or ESXi host with the VM to migrate",
+		"uuid":         "UUID is the UUID of the virtual machine that the backing file is attached to in vCenter/ESXi",
+		"backingFile":  "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
+		"thumbprint":   "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
+		"secretRef":    "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
+		"initImageURL": "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
 	}
 }
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -989,9 +989,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			dv := createVddkDataVolume(dataVolumeName, size, url)
 			configMap, err := f.K8sClient.CoreV1().ConfigMaps(f.CdiInstallNs).Get(context.TODO(), savedVddkConfigMap, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			vddkUrl, ok := configMap.Data[common.VddkConfigDataKey]
+			vddkURL, ok := configMap.Data[common.VddkConfigDataKey]
 			Expect(ok).To(Equal(true))
-			dv.Spec.Source.VDDK.InitImageURL = vddkUrl
+			dv.Spec.Source.VDDK.InitImageURL = vddkURL
 			return dv
 		}
 

--- a/tests/utils/configmaps.go
+++ b/tests/utils/configmaps.go
@@ -108,3 +108,13 @@ func CreateCertConfigMapWeirdFilename(client kubernetes.Interface, destNamespace
 
 	return destName, nil
 }
+
+// DeleteConfigMap deletes a ConfigMap
+func DeleteConfigMap(client kubernetes.Interface, namespace, name string) error {
+	err := client.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds an optional initImageURL field to the VDDK data source spec, so that a VDDK archive image can be specified per-DataVolume. This allows MTV to migrate VMware VMs without interfering with the HCO-managed v2v-vmware ConfigMap.

**Which issue(s) this PR fixes**:
Fixes [BZ#2031033](https://bugzilla.redhat.com/show_bug.cgi?id=2031033) partially, enables complete fix in MTV

**Release note**:
```release-note
Allow optional specification of per-DataVolume VDDK archive image.
```

