### PR TITLE
Run part of update-ca-trust at build time for importer_base

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 load("@bazeldnf//:def.bzl", "bazeldnf")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 py_runtime(
     name = "python2_runtime",
@@ -212,5 +213,18 @@ container_image(
             "//rpm:centos_base_x86_64",
         ],
     }),
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "ca_anchors",
+    outs = ["tls-ca-bundle.pem"],
+    cmd = "/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $@",
+)
+
+pkg_tar(
+    name = "ca_anchors_tar",
+    srcs = [":ca_anchors"],
+    package_dir = "/etc/pki/ca-trust/extracted/pem",
     visibility = ["//visibility:public"],
 )

--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -40,10 +40,8 @@ container_image(
     base = ":importer_base",
     directory = "/usr/bin",
     entrypoint = [
-        "/bin/sh",
-        "-c",
-        "/usr/bin/update-ca-trust && exec /usr/bin/cdi-importer -alsologtostderr \"$@\"",
-        "--",
+        "/usr/bin/cdi-importer",
+        "-alsologtostderr",
     ],
     files = [
         ":cdi-importer",
@@ -58,9 +56,11 @@ container_image(
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//rpm:cdi_importer_base_aarch64",
+            "//:ca_anchors_tar",
         ],
         "//conditions:default": [
             "//rpm:cdi_importer_base_x86_64",
+            "//:ca_anchors_tar",
         ],
     }),
 )


### PR DESCRIPTION
Doing this at build time means we don't need to run update-ca-trust
on every invocation of the importer pod, which also eliminates a bug
where the relevant certs were not produced if invoked as a data
import cron.

**What this PR does / why we need it**:
This only does it for cdi-importer.
The other use cases for update-ca-trust are test containers, which are of a lower importance.
They also require update-crypto-policies to be run - I can take a look at that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [BZ #2079465](https://bugzilla.redhat.com/show_bug.cgi?id=2079465)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix regression since switching to CentOS-stream based images in DataImportCron: run update-ca-trust, so imports using TLS work again.
```

