### PR TITLE
fix<importer>: ip:port endpoint is not valid in s3 importer

### DIFF
--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -223,6 +223,11 @@ func createHTTPClient(certDir string) (*http.Client, error) {
 	}
 
 	if certDir == "" {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		client.Transport = transport
 		return client, nil
 	}
 

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -223,11 +223,6 @@ func createHTTPClient(certDir string) (*http.Client, error) {
 	}
 
 	if certDir == "" {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-		client.Transport = transport
 		return client, nil
 	}
 

--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -186,7 +186,7 @@ var _ = Describe("S3 data source", func() {
 	})
 
 	It("GetS3Client should return a real client", func() {
-		_, err := getS3Client("", "", "", "")
+		_, err := getS3Client("", "", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -210,11 +210,11 @@ type MockS3Client struct {
 	doErr    bool
 }
 
-func failMockS3Client(endpoint, accKey, secKey string, certDir string) (S3Client, error) {
+func failMockS3Client(endpoint, accKey, secKey string, certDir string, urlScheme string) (S3Client, error) {
 	return nil, errors.New("Failed to create client")
 }
 
-func createMockS3Client(endpoint, accKey, secKey string, certDir string) (S3Client, error) {
+func createMockS3Client(endpoint, accKey, secKey string, certDir string, urlScheme string) (S3Client, error) {
 	return &MockS3Client{
 		accKey:  accKey,
 		secKey:  secKey,
@@ -223,7 +223,7 @@ func createMockS3Client(endpoint, accKey, secKey string, certDir string) (S3Clie
 	}, nil
 }
 
-func createErrMockS3Client(endpoint, accKey, secKey string, certDir string) (S3Client, error) {
+func createErrMockS3Client(endpoint, accKey, secKey string, certDir string, urlScheme string) (S3Client, error) {
 	return &MockS3Client{
 		doErr: true,
 	}, nil


### PR DESCRIPTION
Signed-off-by: licheng <chengli@alauda.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fix ip:port endpoint is not valid in s3 importer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2173

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix ip:port endpoint not valid in s3 importer
```

