### PR TITLE
Fix smart clone request size update

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1379,10 +1379,11 @@ func (r *DatavolumeReconciler) expand(log logr.Logger,
 	}
 
 	expansionRequired := actualSize.Cmp(requestedSize) < 0
+	updateRequestSizeRequired := actualSize.Cmp(requestedSize) <= 0 && requestedSize.Cmp(currentSize) > 0
 
 	log.V(3).Info("Expand sizes", "req", requestedSize, "cur", currentSize, "act", actualSize, "exp", expansionRequired)
 
-	if expansionRequired && requestedSize.Cmp(currentSize) != 0 {
+	if updateRequestSizeRequired {
 		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = requestedSize
 		if err := r.client.Update(context.TODO(), pvc); err != nil {
 			return false, err

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1379,7 +1379,7 @@ func (r *DatavolumeReconciler) expand(log logr.Logger,
 	}
 
 	expansionRequired := actualSize.Cmp(requestedSize) < 0
-	updateRequestSizeRequired := actualSize.Cmp(requestedSize) <= 0 && requestedSize.Cmp(currentSize) > 0
+	updateRequestSizeRequired := actualSize.Cmp(requestedSize) <= 0 && currentSize.Cmp(requestedSize) < 0
 
 	log.V(3).Info("Expand sizes", "req", requestedSize, "cur", currentSize, "act", actualSize, "exp", expansionRequired)
 

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1454,7 +1454,7 @@ var _ = Describe("All DataVolume Tests", func() {
 		)
 
 		DescribeTable("After smart clone", func(actualSize resource.Quantity, currentSize resource.Quantity, expectedDvPhase cdiv1.DataVolumePhase) {
-			strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+			strategy := cdiv1.CloneStrategySnapshot
 			controller := true
 
 			dv := newCloneDataVolume("test-dv")

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1453,6 +1453,59 @@ var _ = Describe("All DataVolume Tests", func() {
 			Entry("snapshot", cdiv1.CloneStrategySnapshot),
 		)
 
+		DescribeTable("After smart clone", func(actualSize resource.Quantity, currentSize resource.Quantity, expectedDvPhase cdiv1.DataVolumePhase) {
+			strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+			controller := true
+
+			dv := newCloneDataVolume("test-dv")
+			scName := "testsc"
+			sc := createStorageClassWithProvisioner(scName, map[string]string{
+				AnnDefaultStorageClass: "true",
+			}, map[string]string{}, "csi-plugin")
+			accessMode := []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
+			storageProfile := createStorageProfileWithCloneStrategy(scName,
+				[]cdiv1.ClaimPropertySet{{AccessModes: accessMode, VolumeMode: &blockMode}},
+				&strategy)
+			snapshotClassName := "snap-class"
+			snapClass := createSnapshotClass(snapshotClassName, nil, "csi-plugin")
+
+			srcPvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
+			targetPvc := createPvcInStorageClass("test-dv", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
+			targetPvc.OwnerReferences = append(targetPvc.OwnerReferences, metav1.OwnerReference{
+				Kind:       "DataVolume",
+				Controller: &controller,
+				Name:       "test-dv",
+				UID:        dv.UID,
+			})
+			targetPvc.Spec.Resources.Requests[corev1.ResourceStorage] = currentSize
+			targetPvc.Status.Capacity[corev1.ResourceStorage] = actualSize
+			targetPvc.SetAnnotations(make(map[string]string))
+			targetPvc.GetAnnotations()[AnnCloneOf] = "true"
+
+			reconciler = createDatavolumeReconciler(dv, srcPvc, targetPvc, storageProfile, sc, snapClass, createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
+
+			By("Reconcile")
+			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Not(BeNil()))
+
+			By(fmt.Sprintf("Verifying that dv phase is now in %s", expectedDvPhase))
+			dv = &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(expectedDvPhase))
+
+			By("Verifying that pvc request size as expected")
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1G")))
+
+		},
+			Entry("Should expand pvc when actual and current differ then the requested size", resource.MustParse("500M"), resource.MustParse("500M"), cdiv1.ExpansionInProgress),
+			Entry("Should update request size when current size differ from requested size", resource.MustParse("1G"), resource.MustParse("500M"), cdiv1.ExpansionInProgress),
+			Entry("Should complete clone in case all sizes match", resource.MustParse("1G"), resource.MustParse("1G"), cdiv1.Succeeded),
+		)
 	})
 
 	var _ = Describe("CSI clone", func() {


### PR DESCRIPTION
In case the pvc got an actual size as the expected
size there wasn't an update of the pvc spec with the
actual user request size, which left the pvc spec with
a smaller size then the user requested(the data size).
This caused a discrepancy when trying to restore such pvc,
which restored a pvc with the small size instead of the user request
size.

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #BZ2021354

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix smart clone not updating request size if already got the requested size so expansion is not required
```

