### PR TITLE
[release-v1.34] used uncached client to get cluster proxy configmap (#2055)

### DIFF
--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -382,25 +382,26 @@ func (r *CDIConfigReconciler) reconcileImportProxy(config *cdiv1.CDIConfig) erro
 
 // Create/Update a configmap with the CA certificates in the controllor context with the cluster-wide proxy CA certificates to be used by the importer pod
 func (r *CDIConfigReconciler) reconcileImportProxyCAConfigMap(config *cdiv1.CDIConfig, proxy *ocpconfigv1.Proxy) error {
+	client := r.uncachedClient
 	cmName := proxy.Spec.TrustedCA.Name
 	if cmName == "" {
 		// Using the default cluster-wide proxy CA certificates configmap name
 		cmName = ClusterWideProxyConfigMapName
 	}
 	clusterWideProxyConfigMap := &v1.ConfigMap{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: ClusterWideProxyConfigMapNameSpace}, clusterWideProxyConfigMap); err == nil {
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: ClusterWideProxyConfigMapNameSpace}, clusterWideProxyConfigMap); err == nil {
 		// Copy the cluster-wide proxy CA certificates to the importer pod proxy CA certificates configMap
 		if certBytes, ok := clusterWideProxyConfigMap.Data[ClusterWideProxyConfigMapKey]; ok {
 			configMap := &v1.ConfigMap{}
-			if err := r.client.Get(context.TODO(), types.NamespacedName{Name: common.ImportProxyConfigMapName, Namespace: r.cdiNamespace}, configMap); errors.IsNotFound(err) {
-				if err := r.client.Create(context.TODO(), r.createProxyConfigMap(certBytes)); err != nil {
+			if err := client.Get(context.TODO(), types.NamespacedName{Name: common.ImportProxyConfigMapName, Namespace: r.cdiNamespace}, configMap); errors.IsNotFound(err) {
+				if err := client.Create(context.TODO(), r.createProxyConfigMap(certBytes)); err != nil {
 					return err
 				}
 				return nil
 			}
 			if configMap != nil {
 				configMap.Data[common.ImportProxyConfigMapKey] = certBytes
-				if err := r.client.Update(context.TODO(), configMap); err != nil {
+				if err := client.Update(context.TODO(), configMap); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport of #2055 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix unable to list ConfigMap in cluster scope error messages in cdi controller log.
```

