### PR TITLE
use leases AND configmaps for leader election

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -145,7 +145,14 @@ func start(ctx context.Context, cfg *rest.Config) {
 		klog.Fatalf("Error building extClient: %s", err.Error())
 	}
 
-	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
+	opts := manager.Options{
+		LeaderElection:             true,
+		LeaderElectionNamespace:    namespace,
+		LeaderElectionID:           "cdi-controller-leader-election-helper",
+		LeaderElectionResourceLock: "leases",
+	}
+
+	mgr, err := manager.New(config.GetConfigOrDie(), opts)
 	if err != nil {
 		klog.Errorf("Unable to setup controller manager: %v", err)
 		os.Exit(1)

--- a/cmd/cdi-operator/operator.go
+++ b/cmd/cdi-operator/operator.go
@@ -71,7 +71,7 @@ func main() {
 		LeaderElection:             true,
 		LeaderElectionNamespace:    namespace,
 		LeaderElectionID:           "cdi-operator-leader-election-helper",
-		LeaderElectionResourceLock: "configmaps",
+		LeaderElectionResourceLock: "configmapsleases",
 	}
 
 	// Create a new Manager to provide shared dependencies and start components

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -116,6 +116,17 @@ func createControllerRole() *rbacv1.Role {
 				"delete",
 			},
 		},
+		{
+			APIGroups: []string{
+				"coordination.k8s.io",
+			},
+			Resources: []string{
+				"leases",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
 	}
 	return utils.ResourceBuilder.CreateRole(controllerResourceName, rules)
 }

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -237,6 +237,17 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"patch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"coordination.k8s.io",
+			},
+			Resources: []string{
+				"leases",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
 	}
 	return rules
 }


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Configmap leader election is deprecated.  But we have to continue using them for awhile before fully transitioning to just leases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

