### PR TITLE
[release-v1.43] Expose all CDI CRDs to cluster-readers

### DIFF
--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -85,7 +85,12 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+				"dataimportcrons",
+				"datasources",
 				"datavolumes",
+				"objecttransfers",
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -255,7 +255,12 @@ var _ = Describe("Aggregated role definition tests", func() {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+				"dataimportcrons",
+				"datasources",
 				"datavolumes",
+				"objecttransfers",
+				"storageprofiles",
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #2245

Add get/list/watch cluster RBAC to:
- cdiconfigs.cdi.kubevirt.io
- dataimportcrons.cdi.kubevirt.io
- datasources.cdi.kubevirt.io
- objecttransfers.cdi.kubevirt.io
- storageprofiles.cdi.kubevirt.io

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Expose all CDI CRDs to cluster-readers
```

