### PR TITLE
Run update-ca-trust whenever running cdi-source-update-poller

### DIFF
--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -47,10 +47,16 @@ container_image(
     ],
     files = [
         ":cdi-importer",
+        ":cdi-source-update-poller-wrapper",
         "//tools/cdi-containerimage-server",
         "//tools/cdi-source-update-poller",
     ],
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "cdi-source-update-poller-wrapper",
+    srcs = [":cdi-source-update-poller"],
 )
 
 container_image(

--- a/cmd/cdi-importer/cdi-source-update-poller
+++ b/cmd/cdi-importer/cdi-source-update-poller
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+update-ca-trust
+/usr/bin/cdi-source-update-poller-executable "$@"

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_binary(
     name = "cdi-source-update-poller",
+    out = "cdi-source-update-poller-executable",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Do this using a shell wrapper that runs it first, then calls the
actual executable with the same argument.

Background:
Our switch to building CentOS Stream images from RPMs has introduced
a small problem that root CAs are not installed.

As a temporary measure, we are running update-ca-trust, a very quick
running binary.

We are working around it using BUILD.bazel to avoid making breaking
changes to non-bazel builds.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [BZ #2079465](https://bugzilla.redhat.com/show_bug.cgi?id=2079465)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix regression since switching to CentOS-stream based images in DataImportCron: run update-ca-trust, so imports using TLS work again.
```

