### PR TITLE
Increase time we wait for cdiconfig update

### DIFF
--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -163,7 +163,7 @@ func UpdateCDIConfigWithOptions(c client.Client, opts metav1.UpdateOptions, upda
 		return err
 	}
 
-	if err = wait.PollImmediate(1*time.Second, 20*time.Second, func() (bool, error) {
+	if err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
 		cfg := &cdiv1.CDIConfig{}
 		err := c.Get(context.TODO(), types.NamespacedName{Name: "config"}, cfg)
 		return apiequality.Semantic.DeepEqual(&cfg.Spec, cdi.Spec.Config), err


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With increased proxy tests, there are more restarts of the config controller, and sometimes it takes longer than 20 seconds to come back. This increases the timeout so we are more robust when testing. I have seen some tests fail on waiting for the
cdiconfig to be updated completely during proxy tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

