### PR TITLE
Expose all CDI CRDs to cluster-readers

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/feature-gates:go_default_library",
+        "//pkg/monitoring:go_default_library",
         "//pkg/operator:go_default_library",
         "//pkg/storagecapabilities:go_default_library",
         "//pkg/token:go_default_library",

--- a/pkg/image/BUILD.bazel
+++ b/pkg/image/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring:go_default_library",
         "//pkg/system:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/docker/go-units:go_default_library",

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/image:go_default_library",
+        "//pkg/monitoring:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",

--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/apiserver:go_default_library",
         "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring:go_default_library",
         "//pkg/operator:go_default_library",
         "//pkg/operator/resources/cert:go_default_library",
         "//pkg/operator/resources/cluster:go_default_library",

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -85,7 +85,12 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+				"dataimportcrons",
+				"datasources",
 				"datavolumes",
+				"objecttransfers",
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -255,7 +255,12 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+				"dataimportcrons",
+				"datasources",
 				"datavolumes",
+				"objecttransfers",
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",

--- a/tools/metricsdocs/BUILD.bazel
+++ b/tools/metricsdocs/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["metricsdocs.go"],
     importpath = "kubevirt.io/containerized-data-importer/tools/metricsdocs",
     visibility = ["//visibility:private"],
-    deps = ["//pkg/operator/controller:go_default_library"],
+    deps = ["//pkg/monitoring:go_default_library"],
 )
 
 go_binary(


### PR DESCRIPTION
**What this PR does / why we need it**:

Add get/list/watch cluster RBAC to:
- cdiconfigs.cdi.kubevirt.io
- dataimportcrons.cdi.kubevirt.io
- datasources.cdi.kubevirt.io
- objecttransfers.cdi.kubevirt.io
- storageprofiles.cdi.kubevirt.io

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Expose all CDI CRDs to cluster-readers
```

