### PR TITLE
cloner_startup.sh: "pipefail" requires bash

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #Copyright 2018 The CDI Authors.
 #


### PR DESCRIPTION
This file uses /bin/sh as its interpreter, but uses a Bash-specific
option (pipefail).  This works in Fedora because /bin/sh is a sym link
to /bin/bash, but it fails on distros where /bin/sh is not a sym link
to /bin/bash (e.g., Ubuntu 20, where /bin/sh is a sym link to
/bin/dash).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The commit message above says it all.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Per https://github.com/kubevirt/containerized-data-importer/blob/main/CONTRIBUTING.md, this seemed like a trivial bug fix, and therefore did not warrant filing a Github issue.

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```