### PR TITLE
[release-v1.38] Delete profile as a follow up to storage class getting deleted

### DIFF
--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -41,7 +41,12 @@ func (r *StorageProfileReconciler) Reconcile(_ context.Context, req reconcile.Re
 
 	storageClass := &storagev1.StorageClass{}
 	if err := r.client.Get(context.TODO(), req.NamespacedName, storageClass); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return reconcile.Result{}, r.deleteStorageProfile(req.NamespacedName.Name, log)
+		}
 		return reconcile.Result{}, err
+	} else if storageClass.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, r.deleteStorageProfile(req.NamespacedName.Name, log)
 	}
 
 	return r.reconcileStorageProfile(storageClass)
@@ -150,6 +155,21 @@ func (r *StorageProfileReconciler) createEmptyStorageProfile(sc *storagev1.Stora
 		return nil, err
 	}
 	return storageProfile, nil
+}
+
+func (r *StorageProfileReconciler) deleteStorageProfile(name string, log logr.Logger) error {
+	log.Info("Cleaning up StorageProfile that corresponds to deleted StorageClass", "StorageClass.Name", name)
+	storageProfileObj := &cdiv1.StorageProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := r.client.Delete(context.TODO(), storageProfileObj); IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	return nil
 }
 
 // MakeEmptyStorageProfileSpec creates StorageProfile manifest

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
+)
+
+var (
+	storageProfileLog = logf.Log.WithName("storageprofile-controller-test")
+	storageClassName  = "testSC"
+)
+
+var _ = Describe("Storage profile controller reconcile loop", func() {
+
+	It("Should not requeue if storage class can not be found", func() {
+		reconciler := createStorageProfileReconciler()
+		res, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
+		Expect(res.Requeue).ToNot(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+		storageProfileList := &cdiv1.StorageProfileList{}
+		err = reconciler.client.List(context.TODO(), storageProfileList, &client.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(storageProfileList.Items)).To(Equal(0))
+	})
+
+	It("Should delete storage profile when corresponding storage class gets deleted", func() {
+		storageClass := createStorageClass(storageClassName, map[string]string{AnnDefaultStorageClass: "true"})
+		reconciler := createStorageProfileReconciler(storageClass)
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
+		Expect(err).ToNot(HaveOccurred())
+		storageProfileList := &cdiv1.StorageProfileList{}
+		err = reconciler.client.List(context.TODO(), storageProfileList, &client.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(storageProfileList.Items)).To(Equal(1))
+		err = reconciler.client.Delete(context.TODO(), storageClass)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
+		Expect(err).ToNot(HaveOccurred())
+		err = reconciler.client.List(context.TODO(), storageProfileList, &client.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(storageProfileList.Items)).To(Equal(0))
+	})
+})
+
+func createStorageProfileReconciler(objects ...runtime.Object) *StorageProfileReconciler {
+	objs := []runtime.Object{}
+	objs = append(objs, objects...)
+	objs = append(objs, MakeEmptyCDICR())
+	// Append empty CDIConfig object that normally is created by the reconcile loop
+	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+	cdiConfig.Status = cdiv1.CDIConfigStatus{
+		// ScratchSpaceStorageClass: storageClassName,
+	}
+
+	objs = append(objs, cdiConfig)
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	cdiv1.AddToScheme(s)
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	// Create a ReconcileMemcached object with the scheme and fake client.
+	r := &StorageProfileReconciler{
+		client:         cl,
+		uncachedClient: cl,
+		scheme:         s,
+		log:            storageProfileLog,
+		installerLabels: map[string]string{
+			common.AppKubernetesPartOfLabel:  "testing",
+			common.AppKubernetesVersionLabel: "v0.0.0-tests",
+		},
+	}
+	return r
+}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of one of the commits in https://github.com/kubevirt/containerized-data-importer/pull/2027.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2057301

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: When a storage class is deleted, it will automatically delete the storage profile
```

