### PR TITLE
Reconcile DataSource PVC on update if managed by DataImportCron

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -362,7 +362,7 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 	if err := r.client.Get(ctx, types.NamespacedName{Namespace: dataImportCron.Namespace, Name: dataSourceName}, dataSource); err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("Create DataSource", "name", dataSourceName)
-			dataSource = newDataSource(dataImportCron)
+			dataSource = r.newDataSource(dataImportCron)
 			if err := r.client.Create(ctx, dataSource); err != nil {
 				return err
 			}
@@ -370,8 +370,11 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 			return err
 		}
 	}
+	if dataSource.Labels[common.DataImportCronLabel] == "" {
+		log.Info("DataSource has no DataImportCron label, so it is not updated", "name", dataSourceName)
+		return nil
+	}
 	dataSourceCopy := dataSource.DeepCopy()
-	util.SetRecommendedLabels(dataSource, r.installerLabels, common.CDIControllerName)
 	dataSource.Labels[common.DataImportCronLabel] = dataImportCron.Name
 
 	sourcePVC := dataImportCron.Status.LastImportedPVC
@@ -583,12 +586,11 @@ func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Contro
 	); err != nil {
 		return err
 	}
-	// Watch only for DataSource deletion
 	if err := c.Watch(&source.Kind{Type: &cdiv1.DataSource{}},
 		handler.EnqueueRequestsFromMapFunc(mapToCron),
 		predicate.Funcs{
 			CreateFunc: func(event.CreateEvent) bool { return false },
-			UpdateFunc: func(event.UpdateEvent) bool { return false },
+			UpdateFunc: func(e event.UpdateEvent) bool { return getCronName(e.ObjectNew) != "" },
 			DeleteFunc: func(e event.DeleteEvent) bool { return getCronName(e.Object) != "" },
 		},
 	); err != nil {
@@ -781,13 +783,15 @@ func passCronAnnotationToDv(cron *cdiv1.DataImportCron, dv *cdiv1.DataVolume, an
 	}
 }
 
-func newDataSource(cron *cdiv1.DataImportCron) *cdiv1.DataSource {
+func (r *DataImportCronReconciler) newDataSource(cron *cdiv1.DataImportCron) *cdiv1.DataSource {
 	dataSource := &cdiv1.DataSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cron.Spec.ManagedDataSource,
 			Namespace: cron.Namespace,
 		},
 	}
+	util.SetRecommendedLabels(dataSource, r.installerLabels, common.CDIControllerName)
+	dataSource.Labels[common.DataImportCronLabel] = cron.Name
 	return dataSource
 }
 

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -140,6 +140,17 @@ var _ = Describe("DataImportCron", func() {
 					cron.Status.LastImportedPVC != nil && cron.Status.LastImportedPVC.Name == currentImportDv
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 
+			By("Update DataSource pvc with dummy name")
+			dataSource.Spec.Source.PVC.Name = "dummy"
+			dataSource, err = f.CdiClient.CdiV1beta1().DataSources(dataSource.Namespace).Update(context.TODO(), dataSource, metav1.UpdateOptions{})
+			Expect(err).To(BeNil())
+			By("Verify DataSource pvc name was reconciled")
+			Eventually(func() bool {
+				dataSource, err = f.CdiClient.CdiV1beta1().DataSources(dataSource.Namespace).Get(context.TODO(), dataSource.Name, metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				return dataSource.Spec.Source.PVC.Name == currentImportDv
+			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+
 			By("Delete DataSource")
 			err = f.CdiClient.CdiV1beta1().DataSources(dataSource.Namespace).Delete(context.TODO(), dataSource.Name, metav1.DeleteOptions{})
 			Expect(err).To(BeNil())


### PR DESCRIPTION
Update DataSource only if it has a DataImportCron label

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Reconcile DataSource PVC on update if managed by DataImportCron
```

