### PR TITLE
[release-v1.38] Make CDI clone strategy strings correct types (#2277)

### DIFF
--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -581,13 +581,13 @@ type CDICloneStrategy string
 
 const (
 	// CloneStrategyHostAssisted specifies slower, host-assisted copy
-	CloneStrategyHostAssisted = "copy"
+	CloneStrategyHostAssisted CDICloneStrategy = "copy"
 
 	// CloneStrategySnapshot specifies snapshot-based copying
-	CloneStrategySnapshot = "snapshot"
+	CloneStrategySnapshot CDICloneStrategy = "snapshot"
 
 	// CloneStrategyCsiClone specifies csi volume clone based cloning
-	CloneStrategyCsiClone = "csi-clone"
+	CloneStrategyCsiClone CDICloneStrategy = "csi-clone"
 )
 
 // CDIUninstallStrategy defines the state to leave CDI on uninstall

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1562,7 +1562,7 @@ func (r *DatavolumeReconciler) calculateUsableSpace(srcStorageClass *storagev1.S
 }
 
 func (r *DatavolumeReconciler) getCloneStrategy(dataVolume *cdiv1.DataVolume) (*cdiv1.CDICloneStrategy, error) {
-	defaultCloneStrategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+	defaultCloneStrategy := cdiv1.CloneStrategySnapshot
 	sourcePvc, err := r.findSourcePvc(dataVolume)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1782,7 +1782,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 			spec, err := utils.GetStorageProfileSpec(f.CdiClient, *sourcePVC.Spec.StorageClassName)
 			Expect(err).NotTo(HaveOccurred())
 
-			defaultCloneStrategy := cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot)
+			defaultCloneStrategy := cdiv1.CloneStrategySnapshot
 			cloneStrategy := &defaultCloneStrategy
 			if spec.CloneStrategy != nil {
 				cloneStrategy = spec.CloneStrategy
@@ -1792,7 +1792,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 			Expect(err).ToNot(HaveOccurred())
 			allowsExpansion := sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion
 
-			if *cloneStrategy == cdiv1.CDICloneStrategy(cdiv1.CloneStrategySnapshot) &&
+			if *cloneStrategy == cdiv1.CloneStrategySnapshot &&
 				sourcePVC.Spec.StorageClassName != nil &&
 				targetPVC.Spec.StorageClassName != nil &&
 				*sourcePVC.Spec.StorageClassName == *targetPVC.Spec.StorageClassName &&
@@ -1800,7 +1800,7 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 				(allowsExpansion || sourcePVC.Status.Capacity.Storage().Cmp(*targetPVC.Status.Capacity.Storage()) == 0) {
 				cloneType = "snapshot"
 			}
-			if *cloneStrategy == cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone) &&
+			if *cloneStrategy == cdiv1.CloneStrategyCsiClone &&
 				sourcePVC.Spec.StorageClassName != nil &&
 				targetPVC.Spec.StorageClassName != nil &&
 				*sourcePVC.Spec.StorageClassName == *targetPVC.Spec.StorageClassName &&

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		spec := &storageProfile.Spec
-		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		cs := cdiv1.CloneStrategyCsiClone
 		spec.CloneStrategy = &cs
 		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
 		Expect(err).To(HaveOccurred())
@@ -203,7 +203,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		spec := &storageProfile.Spec
-		cs := cdiv1.CDICloneStrategy(cdiv1.CloneStrategyCsiClone)
+		cs := cdiv1.CloneStrategyCsiClone
 		spec.CloneStrategy = &cs
 		err = utils.UpdateStorageProfile(crClient, profileName, *spec)
 		Expect(err).To(HaveOccurred())

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -51,7 +51,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests th
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
-		var cloneStrategy cdiv1.CDICloneStrategy = cdiv1.CloneStrategyHostAssisted
+		cloneStrategy := cdiv1.CloneStrategyHostAssisted
 		cdiCr.Spec.CloneStrategyOverride = &cloneStrategy
 		_, err := f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &cdiCr, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Noticed the consts were strings instead of the right types
this changes the type to the right type and modifies the usage
to not have to cast to the right type all over the place.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

