### PR TITLE
Bugfix - Correctly handle populated PVC 

### DIFF
--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -937,7 +937,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.Status.Phase = current
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, nil)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, nil, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 
 			dv = &cdiv1.DataVolume{}
@@ -980,7 +980,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1022,7 +1022,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1067,7 +1067,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1106,7 +1106,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1153,7 +1153,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1213,7 +1213,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				pvc.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
 			}
 
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc)
+			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, NoClone)
 			Expect(err).ToNot(HaveOccurred())
 
 			dv = &cdiv1.DataVolume{}

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1180,6 +1180,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 					string(dv.Status.Progress) == "N/A"
 			}, timeout, pollingInterval).Should(BeTrue())
 		})
+
 	})
 
 	Describe("[rfe_id:1111][test_id:2001][crit:low][vendor:cnv-qe@redhat.com][level:component]Verify multiple blank disk creations in parallel", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Correctly handling of the prepopulated volumes created with clone.

Problem: the controller sees "populated for", takes ownership of the PVC, but still gets to the ensureExtendedToken 
This bug has more details: https://bugzilla.redhat.com/show_bug.cgi?id=2070366

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=2070366


**Special notes for your reviewer**:

First version of the PR was meant to cover all edge cases. Now it only covers part of the clone and the rest can be done in following PR's, and is tracked with https://github.com/kubevirt/containerized-data-importer/issues/2250

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Correctly handle populated PVC created with clone operation
```

