### PR TITLE
[release-v1.38] Fix smart clone request size update

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1187,10 +1187,11 @@ func (r *DatavolumeReconciler) expand(log logr.Logger,
 	}
 
 	expansionRequired := actualSize.Cmp(requestedSize) < 0
+	updateRequestSizeRequired := currentSize.Cmp(requestedSize) < 0
 
 	log.V(3).Info("Expand sizes", "req", requestedSize, "cur", currentSize, "act", actualSize, "exp", expansionRequired)
 
-	if expansionRequired && requestedSize.Cmp(currentSize) != 0 {
+	if updateRequestSizeRequired {
 		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = requestedSize
 		if err := r.client.Update(context.TODO(), pvc); err != nil {
 			return false, err

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1195,6 +1195,61 @@ var _ = Describe("All DataVolume Tests", func() {
 			Entry("snapshot", cdiv1.CloneStrategySnapshot),
 		)
 
+		DescribeTable("After smart clone", func(actualSize resource.Quantity, currentSize resource.Quantity, expectedDvPhase cdiv1.DataVolumePhase) {
+			strategy := cdiv1.CloneStrategySnapshot
+			controller := true
+
+			dv := newCloneDataVolume("test-dv")
+			scName := "testsc"
+			sc := createStorageClassWithProvisioner(scName, map[string]string{
+				AnnDefaultStorageClass: "true",
+			}, "csi-plugin")
+			storageProfile := createStorageProfileWithCloneStrategy(scName,
+				[]corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+				corev1.PersistentVolumeBlock,
+				&strategy)
+			snapshotClassName := "snap-class"
+			snapClass := createSnapshotClass(snapshotClassName, nil, "csi-plugin")
+
+			srcPvc := createPvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
+			targetPvc := createPvcInStorageClass("test-dv", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
+			targetPvc.OwnerReferences = append(targetPvc.OwnerReferences, metav1.OwnerReference{
+				Kind:       "DataVolume",
+				Controller: &controller,
+				Name:       "test-dv",
+				UID:        dv.UID,
+			})
+			targetPvc.Spec.Resources.Requests[corev1.ResourceStorage] = currentSize
+			targetPvc.Status.Capacity[corev1.ResourceStorage] = actualSize
+			targetPvc.SetAnnotations(make(map[string]string))
+			targetPvc.GetAnnotations()[AnnCloneOf] = "true"
+
+			reconciler := createDatavolumeReconciler(dv, srcPvc, targetPvc, storageProfile, sc, snapClass)
+			reconciler.extClientSet = extfake.NewSimpleClientset(createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
+
+			By("Reconcile")
+			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Not(BeNil()))
+
+			By(fmt.Sprintf("Verifying that dv phase is now in %s", expectedDvPhase))
+			dv = &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(expectedDvPhase))
+
+			By("Verifying that pvc request size as expected")
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1G")))
+
+		},
+			Entry("Should expand pvc when actual and current differ then the requested size", resource.MustParse("500M"), resource.MustParse("500M"), cdiv1.ExpansionInProgress),
+			Entry("Should update request size when current size differ then the requested size and actual size is bigger then both", resource.MustParse("2G"), resource.MustParse("500M"), cdiv1.ExpansionInProgress),
+			Entry("Should update request size when current size differ from requested size", resource.MustParse("1G"), resource.MustParse("500M"), cdiv1.ExpansionInProgress),
+			Entry("Should complete clone in case all sizes match", resource.MustParse("1G"), resource.MustParse("1G"), cdiv1.Succeeded),
+		)
 	})
 
 	var _ = Describe("CSI clone", func() {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/containerized-data-importer/pull/2276
with a fix on the update condition and some cherry pick adjustments

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix smart clone not updating request size if already got the requested size so expansion is not required
```

