### PR TITLE
Reconcile DVs waiting for default SC

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -340,18 +340,23 @@ func addDatavolumeControllerWatches(mgr manager.Manager, datavolumeController co
 		}
 	}
 
+	const dvPhaseField = "status.phase"
+
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &cdiv1.DataVolume{}, dvPhaseField, func(obj client.Object) []string {
+		return []string{string(obj.(*cdiv1.DataVolume).Status.Phase)}
+	}); err != nil {
+		return err
+	}
+
 	// Watch for SC updates and reconcile the DVs waiting for default SC
-	// FIXME: consider labelling DVs with waitingForDefaultSC instead of checking for empty phase
 	if err := datavolumeController.Watch(&source.Kind{Type: &storagev1.StorageClass{}}, handler.EnqueueRequestsFromMapFunc(
 		func(obj client.Object) (reqs []reconcile.Request) {
 			dvList := &cdiv1.DataVolumeList{}
-			if err := mgr.GetClient().List(context.TODO(), dvList, &client.ListOptions{}); err != nil {
+			if err := mgr.GetClient().List(context.TODO(), dvList, client.MatchingFields{dvPhaseField: ""}); err != nil {
 				return
 			}
 			for _, dv := range dvList.Items {
-				if dv.Status.Phase == "" {
-					reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
-				}
+				reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
 			}
 			return
 		},

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1491,8 +1492,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			config              *cdiv1.CDIConfig
 			origSpec            *cdiv1.CDIConfigSpec
 			originalProfileSpec *cdiv1.StorageProfileSpec
-			err                 error
+			defaultSc           *storagev1.StorageClass
 			defaultScName       string
+			err                 error
 		)
 
 		fillData := "123456789012345678901234567890123456789012345678901234567890"
@@ -1595,6 +1597,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		BeforeEach(func() {
 			defaultScName = utils.DefaultStorageClass.GetName()
+			utils.DefaultStorageClass, err = f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), defaultScName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			defaultSc = utils.DefaultStorageClass
 
 			config, err = f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -1604,6 +1609,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		AfterEach(func() {
+			if defaultSc.Annotations[controller.AnnDefaultStorageClass] != "true" {
+				By("Restoring default storage class")
+				defaultSc.Annotations[controller.AnnDefaultStorageClass] = "true"
+				utils.DefaultStorageClass, err = f.K8sClient.StorageV1().StorageClasses().Update(context.TODO(), defaultSc, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			if originalProfileSpec != nil {
 				By("Restoring the StorageProfile to original state")
 				updateStorageProfileSpec(f.CrClient, defaultScName, *originalProfileSpec)
@@ -1740,6 +1752,49 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
 				return false
 			}, timeout, pollingInterval).Should(BeTrue())
+		})
+
+		It("[test_id:8383]Import fails when no default storage class, and recovers when default is set", func() {
+			By("updating to no default storage class")
+			defaultSc.Annotations[controller.AnnDefaultStorageClass] = "false"
+			defaultSc, err = f.K8sClient.StorageV1().StorageClasses().Update(context.TODO(), defaultSc, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("creating new datavolume %s without accessModes", dataVolumeName))
+			requestedSize := resource.MustParse("100Mi")
+			spec := cdiv1.StorageSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: requestedSize,
+					},
+				},
+			}
+			dataVolume := createDataVolumeForImport(f, spec)
+
+			By("verifying event occurred")
+			Eventually(func() bool {
+				// Only find DV events, we know the PVC gets the same events
+				events, err := RunKubectlCommand(f, "get", "events", "-n", dataVolume.Namespace, "--field-selector=involvedObject.kind=DataVolume")
+				if err == nil {
+					fmt.Fprintf(GinkgoWriter, "%s", events)
+					return strings.Contains(events, controller.ErrClaimNotValid) && strings.Contains(events, "DataVolume.storage spec is missing accessMode and no storageClass to choose profile")
+				}
+				fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
+				return false
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			By("verifying pvc not created")
+			_, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			By("restoring default storage class")
+			defaultSc.Annotations[controller.AnnDefaultStorageClass] = "true"
+			defaultSc, err = f.K8sClient.StorageV1().StorageClasses().Update(context.TODO(), defaultSc, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying pvc created")
+			_, err = utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("[test_id:5913]Import recovers when user adds accessModes to profile", func() {


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
DataVolume controller will not create PVCs without a default storage class, and we'll get error and event:
`DataVolume.storage spec is missing accessMode and no storageClass to choose profile`
However, even after defining default SC, so far DV was not reconciled so it was stuck in this state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Automatically recover DV from unconfigured default storage class, once default is set
```

