### PR TITLE
[release-v1.34] Backport cluster proxy test fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,7 +129,7 @@ http_archive(
 # Pull base image fedora33
 container_pull(
     name = "fedora",
-    digest = "sha256:bfcc10d2d2a3a52fe997daba311c3a5298b426b524ab2b012fa24730dd0eb763",
+    digest = "sha256:f5f3351d2a5d87d1e2b30d6b1ffb518bb6b2d7c21cecaba4ba7d419f2bc305d7",
     registry = "quay.io",
     repository = "fedora/fedora",
     tag = "33-x86_64",

--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -41,7 +41,7 @@ function configure_hpp() {
       ./cluster-up/ssh.sh "node$(printf "%02d" ${i})" "sudo mkdir -p /var/hpvolumes"
       ./cluster-up/ssh.sh "node$(printf "%02d" ${i})" "sudo chcon -t container_file_t -R /var/hpvolumes"
   done
-  HPP_RELEASE=$(curl -s https://github.com/kubevirt/hostpath-provisioner-operator/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+  HPP_RELEASE=v0.9.0
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/namespace.yaml
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/operator.yaml -n hostpath-provisioner
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1269,10 +1269,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			})
 
 			Eventually(func() bool {
-				config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+				config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return reflect.DeepEqual(config.Spec, origSpec)
-			}, 30*time.Second, time.Second)
+				return reflect.DeepEqual(config.Spec, *origSpec)
+			}, 30*time.Second, time.Second).Should(BeTrue())
 		})
 
 		It("[test_id:5911]Import succeeds creating a PVC from DV without accessModes", func() {

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,6 +72,9 @@ var _ = Describe("Import Proxy tests", func() {
 			clusterWideProxy, err := ocpClient.ConfigV1().Proxies().Get(context.TODO(), controller.ClusterWideProxyName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			clusterWideProxySpec = clusterWideProxy.Spec.DeepCopy()
+
+			By("Pausing MCPs - disabling the Machine Config Operator from automatically rebooting since we don't need that to ensure we proxy things")
+			manipulateMachineConfigPools(f, true)
 		}
 		By("Saving original CDIConfig")
 		config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
@@ -90,6 +94,18 @@ var _ = Describe("Import Proxy tests", func() {
 		if utils.IsOpenshift(f.K8sClient) {
 			By("Reverting the cluster wide proxy spec to the original configuration")
 			cleanClusterWideProxy(ocpClient, clusterWideProxySpec)
+
+			By("Resuming MCPs")
+			manipulateMachineConfigPools(f, false)
+
+			By("Finish node reboots")
+			// Wait a bit for the reboot to start so we don't succeed immediately
+			time.Sleep(2 * time.Minute)
+			Eventually(func() error {
+				output, err := RunOcCommand(f, "wait", "mcp", "--all", "--for", "condition=updated", "--timeout", "1s")
+				By(output)
+				return err
+			}, 50*time.Minute, time.Second).ShouldNot(HaveOccurred())
 		}
 
 		By("Restoring CDIConfig to original state")
@@ -98,108 +114,110 @@ var _ = Describe("Import Proxy tests", func() {
 		})
 
 		Eventually(func() bool {
-			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return reflect.DeepEqual(config.Spec, origSpec)
-		}, 30*time.Second, time.Second)
+			return reflect.DeepEqual(config.Spec, *origSpec)
+		}, 30*time.Second, time.Second).Should(BeTrue())
 	})
 
-	DescribeTable("should", func(args importProxyTestArguments) {
-		var proxyHTTPURL string
-		var proxyHTTPSURL string
-		if args.isHTTPS {
-			proxyHTTPSURL = createProxyURL(args.isHTTPS, args.withBasicAuth, f.CdiInstallNs)
-		} else {
-			proxyHTTPURL = createProxyURL(args.isHTTPS, args.withBasicAuth, f.CdiInstallNs)
-		}
-		noProxy := args.noProxy
-		imgURL := createImgURL(args.isHTTPS, f.CdiInstallNs)
-		dvName = args.name
+	Context("[Destructive]", func() {
+		DescribeTable("should", func(args importProxyTestArguments) {
+			var proxyHTTPURL string
+			var proxyHTTPSURL string
+			if args.isHTTPS {
+				proxyHTTPSURL = createProxyURL(args.isHTTPS, args.withBasicAuth, f.CdiInstallNs)
+			} else {
+				proxyHTTPURL = createProxyURL(args.isHTTPS, args.withBasicAuth, f.CdiInstallNs)
+			}
+			noProxy := args.noProxy
+			imgURL := createImgURL(args.isHTTPS, f.CdiInstallNs)
+			dvName = args.name
 
-		By("Updating CDIConfig with ImportProxy configuration")
-		updateProxy(f, proxyHTTPURL, proxyHTTPSURL, noProxy, ocpClient)
+			By("Updating CDIConfig with ImportProxy configuration")
+			updateProxy(f, proxyHTTPURL, proxyHTTPSURL, noProxy, ocpClient)
 
-		By(fmt.Sprintf("Creating new datavolume %s", dvName))
-		dv := createHTTPDataVolume(f, dvName, args.size, imgURL, args.isHTTPS, args.withBasicAuth)
-		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
-		Expect(err).ToNot(HaveOccurred())
+			By(fmt.Sprintf("Creating new datavolume %s", dvName))
+			dv := createHTTPDataVolume(f, dvName, args.size, imgURL, args.isHTTPS, args.withBasicAuth)
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying pvc was created")
-		pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dvName)
-		Expect(err).ToNot(HaveOccurred())
-		f.ForceBindIfWaitForFirstConsumer(pvc)
+			By("Verifying pvc was created")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dvName)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
-		// We do not wait the datavolume to suceed in the end of the test because it is a very slow process due to the rate limit.
-		// Having the importer pod in the phase InProgress is enough to verify if the requests were proxied or not.
-		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dvName)
-		Expect(err).ToNot(HaveOccurred())
+			By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
+			// We do not wait the datavolume to suceed in the end of the test because it is a very slow process due to the rate limit.
+			// Having the importer pod in the phase InProgress is enough to verify if the requests were proxied or not.
+			err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dvName)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
-		verifyImporterPodInfoInProxyLogs(f, dataVolume, imgURL, args.isHTTPS, args.expected)
-	},
-		Entry("succeed creating import dv with a proxied server (http)", importProxyTestArguments{
-			name:          "dv-import-http-proxy",
-			size:          "1Gi",
-			noProxy:       "",
-			isHTTPS:       false,
-			withBasicAuth: false,
-			expected:      BeTrue}),
-		Entry("succeed creating import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
-			name:          "dv-import-http-proxy-auth",
-			size:          "1Gi",
-			noProxy:       "",
-			isHTTPS:       false,
-			withBasicAuth: true,
-			expected:      BeTrue}),
-		Entry("succeed creating import dv with a proxied server (https) with the target server with tls", importProxyTestArguments{
-			name:          "dv-import-https-proxy",
-			size:          "1Gi",
-			noProxy:       "",
-			isHTTPS:       true,
-			withBasicAuth: false,
-			expected:      BeTrue}),
-		Entry("succeed creating import dv with a proxied server (https) with basic autentication and the target server with tls", importProxyTestArguments{
-			name:          "dv-import-https-proxy-auth",
-			size:          "1Gi",
-			noProxy:       "",
-			isHTTPS:       true,
-			withBasicAuth: true,
-			expected:      BeTrue}),
-		Entry("succeed creating import dv with a proxied server (http) but bypassing the proxy", importProxyTestArguments{
-			name:          "dv-import-noproxy",
-			size:          "1Gi",
-			noProxy:       "*",
-			isHTTPS:       false,
-			withBasicAuth: false,
-			expected:      BeFalse}),
-	)
+			By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
+			verifyImporterPodInfoInProxyLogs(f, dataVolume, imgURL, args.isHTTPS, args.expected)
+		},
+			Entry("succeed creating import dv with a proxied server (http)", importProxyTestArguments{
+				name:          "dv-import-http-proxy",
+				size:          "1Gi",
+				noProxy:       "",
+				isHTTPS:       false,
+				withBasicAuth: false,
+				expected:      BeTrue}),
+			Entry("succeed creating import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
+				name:          "dv-import-http-proxy-auth",
+				size:          "1Gi",
+				noProxy:       "",
+				isHTTPS:       false,
+				withBasicAuth: true,
+				expected:      BeTrue}),
+			Entry("succeed creating import dv with a proxied server (https) with the target server with tls", importProxyTestArguments{
+				name:          "dv-import-https-proxy",
+				size:          "1Gi",
+				noProxy:       "",
+				isHTTPS:       true,
+				withBasicAuth: false,
+				expected:      BeTrue}),
+			Entry("succeed creating import dv with a proxied server (https) with basic autentication and the target server with tls", importProxyTestArguments{
+				name:          "dv-import-https-proxy-auth",
+				size:          "1Gi",
+				noProxy:       "",
+				isHTTPS:       true,
+				withBasicAuth: true,
+				expected:      BeTrue}),
+			Entry("succeed creating import dv with a proxied server (http) but bypassing the proxy", importProxyTestArguments{
+				name:          "dv-import-noproxy",
+				size:          "1Gi",
+				noProxy:       "*",
+				isHTTPS:       false,
+				withBasicAuth: false,
+				expected:      BeFalse}),
+		)
 
-	It("should proxy registry imports", func() {
-		By("Updating CDIConfig with ImportProxy configuration")
-		updateProxy(f, "", createProxyURL(true, false, f.CdiInstallNs), "", ocpClient)
+		It("should proxy registry imports", func() {
+			By("Updating CDIConfig with ImportProxy configuration")
+			updateProxy(f, "", createProxyURL(true, false, f.CdiInstallNs), "", ocpClient)
 
-		By("Creating new datavolume")
-		// Note this 'proxy URL' is a rate limit proxy in front of the registry
-		dv := utils.NewDataVolumeWithRegistryImport("import-dv", "1Gi", fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs))
-		cm, err := utils.CopyRegistryCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
-		Expect(err).To(BeNil())
-		dv.Spec.Source.Registry.CertConfigMap = cm
-		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
-		Expect(err).To(BeNil())
-		dvName = dv.Name
+			By("Creating new datavolume")
+			// Note this 'proxy URL' is a rate limit proxy in front of the registry
+			dv := utils.NewDataVolumeWithRegistryImport("import-dv", "1Gi", fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs))
+			cm, err := utils.CopyRegistryCertConfigMap(f.K8sClient, f.Namespace.Name, f.CdiInstallNs)
+			Expect(err).To(BeNil())
+			dv.Spec.Source.Registry.CertConfigMap = cm
+			dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+			Expect(err).To(BeNil())
+			dvName = dv.Name
 
-		pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
-		Expect(err).ToNot(HaveOccurred())
-		f.ForceBindIfWaitForFirstConsumer(pvc)
-		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
-		// We do not wait the datavolume to suceed in the end of the test because it is a very slow process due to the rate limit.
-		// Having the importer pod in the phase InProgress is enough to verify if the requests were proxied or not.
-		err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dv.Name)
-		Expect(err).ToNot(HaveOccurred())
+			pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindIfWaitForFirstConsumer(pvc)
+			By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
+			// We do not wait the datavolume to suceed in the end of the test because it is a very slow process due to the rate limit.
+			// Having the importer pod in the phase InProgress is enough to verify if the requests were proxied or not.
+			err = utils.WaitForDataVolumePhase(f.CdiClient, f.Namespace.Name, cdiv1.ImportInProgress, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
-		verifyImporterPodInfoInProxyLogs(f, dv, imgURL, true, BeTrue)
+			By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
+			verifyImporterPodInfoInProxyLogs(f, dv, imgURL, true, BeTrue)
+		})
 	})
 })
 
@@ -358,4 +376,25 @@ func cleanClusterWideProxy(ocpClient *configclient.Clientset, clusterWideProxySp
 		}
 		return false
 	}, timeout, pollingInterval).Should(BeTrue())
+}
+
+func manipulateMachineConfigPools(f *framework.Framework, paused bool) {
+	pausedStr := strconv.FormatBool(paused)
+	mcpGetOutput, err := RunOcCommand(f, "get", "mcp", "--no-headers", "-o", "custom-columns=:metadata.name")
+	Expect(err).ToNot(HaveOccurred())
+	mcpNames := strings.Split(strings.TrimSuffix(mcpGetOutput, "\n"), "\n")
+	Expect(mcpNames).To(HaveLen(2))
+
+	for _, mcp := range mcpNames {
+		_, err = RunOcCommand(f, "patch", "mcp", mcp, "--type", "merge", "--patch", fmt.Sprintf("{\"spec\":{\"paused\":%s}}", pausedStr))
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() bool {
+			isPaused, err := RunOcCommand(f, "get", "mcp", mcp, "--template", "{{.spec.paused}}")
+			By(fmt.Sprintf("%s .paused = %s", mcp, isPaused))
+			if err != nil {
+				return false
+			}
+			return isPaused == pausedStr
+		}, 180*time.Second, time.Second).Should(BeTrue())
+	}
 }

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -172,8 +172,8 @@ var _ = Describe("[rfe_id:4784][crit:high] Importer respects node placement", fu
 		Eventually(func() bool {
 			cr, err = f.CdiClient.CdiV1beta1().CDIs().Get(context.TODO(), "cdi", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return reflect.DeepEqual(cr.Spec, oldSpec)
-		}, 30*time.Second, time.Second)
+			return reflect.DeepEqual(cr.Spec, *oldSpec)
+		}, 30*time.Second, time.Second).Should(BeTrue())
 	})
 
 	It("[test_id:4783] Should create import pod with node placement", func() {
@@ -185,7 +185,7 @@ var _ = Describe("[rfe_id:4784][crit:high] Importer respects node placement", fu
 			realCR, err := f.CdiClient.CdiV1beta1().CDIs().Get(context.TODO(), "cdi", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return reflect.DeepEqual(cr.Spec, realCR.Spec)
-		}, 30*time.Second, time.Second)
+		}, 30*time.Second, time.Second).Should(BeTrue())
 
 		dv := utils.NewDataVolumeWithHTTPImport("node-placement-test", "100Mi", imageTooLargeSize())
 		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
@@ -228,10 +228,10 @@ var _ = Describe("Importer CDI config manipulation tests", func() {
 		})
 
 		Eventually(func() bool {
-			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return reflect.DeepEqual(config.Spec, origSpec)
-		}, 30*time.Second, time.Second)
+			return reflect.DeepEqual(config.Spec, *origSpec)
+		}, 30*time.Second, time.Second).Should(BeTrue())
 	})
 
 	dvWithPvcSpec := func() *cdiv1.DataVolume {
@@ -959,10 +959,10 @@ var _ = Describe("Preallocation", func() {
 		})
 
 		Eventually(func() bool {
-			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), "cdi", metav1.GetOptions{})
+			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return reflect.DeepEqual(config.Spec, origSpec)
-		}, 30*time.Second, time.Second)
+			return reflect.DeepEqual(config.Spec, *origSpec)
+		}, 30*time.Second, time.Second).Should(BeTrue())
 	})
 
 	It("Importer should add preallocation when requested", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -43,7 +43,7 @@ func CDIFailHandler(message string, callerSkip ...int) {
 	ginkgo.Fail(message, callerSkip...)
 }
 
-//RunKubectlCommand ...
+//RunKubectlCommand runs a kubectl Cmd and returns output and err
 func RunKubectlCommand(f *framework.Framework, args ...string) (string, error) {
 	var errb bytes.Buffer
 	cmd := CreateKubectlCommand(f, args...)
@@ -65,6 +65,36 @@ func RunKubectlCommand(f *framework.Framework, args ...string) (string, error) {
 func CreateKubectlCommand(f *framework.Framework, args ...string) *exec.Cmd {
 	kubeconfig := f.KubeConfig
 	path := f.KubectlPath
+
+	cmd := exec.Command(path, args...)
+	kubeconfEnv := fmt.Sprintf("KUBECONFIG=%s", kubeconfig)
+	cmd.Env = append(os.Environ(), kubeconfEnv)
+
+	return cmd
+}
+
+//RunOcCommand runs an oc Cmd and returns output and err
+func RunOcCommand(f *framework.Framework, args ...string) (string, error) {
+	var errb bytes.Buffer
+	cmd := CreateOcCommand(f, args...)
+
+	cmd.Stderr = &errb
+	stdOutBytes, err := cmd.Output()
+	if err != nil {
+		if len(errb.String()) > 0 {
+			return errb.String(), err
+		}
+		// err will not always be nil calling kubectl, this is expected on no results for instance.
+		// still return the value and let the called decide what to do.
+		return string(stdOutBytes), err
+	}
+	return string(stdOutBytes), nil
+}
+
+// CreateOcCommand returns the Cmd to execute oc
+func CreateOcCommand(f *framework.Framework, args ...string) *exec.Cmd {
+	kubeconfig := f.KubeConfig
+	path := f.OcPath
 
 	cmd := exec.Command(path, args...)
 	kubeconfEnv := fmt.Sprintf("KUBECONFIG=%s", kubeconfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #1778 and #1938 to stop MCP before updating cluster wide proxy and causing issues in the test run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

