### PR TITLE
Fix error message to be without trace

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -143,7 +143,7 @@ func main() {
 				ds.Close()
 				os.Exit(common.ScratchSpaceNeededExitCode)
 			}
-			err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %+v", err))
+			err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %+v", err.Error()))
 			if err != nil {
 				klog.Errorf("%+v", err)
 			}

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -770,7 +770,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				size:         "1Gi",
 				url:          tinyCoreIsoURL,
 				dvFunc:       utils.NewDataVolumeWithArchiveContent,
-				errorMessage: "Unable to process data: exit status 2",
+				errorMessage: "Unable to process data",
 				eventReason:  "Error",
 				phase:        cdiv1.ImportInProgress,
 				readyCondition: &cdiv1.DataVolumeCondition{
@@ -786,7 +786,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				runningCondition: &cdiv1.DataVolumeCondition{
 					Type:    cdiv1.DataVolumeRunning,
 					Status:  v1.ConditionFalse,
-					Message: "Unable to process data: exit status 2",
+					Message: "Unable to process data",
 					Reason:  "Error",
 				}}),
 			table.Entry("[test_id:3932]succeed creating dv from imageio source", dataVolumeTestArguments{


### PR DESCRIPTION
Pass the function only the err without the wraping
back trace which is too long and causes the message
to overflow and not show the specific error.

Fixes: BZ#2000661

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

