### PR TITLE
tighten sync between smart clone and transfer controllers

### DIFF
--- a/pkg/controller/smart-clone-controller_test.go
+++ b/pkg/controller/smart-clone-controller_test.go
@@ -117,6 +117,15 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("Should error with malformed annotation", func() {
+			reconciler := createSmartCloneReconciler()
+			pvc := createPVCWithSnapshotSource("test-dv", "invalid")
+			pvc.Annotations["cdi.kubevirt.io/smartCloneSnapshot"] = "foo/bar/baz"
+			_, err := reconciler.reconcilePvc(reconciler.log, pvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unexpected key format"))
+		})
+
 		It("Should add cloneOf annotation and delete snapshot", func() {
 			pvc := createPVCWithSnapshotSource("test-dv", "invalid")
 			snapshot := createSnapshotVolume("invalid", pvc.Namespace, nil)

--- a/pkg/controller/transfer/pvc.go
+++ b/pkg/controller/transfer/pvc.go
@@ -129,7 +129,8 @@ func (h *pvcTransferHandler) ReconcileRunning(ot *cdiv1.ObjectTransfer) (time.Du
 		return 0, h.reconciler.setCompleteConditionError(ot, err)
 	}
 
-	if sourceExists {
+	// must assert pointing to same PV to avoid races/contention with smartclone controller
+	if sourceExists && source.Spec.VolumeName == pv.Name {
 		if pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimRetain {
 			pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
 			if err := h.reconciler.updateResource(ot, pv); err != nil {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

[BZ: 2057148](https://bugzilla.redhat.com/show_bug.cgi?id=2057148)

There were some pretty nasty synchronization issues between smart clone controller and object transfer controller.  I think this is how we got there:

1.  Smart Clone Controller (SCC) adds "clone of" annotation to tmp pvc
2. SCC errors deleting Volume Snapshot
3. Object Transfer Controller (OTC) deletes tmp PVC
4. SCC creates another tmp PVC

Steps 3 and 4 repeat forever or until we run out of storage/quota in the source namespace

To stop from happening:

1.  SCC deletes VolumeSnapshot before adding "clone of" annotation
2. OTC checks source PVC refers to appropriate PV

I think there is still a possibility that DataVolume controller will recreate the VolumeSnapshot but it requires pretty significant refactoring to fix that.  I believe this gets us 90% of the way to addressing the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # BZ: 2057148

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
6. If no release note is required, just write "NONE".
-->
```release-note
BugFix: BZ#2057148 https://bugzilla.redhat.com/show_bug.cgi?id=2057148
```

