### PR TITLE
Fix prometheus tests failing after bootstrap img bump on CI

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -346,7 +346,7 @@ func getPrometheusURL(f *framework.Framework) string {
 		}, 10*time.Second, time.Second).Should(gomega.BeTrue())
 		port = strings.TrimSpace(port)
 		gomega.Expect(port).ToNot(gomega.BeEmpty())
-		url = fmt.Sprintf("http://localhost:%s", port)
+		url = fmt.Sprintf("http://127.0.0.1:%s", port)
 	}
 
 	return url


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For some reason curling localhost stopped working for us after https://github.com/kubevirt/project-infra/pull/1616,
So let's change to 127.0.0.1. Does not reproduce using on my machine when using a prow mimic:
https://github.com/kubernetes/test-infra under `prow/cmd/phaino`.
Only reproduces on the real prow env. thanks @dhiller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

