### PR TITLE
Improve error handling when pod creation fails

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
@@ -284,7 +285,7 @@ func (r *CloneReconciler) reconcileSourcePod(sourcePod *corev1.Pod, targetPvc *c
 
 		sourcePod, err := r.CreateCloneSourcePod(r.image, r.pullPolicy, targetPvc, log)
 		// Check if pod has failed and, in that case, record an event with the error
-		if podErr := handleFailedPod(err, createCloneSourcePodName(targetPvc), sourcePvc, r.recorder, r.client); podErr != nil {
+		if podErr := handleFailedPod(err, createCloneSourcePodName(targetPvc), targetPvc, r.recorder, r.client); podErr != nil {
 			return 0, podErr
 		}
 

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -539,7 +539,8 @@ func (r *CloneReconciler) CreateCloneSourcePod(image, pullPolicy string, pvc *co
 	util.SetRecommendedLabels(pod, r.installerLabels, "cdi-controller")
 
 	if err := r.client.Create(context.TODO(), pod); err != nil {
-		return nil, errors.Wrap(err, "source pod API create errored")
+		err = errors.Wrap(err, "source pod API create errored")
+		return nil, handleFailedPod(err, createCloneSourcePodName(pvc), sourcePvc, r.recorder, r.client)
 	}
 
 	log.V(1).Info("cloning source pod (image) created\n", "pod.Namespace", pod.Namespace, "pod.Name", pod.Name, "image", image)

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -1556,7 +1556,7 @@ func (r *DatavolumeReconciler) expand(log logr.Logger,
 		var err error
 		pod, err = r.createExpansionPod(pvc, dv, podName)
 		if err != nil {
-			return false, err
+			return false, handleFailedPod(err, podName, pvc, r.recorder, r.client)
 		}
 	}
 
@@ -2959,7 +2959,7 @@ func (r *DatavolumeReconciler) getSizeFromPod(sourcePvc *corev1.PersistentVolume
 
 	pod, err := r.getOrCreateSizeDetectionPod(sourcePvc, dv)
 	if err != nil {
-		return 0, err
+		return 0, handleFailedPod(err, sizeDetectionPodName(sourcePvc), sourcePvc, r.recorder, r.client)
 	} else if !isPodComplete(pod) {
 		r.recorder.Event(dv, corev1.EventTypeNormal, SizeDetectionPodNotReady, MessageSizeDetectionPodNotReady)
 		return 0, nil

--- a/pkg/controller/datavolume-controller_test.go
+++ b/pkg/controller/datavolume-controller_test.go
@@ -1239,23 +1239,23 @@ var _ = Describe("All DataVolume Tests", func() {
 			Entry("should switch to bound for import", newImportDataVolume("test-dv"), cdiv1.Unknown, cdiv1.PVCBound, corev1.ClaimBound, corev1.PodPending, "invalid", "PVC test-dv Bound", AnnPriorityClassName, "p0"),
 			Entry("should switch to scheduled for import", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportScheduled, corev1.ClaimBound, corev1.PodPending, AnnImportPod, "Import into test-dv scheduled", AnnPriorityClassName, "p0"),
 			Entry("should switch to inprogress for import", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportInProgress, corev1.ClaimBound, corev1.PodRunning, AnnImportPod, "Import into test-dv in progress", AnnPriorityClassName, "p0"),
-			Entry("should switch to failed for import", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimBound, corev1.PodFailed, AnnImportPod, "Failed to import into PVC test-dv", AnnPriorityClassName, "p0"),
+			Entry("should stay the same for import after pod fails", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportScheduled, corev1.ClaimBound, corev1.PodFailed, AnnImportPod, "Failed to import into PVC test-dv", AnnPriorityClassName, "p0"),
 			Entry("should switch to failed on claim lost for impot", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimLost, corev1.PodFailed, AnnImportPod, "PVC test-dv lost", AnnPriorityClassName, "p0"),
 			Entry("should switch to succeeded for import", newImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.Succeeded, corev1.ClaimBound, corev1.PodSucceeded, AnnImportPod, "Successfully imported into PVC test-dv", AnnPriorityClassName, "p0"),
 			Entry("should switch to scheduled for clone", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.CloneScheduled, corev1.ClaimBound, corev1.PodPending, AnnCloneRequest, "Cloning from default/test into default/test-dv scheduled", AnnPriorityClassName, "p0-clone"),
 			Entry("should switch to clone in progress for clone", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.CloneInProgress, corev1.ClaimBound, corev1.PodRunning, AnnCloneRequest, "Cloning from default/test into default/test-dv in progress", AnnPriorityClassName, "p0-clone"),
-			Entry("should switch to failed for clone", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimBound, corev1.PodFailed, AnnCloneRequest, "Cloning from default/test into default/test-dv failed", AnnPriorityClassName, "p0-clone"),
+			Entry("should stay the same for clone after pod fails", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.CloneScheduled, corev1.ClaimBound, corev1.PodFailed, AnnCloneRequest, "Cloning from default/test into default/test-dv failed", AnnPriorityClassName, "p0-clone"),
 			Entry("should switch to failed on claim lost for clone", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimLost, corev1.PodFailed, AnnCloneRequest, "PVC test-dv lost", AnnPriorityClassName, "p0-clone"),
 			Entry("should switch to succeeded for clone", newCloneDataVolume("test-dv"), cdiv1.Pending, cdiv1.Succeeded, corev1.ClaimBound, corev1.PodSucceeded, AnnCloneRequest, "Successfully cloned from default/test into default/test-dv", AnnPriorityClassName, "p0-clone"),
 
 			Entry("should switch to scheduled for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadScheduled, corev1.ClaimBound, corev1.PodPending, AnnUploadRequest, "Upload into test-dv scheduled", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to uploadready for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadReady, corev1.ClaimBound, corev1.PodRunning, AnnUploadRequest, "Upload into test-dv ready", AnnPodReady, "true", AnnPriorityClassName, "p0-upload"),
-			Entry("should switch to failed for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimBound, corev1.PodFailed, AnnUploadRequest, "Upload into test-dv failed", AnnPriorityClassName, "p0-upload"),
+			Entry("should stay the same for upload after pod fails", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadScheduled, corev1.ClaimBound, corev1.PodFailed, AnnUploadRequest, "Upload into test-dv failed", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to failed on claim lost for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimLost, corev1.PodFailed, AnnUploadRequest, "PVC test-dv lost", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to succeeded for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.Succeeded, corev1.ClaimBound, corev1.PodSucceeded, AnnUploadRequest, "Successfully uploaded into test-dv", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to scheduled for blank", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportScheduled, corev1.ClaimBound, corev1.PodPending, AnnImportPod, "Import into test-dv scheduled", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to inprogress for blank", newBlankImageDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportInProgress, corev1.ClaimBound, corev1.PodRunning, AnnImportPod, "Import into test-dv in progress"),
-			Entry("should switch to failed for blank", newBlankImageDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimBound, corev1.PodFailed, AnnImportPod, "Failed to import into PVC test-dv"),
+			Entry("should stay the same for blank after pod fails", newBlankImageDataVolume("test-dv"), cdiv1.Pending, cdiv1.ImportScheduled, corev1.ClaimBound, corev1.PodFailed, AnnImportPod, "Failed to import into PVC test-dv"),
 			Entry("should switch to failed on claim lost for blank", newBlankImageDataVolume("test-dv"), cdiv1.Pending, cdiv1.Failed, corev1.ClaimLost, corev1.PodFailed, AnnImportPod, "PVC test-dv lost"),
 			Entry("should switch to succeeded for blank", newBlankImageDataVolume("test-dv"), cdiv1.Pending, cdiv1.Succeeded, corev1.ClaimBound, corev1.PodSucceeded, AnnImportPod, "Successfully imported into PVC test-dv"),
 		)
@@ -1693,13 +1693,14 @@ var _ = Describe("All DataVolume Tests", func() {
 		It("Size-detection fails when source PVC is not attainable", func() {
 			dv := newCloneDataVolumeWithEmptyStorage("test-dv", "default")
 			cloneStrategy := cdiv1.CloneStrategyHostAssisted
+			targetPvc := &corev1.PersistentVolumeClaim{}
 			storageProfile := createStorageProfileWithCloneStrategy(scName, []cdiv1.ClaimPropertySet{
 				{AccessModes: accessMode, VolumeMode: &blockMode}}, &cloneStrategy)
 
 			reconciler := createDatavolumeReconciler(dv, storageProfile, sc)
 			pvcSpec, err := RenderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, targetPvc, pvcSpec, HostAssistedClone)
 			Expect(err).To(HaveOccurred())
 			Expect(done).To(BeFalse())
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
@@ -1716,7 +1717,7 @@ var _ = Describe("All DataVolume Tests", func() {
 
 			pvcSpec, err := RenderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(done).To(BeFalse())
 			By("Checking events recorded")
@@ -1744,7 +1745,7 @@ var _ = Describe("All DataVolume Tests", func() {
 
 			pvcSpec, err := RenderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(done).To(BeFalse())
 			By("Checking events recorded")
@@ -1780,7 +1781,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			// Checks
 			pvcSpec, err := RenderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, HostAssistedClone)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(ErrInvalidTermMsg))
 			Expect(done).To(BeFalse())
@@ -1825,7 +1826,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			expectedSizeInt64, _ := expectedSize.AsInt64()
 
 			// Checks
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(done).To(BeTrue())
 			Expect(dv.GetAnnotations()[AnnPermissiveClone]).To(Equal("true"))
@@ -1854,7 +1855,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			expectedSizeInt64, _ := expectedSize.AsInt64()
 
 			// Checks
-			done, err := reconciler.detectCloneSize(dv, pvcSpec, HostAssistedClone)
+			done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(done).To(BeTrue())
 			Expect(dv.GetAnnotations()[AnnPermissiveClone]).To(Equal("true"))
@@ -1876,7 +1877,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				pvcSpec, err := RenderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 				Expect(err).ToNot(HaveOccurred())
 				expectedSize := *pvc.Status.Capacity.Storage()
-				done, err := reconciler.detectCloneSize(dv, pvcSpec, selectedCloneStrategy)
+				done, err := reconciler.detectCloneSize(dv, pvc, pvcSpec, selectedCloneStrategy)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(done).To(BeTrue())
 				Expect(pvc.Spec.Resources.Requests.Storage().Cmp(expectedSize)).To(Equal(0))

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -528,9 +528,11 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 	}
 
 	pod, err := createImporterPod(r.log, r.client, podArgs, r.installerLabels)
-	if err != nil {
-		return handleFailedPod(err, pvc.Annotations[AnnImportPod], pvc, r.recorder, r.client)
+	// Check if pod has failed and, in that case, record an event with the error
+	if podErr := handleFailedPod(err, pvc.Annotations[AnnImportPod], pvc, r.recorder, r.client); podErr != nil {
+		return podErr
 	}
+
 	r.log.V(1).Info("Created POD", "pod.Name", pod.Name)
 
 	// If importing from image stream, add finalizer. Note we don't watch the importer pod in this case,

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -529,7 +529,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 
 	pod, err := createImporterPod(r.log, r.client, podArgs, r.installerLabels)
 	if err != nil {
-		return err
+		return handleFailedPod(err, pvc.Annotations[AnnImportPod], pvc, r.recorder, r.client)
 	}
 	r.log.V(1).Info("Created POD", "pod.Name", pod.Name)
 

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -385,7 +385,7 @@ func (r *UploadReconciler) createUploadPodForPvc(pvc *v1.PersistentVolumeClaim, 
 	r.log.V(3).Info("Creating upload pod")
 	pod, err := r.createUploadPod(args)
 	if err != nil {
-		return nil, err
+		return nil, handleFailedPod(err, podName, pvc, r.recorder, r.client)
 	}
 
 	if err := r.ensureCertSecret(args, pod); err != nil {

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -384,8 +384,9 @@ func (r *UploadReconciler) createUploadPodForPvc(pvc *v1.PersistentVolumeClaim, 
 
 	r.log.V(3).Info("Creating upload pod")
 	pod, err := r.createUploadPod(args)
-	if err != nil {
-		return nil, handleFailedPod(err, podName, pvc, r.recorder, r.client)
+	// Check if pod has failed and, in that case, record an event with the error
+	if podErr := handleFailedPod(err, podName, pvc, r.recorder, r.client); podErr != nil {
+		return nil, podErr
 	}
 
 	if err := r.ensureCertSecret(args, pod); err != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1192,6 +1192,7 @@ func handleFailedPod(err error, podName string, pvc *v1.PersistentVolumeClaim, r
 
 	recorder.Event(pvc, v1.EventTypeWarning, reason, msg)
 
+	AddAnnotation(pvc, AnnRunningCondition, "false")
 	AddAnnotation(pvc, AnnPodPhase, string(v1.PodFailed))
 	if err := c.Update(context.TODO(), pvc); err != nil {
 		return err

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -148,7 +148,7 @@ const (
 	// ErrStartingPod provides a const to indicate that a pod wasn't able to start without providing sensitive information (reason)
 	ErrStartingPod = "ErrStartingPod"
 	// MessageErrStartingPod provides a const to indicate that a pod wasn't able to start without providing sensitive information (message)
-	MessageErrStartingPod = "Error starting pod '%s': For more information, request access to cdi-deploy logs to your sysadmin"
+	MessageErrStartingPod = "Error starting pod '%s': For more information, request access to cdi-deploy logs from your sysadmin"
 )
 
 const (
@@ -1178,6 +1178,9 @@ func inflateSizeWithOverhead(c client.Client, imgSize int64, pvcSpec *v1.Persist
 
 // handleFailedPod handles pod-creation errors and updates the pod's PVC without providing sensitive information
 func handleFailedPod(err error, podName string, pvc *v1.PersistentVolumeClaim, recorder record.EventRecorder, c client.Client) error {
+	if err == nil {
+		return nil
+	}
 	// Generic reason and msg to avoid providing sensitive information
 	reason := ErrStartingPod
 	msg := fmt.Sprintf(MessageErrStartingPod, podName)

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1845,9 +1845,8 @@ var _ = Describe("all clone tests", func() {
 				return log
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
-			By("Verify target DV is in failed phase")
-			err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Failed, "target-dv", 3*90*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			By("Verify target DV has 'false' as running condition")
+			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
 
 			By("Check the expected event")
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv")
@@ -1888,9 +1887,8 @@ var _ = Describe("all clone tests", func() {
 				return log
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
-			By("Verify target DV is in failed phase")
-			err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Failed, "target-dv", 3*90*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			By("Verify target DV has 'false' as running condition")
+			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
 
 			By("Check the expected event")
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv")

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -49,10 +49,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
 
 		dataVolume, md5 := createDataVolume("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 	})
@@ -66,10 +66,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		utils.ConfigureCloneStrategy(f.CrClient, f.CdiClient, f.CsiCloneSCName, originalProfileSpec, cdiv1.CloneStrategyCsiClone)
 
 		dataVolume, expectedMd5 := createDataVolume("dv-csi-clone-test-1", utils.DefaultPvcMountPath, v1.PersistentVolumeBlock, f.CsiCloneSCName, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CSICloneInProgress))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CSICloneInProgress))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultPvcMountPath, expectedMd5)
 	})
@@ -87,7 +87,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 
 		dataVolume, _ := createDataVolumeDontWait("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, cloneStorageClassName, f)
 		waitForDvPhase(cdiv1.CloneScheduled, dataVolume, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrUnableToClone))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.ErrUnableToClone))
 	})
 
 	It("[test_id:7736] Should fail to create pvc in namespace with storage quota, then succeed once the quota is large enough", func() {
@@ -105,7 +105,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		dataVolume, md5 := createDataVolumeDontWait("dv-csi-clone-test-1", utils.DefaultImagePath, v1.PersistentVolumeFilesystem, f.CsiCloneSCName, f)
 		By("Verify Quota was exceeded in events and dv conditions")
 		waitForDvPhase(cdiv1.Pending, dataVolume, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
 		boundCondition := &cdiv1.DataVolumeCondition{
 			Type:    cdiv1.DataVolumeBound,
 			Status:  v1.ConditionUnknown,
@@ -125,10 +125,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify clone completed after quota increase")
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(string(cdiv1.CSICloneInProgress)))
 		// Wait for operation Succeeded
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
-		expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
+		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 		// Verify PVC's content
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -377,7 +377,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				readyCondition.Reason = controller.SnapshotForSmartCloneInProgress
 			}
 			waitForDvPhase(expectedPhase, dataVolume, f)
-			expectEvent(f, dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
+			f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.ErrExceededQuota))
 			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, readyCondition)
 
 			By("Increase quota")

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -593,6 +593,19 @@ func (f *Framework) UpdateCdiConfigResourceLimits(resourceCPU, resourceMemory, l
 	})
 }
 
+// ExpectEvent polls and fetches events during a defined period of time
+func (f *Framework) ExpectEvent(dataVolumeNamespace string) gomega.AsyncAssertion {
+	return gomega.Eventually(func() string {
+		events, err := f.runKubectlCommand("get", "events", "-n", dataVolumeNamespace)
+		if err == nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "%s", events)
+			return events
+		}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "ERROR: %s\n", err.Error())
+		return ""
+	}, timeout, pollingInterval)
+}
+
 //runKubectlCommand ...
 func (f *Framework) runKubectlCommand(args ...string) (string, error) {
 	var errb bytes.Buffer

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -808,6 +808,11 @@ var _ = Describe("Namespace with quota", func() {
 			Expect(err).NotTo(HaveOccurred())
 			return strings.Trim(log, " ")
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
+
+		By("Check the expected event")
+		msg := fmt.Sprintf(controller.MessageErrStartingPod, "importer-import-image-to-pvc")
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(msg))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(controller.ErrExceededQuota))
 	})
 
 	It("[test_id:4983]Should fail to create import pod in namespace with quota, then succeed once the quota is large enough", func() {
@@ -837,6 +842,11 @@ var _ = Describe("Namespace with quota", func() {
 			Expect(err).NotTo(HaveOccurred())
 			return strings.Trim(log, " ")
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
+
+		By("Check the expected event")
+		msg := fmt.Sprintf(controller.MessageErrStartingPod, "importer-import-image-to-pvc")
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(msg))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(controller.ErrExceededQuota))
 
 		err = f.UpdateQuotaInNs(int64(2), int64(512*1024*1024), int64(2), int64(512*1024*1024))
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -769,6 +769,11 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			return log
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
+
+		By("Check the expected event")
+		msg := fmt.Sprintf(controller.MessageErrStartingPod, utils.UploadPodName(pvc))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(msg))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(controller.ErrExceededQuota))
 	})
 
 	It("[test_id:4992]Should fail to create upload pod in namespace with quota, and recover when quota fixed", func() {
@@ -787,6 +792,12 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			return log
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
+
+		By("Check the expected event")
+		msg := fmt.Sprintf(controller.MessageErrStartingPod, utils.UploadPodName(pvc))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(msg))
+		f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(controller.ErrExceededQuota))
+
 		By("Updating the quota to be enough")
 		err = f.UpdateQuotaInNs(int64(2), int64(512*1024*1024), int64(2), int64(1024*1024*1024))
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: When pod creation fails, the error is usually logged without providing additional information to the user. This behavior is especially risky when the user lacks the permits to check the logs, making it unintuitive and almost impossible to find the source of the problem.

This PR aims to improve the error handling of the pod-creation process, so pertinent info about the failure is included in the pod's PVC/DV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve error handling when pod creation fails
```

