### PR TITLE
Add an infra label to each of CDI alerts

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -296,6 +296,7 @@ var _ = Describe("Controller", func() {
 						"severity":                      "warning",
 						"kubernetes_operator_part_of":   "kubevirt",
 						"kubernetes_operator_component": "containerized-data-importer",
+						"infra_alert":                   "true",
 					},
 				}
 

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -53,6 +53,7 @@ const (
 	partOfAlertLabelValue    = "kubevirt"
 	componentAlertLabelKey   = "kubernetes_operator_component"
 	componentAlertLabelValue = common.CDILabelValue
+	infraAlertLabelKey       = "infra_alert"
 )
 
 func ensurePrometheusResourcesExist(c client.Client, scheme *runtime.Scheme, owner metav1.Object) error {
@@ -153,6 +154,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -167,6 +169,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -181,6 +184,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -195,6 +199,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "info",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -209,6 +214,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "info",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 	}


### PR DESCRIPTION
This PR adds a boolean label to each of CDI alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 
For more info, please see [#7796](https://github.com/kubevirt/kubevirt/pull/7796).

Signed-off-by: assafad [aadmi@redhat.com](mailto:aadmi@redhat.com)

```release-note
None
```