### PR TITLE
Debug flaky imageio tests

### DIFF
--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -40,7 +40,7 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; ovirt-imageioctl add-ticket myticket.json; sleep infinity"]
+        args: ["-c", "openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; ovirt-imageioctl add-ticket myticket.json; tail -n+1 -f /var/log/ovirt-imageio/daemon.log"]
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: quay.io/kubevirt/fakeovirt:v1.38.0


### PR DESCRIPTION
Add the imageio log to the pod log.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The image logs were not being recorded in the pod log, and thus it was impossible to see why the imageio server is returning a 403. This PR adds the log to the pod log so we can see it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

