### PR TITLE
Use aarch64 RPMs for aarch64, add lint check for this error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test-functional: build-functest
 test-lint:
 	${DO_BAZ} "./hack/build/run-lint-checks.sh"
 	"./hack/ci/language.sh"
+	"./hack/ci/duplicate-sha256.sh"
 
 docker-registry-cleanup:
 	./hack/build/cleanup_docker.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -924,10 +924,10 @@ http_file(
 
 http_file(
     name = "ovirt-imageio-client-aarch64",
-    sha256 = "a012d8204098d992099620de1d14b423bfd179b54a618deec98cdcb37027a0cd",
+    sha256 = "f972a72737a104bf0315be72b45916225b10d08df5651a7d3b473e8753cf69c7",
     urls = [
-        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-client-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm",
-        "https://storage.googleapis.com/builddeps/a012d8204098d992099620de1d14b423bfd179b54a618deec98cdcb37027a0cd",
+        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03544054-ovirt-imageio/ovirt-imageio-client-2.4.1-0.202202242042.git51121ad.fc34.aarch64.rpm",
+        "https://storage.googleapis.com/builddeps/f972a72737a104bf0315be72b45916225b10d08df5651a7d3b473e8753cf69c7",
     ],
 )
 
@@ -942,10 +942,10 @@ http_file(
 
 http_file(
     name = "ovirt-imageio-common-aarch64",
-    sha256 = "a6f78aff23fbc6b1f68cea041144da7a6a830b7a9922bf13a140db5c1376b55c",
+    sha256 = "6ca0a205bbc023f71e05bd8359950c42453549acdac51ee4cf51e130ff422477",
     urls = [
-        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-common-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm",
-        "https://storage.googleapis.com/builddeps/a6f78aff23fbc6b1f68cea041144da7a6a830b7a9922bf13a140db5c1376b55c",
+        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03544054-ovirt-imageio/ovirt-imageio-common-2.4.1-0.202202242042.git51121ad.fc34.aarch64.rpm",
+        "https://storage.googleapis.com/builddeps/6ca0a205bbc023f71e05bd8359950c42453549acdac51ee4cf51e130ff422477",
     ],
 )
 
@@ -960,10 +960,10 @@ http_file(
 
 http_file(
     name = "ovirt-imageio-daemon-aarch64",
-    sha256 = "5cc941ed70952899802026a896e946736f6e3f18d3542cfc55699a06a3b42aa9",
+    sha256 = "9e848657b5bbd675c9253f684050adf41a2c70a3531390879fadafe1cf8ca449",
     urls = [
-        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03380475-ovirt-imageio/ovirt-imageio-daemon-2.4.1-0.202202080814.git10cee74.fc34.aarch64.rpm",
-        "https://storage.googleapis.com/builddeps/5cc941ed70952899802026a896e946736f6e3f18d3542cfc55699a06a3b42aa9",
+        "https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/fedora-34-aarch64/03544054-ovirt-imageio/ovirt-imageio-daemon-2.4.1-0.202202242042.git51121ad.fc34.aarch64.rpm",
+        "https://storage.googleapis.com/builddeps/9e848657b5bbd675c9253f684050adf41a2c70a3531390879fadafe1cf8ca449",
     ],
 )
 

--- a/hack/ci/duplicate-sha256.sh
+++ b/hack/ci/duplicate-sha256.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Check for duplicate SHA256 files in WORKSPACE.
+#
+
+CDI_DIR="$(cd $(dirname $0)/../../ && pwd -P)"
+
+DUPLICATES=$(grep sha256 "${CDI_DIR}/WORKSPACE" | sort | uniq -d)
+if [ ! -z "${DUPLICATES}" ]; then
+    echo "Found duplicate SHA256 lines in WORKSPACE."
+    echo "${DUPLICATES}"
+    echo "Please make sure you are fetching a different file for other architectures!"
+    exit 1
+fi
+


### PR DESCRIPTION
**What this PR does / why we need it**:
In #2156 we added a 404 URL for aarch64 RPMs.
[This initially caused a post-submit job to fail](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-containerized-data-importer-push-nightly-ARM64/1496319407448657920).

But this error was later concealed by #2164.
We cache files on Google Storage, and the files are fetched by checksum.
Since the checksum was specified the same as the x86_64 files, we started fetching the x86_64 RPMs and not fail to build any more.

This is somewhat hard to spot without the intermediate post-submit job failure, so let's add a test for it, running during `make test-lint`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

