### PR TITLE
Disable DV garbage collection by default in func tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -112,5 +112,9 @@ if [[ -n "$CDI_E2E_SKIP" ]]; then
   ginko_params="${ginko_params} --ginkgo.skip=${CDI_E2E_SKIP}"
 fi
 
+if [[ -n "$CDI_DV_GC" ]]; then
+    kubectl patch cdi $CDI_NAMESPACE --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '$CDI_DV_GC'}}}'
+fi
+
 # Run functional tests
 TEST_ARGS=$ginko_params make test-functional

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -65,8 +65,6 @@ type Config struct {
 
 	// FeatureGates may be overridden for a framework
 	FeatureGates []string
-	// DataVolume garbage collection
-	DataVolumeTTLSeconds *int32
 }
 
 // Clients is the struct containing the client-go kubernetes clients
@@ -134,8 +132,7 @@ type Framework struct {
 // cannot work when called during test tree construction.
 func NewFramework(prefix string, config ...Config) *Framework {
 	cfg := Config{
-		FeatureGates:         []string{featuregates.HonorWaitForFirstConsumer},
-		DataVolumeTTLSeconds: &[]int32{0}[0],
+		FeatureGates: []string{featuregates.HonorWaitForFirstConsumer},
 	}
 	if len(config) > 0 {
 		cfg = config[0]
@@ -685,13 +682,9 @@ func (f *Framework) IsBindingModeWaitForFirstConsumer(storageClassName *string) 
 
 func (f *Framework) updateCDIConfig() {
 	ginkgo.By(fmt.Sprintf("Configuring default FeatureGates %q", f.FeatureGates))
-	if f.DataVolumeTTLSeconds != nil {
-		ginkgo.By(fmt.Sprintf("Configuring default DataVolumeTTLSeconds %d", *f.DataVolumeTTLSeconds))
-	}
 	gomega.Eventually(func() bool {
 		err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
 			config.FeatureGates = f.FeatureGates
-			config.DataVolumeTTLSeconds = f.DataVolumeTTLSeconds
 		})
 		return err == nil
 	}, timeout, pollingInterval).Should(gomega.BeTrue())


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Since GC if currently disabled by default in OpenShift, we keep it disabled in func tests by default, as we need test coverage when TTL is nil. We already override it for specific GC tests, and we will add a specific lane that enables it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

