### PR TITLE
[release-v1.34] Correct backport of 'Use dedicated ServiceAccount for test manifests (#1905)'

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -115,7 +115,6 @@ function wait_cdi_pods_updated {
 # We skip the functional test additions for external provider for now, as they're specific
 if [ "${KUBEVIRT_PROVIDER}" != "external" ] && [ "${CDI_SYNC}" == "test-infra" ]; then
   configure_storage
-
   _kubectl apply -f "./_out/manifests/cdi-testing-sa.yaml"
   _kubectl apply -f "./_out/manifests/bad-webserver.yaml"
   _kubectl apply -f "./_out/manifests/file-host.yaml"

--- a/manifests/templates/cdi-testing-scc.yaml.in
+++ b/manifests/templates/cdi-testing-scc.yaml.in
@@ -1,0 +1,14 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  labels:
+    cdi.kubevirt.io/testing: ""
+  name: cdi-testing-scc
+allowedCapabilities:
+- 'SETFCAP'
+seLinuxContext:
+  type: RunAsAny
+runAsUser:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Namespace }}:cdi-testing-sa

--- a/manifests/templates/file-host.yaml.in
+++ b/manifests/templates/file-host.yaml.in
@@ -19,7 +19,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
-      serviceAccountName: cdi-sa
+      serviceAccountName: cdi-testing-sa
       initContainers:
       - name: init
         image: {{ .DockerRepo }}/cdi-func-test-file-host-init:{{ .DockerTag }}

--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -19,7 +19,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
-      serviceAccountName: cdi-sa
+      serviceAccountName: cdi-testing-sa
       initContainers:
       - name: init
         image: {{ .DockerRepo }}/imageio-init:{{ .DockerTag }}

--- a/manifests/templates/registry-host.yaml.in
+++ b/manifests/templates/registry-host.yaml.in
@@ -18,7 +18,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
-      serviceAccountName: cdi-sa
+      serviceAccountName: cdi-testing-sa
       initContainers:
       - name: registry-init
         image: {{ .DockerRepo }}/cdi-func-test-registry-init:{{ .DockerTag }}

--- a/manifests/templates/vcenter.yaml.in
+++ b/manifests/templates/vcenter.yaml.in
@@ -19,7 +19,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
-      serviceAccountName: cdi-sa
+      serviceAccountName: cdi-testing-sa
       containers:
       - name: vcsim
         image: {{ .DockerRepo }}/vcenter-simulator:{{ .DockerTag }}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We were backporting this in as part of #2139, missed the SCC which is needed for testing in OpenShift.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
