### PR TITLE
Create imageio container during CDI build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -59,6 +59,7 @@ container_bundle(
         "$(container_prefix)/vddk-init:$(container_tag)": "//tools/vddk-init:vddk-init-image",
         "$(container_prefix)/vddk-test:$(container_tag)": "//tools/vddk-test:vddk-test-image",
         "$(container_prefix)/cdi-func-test-tinycore:$(container_tag)": "//tests:cdi-func-test-tinycore",
+        "$(container_prefix)/cdi-func-test-imageio:$(container_tag)": "//tools/image-io:cdi-func-test-imageio-image",
     },
 )
 
@@ -76,6 +77,7 @@ container_bundle(
         "$(container_prefix)/loop-back-lvm:$(container_tag)": "//tools/loop-back-lvm:loop-back-lvm-image",
         "$(container_prefix)/vcenter-simulator:$(container_tag)": "//tools/vddk-test:vcenter-simulator",
         "$(container_prefix)/cdi-func-test-tinycore:$(container_tag)": "//tests:cdi-func-test-tinycore",
+        "$(container_prefix)/cdi-func-test-imageio:$(container_tag)": "//tools/image-io:cdi-func-test-imageio-image",
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -911,3 +911,71 @@ http_file(
         "https://storage.googleapis.com/builddeps/ab5a824d402c717bfe8e01cfb216a70fd4a7e1d66d2d7baa80ac6ad6581081c9",
     ],
 )
+
+http_file(
+    name = "ovirt-imageio-client",
+    sha256 = "a012d8204098d992099620de1d14b423bfd179b54a618deec98cdcb37027a0cd",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-x86_64/03380475-ovirt-imageio/ovirt-imageio-client-2.4.1-0.202202080814.git10cee74.fc34.x86_64.rpm"],
+)
+
+http_file(
+    name = "ovirt-imageio-client-aarch64",
+    sha256 = "a012d8204098d992099620de1d14b423bfd179b54a618deec98cdcb37027a0cd",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-client-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm"],
+)
+
+http_file(
+    name = "ovirt-imageio-common",
+    sha256 = "91b4e27378d7c66bc3fd9065e7390cdc969ad46de2ff9b669cbac3b02eb036ce",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-x86_64/03380475-ovirt-imageio/ovirt-imageio-common-2.4.1-0.202202080814.git10cee74.fc34.x86_64.rpm"],
+)
+
+http_file(
+    name = "ovirt-imageio-common-aarch64",
+    sha256 = "a6f78aff23fbc6b1f68cea041144da7a6a830b7a9922bf13a140db5c1376b55c",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-common-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm"],
+)
+
+http_file(
+    name = "ovirt-imageio-daemon",
+    sha256 = "abbf056b5ef3a27e7485966959651d56e4c34c853782a8f4726cfc73e11bda77",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-x86_64/03380475-ovirt-imageio/ovirt-imageio-daemon-2.4.1-0.202202080814.git10cee74.fc34.x86_64.rpm"],
+)
+
+http_file(
+    name = "ovirt-imageio-daemon-aarch64",
+    sha256 = "5cc941ed70952899802026a896e946736f6e3f18d3542cfc55699a06a3b42aa9",
+    urls = ["https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-daemon-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm"],
+)
+
+http_file(
+    name = "python3-systemd",
+    sha256 = "883d4369f52801efacb50508b455a21667fe614f3856ef923d6b13cad45f3d93",
+    urls = [
+        "https://ftp-stud.hs-esslingen.de/pub/fedora/linux/updates/33/Everything/x86_64/Packages/p/python3-systemd-234-19.fc33.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "python3-systemd-aarch64",
+    sha256 = "fa45405ee30180ad84bf8f300b88bfe18b3529f2fd8d0feef9bc93ff49c42c0f",
+    urls = [
+        "https://ftp-stud.hs-esslingen.de/pub/fedora/linux/updates/33/Everything/aarch64/Packages/p/python3-systemd-234-19.fc33.aarch64.rpm",
+    ],
+)
+
+http_file(
+    name = "openssl",
+    sha256 = "e09142081d33d3977dfea2c0740c2c8f07810b7a598819ec69903b923f998a14",
+    urls = [
+        "https://ftp-stud.hs-esslingen.de/pub/fedora/linux/updates/33/Everything/x86_64/Packages/o/openssl-1.1.1l-2.fc33.x86_64.rpm",
+    ],
+)
+
+http_file(
+    name = "openssl-aarch64",
+    sha256 = "2019d6cb2a2ec5207ebc412d8dc2246da68aa9b443cb89939ec1d1d2260c6771",
+    urls = [
+        "https://ftp-stud.hs-esslingen.de/pub/fedora/linux/updates/33/Everything/aarch64/Packages/o/openssl-1.1.1l-2.fc33.aarch64.rpm",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -912,6 +912,7 @@ http_file(
     ],
 )
 
+#imageio rpms and dependencies
 http_file(
     name = "ovirt-imageio-client",
     sha256 = "a012d8204098d992099620de1d14b423bfd179b54a618deec98cdcb37027a0cd",

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -32,8 +32,7 @@ spec:
           mountPath: "/tmp"
       containers:
       - name: imageiotest
-        # Docker file: https://github.com/machacekondra/imageiotest
-        image: quay.io/kubevirt/imageiotest:v0.0.1
+        image: {{ .DockerRepo }}/cdi-func-test-imageio:{{ .DockerTag }}
         imagePullPolicy: {{ .PullPolicy }}
         ports:
         - containerPort: 12345
@@ -41,7 +40,7 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "openssl ca x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /ovirt-imageio/daemon/test/pki/cert.pem; cp /tmp/certs/tls.key /ovirt-imageio/daemon/test/pki/key.pem; cd ovirt-imageio/daemon; ./ovirt-imageio -c test/conf& sleep 3; curl --unix-socket /ovirt-imageio/daemon/test/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
+        args: ["-c", "mkdir -p /images; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; curl --unix-socket /tmp/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: quay.io/kubevirt/fakeovirt:v1.38.0

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -40,7 +40,7 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "mkdir -p /images; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; curl --unix-socket /tmp/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
+        args: ["-c", "cp /images/cirros.raw /images/cirros.img; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; curl --unix-socket /tmp/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: quay.io/kubevirt/fakeovirt:v1.38.0

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -40,7 +40,7 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "cp /images/cirros.raw /images/cirros.img; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; curl --unix-socket /tmp/daemon.sock -X PUT -d '{\"uuid\": \"cirros\", \"size\": 46137344, \"url\": \"file:///images/cirros.img\", \"timeout\": 30000000000000, \"ops\": [\"read\"]}' http://localhost:12345/tickets/cirros; sleep infinity"]
+        args: ["-c", "openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; ovirt-imageioctl add-ticket myticket.json; sleep infinity"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: quay.io/kubevirt/fakeovirt:v1.38.0

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -526,22 +526,6 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 		priorityClassName: getPriorityClass(pvc),
 	}
 
-	// Check for old terminating scratch spaces, this can happen in warm migration scenarios where the scratch
-	// space for a previous pod has not been deleted yet. In that case check if the scratch PVC is terminating
-	// before creating the new importer pod. This should give the PVC time to get deleted.
-	if requiresScratch && podArgs.scratchPvcName != nil {
-		r.log.V(1).Info("Checking for old scratch pvcs")
-		scratchPvc := &corev1.PersistentVolumeClaim{}
-		err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: pvc.GetNamespace(), Name: *podArgs.scratchPvcName}, scratchPvc)
-		if IgnoreNotFound(err) != nil {
-			return err
-		}
-		if scratchPvc.DeletionTimestamp != nil {
-			// Old scratch space with same name is still being cleaned up, return error.
-			return errors.New("Waiting for scratch space to be deleted")
-		}
-	}
-
 	pod, err := createImporterPod(r.log, r.client, podArgs, r.installerLabels)
 	if err != nil {
 		return err
@@ -782,6 +766,16 @@ func (r *ImportReconciler) createScratchPvcForPod(pvc *corev1.PersistentVolumeCl
 		anno[AnnBoundConditionMessage] = "Creating scratch space"
 		anno[AnnBoundConditionReason] = creatingScratch
 	} else {
+		if scratchPvc.DeletionTimestamp != nil {
+			// Delete the pod since we are in a deadlock situation now. The scratch PVC from the previous import is not gone
+			// yet but terminating, and the new pod is still being created and the scratch PVC now has a finalizer on it.
+			// Only way to break it, is to delete the importer pod, and give the pvc a chance to disappear.
+			err = r.client.Delete(context.TODO(), pod)
+			if err != nil {
+				return err
+			}
+			return errors.New("terminating scratch space found, deleted pod")
+		}
 		setBoundConditionFromPVC(anno, AnnBoundCondition, scratchPvc)
 	}
 	anno[AnnRequiresScratch] = "false"

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -130,6 +130,27 @@ var _ = Describe("Test PVC annotations status", func() {
 		}, nil)
 		Expect(r.shouldReconcilePVC(testPvc, importLog)).To(BeTrue())
 	})
+
+	It("Should be interesting if complete, and endpoint and source is set, and multistage import not done", func() {
+		r := createImportReconciler()
+		testPvc := createPvc("testPvc1", "default", map[string]string{
+			AnnPodPhase: string(corev1.PodSucceeded),
+			AnnEndpoint: testEndPoint, AnnSource: SourceHTTP,
+			AnnCurrentCheckpoint: "test-check",
+		}, nil)
+		Expect(r.shouldReconcilePVC(testPvc, importLog)).To(BeTrue())
+	})
+
+	It("Should NOT be interesting if complete, and endpoint and source is set, and multistage import done", func() {
+		r := createImportReconciler()
+		testPvc := createPvc("testPvc1", "default", map[string]string{
+			AnnPodPhase: string(corev1.PodSucceeded),
+			AnnEndpoint: testEndPoint, AnnSource: SourceHTTP,
+			AnnCurrentCheckpoint:    "test-check",
+			AnnMultiStageImportDone: "true",
+		}, nil)
+		Expect(r.shouldReconcilePVC(testPvc, importLog)).To(BeFalse())
+	})
 })
 
 var _ = Describe("ImportConfig Controller reconcile loop", func() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -773,7 +773,11 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					Message: "Import Complete",
 					Reason:  "Completed",
 				}}),
-			table.PEntry("[test_id:3937]succeed creating warm import dv from imageio source", dataVolumeTestArguments{
+			table.Entry("[test_id:3937]succeed creating warm import dv from imageio source", dataVolumeTestArguments{
+				// The final snapshot importer pod will give an error due to the static response from the fake imageio
+				// it returns the previous snapshot data, which will fail the commit to the target image.
+				// the importer pod will restart and then succeed because the fake imageio now sends the
+				// right data. This is normal.
 				name:             "dv-imageio-test",
 				size:             "1Gi",
 				url:              imageioURL,

--- a/tests/imageio-inventory.go
+++ b/tests/imageio-inventory.go
@@ -450,8 +450,8 @@ func postInventoryStubs(f *framework.Framework, pod *v1.Pod, stubs *bytes.Buffer
 func copyDiskImage(f *framework.Framework, pod *v1.Pod, name string) {
 	path := getSnapshotPath(name)
 	dest := fmt.Sprintf("%s:/images/%s", pod.Name, name)
-	_, err := RunKubectlCommand(f, "cp", "-n", pod.Namespace, "-c", "imageiotest", path, dest)
-	gomega.Expect(err).To(gomega.BeNil())
+	out, err := RunKubectlCommand(f, "cp", "-n", pod.Namespace, "-c", "imageiotest", path, dest)
+	gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("%s", out))
 }
 
 // Add ticket to imageiotest API, so importer can download it
@@ -474,7 +474,7 @@ func addTicket(f *framework.Framework, pod *v1.Pod, snapshot imageIoDiskSnapshot
 	gomega.Expect(err).To(gomega.BeNil())
 
 	// Post to API in imageiotest container
-	command := CreateKubectlCommand(f, "exec", "-i", "-n", pod.Namespace, pod.Name, "-c", "imageiotest", "--", "/usr/bin/curl", "-s", "--unix-socket", "/ovirt-imageio/daemon/test/daemon.sock", "-X", "PUT", "-d", "@-", fmt.Sprintf("http://localhost:12345/tickets/%s", snapshot.SnapshotID))
+	command := CreateKubectlCommand(f, "exec", "-i", "-n", pod.Namespace, pod.Name, "-c", "imageiotest", "--", "/usr/bin/curl", "-s", "--unix-socket", "/tmp/daemon.sock", "-X", "PUT", "-d", "@-", fmt.Sprintf("http://localhost:12345/tickets/%s", snapshot.SnapshotID))
 	command.Stdin = ticketBytes
 	command.Stdout = os.Stdout
 	command.Stderr = command.Stdout

--- a/tools/image-io/99-cdi.conf
+++ b/tools/image-io/99-cdi.conf
@@ -1,0 +1,40 @@
+[tls]
+key_file = /tmp/certs/tls.key
+cert_file = /tmp/certs/tls.crt
+ca_file = /tmp/certs/tls.crt
+
+[control]
+transport = unix
+socket = /tmp/daemon.sock
+
+[handlers]
+keys = logfile
+
+[logger_root]
+level = DEBUG
+handlers = logfile
+
+[remote]
+port = 12345
+host =
+
+[loggers]
+keys = root
+
+[handler_logfile]
+class = logging.handlers.RotatingFileHandler
+args = ('/var/log/ovirt-imageio/daemon.log',)
+kwargs = {'maxBytes': 20971520, 'backupCount': 10}
+level = DEBUG
+formatter = long
+
+[daemon]
+group_name = root
+user_name = root
+poll_interval = 0.1
+buffer_size = 131072
+drop_privileges = false
+
+[local]
+socket =
+

--- a/tools/image-io/BUILD.bazel
+++ b/tools/image-io/BUILD.bazel
@@ -37,13 +37,15 @@ container_image(
         "//conditions:default": "amd64",
     }),
     base = ":cdi-func-test-imageio-base-image",
-    cmd = "mkdir -p /images",
     directory = "/",
     entrypoint = ["ovirt-imageio"],
     ports = [
         "12345",
     ],
-    tars = [":ovirt-imageio-conf-tar"],
+    tars = [
+        ":ovirt-imageio-conf-tar",
+        ":test-img-tar",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -59,4 +61,11 @@ pkg_tar(
     srcs = [":ovirt-imageio-conf"],
     mode = "644",
     package_dir = "/etc/ovirt-imageio/conf.d",
+)
+
+pkg_tar(
+    name = "test-img-tar",
+    srcs = ["//:test-images"],
+    mode = "644",
+    package_dir = "/images",
 )

--- a/tools/image-io/BUILD.bazel
+++ b/tools/image-io/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@io_bazel_rules_container_rpm//rpm:rpm.bzl", "rpm_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+rpm_image(
+    name = "cdi-func-test-imageio-base-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora-aarch64//image",
+        "//conditions:default": "@fedora//image",
+    }),
+    rpms = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "@ovirt-imageio-client-aarch64//file",
+            "@ovirt-imageio-common-aarch64//file",
+            "@ovirt-imageio-daemon-aarch64//file",
+            "@python3-systemd-aarch64//file",
+            "@openssl-aarch64//file",
+        ],
+        "//conditions:default": [
+            "@ovirt-imageio-client//file",
+            "@ovirt-imageio-common//file",
+            "@ovirt-imageio-daemon//file",
+            "@python3-systemd//file",
+            "@openssl//file",
+        ],
+    }),
+)
+
+container_image(
+    name = "cdi-func-test-imageio-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = ":cdi-func-test-imageio-base-image",
+    cmd = "mkdir -p /images",
+    directory = "/",
+    entrypoint = ["ovirt-imageio"],
+    ports = [
+        "12345",
+    ],
+    tars = [":ovirt-imageio-conf-tar"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ovirt-imageio-conf",
+    srcs = [
+        ":99-cdi.conf",
+    ],
+)
+
+pkg_tar(
+    name = "ovirt-imageio-conf-tar",
+    srcs = [":ovirt-imageio-conf"],
+    mode = "644",
+    package_dir = "/etc/ovirt-imageio/conf.d",
+)

--- a/tools/image-io/BUILD.bazel
+++ b/tools/image-io/BUILD.bazel
@@ -45,6 +45,7 @@ container_image(
     tars = [
         ":ovirt-imageio-conf-tar",
         ":test-img-tar",
+        ":test-ticket-tar",
     ],
     visibility = ["//visibility:public"],
 )
@@ -53,6 +54,13 @@ filegroup(
     name = "ovirt-imageio-conf",
     srcs = [
         ":99-cdi.conf",
+    ],
+)
+
+filegroup(
+    name = "test-ticket",
+    srcs = [
+        ":myticket.json",
     ],
 )
 
@@ -68,4 +76,11 @@ pkg_tar(
     srcs = ["//:test-images"],
     mode = "644",
     package_dir = "/images",
+)
+
+pkg_tar(
+    name = "test-ticket-tar",
+    srcs = [":test-ticket"],
+    mode = "644",
+    package_dir = "/",
 )

--- a/tools/image-io/myticket.json
+++ b/tools/image-io/myticket.json
@@ -1,0 +1,6 @@
+{"uuid": "cirros",
+ "size": 46137344,
+ "url": "file:///images/cirros.raw",
+ "timeout": 30000000000000, 
+ "ops": ["read"]
+}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of using a really old imageio, use bazel to build a new imageio based on 2.5.0. Update the tests to use the new image
and paths in that new image. This requires a new repo in quay for us to push the image to.

Also changed the approach of resolving the warm import potential dead lock (scratch PVC from previous import pod terminating, while the new pod is trying to create itself). Instead of trying to avoid in all scenarios, detect the state, and delete the pod so the dead lock can be resolved.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2145 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

