### PR TITLE
Fix VerifySparse to look at content size and not size on disk

### DIFF
--- a/tests/framework/BUILD.bazel
+++ b/tests/framework/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//tests/utils:go_default_library",
         "//vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
+        "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -208,7 +209,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		By("Creating PVC with upload target annotation and archive context-type")
+		By("Creating PVC with upload target annotation and archive content-type")
 		archivePVC, err = f.CreateBoundPVCFromDefinition(utils.UploadArchivePVCDefinition())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -242,7 +243,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			By("Verify content")
 			for file, expectedMd5 := range filesToUpload {
-				pathInPvc := utils.DefaultPvcMountPath + "/" + file
+				pathInPvc := filepath.Join(utils.DefaultPvcMountPath, file)
 				same, err := f.VerifyTargetPVCContentMD5(f.Namespace, archivePVC, pathInPvc, expectedMd5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(same).To(BeTrue())


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We consistently fail on the check that `info.VirtualSize >= info.ActualSize`
on a real external nfs sever with different block size to what we're using upstream.

This happens because qemu-img info gives us the size on disk in ActualSize.
For the purpose of sparseness, I believe we are interested in the content size and not the padded size on disk.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I have kept a check that fails if the diff between size on disk and content is significant,
so we can still keep looking into the following flake:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/2162/pull-containerized-data-importer-e2e-k8s-1.22-nfs/1495845677580685312

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
