### PR TITLE
Extract the clone logic from main reconcile loop

### DIFF
--- a/pkg/controller/datavolume-conditions.go
+++ b/pkg/controller/datavolume-conditions.go
@@ -122,7 +122,7 @@ func updateReadyCondition(conditions []cdiv1.DataVolumeCondition, status corev1.
 }
 
 func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, reason string) []cdiv1.DataVolumeCondition {
-	if pvc != nil && pvc.Name != "" {
+	if pvc != nil {
 		pvcCondition := getPVCCondition(pvc.GetAnnotations())
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -395,13 +395,12 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 		return reconcile.Result{}, err
 	}
 
-	pvcExists := true
 	// Get the pvc with the name specified in DataVolume.spec
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: datavolume.Namespace, Name: datavolume.Name}, pvc); err != nil {
 		// If the resource doesn't exist, we'll create it
 		if k8serrors.IsNotFound(err) {
-			pvcExists = false
+			pvc = nil
 		} else if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -441,11 +440,11 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 	_, prePopulated := datavolume.Annotations[AnnPrePopulated]
 
 	if selectedCloneStrategy != NoClone {
-		return r.reconcileClone(log, datavolume, pvc, pvcSpec, transferName, prePopulated, pvcExists, selectedCloneStrategy)
+		return r.reconcileClone(log, datavolume, pvc, pvcSpec, transferName, prePopulated, selectedCloneStrategy)
 	}
 
 	if !prePopulated {
-		if !pvcExists {
+		if pvc == nil {
 			newPvc, err := r.createPvcForDatavolume(log, datavolume, pvcSpec)
 			if err != nil {
 				if errQuotaExceeded(err) {
@@ -491,11 +490,10 @@ func (r *DatavolumeReconciler) reconcileClone(log logr.Logger,
 	pvcSpec *corev1.PersistentVolumeClaimSpec,
 	transferName string,
 	prePopulated bool,
-	pvcExists bool,
 	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
 
 	if !prePopulated {
-		if !pvcExists {
+		if pvc == nil {
 			if selectedCloneStrategy == SmartClone {
 				snapshotClassName, _ := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
 				return r.reconcileSmartClonePvc(log, datavolume, pvcSpec, transferName, snapshotClassName)
@@ -2051,7 +2049,7 @@ func (r *DatavolumeReconciler) reconcileDataVolumeStatus(dataVolume *cdiv1.DataV
 	result := reconcile.Result{}
 
 	curPhase := dataVolumeCopy.Status.Phase
-	if pvc != nil && pvc.Name != "" {
+	if pvc != nil {
 		storageClassBindingMode, err := r.getStorageClassBindingMode(pvc.Spec.StorageClassName)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -440,6 +440,60 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 
 	_, prePopulated := datavolume.Annotations[AnnPrePopulated]
 
+	if selectedCloneStrategy != NoClone {
+		return r.reconcileClone(log, datavolume, pvc, pvcSpec, transferName, prePopulated, pvcExists, selectedCloneStrategy)
+	}
+
+	if !prePopulated {
+		if !pvcExists {
+			newPvc, err := r.createPvcForDatavolume(log, datavolume, pvcSpec)
+			if err != nil {
+				if errQuotaExceeded(err) {
+					r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, datavolume, nil, selectedCloneStrategy,
+						DataVolumeEvent{
+							eventType: corev1.EventTypeWarning,
+							reason:    ErrExceededQuota,
+							message:   err.Error(),
+						})
+				}
+				return reconcile.Result{}, err
+			}
+			pvc = newPvc
+		} else {
+			if getSource(pvc) == SourceVDDK {
+				changed, err := r.getVddkAnnotations(datavolume, pvc)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
+				if changed {
+					err = r.client.Get(context.TODO(), req.NamespacedName, datavolume)
+					if err != nil {
+						return reconcile.Result{}, err
+					}
+				}
+			}
+
+			err = r.maybeSetMultiStageAnnotation(pvc, datavolume)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
+	// Finally, we update the status block of the DataVolume resource to reflect the
+	// current state of the world
+	return r.reconcileDataVolumeStatus(datavolume, pvc)
+}
+
+func (r *DatavolumeReconciler) reconcileClone(log logr.Logger,
+	datavolume *cdiv1.DataVolume,
+	pvc *corev1.PersistentVolumeClaim,
+	pvcSpec *corev1.PersistentVolumeClaimSpec,
+	transferName string,
+	prePopulated bool,
+	pvcExists bool,
+	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
+
 	if !prePopulated {
 		if !pvcExists {
 			if selectedCloneStrategy == SmartClone {
@@ -478,24 +532,6 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 				return reconcile.Result{}, err
 			}
 			pvc = newPvc
-		} else {
-			if getSource(pvc) == SourceVDDK {
-				changed, err := r.getVddkAnnotations(datavolume, pvc)
-				if err != nil {
-					return reconcile.Result{}, err
-				}
-				if changed {
-					err = r.client.Get(context.TODO(), req.NamespacedName, datavolume)
-					if err != nil {
-						return reconcile.Result{}, err
-					}
-				}
-			}
-
-			err = r.maybeSetMultiStageAnnotation(pvc, datavolume)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
 		}
 
 		switch selectedCloneStrategy {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This change only extracts the code branch that handles the clone. The main idea is to divide the reconcile loop into parts doing import, upload and clone. This makes code easier to read and understand. Additionally a small change to the check if pvc exists was done. There is no more a reduntant bool pvcExists, as it can be checkec with `pvc != nil`.

What is more important it makes it much easier to work on fixes like the one here: https://github.com/kubevirt/containerized-data-importer/pull/2227. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

There is no change in logic. Just the extraction of one function. And dropping the pvcExists boolean. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

