### PR TITLE
Small shim so libvddk-test-plugin.so can run on older glibc

### DIFF
--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -53,6 +53,9 @@ void *fakevddk_open(int readonly) {
     return (void *) &fd;
 }
 
+// Avoid requiring glibc 2.33 by using the older fstat
+extern int __fxstat(int, int, struct stat *);
+#define fstat(fd, buf) __fxstat(1, fd, buf)
 int64_t fakevddk_get_size(void *handle) {
     struct stat info;
     fstat(*((int *) handle), &info);


### PR DESCRIPTION
vddk-test is special, it creates a dynamic library that is
loaded by the importer for test suite runs.

When running tests on a cluster built with an importer built from a
different base image, e.g. when RedHat builds with a CentOS8
equivalent, we might be attempting to load libvddk-test-plugin.so on
the CentOS8 importer. This breaks, as it doesn't have newer symbols.

There's only one new glibc symbol used, for fstat. Let's use
the older glibc definition of fstat, __fxstat explicitly.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix regression where the testsuite cannot be run if the importer image is built with an older base image (like centos 8)
```

