### PR TITLE
Do not factor fs overhead into available space during validation

### DIFF
--- a/hack/build/bazel-generate.sh
+++ b/hack/build/bazel-generate.sh
@@ -10,11 +10,11 @@ bazel run \
     //:gazelle $@
 
 if [[ "$@" =~ "vendor" ]]; then
-  bazel run \
-      --config=${ARCHITECTURE} \
-      -- @com_github_bazelbuild_buildtools//buildozer 'add clinkopts -lnbd' //$HOME/go/src/kubevirt.io/containerized-data-importer/vendor/libguestfs.org/libnbd/:go_default_library
- 
-  bazel run \
-      --config=${ARCHITECTURE} \
-      -- @com_github_bazelbuild_buildtools//buildozer 'add copts -D_GNU_SOURCE=1' //$HOME/go/src/kubevirt.io/containerized-data-importer/vendor/libguestfs.org/libnbd/:go_default_library
+    bazel run \
+        --config=${ARCHITECTURE} \
+        -- @com_github_bazelbuild_buildtools//buildozer 'add clinkopts -lnbd' //$HOME/go/src/kubevirt.io/containerized-data-importer/vendor/libguestfs.org/libnbd/:go_default_library
+
+    bazel run \
+        --config=${ARCHITECTURE} \
+        -- @com_github_bazelbuild_buildtools//buildozer 'add copts -D_GNU_SOURCE=1' //$HOME/go/src/kubevirt.io/containerized-data-importer/vendor/libguestfs.org/libnbd/:go_default_library
 fi

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -25,6 +25,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1alpha1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1beta1"
 	uploadv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/upload/v1alpha1"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+
 	clientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1alpha1"
 	fakecdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1alpha1/fake"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -24,6 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -24,6 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/cdi.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/cdiconfig.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/datavolume.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/datavolume.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdi.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_cdiconfig.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -21,6 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_datavolume.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_datavolume.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/cdi.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/cdiconfig.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/core_client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/dataimportcron.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/dataimportcron.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/datasource.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/datasource.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/datavolume.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/datavolume.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_cdi.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_cdi.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_cdiconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_cdiconfig.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_core_client.go
@@ -21,6 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_dataimportcron.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_dataimportcron.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_datasource.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_datasource.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_datavolume.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_datavolume.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_objecttransfer.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_objecttransfer.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_storageprofile.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/fake/fake_storageprofile.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/objecttransfer.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/objecttransfer.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/core/v1beta1/storageprofile.go
+++ b/pkg/client/clientset/versioned/typed/core/v1beta1/storageprofile.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/upload/v1alpha1/fake/fake_upload_client.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1alpha1/fake/fake_upload_client.go
@@ -21,6 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/upload/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/upload/v1alpha1/fake/fake_uploadtokenrequest.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1alpha1/fake/fake_uploadtokenrequest.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"
 )
 

--- a/pkg/client/clientset/versioned/typed/upload/v1alpha1/upload_client.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1alpha1/upload_client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/upload/v1alpha1/uploadtokenrequest.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1alpha1/uploadtokenrequest.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/upload/v1beta1/fake/fake_upload_client.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1beta1/fake/fake_upload_client.go
@@ -21,6 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/upload/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/upload/v1beta1/fake/fake_uploadtokenrequest.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1beta1/fake/fake_uploadtokenrequest.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )
 

--- a/pkg/client/clientset/versioned/typed/upload/v1beta1/upload_client.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1beta1/upload_client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/clientset/versioned/typed/upload/v1beta1/uploadtokenrequest.go
+++ b/pkg/client/clientset/versioned/typed/upload/v1beta1/uploadtokenrequest.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 	scheme "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 )

--- a/pkg/client/informers/externalversions/core/v1alpha1/cdi.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/cdi.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/cdiconfig.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1alpha1/datavolume.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/datavolume.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/cdi.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/cdi.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/cdiconfig.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/cdiconfig.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/dataimportcron.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/dataimportcron.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/datasource.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/datasource.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/datavolume.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/datavolume.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/objecttransfer.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/objecttransfer.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/core/v1beta1/storageprofile.go
+++ b/pkg/client/informers/externalversions/core/v1beta1/storageprofile.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	corev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -27,6 +27,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	core "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/core"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -23,6 +23,7 @@ import (
 
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
+
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 )
 

--- a/pkg/client/informers/externalversions/upload/v1alpha1/uploadtokenrequest.go
+++ b/pkg/client/informers/externalversions/upload/v1alpha1/uploadtokenrequest.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	uploadv1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/informers/externalversions/upload/v1beta1/uploadtokenrequest.go
+++ b/pkg/client/informers/externalversions/upload/v1beta1/uploadtokenrequest.go
@@ -26,6 +26,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
 	uploadv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 	versioned "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	internalinterfaces "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions/internalinterfaces"

--- a/pkg/client/listers/core/v1alpha1/cdi.go
+++ b/pkg/client/listers/core/v1alpha1/cdi.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/listers/core/v1alpha1/cdiconfig.go
+++ b/pkg/client/listers/core/v1alpha1/cdiconfig.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/listers/core/v1alpha1/datavolume.go
+++ b/pkg/client/listers/core/v1alpha1/datavolume.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1"
 )
 

--- a/pkg/client/listers/core/v1beta1/cdi.go
+++ b/pkg/client/listers/core/v1beta1/cdi.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/cdiconfig.go
+++ b/pkg/client/listers/core/v1beta1/cdiconfig.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/dataimportcron.go
+++ b/pkg/client/listers/core/v1beta1/dataimportcron.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/datasource.go
+++ b/pkg/client/listers/core/v1beta1/datasource.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/datavolume.go
+++ b/pkg/client/listers/core/v1beta1/datavolume.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/objecttransfer.go
+++ b/pkg/client/listers/core/v1beta1/objecttransfer.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/core/v1beta1/storageprofile.go
+++ b/pkg/client/listers/core/v1beta1/storageprofile.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/client/listers/upload/v1alpha1/uploadtokenrequest.go
+++ b/pkg/client/listers/upload/v1alpha1/uploadtokenrequest.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1alpha1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1alpha1"
 )
 

--- a/pkg/client/listers/upload/v1beta1/uploadtokenrequest.go
+++ b/pkg/client/listers/upload/v1beta1/uploadtokenrequest.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )
 

--- a/pkg/controller/datasource-controller.go
+++ b/pkg/controller/datasource-controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -36,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 // DataSourceReconciler members

--- a/pkg/controller/datasource-controller_test.go
+++ b/pkg/controller/datasource-controller_test.go
@@ -26,9 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 const (

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -62,7 +62,7 @@ type QEMUOperations interface {
 	ConvertToRawStream(*url.URL, string, bool) error
 	Resize(string, resource.Quantity, bool) error
 	Info(url *url.URL) (*ImgInfo, error)
-	Validate(*url.URL, int64, float64) error
+	Validate(*url.URL, int64) error
 	CreateBlankImage(string, resource.Quantity, bool) error
 	Rebase(backingFile string, delta string) error
 	Commit(image string) error
@@ -215,7 +215,7 @@ func isSupportedFormat(value string) bool {
 	}
 }
 
-func checkIfURLIsValid(info *ImgInfo, availableSize int64, filesystemOverhead float64, image string) error {
+func checkIfURLIsValid(info *ImgInfo, availableSize int64, image string) error {
 	if !isSupportedFormat(info.Format) {
 		return errors.Errorf("Invalid format %s for image %s", info.Format, image)
 	}
@@ -226,18 +226,18 @@ func checkIfURLIsValid(info *ImgInfo, availableSize int64, filesystemOverhead fl
 		}
 	}
 
-	if int64(float64(availableSize)*(1-filesystemOverhead)) < info.VirtualSize {
-		return errors.Errorf("Virtual image size %d is larger than available size %d (PVC size %d, reserved overhead %f%%). A larger PVC is required.", info.VirtualSize, int64((1-filesystemOverhead)*float64(availableSize)), info.VirtualSize, filesystemOverhead)
+	if availableSize < info.VirtualSize {
+		return errors.Errorf("Virtual image size %d is larger than the reported available storage %d (PVC size %d). A larger PVC is required.", info.VirtualSize, availableSize, info.VirtualSize)
 	}
 	return nil
 }
 
-func (o *qemuOperations) Validate(url *url.URL, availableSize int64, filesystemOverhead float64) error {
+func (o *qemuOperations) Validate(url *url.URL, availableSize int64) error {
 	info, err := o.Info(url)
 	if err != nil {
 		return err
 	}
-	return checkIfURLIsValid(info, availableSize, filesystemOverhead, url.String())
+	return checkIfURLIsValid(info, availableSize, url.String())
 }
 
 // ConvertToRawStream converts an http accessible image to raw format without locally caching the image
@@ -246,8 +246,8 @@ func ConvertToRawStream(url *url.URL, dest string, preallocate bool) error {
 }
 
 // Validate does basic validation of a qemu image
-func Validate(url *url.URL, availableSize int64, filesystemOverhead float64) error {
-	return qemuIterface.Validate(url, availableSize, filesystemOverhead)
+func Validate(url *url.URL, availableSize int64) error {
+	return qemuIterface.Validate(url, availableSize)
 }
 
 func reportProgress(line string) {

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -217,9 +217,9 @@ var _ = Describe("Resize", func() {
 var _ = Describe("Validate", func() {
 	imageName, _ := url.Parse("myimage.qcow2")
 
-	table.DescribeTable("Validate should", func(execfunc execFunctionType, errString string, image *url.URL, overhead float64) {
+	table.DescribeTable("Validate should", func(execfunc execFunctionType, errString string, image *url.URL) {
 		replaceExecFunction(execfunc, func() {
-			err := Validate(image, 42949672960, overhead)
+			err := Validate(image, 42949672960)
 
 			if errString == "" {
 				Expect(err).NotTo(HaveOccurred())
@@ -232,13 +232,12 @@ var _ = Describe("Validate", func() {
 			}
 		})
 	},
-		table.Entry("should return success", mockExecFunction(goodValidateJSON, "", expectedLimits, "info", "--output=json", imageName.String()), "", imageName, 0.0),
-		table.Entry("should return error", mockExecFunction("explosion", "exit 1", expectedLimits), "explosion, exit 1", imageName, 0.0),
-		table.Entry("should return error on bad json", mockExecFunction(badValidateJSON, "", expectedLimits), "unexpected end of JSON input", imageName, 0.0),
-		table.Entry("should return error on bad format", mockExecFunction(badFormatValidateJSON, "", expectedLimits), fmt.Sprintf("Invalid format raw2 for image %s", imageName), imageName, 0.0),
-		table.Entry("should return error on invalid backing file", mockExecFunction(backingFileValidateJSON, "", expectedLimits), fmt.Sprintf("Image %s is invalid because it has invalid backing file backing-file.qcow2", imageName), imageName, 0.0),
-		table.Entry("should return error when PVC is too small", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("Virtual image size %d is larger than available size %d (PVC size %d, reserved overhead %f%%). A larger PVC is required.", 52949672960, 42949672960, 52949672960, 0.0), imageName, 0.0),
-		table.Entry("should return error when PVC is too small with overhead", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("Virtual image size %d is larger than available size %d (PVC size %d, reserved overhead %f%%). A larger PVC is required.", 52949672960, 34359738368, 52949672960, 0.2), imageName, 0.2),
+		table.Entry("should return success", mockExecFunction(goodValidateJSON, "", expectedLimits, "info", "--output=json", imageName.String()), "", imageName),
+		table.Entry("should return error", mockExecFunction("explosion", "exit 1", expectedLimits), "explosion, exit 1", imageName),
+		table.Entry("should return error on bad json", mockExecFunction(badValidateJSON, "", expectedLimits), "unexpected end of JSON input", imageName),
+		table.Entry("should return error on bad format", mockExecFunction(badFormatValidateJSON, "", expectedLimits), fmt.Sprintf("Invalid format raw2 for image %s", imageName), imageName),
+		table.Entry("should return error on invalid backing file", mockExecFunction(backingFileValidateJSON, "", expectedLimits), fmt.Sprintf("Image %s is invalid because it has invalid backing file backing-file.qcow2", imageName), imageName),
+		table.Entry("should return error when PVC is too small", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("Virtual image size %d is larger than the reported available storage %d (PVC size %d). A larger PVC is required.", 52949672960, 42949672960, 52949672960), imageName),
 	)
 
 })

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -286,7 +286,7 @@ func (dp *DataProcessor) ProcessDataWithPause() error {
 
 func (dp *DataProcessor) validate(url *url.URL) error {
 	klog.V(1).Infoln("Validating image")
-	err := qemuOperations.Validate(url, dp.availableSpace, dp.filesystemOverhead)
+	err := qemuOperations.Validate(url, dp.availableSpace)
 	if err != nil {
 		return ValidationSizeError{err: err}
 	}

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -579,7 +579,7 @@ func (o *fakeQEMUOperations) ConvertToRawStream(*url.URL, string, bool) error {
 	return o.e2
 }
 
-func (o *fakeQEMUOperations) Validate(*url.URL, int64, float64) error {
+func (o *fakeQEMUOperations) Validate(*url.URL, int64) error {
 	return o.e5
 }
 

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -48,10 +48,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	libnbd "libguestfs.org/libnbd"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
-	libnbd "libguestfs.org/libnbd"
 )
 
 // May be overridden in tests

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -22,8 +22,9 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 
-	"kubevirt.io/containerized-data-importer/pkg/image"
 	libnbd "libguestfs.org/libnbd"
+
+	"kubevirt.io/containerized-data-importer/pkg/image"
 )
 
 const (


### PR DESCRIPTION
    Do not factor fs overhead into available space during validation
    
    Fixes bz#2064936.
    
    When validating whether an image will fit into a PV we compare the
    image's virtual size to the filesystem's reported available space to
    guage whether it will fit.  The current calculation reduces the apparent
    available space by the configured filesystem overhead value but the
    overhead is already (mostly) factored into the result of Statfs.  This
    causes the check to fail for PVCs that are just large enough to
    accommodate an image plus overhead (ie. when using the DataVolume
    Storage API with filesystem PVs with capacity constrained by the PVC
    storage request size).
    
    This was not caught in testing because HPP does not have capacity
    constrained PVs and we are typically testing block volumes in the ceph
    lanes.  It can be triggered in our CI by allocating a Filesystem PV on
    ceph-rbd storage because these volumes are capacity constrained and
    subject to filesystem overhead.
    
    Signed-off-by: Adam Litke <alitke@redhat.com>

```release-note
NONE
```

