### PR TITLE
[release-v1.34] Change the way we fetch latest release from GitHub (manual backport #2256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CDI features specialized handling for two types of content: Kubevirt VM disk ima
 Deploying the CDI controller is straightforward. In this document the _default_ namespace is used, but in a production setup a protected namespace that is inaccessible to regular users should be used instead.
 
   ```
-  $ export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+  $ export VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
   $ kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
   $ kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
   ```

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -36,6 +36,8 @@ fi
 readonly ARTIFACTS_PATH="${ARTIFACTS}"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/containerized-data-importer}"
 
+source hack/common-funcs.sh
+
 export KUBEVIRT_PROVIDER=$TARGET
 
 if [[ $TARGET =~ openshift-.* ]]; then
@@ -56,7 +58,7 @@ fi
 
 # Don't upgrade if we are using a random CR name, otherwise the upgrade will fail
 if [[ -z "$UPGRADE_FROM" ]] && [[ -z "$RANDOM_CR" ]]; then
-  export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+  export UPGRADE_FROM=$(get_latest_release "kubevirt/containerized-data-importer")
   echo "Upgrading from verions: $UPGRADE_FROM"
 fi
 export KUBEVIRT_NUM_NODES=2

--- a/cluster-sync/ephemeral_provider.sh
+++ b/cluster-sync/ephemeral_provider.sh
@@ -2,6 +2,7 @@
 set -e
 
 source cluster-sync/install.sh
+source hack/common-funcs.sh
 
 ROOK_CEPH_VERSION=${ROOK_CEPH_VERSION:-v1.1.4}
 

--- a/cluster-sync/external/provider.sh
+++ b/cluster-sync/external/provider.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source cluster-sync/ephemeral_provider.sh
+source hack/common-funcs.sh
 
 function _kubectl(){
   kubectl "$@"
@@ -23,7 +24,7 @@ function configure_storage() {
   if [[ $KUBEVIRT_STORAGE == "hpp" ]] ; then
     _kubectl apply -f ./cluster-sync/external/resources/machineconfig-worker.yaml
     echo "Installing hostpath provisioner storage, please ensure /var/hpvolumes exists and has the right SELinux labeling"
-    HPP_RELEASE=$(curl -s https://github.com/kubevirt/hostpath-provisioner-operator/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+    HPP_RELEASE=$(get_latest_release "kubevirt/hostpath-provisioner-operator")
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/namespace.yaml
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/operator.yaml -n hostpath-provisioner
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner

--- a/hack/common-funcs.sh
+++ b/hack/common-funcs.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Copyright 2022 The CDI Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Common functions used by test scripts
+#
+
+get_latest_release() {
+  curl -s "https://api.github.com/repos/$1/releases/latest" |       # Get latest release from GitHub api
+    grep '"tag_name":' |                                            # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value (avoid jq)
+}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CI is failing, it looks like gh releases/latest now redirects (302 HTTP).
Also seems like the go to is to use the gh API for this

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

