### PR TITLE
Build builder for arm64 and amd64, use Go 1.18.1

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -33,7 +33,7 @@ RUN pip3 install --upgrade j2cli operator-courier==2.1.11 && \
 	ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
 	rm gradle-6.6-bin.zip
 
-ENV GIMME_GO_VERSION=1.17.5 GOPATH="/go" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.18.1 GOPATH="/go" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 
@@ -50,7 +50,7 @@ RUN \
 	go install github.com/securego/gosec/v2/cmd/gosec@0ce48a5 && \
 	rm -rf "${GOPATH}/pkg"
 
-ENV BAZEL_VERSION 3.7.2
+ENV BAZEL_VERSION 5.1.1
 
 COPY output-arch.sh /output-arch.sh
 

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -52,7 +52,9 @@ RUN \
 
 ENV BAZEL_VERSION 3.7.2
 
-RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64 && chmod u+x /usr/bin/bazel
+COPY output-arch.sh /output-arch.sh
+
+RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-arch.sh)  && chmod u+x /usr/bin/bazel
 
 # Until we use a version including the fix for this Bazel issue:
 # https://github.com/bazelbuild/bazel/issues/11554

--- a/hack/build/docker/builder/output-arch.sh
+++ b/hack/build/docker/builder/output-arch.sh
@@ -1,0 +1,15 @@
+PLATFORM=$(uname -m)
+case ${PLATFORM} in
+x86_64* | i?86_64* | amd64*)
+    ARCH="x86_64"
+    ;;
+aarch64* | arm64*)
+    ARCH="arm64"
+    ;;
+*)
+    echo "invalid Arch, only support x86_64, aarch64"
+    exit 1
+    ;;
+esac
+
+echo $ARCH


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to sync up with the upcoming k8s 1.24, and that uses Go 1.18.
We want to build an arm64 builder as well (using buildah and qemu-user-static), so native `make cluster-sync` works on arm64.
Make a check for qemu-user-static on Linux, if it's not installed, the error is "exec format error" and it's hard to tell what is missing.

I have tested arm64 `make cluster-sync` with kind and only non-CDI images are problematic (fakeovirt, minio, quay.io/external_storage/local-volume-provisioner).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part 1 of 2 to fix #2211 (need to update the builder used before that issue can be closed)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use Go 1.18.1 for the builder
Allow native builds on arm64
```