### PR TITLE
Retry adding ticket on imageio container startup

### DIFF
--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -40,7 +40,11 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem; openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/cert.pem; ovirt-imageio& sleep 3; ovirt-imageioctl add-ticket myticket.json; sleep infinity"]
+        args:
+        - -c
+        - openssl x509 -in /tmp/certs/tls.crt -out /tmp/certs/ca.pem && openssl x509 -in
+          /tmp/certs/tls.crt -out /tmp/certs/cert.pem && ovirt-imageio& sleep 15 && ovirt-imageioctl
+          add-ticket myticket.json && tail -n+1 -f /var/log/ovirt-imageio/daemon.log
       - name: fakeovirt
         # Docker file: https://github.com/machacekondra/fakeovirt
         image: quay.io/kubevirt/fakeovirt:v1.38.0
@@ -54,7 +58,10 @@ spec:
         - name: "certs"
           mountPath: "/tmp"
         command: ["/bin/bash"]
-        args: ["-c", "cp /tmp/certs/tls.crt /app/imageio.crt; cp /tmp/certs/tls.key /app/server.key;/app/main"]
+        args:
+        - -c
+        - cp /tmp/certs/tls.crt /app/imageio.crt && cp /tmp/certs/tls.key /app/server.key
+          && /app/main
       volumes:
       - name: "certs"
         emptyDir: {}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes we see that ticket is not there (thx awels), we might want to
try a few times before giving up.
With `&&` if the add-ticket command fails, the container will keep restarting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

