### PR TITLE
Detect storage capabilities for no-provisioner storage classes

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -774,8 +774,8 @@ func ValidateCanCloneSourceAndTargetSpec(sourceSpec, targetSpec *corev1.Persiste
 		return err
 	}
 	// Allow different source and target volume modes only on KubeVirt content type
-	sourceVolumeMode := resolveVolumeMode(sourceSpec.VolumeMode)
-	targetVolumeMode := resolveVolumeMode(targetSpec.VolumeMode)
+	sourceVolumeMode := util.ResolveVolumeMode(sourceSpec.VolumeMode)
+	targetVolumeMode := util.ResolveVolumeMode(targetSpec.VolumeMode)
 	if sourceVolumeMode != targetVolumeMode && contentType != cdiv1.DataVolumeKubeVirt {
 		return fmt.Errorf("source volumeMode (%s) and target volumeMode (%s) do not match, contentType (%s)",
 			sourceVolumeMode, targetVolumeMode, contentType)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1665,12 +1665,12 @@ func (r *DatavolumeReconciler) validateSameVolumeMode(
 	sourcePvc *corev1.PersistentVolumeClaim,
 	targetStorageClass *storagev1.StorageClass) (bool, error) {
 
-	sourceVolumeMode := resolveVolumeMode(sourcePvc.Spec.VolumeMode)
+	sourceVolumeMode := util.ResolveVolumeMode(sourcePvc.Spec.VolumeMode)
 	targetSpecVolumeMode, err := getStorageVolumeMode(r.client, dataVolume, targetStorageClass)
 	if err != nil {
 		return false, err
 	}
-	targetVolumeMode := resolveVolumeMode(targetSpecVolumeMode)
+	targetVolumeMode := util.ResolveVolumeMode(targetSpecVolumeMode)
 
 	if sourceVolumeMode != targetVolumeMode {
 		r.log.V(3).Info("Source PVC and target PVC have different volume modes, falling back to host assisted clone",
@@ -1720,7 +1720,7 @@ func (r *DatavolumeReconciler) calculateUsableSpace(srcStorageClass *storagev1.S
 	mode *corev1.PersistentVolumeMode,
 	srcRequest resource.Quantity) (resource.Quantity, error) {
 
-	if resolveVolumeMode(mode) == corev1.PersistentVolumeFilesystem {
+	if util.ResolveVolumeMode(mode) == corev1.PersistentVolumeFilesystem {
 		fsOverhead, err := GetFilesystemOverheadForStorageClass(r.client, &srcStorageClass.Name)
 		if err != nil {
 			return resource.Quantity{}, err
@@ -2401,7 +2401,7 @@ func (r *DatavolumeReconciler) newPersistentVolumeClaim(dataVolume *cdiv1.DataVo
 	labels := map[string]string{
 		common.CDILabelKey: common.CDILabelValue,
 	}
-	if resolveVolumeMode(targetPvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
+	if util.ResolveVolumeMode(targetPvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
 		labels[common.KubePersistentVolumeFillingUpSuppressLabelKey] = common.KubePersistentVolumeFillingUpSuppressLabelValue
 	}
 	annotations := make(map[string]string)

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -568,7 +568,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			scName := "testsc"
 			sc := createStorageClassWithProvisioner(scName, map[string]string{
 				AnnDefaultStorageClass: "true",
-			}, "csi-plugin")
+			}, map[string]string{}, "csi-plugin")
 			sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, blockMode)
 
 			dv.Spec.PVC.StorageClassName = &scName
@@ -595,7 +595,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			scName := "testsc"
 			sc := createStorageClassWithProvisioner(scName, map[string]string{
 				AnnDefaultStorageClass: "true",
-			}, "csi-plugin")
+			}, map[string]string{}, "csi-plugin")
 			sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, blockMode)
 
 			dv.Spec.PVC.StorageClassName = &scName
@@ -652,7 +652,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			scName := "testsc"
 			sc := createStorageClassWithProvisioner(scName, map[string]string{
 				AnnDefaultStorageClass: "true",
-			}, "csi-plugin")
+			}, map[string]string{}, "csi-plugin")
 			sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, blockMode)
 
 			dv.Spec.PVC.StorageClassName = &scName
@@ -684,7 +684,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			scName := "testsc"
 			sc := createStorageClassWithProvisioner(scName, map[string]string{
 				AnnDefaultStorageClass: "true",
-			}, "csi-plugin")
+			}, map[string]string{}, "csi-plugin")
 			sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, blockMode)
 
 			dv.Spec.PVC.StorageClassName = &scName
@@ -1187,7 +1187,7 @@ var _ = Describe("All DataVolume Tests", func() {
 
 			// this pvc is only used by the "clone" DV
 			srcPvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
-			sc := createStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, "csi-plugin")
+			sc := createStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
 			storageProfile := createStorageProfile(scName, nil, blockMode)
 
 			reconciler = createDatavolumeReconciler(testDv, srcPvc, sc, storageProfile)
@@ -1436,7 +1436,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			scName := "testsc"
 			sc := createStorageClassWithProvisioner(scName, map[string]string{
 				AnnDefaultStorageClass: "true",
-			}, "csi-plugin")
+			}, map[string]string{}, "csi-plugin")
 			dv.Spec.PVC.StorageClassName = &scName
 			pvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
 			expectedSnapshotClass := "snap-class"
@@ -1491,7 +1491,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				})
 				sc := createStorageClassWithProvisioner(scName, map[string]string{
 					AnnDefaultStorageClass: "true",
-				}, "csi-plugin")
+				}, map[string]string{}, "csi-plugin")
 
 				accessMode := []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
 				storageProfile := createStorageProfileWithCloneStrategy(scName,
@@ -1543,7 +1543,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				pvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
 				sc := createStorageClassWithProvisioner(scName, map[string]string{
 					AnnDefaultStorageClass: "true",
-				}, "csi-plugin")
+				}, map[string]string{}, "csi-plugin")
 
 				accessMode := []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
 				storageProfile := createStorageProfileWithCloneStrategy(scName,

--- a/pkg/controller/smart-clone-controller.go
+++ b/pkg/controller/smart-clone-controller.go
@@ -341,7 +341,7 @@ func newPvcFromSnapshot(snapshot *snapshotv1.VolumeSnapshot, targetPvcSpec *core
 		common.CDILabelKey:       common.CDILabelValue,
 		common.CDIComponentLabel: common.SmartClonerCDILabel,
 	}
-	if resolveVolumeMode(targetPvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
+	if util.ResolveVolumeMode(targetPvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
 		labels[common.KubePersistentVolumeFillingUpSuppressLabelKey] = common.KubePersistentVolumeFillingUpSuppressLabelValue
 	}
 

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -141,7 +141,7 @@ func (r *StorageProfileReconciler) getStorageProfile(sc *storagev1.StorageClass)
 
 func (r *StorageProfileReconciler) reconcilePropertySets(sc *storagev1.StorageClass) []cdiv1.ClaimPropertySet {
 	claimPropertySets := []cdiv1.ClaimPropertySet{}
-	capabilities, found := storagecapabilities.Get(sc)
+	capabilities, found := storagecapabilities.Get(r.client, sc)
 	if found {
 		for i := range capabilities {
 			claimPropertySet := cdiv1.ClaimPropertySet{

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -221,16 +221,7 @@ func GetVolumeMode(pvc *v1.PersistentVolumeClaim) v1.PersistentVolumeMode {
 
 // returns the volumeMode from PVC handling default empty value
 func getVolumeMode(pvc *v1.PersistentVolumeClaim) v1.PersistentVolumeMode {
-	return resolveVolumeMode(pvc.Spec.VolumeMode)
-}
-
-// resolveVolumeMode returns the volume mode if set, otherwise defaults to file system mode
-func resolveVolumeMode(volumeMode *v1.PersistentVolumeMode) v1.PersistentVolumeMode {
-	retVolumeMode := v1.PersistentVolumeFilesystem
-	if volumeMode != nil && *volumeMode == v1.PersistentVolumeBlock {
-		retVolumeMode = v1.PersistentVolumeBlock
-	}
-	return retVolumeMode
+	return util.ResolveVolumeMode(pvc.Spec.VolumeMode)
 }
 
 // checks if particular label exists in pvc
@@ -1095,7 +1086,7 @@ func volumeSize(c client.Client, storage *cdiv1.StorageSpec, volumeMode *v1.Pers
 	}
 
 	// disk or image size, inflate it with overhead
-	if resolveVolumeMode(volumeMode) == v1.PersistentVolumeFilesystem {
+	if util.ResolveVolumeMode(volumeMode) == v1.PersistentVolumeFilesystem {
 		fsOverhead, err := GetFilesystemOverheadForStorageClass(c, storage.StorageClassName)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -525,6 +525,25 @@ func createPvcInStorageClass(name, ns string, storageClassName *string, annotati
 	return pvc
 }
 
+func CreatePv(name string, storageClassName string) *v1.PersistentVolume {
+	volumeMode := v1.PersistentVolumeFilesystem
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID(name),
+		},
+		Spec: v1.PersistentVolumeSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany, v1.ReadWriteOnce},
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("1G"),
+			},
+			StorageClassName: storageClassName,
+			VolumeMode:       &volumeMode,
+		},
+	}
+	return pv
+}
+
 func createScratchPvc(pvc *v1.PersistentVolumeClaim, pod *v1.Pod, storageClassName string) *v1.PersistentVolumeClaim {
 	t := true
 	labels := map[string]string{
@@ -693,12 +712,13 @@ func createStorageClassWithBindingMode(name string, annotations map[string]strin
 	}
 }
 
-func createStorageClassWithProvisioner(name string, annotations map[string]string, provisioner string) *storagev1.StorageClass {
+func createStorageClassWithProvisioner(name string, annotations, labels map[string]string, provisioner string) *storagev1.StorageClass {
 	return &storagev1.StorageClass{
 		Provisioner: provisioner,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: annotations,
+			Labels:      labels,
 		},
 	}
 }

--- a/pkg/monitoring/BUILD.bazel
+++ b/pkg/monitoring/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/common:go_default_library"],
+)

--- a/pkg/storagecapabilities/BUILD.bazel
+++ b/pkg/storagecapabilities/BUILD.bazel
@@ -6,7 +6,9 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/storagecapabilities",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -457,3 +457,12 @@ func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
 	// This later conflicts with image size validation.
 	return RoundDown(spaceWithOverhead, DefaultAlignBlockSize)
 }
+
+// ResolveVolumeMode returns the volume mode if set, otherwise defaults to file system mode
+func ResolveVolumeMode(volumeMode *v1.PersistentVolumeMode) v1.PersistentVolumeMode {
+	retVolumeMode := v1.PersistentVolumeFilesystem
+	if volumeMode != nil && *volumeMode == v1.PersistentVolumeBlock {
+		retVolumeMode = v1.PersistentVolumeBlock
+	}
+	return retVolumeMode
+}


### PR DESCRIPTION
Assume there's a persistent volume that we can look up to infer the
correct values for volume mode and access modes.

Move storagecapabilities code into controller as a path of lower
resistance to using "resolveVolumeMode"

**Special notes for your reviewer**:
As a side-note, this was aiming to detect the storage configuration of [local storage operator](https://github.com/openshift/local-storage-operator).
Looking up the configmap of this operator felt like it might be a layering violation, so I looked for another way.
Looking up persistent volumes actually works for any no-provisioner storage class, which is even better!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Detect storage capabilities for no-provisioner storage classes by looking up persistent volumes
```

