### PR TITLE
Allow non amd64 native Go builds

### DIFF
--- a/hack/build/build-go.sh
+++ b/hack/build/build-go.sh
@@ -56,8 +56,8 @@ elif [ "${go_opt}" == "build" ]; then
         rm -f ${outLink}
         (
             cd $tgt
-            # Only build executables for linux amd64
-            GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"' -ldflags "$(cdi::version::ldflags)"
+            # Only build executables for linux
+            GOOS=linux go build -o ${outFile} -ldflags '-extldflags "static"' -ldflags "$(cdi::version::ldflags)"
 
             ln -sf ${outFile} ${outLink}
         )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR removes hardcoded GOARCH=amd64 to enable builds for other architectures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2048

**Special notes for your reviewer**:

The fix is needed for building downstream CDI images. We do not use Bazel and therefore we rely on the native go build. This will simplify the aarch64 support.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

