### PR TITLE
Include namespace on upgrade test manifest/attempt to fix quota test

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -140,8 +140,7 @@ function setup_for_upgrade_testing {
   _kubectl apply -f "./_out/manifests/registry-host.yaml"
   echo "Waiting for testing tools to be ready"
   _kubectl wait pod -n ${CDI_NAMESPACE} --for=condition=Ready --all --timeout=${CDI_AVAILABLE_TIMEOUT}s
-  _kubectl create namespace cdi-testing-old-version-artifacts
-  _kubectl apply --namespace cdi-testing-old-version-artifacts -f "./_out/manifests/upgrade-testing-artifacts.yaml"
+  _kubectl apply -f "./_out/manifests/upgrade-testing-artifacts.yaml"
   echo "Waiting for old version artifacts to come up"
   _kubectl wait dv --namespace cdi-testing-old-version-artifacts --for=condition=Ready --all --timeout=${CDI_AVAILABLE_TIMEOUT}s
 }

--- a/manifests/templates/upgrade-testing-artifacts.yaml.in
+++ b/manifests/templates/upgrade-testing-artifacts.yaml.in
@@ -1,8 +1,14 @@
 # This example assumes you are using a default storage class
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cdi-testing-old-version-artifacts
+---
 apiVersion: cdi.kubevirt.io/v1alpha1
 kind: DataVolume
 metadata:
   name: olddv-v1alpha1
+  namespace: cdi-testing-old-version-artifacts
 spec:
   source:
       http:
@@ -18,6 +24,7 @@ apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: olddv-v1beta1
+  namespace: cdi-testing-old-version-artifacts
 spec:
   source:
       http:

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -497,7 +497,8 @@ func (f *Framework) CreateStorageQuota(numPVCs, requestStorage int64) error {
 	return wait.PollImmediate(2*time.Second, nsDeleteTime, func() (bool, error) {
 		quota, err := f.K8sClient.CoreV1().ResourceQuotas(ns).Get(context.TODO(), "test-storage-quota", metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			fmt.Fprintf(ginkgo.GinkgoWriter, "ERROR: GET ResourceQuota failed once, retrying: %v\n", err.Error())
+			return false, nil
 		}
 		return len(quota.Status.Hard) == 2, nil
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
* Don't back out until we verify quota status is set following us POSTing it
Otherwise its possible that we attempt to create PVC when quota not yet applied:
```bash
persistentvolumeclaims \"test-pvc\" is forbidden: status unknown for quota: test-storage-quota, resources: persistentvolumeclaims,requests.storage
```
* Include namespace of upgrade testing manifests in yaml
More friendly towards testing us on a different environment than our CI
(won't use cluster-sync on OpenShift testing for example)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

