### PR TITLE
Improve handling of prePopulated DV

### DIFF
--- a/pkg/controller/datavolume-conditions.go
+++ b/pkg/controller/datavolume-conditions.go
@@ -122,7 +122,7 @@ func updateReadyCondition(conditions []cdiv1.DataVolumeCondition, status corev1.
 }
 
 func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, reason string) []cdiv1.DataVolumeCondition {
-	if pvc != nil {
+	if pvc != nil && pvc.Name != "" {
 		pvcCondition := getPVCCondition(pvc.GetAnnotations())
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 	"regexp"
 	"strings"
@@ -1118,6 +1119,45 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			table.Entry("[test_id:8044]for upload DataVolume", createUploadDataVolume, tinyCoreIsoURL()),
 			table.Entry("[test_id:8045]for clone DataVolume", createCloneDataVolume, fillCommand),
 		)
+
+		It("Should handle a pre populated DV", func() {
+			By(fmt.Sprintf("initializing dataVolume marked as prePopulated %s", dataVolumeName))
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", cirrosURL())
+			dataVolume.Annotations["cdi.kubevirt.io/storage.prePopulated"] = dataVolumeName
+
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying Pending without PVC")
+			Eventually(func() cdiv1.DataVolumePhase {
+				dv, _ := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return dv.Status.Phase
+			}, timeout, pollingInterval).Should(Equal(cdiv1.Pending))
+
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "PVC Should not exist")
+
+			By("Create PVC")
+			annotations := map[string]string{"cdi.kubevirt.io/storage.populatedFor": dataVolumeName}
+			pvcDef := utils.NewPVCDefinition(dataVolumeName, "100m", annotations, nil)
+			pvcDef.OwnerReferences = append(pvcDef.OwnerReferences,
+				*metav1.NewControllerRef(dataVolume, schema.GroupVersionKind{
+					Group:   cdiv1.SchemeGroupVersion.Group,
+					Version: cdiv1.SchemeGroupVersion.Version,
+					Kind:    "DataVolume",
+				}))
+			_, err = f.CreateBoundPVCFromDefinition(pvcDef)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying Succeed with PVC Bound")
+			Eventually(func() cdiv1.DataVolumePhase {
+				dv, _ := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return dv.Status.Phase
+			}, timeout, pollingInterval).Should(Equal(cdiv1.Succeeded))
+
+		})
 
 		It("[test_id:4961]should handle a pre populated PVC", func() {
 			By(fmt.Sprintf("initializing source PVC %s", dataVolumeName))


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Previously, when a DataVolume was Reconciled then CDI created PVC
regardless of prePopulated annotation.

There is a possibility that DataVolume and PVC pair is being
restored or moved from other cluster. When DataVolume is marked
as prePopulated, the CDI should not try to populate it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle prepopulated DV
```

