### PR TITLE
Delete erroneous DataVolume on DataImportCron desired digest update

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -253,6 +253,9 @@ const (
 	// UnusualRestartCountThreshold is the number of pod restarts that we consider unusual and would like to alert about
 	UnusualRestartCountThreshold = 3
 
+	// GenericError is a generic error string
+	GenericError = "Error"
+
 	// CDIControllerLeaderElectionHelperName is the name of the configmap that is used as a helper for controller leader election
 	CDIControllerLeaderElectionHelperName = "cdi-controller-leader-election-helper"
 )

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -54,6 +55,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/operator"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/pkg/util/naming"
 )
 
 const (
@@ -241,7 +243,6 @@ func getCronRegistrySource(cron *cdiv1.DataImportCron) (*cdiv1.DataVolumeSourceR
 	return source.Registry, nil
 }
 
-// FIXME: refactor and adapt for concurrent imports
 func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *cdiv1.DataImportCron) (reconcile.Result, error) {
 	log := r.log.WithName("update")
 	res := reconcile.Result{}
@@ -862,17 +863,17 @@ func createDvName(prefix, digest string) (string, error) {
 	if len(digest) < toIdx {
 		return "", errors.Errorf("Digest is too short")
 	}
-	return prefix + "-" + digest[fromIdx:toIdx], nil
+	return naming.GetResourceName(prefix, digest[fromIdx:toIdx]), nil
 }
 
 // GetCronJobName get CronJob name based on cron name and UID
 func GetCronJobName(cron *cdiv1.DataImportCron) string {
-	return cron.Name + "-" + string(cron.UID)[:cronJobUIDSuffixLength]
+	return naming.GetResourceName(cron.Name, string(cron.UID)[:cronJobUIDSuffixLength])
 }
 
 // GetInitialJobName get initial job name based on cron name and UID
 func GetInitialJobName(cron *cdiv1.DataImportCron) string {
-	return "initial-job-" + GetCronJobName(cron)
+	return naming.GetResourceName("initial-job", GetCronJobName(cron))
 }
 
 func getSelector(matchLabels map[string]string) (labels.Selector, error) {
@@ -880,5 +881,10 @@ func getSelector(matchLabels map[string]string) (labels.Selector, error) {
 }
 
 func getCronJobLabelValue(cronNamespace, cronName string) string {
-	return cronNamespace + "." + cronName
+	const maxLen = validation.DNS1035LabelMaxLength
+	label := cronNamespace + "." + cronName
+	if len(label) > maxLen {
+		return label[:maxLen]
+	}
+	return label
 }

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -228,6 +228,18 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(len(dvList.Items)).To(Equal(0))
 		})
 
+		DescribeTable("Should fail when digest", func(digest, errorString string) {
+			cron = newDataImportCron(cronName)
+			cron.Annotations[AnnSourceDesiredDigest] = digest
+			reconciler = createDataImportCronReconciler(cron)
+			_, err := reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(errorString))
+		},
+			Entry("has no supported prefix", "sha234:012345678901", "Digest has no supported prefix"),
+			Entry("is too short", "sha256:01234567890", "Digest is too short"),
+		)
+
 		DescribeTable("Should fail when ImageStream", func(taggedImageStreamName, errorString string) {
 			cron = newDataImportCronWithImageStream(cronName, taggedImageStreamName)
 			imageStream := newImageStream(imageStreamName)

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -56,7 +57,7 @@ const (
 	// ProcessingPhasePause is the phase where we pause processing and end the loop, and expect something to call the process loop again.
 	ProcessingPhasePause ProcessingPhase = "Pause"
 	// ProcessingPhaseError is the phase in which we encountered an error and need to exit ungracefully.
-	ProcessingPhaseError ProcessingPhase = "Error"
+	ProcessingPhaseError ProcessingPhase = common.GenericError
 	// ProcessingPhaseMergeDelta is the phase in a multi-stage import where a delta image downloaded to scratch is applied to the base image
 	ProcessingPhaseMergeDelta ProcessingPhase = "MergeDelta"
 )

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -88,10 +88,9 @@ var _ = Describe("DataImportCron", func() {
 				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				condProgressing := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronProgressing)
-				Expect(condProgressing).ToNot(BeNil())
 				condUpToDate := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
-				Expect(condUpToDate).ToNot(BeNil())
-				return condProgressing.Status == statusProgressing && condUpToDate.Status == statusUpToDate
+				return condProgressing != nil && condProgressing.Status == statusProgressing &&
+					condUpToDate != nil && condUpToDate.Status == statusUpToDate
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 		}
 

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -28,90 +29,120 @@ const (
 )
 
 var (
-	importsToKeep       int32 = 1
-	registryPullNode          = cdiv1.RegistryPullNode
-	externalRegistryURL       = "docker://quay.io/kubevirt/cirros-container-disk-demo"
+	importsToKeep int32 = 1
 )
 
 var _ = Describe("DataImportCron", func() {
 	var (
-		f                  = framework.NewFramework(namespacePrefix)
-		trustedRegistryURL = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
-		dataSourceName     = "datasource-test"
-		cronName           = "cron-test"
-		cron               *cdiv1.DataImportCron
-		err                error
-		ns                 string
+		f              = framework.NewFramework(namespacePrefix)
+		dataSourceName = "datasource-test"
+		cronName       = "cron-test"
+		dvName         = "dv-garbage"
+		cron           *cdiv1.DataImportCron
+		ns             string
 	)
 
 	BeforeEach(func() {
 		ns = f.Namespace.Name
 	})
 
-	table.DescribeTable("should", func(schedule string, retentionPolicy cdiv1.DataImportCronRetentionPolicy, repeat int, checkGarbageCollection bool) {
-		var url string
+	table.DescribeTable("should", func(garbageCollection, retention, createErrorDv bool, repeat int) {
+		reg, err := getDataVolumeSourceRegistry(f)
+		Expect(err).To(BeNil())
+		defer utils.RemoveInsecureRegistry(f.CrClient, *reg.URL)
 
-		if repeat > 1 || utils.IsOpenshift(f.K8sClient) {
-			url = externalRegistryURL
-		} else {
-			url = trustedRegistryURL()
-			err = utils.AddInsecureRegistry(f.CrClient, url)
-			Expect(err).To(BeNil())
+		By(fmt.Sprintf("Create labeled DatVolume %s for garbage collection test", dvName))
+		dv := utils.NewDataVolumeWithRegistryImport(dvName, "5Gi", "")
+		dv.Spec.Source.Registry = reg
+		dv.Labels = map[string]string{common.DataImportCronLabel: cronName}
+		_, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, ns, dv)
+		Expect(err).ToNot(HaveOccurred())
 
-			hasInsecReg, err := utils.HasInsecureRegistry(f.CrClient, url)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasInsecReg).To(BeTrue())
-			defer utils.RemoveInsecureRegistry(f.CrClient, url)
+		By(fmt.Sprintf("Create new DataImportCron %s, url %s", cronName, *reg.URL))
+		cron = NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, *reg)
+		if !garbageCollection {
+			garbageCollect := cdiv1.DataImportCronGarbageCollectNever
+			cron.Spec.GarbageCollect = &garbageCollect
 		}
-
-		cron = NewDataImportCron(cronName, "5Gi", schedule, dataSourceName, cdiv1.DataVolumeSourceRegistry{URL: &url, PullMethod: &registryPullNode}, retentionPolicy)
-		By(fmt.Sprintf("Create new DataImportCron %s", url))
+		if !retention {
+			retentionPolicy := cdiv1.DataImportCronRetainNone
+			cron.Spec.RetentionPolicy = &retentionPolicy
+		}
 		cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		if schedule == scheduleEveryMinute {
-			By("Verify cronjob was created")
+		By("Verify cronjob was created")
+		Eventually(func() bool {
+			_, err := f.K8sClient.BatchV1().CronJobs(f.CdiInstallNs).Get(context.TODO(), controller.GetCronJobName(cron), metav1.GetOptions{})
+			if errors.IsNotFound(err) {
+				return false
+			}
+			Expect(err).ToNot(HaveOccurred())
+			return true
+		}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+
+		waitForConditions := func(statusProgressing, statusUpToDate corev1.ConditionStatus) {
+			By(fmt.Sprintf("Wait for DataImportCron Progressing:%s, UpToDate:%s", statusProgressing, statusUpToDate))
 			Eventually(func() bool {
-				_, err = f.K8sClient.BatchV1beta1().CronJobs(f.CdiInstallNs).Get(context.TODO(), controller.GetCronJobName(cron), metav1.GetOptions{})
-				if errors.IsNotFound(err) {
-					return false
-				}
-				return err == nil
+				var err error
+				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				condProgressing := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronProgressing)
+				Expect(condProgressing).ToNot(BeNil())
+				condUpToDate := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
+				Expect(condUpToDate).ToNot(BeNil())
+				return condProgressing.Status == statusProgressing && condUpToDate.Status == statusUpToDate
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 		}
 
 		var lastImportDv, currentImportDv string
 		for i := 0; i < repeat; i++ {
+			By(fmt.Sprintf("Iter #%d", i))
 			if i > 0 {
-				// Emulate source update using digests from https://quay.io/repository/kubevirt/cirros-container-disk-demo?tab=tags
-				digest := []string{
-					"sha256:68b44fc891f3fae6703d4b74bcc9b5f24df8d23f12e642805d1420cbe7a4be70",
-					"sha256:90e064fca2f47eabce210d218a45ba48cc7105b027d3f39761f242506cad15d6",
-				}[i%2]
-
-				By(fmt.Sprintf("Update source desired digest to %s", digest))
-				Eventually(func() bool {
+				if createErrorDv {
+					By("Set desired digest to nonexisting one")
 					cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					if cron.Annotations == nil {
-						cron.Annotations = make(map[string]string)
-					}
-					cron.Annotations[controller.AnnSourceDesiredDigest] = digest
+					cron.Annotations[controller.AnnSourceDesiredDigest] = "sha256:12345678900987654321"
 					cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Update(context.TODO(), cron, metav1.UpdateOptions{})
-					return err == nil
-				}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
-			}
-			By("Wait for CurrentImports DataVolumeName update")
-			Eventually(func() bool {
-				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				if len(cron.Status.CurrentImports) == 0 {
-					return false
-				}
-				currentImportDv = cron.Status.CurrentImports[0].DataVolumeName
-				return currentImportDv != "" && currentImportDv != lastImportDv
-			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+					Expect(err).ToNot(HaveOccurred())
 
+					By("Wait for CurrentImports update")
+					Eventually(func() bool {
+						cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+						currentImportDv = cron.Status.CurrentImports[0].DataVolumeName
+						Expect(currentImportDv).ToNot(BeEmpty())
+						return currentImportDv != lastImportDv
+					}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+					lastImportDv = currentImportDv
+				} else {
+					By("Reset desired digest")
+					cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					cron.Annotations[controller.AnnSourceDesiredDigest] = ""
+					cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Update(context.TODO(), cron, metav1.UpdateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Delete last import DV")
+					err = f.CdiClient.CdiV1beta1().DataVolumes(ns).Delete(context.TODO(), currentImportDv, metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Wait for no CurrentImports")
+					Eventually(func() bool {
+						cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return len(cron.Status.CurrentImports) == 0
+					}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+					lastImportDv = ""
+				}
+			}
+
+			waitForConditions(corev1.ConditionFalse, corev1.ConditionTrue)
+			By("Verify DesiredDigest and CurrentImports update")
+			Expect(cron.Annotations[controller.AnnSourceDesiredDigest]).ToNot(BeEmpty())
+			currentImportDv = cron.Status.CurrentImports[0].DataVolumeName
+			Expect(currentImportDv).ToNot(BeEmpty())
+			Expect(currentImportDv).ToNot(Equal(lastImportDv))
 			lastImportDv = currentImportDv
 
 			By(fmt.Sprintf("Verify pvc was created %s", currentImportDv))
@@ -136,15 +167,8 @@ var _ = Describe("DataImportCron", func() {
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verify cron was updated")
-			Eventually(func() bool {
-				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				progressCond := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronProgressing)
-				upToDateCond := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
-				return progressCond != nil && progressCond.Status == corev1.ConditionFalse &&
-					upToDateCond != nil && upToDateCond.Status == corev1.ConditionTrue &&
-					cron.Status.LastImportedPVC != nil && cron.Status.LastImportedPVC.Name == currentImportDv
-			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+			Expect(cron.Status.LastImportedPVC).ToNot(BeNil())
+			Expect(cron.Status.LastImportedPVC.Name).To(Equal(currentImportDv))
 
 			By("Update DataSource pvc with dummy name")
 			dataSource.Spec.Source.PVC.Name = "dummy"
@@ -174,23 +198,36 @@ var _ = Describe("DataImportCron", func() {
 				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), currentPvc.Name, metav1.GetOptions{})
 				return err == nil && pvc.UID != currentPvc.UID
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
+
+			By("Wait for import completion")
+			err = utils.WaitForDataVolumePhase(f.CdiClient, ns, cdiv1.Succeeded, currentImportDv)
+			Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
 		}
-		if checkGarbageCollection {
-			Eventually(func() bool {
-				dvList, err := f.CdiClient.CdiV1beta1().DataVolumes(ns).List(context.TODO(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return len(dvList.Items) == int(importsToKeep)
-			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
-		}
+		By("Check garbage collection")
+		Eventually(func() bool {
+			dvList, err := f.CdiClient.CdiV1beta1().DataVolumes(ns).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			if !garbageCollection {
+				return len(dvList.Items) == 2
+			}
+			return len(dvList.Items) == int(importsToKeep)
+		}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 
 		lastImportedPVC := cron.Status.LastImportedPVC
-		retention := cron.Spec.RetentionPolicy
 
 		By("Delete cron")
 		err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Delete(context.TODO(), cronName, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		if retention != nil && *retention == cdiv1.DataImportCronRetainNone {
+		if retention {
+			By("Verify DataSource retention")
+			_, err := f.CdiClient.CdiV1beta1().DataSources(ns).Get(context.TODO(), dataSourceName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			By("Verify last PVC retention")
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), lastImportedPVC.Name, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		} else {
 			By("Verify DataSource deletion")
 			Eventually(func() bool {
 				_, err := f.CdiClient.CdiV1beta1().DataSources(ns).Get(context.TODO(), dataSourceName, metav1.GetOptions{})
@@ -203,25 +240,20 @@ var _ = Describe("DataImportCron", func() {
 				Expect(err).ToNot(HaveOccurred())
 				return len(pvcs.Items) == 0
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
-		} else {
-			By("Verify DataSource retention")
-			_, err := f.CdiClient.CdiV1beta1().DataSources(ns).Get(context.TODO(), dataSourceName, metav1.GetOptions{})
-			Expect(err).To(BeNil())
-
-			By("Verify last PVC retention")
-			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), lastImportedPVC.Name, metav1.GetOptions{})
-			Expect(err).To(BeNil())
 		}
 	},
-		table.Entry("[test_id:7403] Should successfully import PVC from registry URL as scheduled", scheduleEveryMinute, cdiv1.DataImportCronRetainAll, 1, false),
-		table.Entry("[test_id:7414] Should successfully import PVC from registry URL on source digest update", scheduleOnceAYear, cdiv1.DataImportCronRetainAll, 2, false),
-		table.Entry("[test_id:7406] Should successfully garbage collect old PVCs when importing new ones", scheduleOnceAYear, cdiv1.DataImportCronRetainNone, 2, true),
+		table.Entry("[test_id:7403] succeed importing initial PVC from registry URL", false, true, false, 1),
+		table.Entry("[test_id:7414] succeed importing PVC from registry URL on source digest update", false, true, false, 2),
+		table.Entry("[test_id:7406] succeed garbage collecting old PVCs when importing new ones", true, false, false, 2),
+		table.Entry("[test_id:8266] succeed deleting error DVs when importing new ones", true, false, true, 2),
 	)
 
 	It("[test_id:8033] should delete jobs on deletion", func() {
-		url := trustedRegistryURL()
+		reg, err := getDataVolumeSourceRegistry(f)
+		Expect(err).To(BeNil())
 		noSuchCM := "nosuch"
-		cron = NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, dataSourceName, cdiv1.DataVolumeSourceRegistry{URL: &url, PullMethod: &registryPullNode, CertConfigMap: &noSuchCM}, cdiv1.DataImportCronRetainAll)
+		reg.CertConfigMap = &noSuchCM
+		cron = NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, dataSourceName, *reg)
 		By("Create new DataImportCron")
 		cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -243,7 +275,7 @@ var _ = Describe("DataImportCron", func() {
 		cronJobName := controller.GetCronJobName(cron)
 		jobName := ""
 		Eventually(func() string {
-			cronjob, _ := f.K8sClient.BatchV1beta1().CronJobs(f.CdiInstallNs).Get(context.TODO(), cronJobName, metav1.GetOptions{})
+			cronjob, _ := f.K8sClient.BatchV1().CronJobs(f.CdiInstallNs).Get(context.TODO(), cronJobName, metav1.GetOptions{})
 			if cronjob != nil && len(cronjob.Status.Active) > 0 {
 				jobName = cronjob.Status.Active[0].Name
 			}
@@ -268,7 +300,7 @@ var _ = Describe("DataImportCron", func() {
 
 		By("Verify cronjob deleted")
 		Eventually(func() bool {
-			_, err := f.K8sClient.BatchV1beta1().CronJobs(f.CdiInstallNs).Get(context.TODO(), cronJobName, metav1.GetOptions{})
+			_, err := f.K8sClient.BatchV1().CronJobs(f.CdiInstallNs).Get(context.TODO(), cronJobName, metav1.GetOptions{})
 			return errors.IsNotFound(err)
 		}, dataImportCronTimeout, pollingInterval).Should(BeTrue())
 
@@ -299,9 +331,7 @@ var _ = Describe("DataImportCron", func() {
 })
 
 // NewDataImportCron initializes a DataImportCron struct
-func NewDataImportCron(name, size, schedule, dataSource string, source cdiv1.DataVolumeSourceRegistry, retentionPolicy cdiv1.DataImportCronRetentionPolicy) *cdiv1.DataImportCron {
-	garbageCollect := cdiv1.DataImportCronGarbageCollectOutdated
-
+func NewDataImportCron(name, size, schedule, dataSource string, source cdiv1.DataVolumeSourceRegistry) *cdiv1.DataImportCron {
 	return &cdiv1.DataImportCron{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -327,9 +357,28 @@ func NewDataImportCron(name, size, schedule, dataSource string, source cdiv1.Dat
 			},
 			Schedule:          schedule,
 			ManagedDataSource: dataSource,
-			GarbageCollect:    &garbageCollect,
 			ImportsToKeep:     &importsToKeep,
-			RetentionPolicy:   &retentionPolicy,
 		},
 	}
+}
+
+func getDataVolumeSourceRegistry(f *framework.Framework) (*cdiv1.DataVolumeSourceRegistry, error) {
+	reg := &cdiv1.DataVolumeSourceRegistry{}
+	var (
+		pullMethod cdiv1.RegistryPullMethod
+		url        string
+	)
+	if utils.IsOpenshift(f.K8sClient) {
+		url = fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs)
+		pullMethod = cdiv1.RegistryPullPod
+	} else {
+		url = fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix)
+		pullMethod = cdiv1.RegistryPullNode
+	}
+	reg.URL = &url
+	reg.PullMethod = &pullMethod
+	if err := utils.AddInsecureRegistry(f.CrClient, url); err != nil {
+		return nil, err
+	}
+	return reg, nil
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -483,10 +483,11 @@ var _ = Describe("ALL Operator tests", func() {
 
 				removeCDI()
 
-				By("Verify no DataImportCrons are found as CRDs and cdi-deployment are gone")
-				_, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(errors.IsNotFound(err)).To(BeTrue())
+				By("Verify no DataImportCrons are found")
+				Eventually(func() bool {
+					_, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+					return err != nil && errors.IsNotFound(err)
+				}, 1*time.Minute, 2*time.Second).Should(BeTrue())
 
 				By("Verify no cronjobs left")
 				Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
When a DataImportCron import DV has condition Running=False with Reason=Error, it indicates this DIC might get stuck with this DV forever, so no new import DVs will be created even if the source sha256 is updated. So with this change, when digest is updated, before creating the new DV, we simply delete the erroneous DV if necessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Also includes some DataImportCron tests improvements and cleanup

**Release note**:
```release-note
Delete erroneous DataVolumes on DataImportCron source digest update
```

