### PR TITLE
[release-v1.43] Tighten DataImportCron & DataSource max name length

### DIFF
--- a/pkg/apiserver/webhooks/dataimportcron-validate.go
+++ b/pkg/apiserver/webhooks/dataimportcron-validate.go
@@ -28,6 +28,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 
@@ -51,7 +52,7 @@ func (wh *dataImportCronValidatingWebhook) Admit(ar admissionv1.AdmissionReview)
 		return toAdmissionResponseError(err)
 	}
 
-	causes := validateNameLength(cron.Name)
+	causes := validateNameLength(cron.Name, validation.DNS1035LabelMaxLength)
 	if len(causes) > 0 {
 		return toRejectedAdmissionResponse(causes)
 	}
@@ -151,7 +152,7 @@ func (wh *dataImportCronValidatingWebhook) validateDataImportCronSpec(request *a
 		return causes
 	}
 
-	causes = validateNameLength(spec.ManagedDataSource)
+	causes = validateNameLength(spec.ManagedDataSource, validation.DNS1035LabelMaxLength)
 	if len(causes) > 0 {
 		return causes
 	}

--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -60,12 +60,12 @@ func validateSourceURL(sourceURL string) string {
 	return ""
 }
 
-func validateNameLength(name string) []metav1.StatusCause {
+func validateNameLength(name string, maxLen int) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	if len(name) > kvalidation.DNS1123SubdomainMaxLength {
+	if len(name) > maxLen {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Name cannot be longer than %d characters", kvalidation.DNS1123SubdomainMaxLength),
+			Message: fmt.Sprintf("Name cannot be longer than %d characters", maxLen),
 			Field:   "",
 		})
 	}
@@ -526,7 +526,7 @@ func (wh *dataVolumeValidatingWebhook) Admit(ar admissionv1.AdmissionReview) *ad
 		}
 	}
 
-	causes := validateNameLength(dv.Name)
+	causes := validateNameLength(dv.Name, kvalidation.DNS1123SubdomainMaxLength)
 	if len(causes) > 0 {
 		klog.Infof("rejected DataVolume admission")
 		return toRejectedAdmissionResponse(causes)


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #2240

Tighten DataImportCron & DataSource max name length as it's used for labeling and indexing which are limited to length 63, unlike DataVolume and other CR names which are limited to length 253.

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

