### PR TITLE
Make CDI clone strategy strings correct types

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1779,7 +1779,7 @@ func (r *DatavolumeReconciler) calculateUsableSpace(srcStorageClass *storagev1.S
 }
 
 func (r *DatavolumeReconciler) getCloneStrategy(dataVolume *cdiv1.DataVolume) (*cdiv1.CDICloneStrategy, error) {
-	defaultCloneStrategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+	defaultCloneStrategy := cdiv1.CloneStrategySnapshot
 	sourcePvc, err := r.findSourcePvc(dataVolume)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1449,8 +1449,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*cloneStrategy).To(Equal(expectedCloneStrategy))
 		},
-			Entry("copy", cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-			Entry("snapshot", cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
+			Entry("copy", cdiv1.CloneStrategyHostAssisted),
+			Entry("snapshot", cdiv1.CloneStrategySnapshot),
 		)
 
 	})
@@ -1458,7 +1458,7 @@ var _ = Describe("All DataVolume Tests", func() {
 	var _ = Describe("CSI clone", func() {
 		DescribeTable("Starting from Failed DV",
 			func(targetPvcPhase corev1.PersistentVolumeClaimPhase, expectedDvPhase cdiv1.DataVolumePhase) {
-				strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+				strategy := cdiv1.CloneStrategyCsiClone
 				controller := true
 
 				dv := newCloneDataVolume("test-dv")
@@ -1505,22 +1505,13 @@ var _ = Describe("All DataVolume Tests", func() {
 
 	var _ = Describe("Clone strategy", func() {
 		var (
-			hostAssited = cdiv1.CloneStrategyHostAssisted
-			snapshot    = cdiv1.CloneStrategySnapshot
-			csiClone    = cdiv1.CloneStrategyCsiClone
+			hostAssisted = cdiv1.CloneStrategyHostAssisted
+			snapshot     = cdiv1.CloneStrategySnapshot
+			csiClone     = cdiv1.CloneStrategyCsiClone
 		)
 
-		getStrategy := func(strategyName *string) *cdiv1.CDICloneStrategy {
-			if strategyName != nil {
-				strategy := cdiv1.CDICloneStrategy(*strategyName)
-				return &strategy
-			}
-
-			return nil
-		}
-
 		DescribeTable("Setting clone strategy affects the output of getCloneStrategy",
-			func(override, preferredCloneStrategy *string, expectedCloneStrategy cdiv1.CDICloneStrategy) {
+			func(override, preferredCloneStrategy *cdiv1.CDICloneStrategy, expectedCloneStrategy cdiv1.CDICloneStrategy) {
 				dv := newCloneDataVolume("test-dv")
 				scName := "testsc"
 				pvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
@@ -1531,7 +1522,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				accessMode := []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
 				storageProfile := createStorageProfileWithCloneStrategy(scName,
 					[]cdiv1.ClaimPropertySet{{AccessModes: accessMode, VolumeMode: &blockMode}},
-					getStrategy(preferredCloneStrategy))
+					preferredCloneStrategy)
 
 				reconciler = createDatavolumeReconciler(dv, pvc, storageProfile, sc)
 
@@ -1539,7 +1530,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "cdi"}, cr)
 				Expect(err).ToNot(HaveOccurred())
 
-				cr.Spec.CloneStrategyOverride = getStrategy(override)
+				cr.Spec.CloneStrategyOverride = override
 				err = reconciler.client.Update(context.TODO(), cr)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1547,20 +1538,20 @@ var _ = Describe("All DataVolume Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(*cloneStrategy).To(Equal(expectedCloneStrategy))
 			},
-			Entry("override hostAssisted /host", &hostAssited, &hostAssited, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-			Entry("override hostAssisted /snapshot", &hostAssited, &snapshot, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-			Entry("override hostAssisted /csiClone", &hostAssited, &csiClone, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-			Entry("override hostAssisted /nil", &hostAssited, nil, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
+			Entry("override hostAssisted /host", &hostAssisted, &hostAssisted, cdiv1.CloneStrategyHostAssisted),
+			Entry("override hostAssisted /snapshot", &hostAssisted, &snapshot, cdiv1.CloneStrategyHostAssisted),
+			Entry("override hostAssisted /csiClone", &hostAssisted, &csiClone, cdiv1.CloneStrategyHostAssisted),
+			Entry("override hostAssisted /nil", &hostAssisted, nil, cdiv1.CloneStrategyHostAssisted),
 
-			Entry("override snapshot /host", &snapshot, &hostAssited, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
-			Entry("override snapshot /snapshot", &snapshot, &snapshot, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
-			Entry("override snapshot /csiClone", &snapshot, &csiClone, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
-			Entry("override snapshot /nil", &snapshot, nil, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
+			Entry("override snapshot /host", &snapshot, &hostAssisted, cdiv1.CloneStrategySnapshot),
+			Entry("override snapshot /snapshot", &snapshot, &snapshot, cdiv1.CloneStrategySnapshot),
+			Entry("override snapshot /csiClone", &snapshot, &csiClone, cdiv1.CloneStrategySnapshot),
+			Entry("override snapshot /nil", &snapshot, nil, cdiv1.CloneStrategySnapshot),
 
-			Entry("preferred snapshot", nil, &snapshot, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
-			Entry("preferred hostassisted", nil, &hostAssited, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-			Entry("preferred csiClone", nil, &csiClone, cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)),
-			Entry("should default to snapshot", nil, nil, cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
+			Entry("preferred snapshot", nil, &snapshot, cdiv1.CloneStrategySnapshot),
+			Entry("preferred hostassisted", nil, &hostAssisted, cdiv1.CloneStrategyHostAssisted),
+			Entry("preferred csiClone", nil, &csiClone, cdiv1.CloneStrategyCsiClone),
+			Entry("should default to snapshot", nil, nil, cdiv1.CloneStrategySnapshot),
 		)
 	})
 	var _ = Describe("Get Pod from PVC", func() {

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -160,13 +160,13 @@ func (r *StorageProfileReconciler) reconcileCloneStrategy(sc *storagev1.StorageC
 
 	if clonestrategy == nil {
 		if sc.Annotations["cdi.kubevirt.io/clone-strategy"] == "copy" {
-			strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)
+			strategy := cdiv1.CloneStrategyHostAssisted
 			return &strategy
 		} else if sc.Annotations["cdi.kubevirt.io/clone-strategy"] == "snapshot" {
-			strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+			strategy := cdiv1.CloneStrategySnapshot
 			return &strategy
 		} else if sc.Annotations["cdi.kubevirt.io/clone-strategy"] == "csi-clone" {
-			strategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+			strategy := cdiv1.CloneStrategyCsiClone
 			return &strategy
 		} else {
 			return clonestrategy

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -303,9 +303,9 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(*sp.Status.StorageClass).To(Equal(storageClassName))
 		Expect(*sp.Status.CloneStrategy).To(Equal(cloneStrategy))
 	},
-		table.Entry("None", cdiv1.CDICloneStrategy(cdiv1.CloneStrategyHostAssisted)),
-		table.Entry("Snapshot", cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)),
-		table.Entry("Clone", cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)),
+		table.Entry("None", cdiv1.CloneStrategyHostAssisted),
+		table.Entry("Snapshot", cdiv1.CloneStrategySnapshot),
+		table.Entry("Clone", cdiv1.CloneStrategyCsiClone),
 	)
 
 })

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -654,13 +654,13 @@ type CDICloneStrategy string
 
 const (
 	// CloneStrategyHostAssisted specifies slower, host-assisted copy
-	CloneStrategyHostAssisted = "copy"
+	CloneStrategyHostAssisted CDICloneStrategy = "copy"
 
 	// CloneStrategySnapshot specifies snapshot-based copying
-	CloneStrategySnapshot = "snapshot"
+	CloneStrategySnapshot CDICloneStrategy = "snapshot"
 
 	// CloneStrategyCsiClone specifies csi volume clone based cloning
-	CloneStrategyCsiClone = "csi-clone"
+	CloneStrategyCsiClone CDICloneStrategy = "csi-clone"
 )
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -640,7 +640,7 @@ var _ = Describe("all clone tests", func() {
 		})
 
 		Context("CloneStrategy on storageclass annotation", func() {
-			cloneType := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+			cloneType := cdiv1.CloneStrategyCsiClone
 
 			BeforeEach(func() {
 				if !f.IsCSIVolumeCloneStorageClassAvailable() {
@@ -1956,7 +1956,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 			spec, err := utils.GetStorageProfileSpec(f.CdiClient, *sourcePVC.Spec.StorageClassName)
 			Expect(err).NotTo(HaveOccurred())
 
-			defaultCloneStrategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+			defaultCloneStrategy := cdiv1.CloneStrategySnapshot
 			cloneStrategy := &defaultCloneStrategy
 			if spec.CloneStrategy != nil {
 				cloneStrategy = spec.CloneStrategy
@@ -1966,7 +1966,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 			Expect(err).ToNot(HaveOccurred())
 			allowsExpansion := sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion
 
-			if *cloneStrategy == cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot) &&
+			if *cloneStrategy == cdiv1.CloneStrategySnapshot &&
 				sourcePVC.Spec.StorageClassName != nil &&
 				targetPVC.Spec.StorageClassName != nil &&
 				*sourcePVC.Spec.StorageClassName == *targetPVC.Spec.StorageClassName &&
@@ -1974,7 +1974,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 				(allowsExpansion || sourcePVC.Status.Capacity.Storage().Cmp(*targetPVC.Status.Capacity.Storage()) == 0) {
 				cloneType = "snapshot"
 			}
-			if *cloneStrategy == cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone) &&
+			if *cloneStrategy == cdiv1.CloneStrategyCsiClone &&
 				sourcePVC.Spec.StorageClassName != nil &&
 				targetPVC.Spec.StorageClassName != nil &&
 				*sourcePVC.Spec.StorageClassName == *targetPVC.Spec.StorageClassName &&

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		spec := &storageProfile.Spec
-		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		cs := cdiv1.CloneStrategyCsiClone
 		spec.CloneStrategy = &cs
 		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
 		Expect(err).To(HaveOccurred())
@@ -203,7 +203,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		spec := &storageProfile.Spec
-		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		cs := cdiv1.CloneStrategyCsiClone
 		spec.CloneStrategy = &cs
 		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
 		Expect(err).To(HaveOccurred())

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -51,7 +51,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests th
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
-		var cloneStrategy cdiv1.CDICloneStrategy = cdiv1.CloneStrategyHostAssisted
+		cloneStrategy := cdiv1.CloneStrategyHostAssisted
 		cdiCr.Spec.CloneStrategyOverride = &cloneStrategy
 		_, err := f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &cdiCr, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Noticed the consts were strings instead of the right types this changes the type to the right type and modifies the usage to not have to cast to the right type all over the place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Modified CDICloneStrategy strings to be correct type
```

