### PR TITLE
Extend tests to check explicit storage class name

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1524,9 +1524,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 	Describe("Create a PVC using data from StorageProfile", func() {
 		var (
-			config   *cdiv1.CDIConfig
-			origSpec *cdiv1.CDIConfigSpec
-			err      error
+			config              *cdiv1.CDIConfig
+			origSpec            *cdiv1.CDIConfigSpec
+			originalProfileSpec *cdiv1.StorageProfileSpec
+			err                 error
+			defaultScName       string
 		)
 
 		fillData := "123456789012345678901234567890123456789012345678901234567890"
@@ -1590,9 +1592,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		configureStorageProfile := func(client client.Client,
 			storageClassName string,
 			accessModes []v1.PersistentVolumeAccessMode,
-			volumeMode v1.PersistentVolumeMode) *cdiv1.StorageProfileSpec {
+			volumeMode v1.PersistentVolumeMode) {
 
-			originalProfileSpec := getStorageProfileSpec(client, storageClassName)
 			propertySet := cdiv1.ClaimPropertySet{AccessModes: accessModes, VolumeMode: &volumeMode}
 			updateStorageProfileSpec(client,
 				storageClassName,
@@ -1606,8 +1607,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				}
 				return cdiv1.ClaimPropertySet{}
 			}, time.Second*30, time.Second).Should(Equal(propertySet))
-
-			return originalProfileSpec
 		}
 
 		findStorageProfileWithoutAccessModes := func(client client.Client) string {
@@ -1631,12 +1630,21 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}
 
 		BeforeEach(func() {
+			defaultScName = utils.DefaultStorageClass.GetName()
+
 			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			origSpec = config.Spec.DeepCopy()
+
+			originalProfileSpec = getStorageProfileSpec(f.CrClient, defaultScName)
 		})
 
 		AfterEach(func() {
+			if originalProfileSpec != nil {
+				By("Restoring the StorageProfile to original state")
+				updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
+			}
+
 			By("Restoring CDIConfig to original state")
 			err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
 				origSpec.DeepCopyInto(config)
@@ -1650,10 +1658,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:5911]Import succeeds creating a PVC from DV without accessModes and storageClass name", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
-
 			By(fmt.Sprintf("configure storage profile %s", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeFilesystem)
@@ -1677,15 +1683,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
 			Expect(*pvc.Spec.StorageClassName).To(And(Not(BeNil())), Equal(defaultScName))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
-		It("[test_id:8170]Import succeeds when storage class is not specified, but access mode is", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 
+		It("[test_id:8170]Import succeeds when storage class is not specified, but access mode is", func() {
 			By(fmt.Sprintf("configure storage profile %s", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeFilesystem)
@@ -1710,15 +1712,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.AccessModes).To(Equal(expectedMode))
 			Expect(*pvc.Spec.StorageClassName).To(And(Not(BeNil())), Equal(defaultScName))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
-		It("[test_id:8169]Import succeeds when storage class is not specified, but volume mode is", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 
+		It("[test_id:8169]Import succeeds when storage class is not specified, but volume mode is", func() {
 			By(fmt.Sprintf("configure storage profile %s", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeFilesystem)
@@ -1744,20 +1742,17 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
 			Expect(*pvc.Spec.VolumeMode).To(Equal(expectedVolumeMode))
 			Expect(*pvc.Spec.StorageClassName).To(And(Not(BeNil())), Equal(defaultScName))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
 		It("[test_id:5912]Import fails creating a PVC from DV without accessModes and volume mode, no profile", func() {
 			// assumes local is available and has no volumeMode
-			defaultScName := findStorageProfileWithoutAccessModes(f.CrClient)
+			storageProfileName := findStorageProfileWithoutAccessModes(f.CrClient)
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
 			requestedSize := resource.MustParse("100Mi")
 			spec := cdiv1.StorageSpec{
 				AccessModes:      nil,
 				VolumeMode:       nil,
-				StorageClassName: &defaultScName,
+				StorageClassName: &storageProfileName,
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
 						v1.ResourceStorage: requestedSize,
@@ -1785,13 +1780,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		It("[test_id:5913]Import recovers when user adds accessModes to profile", func() {
 			// assumes local is available and has no volumeMode
-			defaultScName := findStorageProfileWithoutAccessModes(f.CrClient)
+			storageProfileName := findStorageProfileWithoutAccessModes(f.CrClient)
 			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
 			requestedSize := resource.MustParse("100Mi")
 			spec := cdiv1.StorageSpec{
 				AccessModes:      nil,
 				VolumeMode:       nil,
-				StorageClassName: &defaultScName,
+				StorageClassName: &storageProfileName,
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
 						v1.ResourceStorage: requestedSize,
@@ -1816,9 +1811,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				return false
 			}, timeout, pollingInterval).Should(BeTrue())
 
-			By(fmt.Sprintf("configure storage profile %s", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
-				defaultScName,
+			By(fmt.Sprintf("configure storage profile %s", storageProfileName))
+			originalProfileSpec := getStorageProfileSpec(f.CrClient, storageProfileName)
+			configureStorageProfile(f.CrClient,
+				storageProfileName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeFilesystem)
 
@@ -1828,11 +1824,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
 
 			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
+			updateStorageProfileSpec(f.CrClient, storageProfileName, *originalProfileSpec)
 		})
 
 		It("[test_id:6483]Import pod should not have size corrected on block", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
@@ -1860,14 +1855,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6484]Import pod should not have size corrected on block, when no volumeMode on DV", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
 			expectedSize := resource.MustParse("100Mi")
 
 			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeBlock)
@@ -1889,13 +1883,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
 		It("[test_id:6485]Import pod should have size corrected on filesystem", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// given 50 percent overhead, expected size is 2x requestedSize
@@ -1926,7 +1916,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6099]Upload pvc should have size corrected on filesystem volume", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// given 50 percent overhead, expected size is 2x requestedSize
@@ -1953,7 +1942,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6100]Upload pvc should not have size corrected on block volume", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
@@ -1981,14 +1969,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6486]Upload pvc should not have size corrected on block volume, when no volumeMode on DV", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
 			expectedSize := resource.MustParse("100Mi")
 
 			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeBlock)
@@ -2009,13 +1996,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
 		It("[test_id:6101]Clone pod should not have size corrected on block", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
@@ -2043,14 +2026,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6487]Clone pod should not have size corrected on block, when no volumeMode on DV", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
 			expectedSize := resource.MustParse("100Mi")
 
 			By(fmt.Sprintf("configure storage profile %s to volumeModeBlock", defaultScName))
-			originalProfileSpec := configureStorageProfile(f.CrClient,
+			configureStorageProfile(f.CrClient,
 				defaultScName,
 				[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				v1.PersistentVolumeBlock)
@@ -2072,13 +2054,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 			Expect(pvc.Spec.AccessModes).To(Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
-
-			By("Restore the profile")
-			updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
 		})
 
 		It("[test_id:6102]Clone pod should have size corrected on filesystem", func() {
-			defaultScName := utils.DefaultStorageClass.GetName()
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// given 50 percent overhead, expected size is 2x requestedSize


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Storage class name is always set on the PVC when that PVC is created
by the CDI. Updated a few tests to check for this behavior. Added two new scenarios.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

