### PR TITLE
[release-v1.38] Fix failing imageio test (#2148)

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -458,9 +458,25 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 	if err != nil {
 		return err
 	}
+
+	// Check for old terminating scratch spaces, this can happen in warm migration scenarios where the scratch
+	// space for a previous pod has not been deleted yet. In that case check if the scratch PVC is terminating
+	// before creating the new importer pod. This should give the PVC time to get deleted.
+	if requiresScratch && scratchPvcName != nil {
+		r.log.V(1).Info("Checking for old scratch pvcs")
+		scratchPvc := &corev1.PersistentVolumeClaim{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: pvc.GetNamespace(), Name: *scratchPvcName}, scratchPvc)
+		if IgnoreNotFound(err) != nil {
+			return err
+		}
+		if scratchPvc.DeletionTimestamp != nil {
+			// Old scratch space with same name is still being cleaned up, return error.
+			return errors.New("Waiting for scratch space to be deleted")
+		}
+	}
+
 	// all checks passed, let's create the importer pod!
 	pod, err := createImporterPod(r.log, r.client, r.image, r.verbose, r.pullPolicy, podEnvVar, pvc, scratchPvcName, vddkImageName, getPriorityClass(pvc), r.installerLabels)
-
 	if err != nil {
 		return err
 	}
@@ -637,6 +653,10 @@ func (r *ImportReconciler) requiresScratchSpace(pvc *corev1.PersistentVolumeClai
 		switch getSource(pvc) {
 		case SourceGlance:
 			scratchRequired = true
+		case SourceImageio:
+			if val, ok := pvc.Annotations[AnnCurrentCheckpoint]; ok {
+				scratchRequired = val != ""
+			}
 		case SourceRegistry:
 			scratchRequired = true
 		}


### PR DESCRIPTION
* Fix failing imageio test

Always enable scratch space for imageio imports.

Signed-off-by: Alexander Wels <awels@redhat.com>

* Only always enable scratch space with warm migration imports.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport to 1.38

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

