### PR TITLE
Improve failure reporting in tests

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -245,17 +245,16 @@ var _ = Describe("all clone tests", func() {
 
 				actualCloneType := utils.GetCloneType(f.CdiClient, dataVolume)
 				if actualCloneType == "snapshot" {
-					eventReason := controller.SmartCloneSourceInUse
-					verifyEvent(eventReason, targetNamespaceName, f)
+					expectEvent(f, targetNamespaceName).Should(ContainSubstring(controller.SmartCloneSourceInUse))
 				} else if actualCloneType == "csivolumeclone" {
-					verifyEvent(controller.CSICloneSourceInUse, targetNamespaceName, f)
+					expectEvent(f, targetNamespaceName).Should(ContainSubstring(controller.CSICloneSourceInUse))
 				} else {
 					Fail(fmt.Sprintf("Unknown clonetype %s", actualCloneType))
 				}
 				err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				//verify event
-				verifyEvent(controller.ErrResourceExists, targetNamespaceName, f)
+				expectEvent(f, targetNamespaceName).Should(ContainSubstring(controller.ErrResourceExists))
 			})
 
 			It("[test_id:1356]Should not clone anything when CloneOf annotation exists", func() {
@@ -1673,11 +1672,11 @@ func doInUseCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolumeClai
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 
-		verifyEvent(controller.CloneSourceInUse, targetNs.Name, f)
+		expectEvent(f, targetNs.Name).Should(ContainSubstring(controller.CloneSourceInUse))
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	} else if cloneType == "snapshot" {
-		verifyEvent(controller.SmartCloneSourceInUse, targetNs.Name, f)
+		expectEvent(f, targetNs.Name).Should(ContainSubstring(controller.SmartCloneSourceInUse))
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1685,7 +1684,7 @@ func doInUseCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolumeClai
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 	} else {
-		verifyEvent(controller.CSICloneSourceInUse, targetNs.Name, f)
+		expectEvent(f, targetNs.Name).Should(ContainSubstring(controller.CSICloneSourceInUse))
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -49,10 +49,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
 
 		dataVolume, md5 := createDataVolume("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
-		verifyEvent(string(cdiv1.CSICloneInProgress), dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 	})
@@ -66,10 +66,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
 
 		dataVolume, expectedMd5 := createDataVolume("dv-csi-clone-test-1", utils.DefaultPvcMountPath, v1.PersistentVolumeBlock, f.CsiCloneSCName, f)
-		verifyEvent(controller.CSICloneInProgress, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CSICloneInProgress))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, expectedMd5)
 	})
@@ -87,7 +87,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 
 		dataVolume, _ := createDataVolumeDontWait("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, cloneStorageClassName, f)
 		waitForDvPhase(cdiv1.CloneScheduled, dataVolume, f)
-		verifyEvent(controller.ErrUnableToClone, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrUnableToClone))
 	})
 
 	It("[test_id:7736] Should fail to create pvc in namespace with storage quota, then succeed once the quota is large enough", func() {
@@ -105,7 +105,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		dataVolume, md5 := createDataVolumeDontWait("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
 		By("Verify Quota was exceeded in events and dv conditions")
 		waitForDvPhase(cdiv1.Pending, dataVolume, f)
-		verifyEvent(controller.ErrExceededQuota, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
 		boundCondition := &cdiv1.DataVolumeCondition{
 			Type:    cdiv1.DataVolumeBound,
 			Status:  v1.ConditionUnknown,
@@ -125,10 +125,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify clone completed after quota increase")
-		verifyEvent(string(cdiv1.CSICloneInProgress), dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		verifyEvent(controller.CloneSucceeded, dataVolume.Namespace, f)
+		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -412,7 +412,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				readyCondition.Reason = controller.SnapshotForSmartCloneInProgress
 			}
 			waitForDvPhase(expectedPhase, dataVolume, f)
-			verifyEvent(controller.ErrExceededQuota, dataVolume.Namespace, f)
+			expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
 			WaitForConditions(f, dataVolume.Name, timeout, pollingInterval, boundCondition, readyCondition)
 
 			By("Increase quota")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Previous method failed with not a message "expected <bool> ...", now it is changed
to a string comparison, so the expected and received events are shown.

Additionally, the signature was changed, so now it returns AsyncAssert. That way it
correctly reports the line number when it fails.

Improves reading test reports.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

It is just a first small improvement. I think I can find some more places when looking at current reports with failed tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

