### PR TITLE
fix issue #2323: Cross namespace smart clone not cleaning up

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -541,14 +541,14 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 		return reconcile.Result{}, nil
 	}
 
+	if err := r.populateSourceIfSourceRef(datavolume); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if isCrossNamespaceClone(datavolume) && datavolume.Status.Phase == cdiv1.Succeeded {
 		if err := r.cleanupTransfer(log, datavolume, transferName); err != nil {
 			return reconcile.Result{}, err
 		}
-	}
-
-	if err := r.populateSourceIfSourceRef(datavolume); err != nil {
-		return reconcile.Result{}, err
 	}
 
 	pvcPopulated := false

--- a/pkg/controller/smart-clone-controller.go
+++ b/pkg/controller/smart-clone-controller.go
@@ -191,6 +191,10 @@ func (r *SmartCloneReconciler) reconcileSnapshot(log logr.Logger, snapshot *snap
 		WithValues("snapshot.Namespace", snapshot.Namespace).
 		Info("Reconciling snapshot")
 
+	if snapshot.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	dataVolume, err := r.getDataVolume(snapshot)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/smart-clone-controller_test.go
+++ b/pkg/controller/smart-clone-controller_test.go
@@ -164,6 +164,20 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("Should do nothing if snapshot deleted", func() {
+			reconciler := createSmartCloneReconciler()
+			snapshot := createSnapshotVolume("test-dv", metav1.NamespaceDefault, nil)
+			ts := metav1.Now()
+			snapshot.DeletionTimestamp = &ts
+			_, err := reconciler.reconcileSnapshot(reconciler.log, snapshot)
+			Expect(err).ToNot(HaveOccurred())
+
+			nn := types.NamespacedName{Namespace: snapshot.Namespace, Name: snapshot.Name}
+			err = reconciler.client.Get(context.TODO(), nn, &corev1.PersistentVolumeClaim{})
+			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("Should delete snapshot if DataVolume deleted", func() {
 			dv := newCloneDataVolume("test-dv")
 			ts := metav1.Now()

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2444,12 +2444,14 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 				Expect(tmpPvc.DeletionTimestamp).ToNot(BeNil())
 			}
 
-			ot, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), tmpName, metav1.GetOptions{})
-			if err != nil {
-				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-			} else {
-				Expect(ot.DeletionTimestamp).ToNot(BeNil())
-			}
+			Eventually(func() bool {
+				ot, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), tmpName, metav1.GetOptions{})
+				if err != nil {
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+					return true
+				}
+				return ot.DeletionTimestamp != nil
+			}, 30*time.Second, 2*time.Second).Should(BeTrue())
 		}
 	case "network":
 		s, err := f.K8sClient.CoreV1().Secrets(f.CdiInstallNs).Get(context.TODO(), "cdi-api-signing-key", metav1.GetOptions{})

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2420,18 +2420,36 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 
 	validateCloneType(f, dv)
 
+	sns := dv.Spec.Source.PVC.Namespace
+	if sns == "" {
+		sns = dv.Namespace
+	}
+
 	switch utils.GetCloneType(f.CdiClient, dv) {
 	case "snapshot":
-		sns := dv.Spec.Source.PVC.Namespace
-		if sns == "" {
-			sns = dv.Namespace
-		}
-
 		snapshots := &snapshotv1.VolumeSnapshotList{}
 		err = f.CrClient.List(context.TODO(), snapshots, &client.ListOptions{Namespace: sns})
 		Expect(err).ToNot(HaveOccurred())
 		for _, s := range snapshots.Items {
 			Expect(s.DeletionTimestamp).ToNot(BeNil())
+		}
+		fallthrough
+	case "csivolumeclone":
+		if sns != dv.Namespace {
+			tmpName := fmt.Sprintf("cdi-tmp-%s", dv.UID)
+			tmpPvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(sns).Get(context.TODO(), tmpName, metav1.GetOptions{})
+			if err != nil {
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			} else {
+				Expect(tmpPvc.DeletionTimestamp).ToNot(BeNil())
+			}
+
+			ot, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), tmpName, metav1.GetOptions{})
+			if err != nil {
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			} else {
+				Expect(ot.DeletionTimestamp).ToNot(BeNil())
+			}
 		}
 	case "network":
 		s, err := f.K8sClient.CoreV1().Secrets(f.CdiInstallNs).Get(context.TODO(), "cdi-api-signing-key", metav1.GetOptions{})

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2444,6 +2444,12 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 				Expect(tmpPvc.DeletionTimestamp).ToNot(BeNil())
 			}
 
+			Eventually(func() []string {
+				tmp, err := f.CdiClient.CdiV1beta1().DataVolumes(targetNs.Name).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return tmp.Finalizers
+			}, 90*time.Second, 2*time.Second).Should(BeEmpty())
+
 			Eventually(func() bool {
 				ot, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), tmpName, metav1.GetOptions{})
 				if err != nil {
@@ -2451,7 +2457,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 					return true
 				}
 				return ot.DeletionTimestamp != nil
-			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+			}, 90*time.Second, 2*time.Second).Should(BeTrue())
 		}
 	case "network":
 		s, err := f.K8sClient.CoreV1().Secrets(f.CdiInstallNs).Get(context.TODO(), "cdi-api-signing-key", metav1.GetOptions{})


### PR DESCRIPTION
1.  Make sure smart clone controller does not create PVCs if VolumeSnapshot deleted

2.  Make sure that ObjectTransfer cleanup occurs.

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2323

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

