### PR TITLE
Don't manage certs if CDI being deleted

### DIFF
--- a/pkg/operator/controller/reconciler-hooks.go
+++ b/pkg/operator/controller/reconciler-hooks.go
@@ -72,6 +72,9 @@ func (r *ReconcileCDI) checkSanity(cr client.Object, reqLogger logr.Logger) (*re
 // sync syncs certificates used by CDU
 func (r *ReconcileCDI) sync(cr client.Object, logger logr.Logger) error {
 	cdi := cr.(*cdiv1.CDI)
+	if cdi.DeletionTimestamp != nil {
+		return nil
+	}
 	return r.certManager.Sync(r.getCertificateDefinitions(cdi))
 }
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Sometimes tls certs get recreated while CDI is deleting

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

