### PR TITLE
Fix a few VDDK-related nbdkit issues.

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -256,7 +256,7 @@ spec:
            uuid: "52260566-b032-36cb-55b1-79bf29e30490"
            thumbprint: "20:6C:8A:5D:44:40:B3:79:4B:28:EA:76:13:60:90:6E:49:D9:D9:A3" # SSL fingerprint of vCenter/ESX host
            secretRef: "vddk-credentials"
-           initImageURL: "http://registry:5000/vddk-init:latest"
+           initImageURL: "registry:5000/vddk-init:latest"
     pvc:
        accessModes:
          - ReadWriteOnce

--- a/hack/build/rpm-deps.sh
+++ b/hack/build/rpm-deps.sh
@@ -51,6 +51,7 @@ qemu-img
 
 cdi_importer_extra_x86_64="
 nbdkit-vddk-plugin
+sqlite-libs
 "
 
 cdi_uploadserver="

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -52,6 +52,7 @@ const (
 	NbdkitTarFilter   NbdkitFilter = "tar"
 	NbdkitGzipFilter  NbdkitFilter = "gzip"
 	NbdkitRetryFilter NbdkitFilter = "retry"
+	NbdkitCacheExtentsFilter NbdkitFilter = "cacheextents"
 )
 
 // Nbdkit represents struct for an nbdkit instance
@@ -142,6 +143,7 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 	}
 
 	n.AddFilter(NbdkitRetryFilter)
+	n.AddFilter(NbdkitCacheExtentsFilter)
 	if err := n.validatePlugin(); err != nil {
 		return nil, err
 	}

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	nbdVddkLibraryPath    = "/opt/vmware-vix-disklib-distrib/lib64"
+	nbdVddkLibraryPath    = "/opt/vmware-vix-disklib-distrib"
 	startupTimeoutSeconds = 15
 )
 
@@ -141,7 +141,6 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 		Socket:     socket,
 	}
 
-	n.AddEnvVariable("LD_LIBRARY_PATH=" + nbdVddkLibraryPath)
 	n.AddFilter(NbdkitRetryFilter)
 	if err := n.validatePlugin(); err != nil {
 		return nil, err

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -48,10 +48,10 @@ const (
 
 // Nbdkit filters
 const (
-	NbdkitXzFilter    NbdkitFilter = "xz"
-	NbdkitTarFilter   NbdkitFilter = "tar"
-	NbdkitGzipFilter  NbdkitFilter = "gzip"
-	NbdkitRetryFilter NbdkitFilter = "retry"
+	NbdkitXzFilter           NbdkitFilter = "xz"
+	NbdkitTarFilter          NbdkitFilter = "tar"
+	NbdkitGzipFilter         NbdkitFilter = "gzip"
+	NbdkitRetryFilter        NbdkitFilter = "retry"
 	NbdkitCacheExtentsFilter NbdkitFilter = "cacheextents"
 )
 

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -237,6 +237,7 @@ rpmtree(
         "@readline-0__8.1-4.el9.x86_64//rpm",
         "@sed-0__4.8-9.el9.x86_64//rpm",
         "@setup-0__2.13.7-6.el9.x86_64//rpm",
+        "@sqlite-libs-0__3.34.1-5.el9.x86_64//rpm",
         "@systemd-libs-0__250-4.el9.x86_64//rpm",
         "@tar-2__1.34-3.el9.x86_64//rpm",
         "@tzdata-0__2021e-1.el9.x86_64//rpm",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes nbdkit usage of VDDK library for import from VMware.

**Which issue(s) this PR fixes**:
No bug, I just tried to do some VDDK imports using CDI main and noticed nbdkit failing, likely from the big CentOS update.
`/opt/vmware-vix-disklib-distrib/lib64/lib64/libvixDiskLib.so.7: cannot open shared object file: No such file or directory`
`libsqlite3.so.0: cannot open shared object file: No such file or directory`

**Special notes for your reviewer**:
I also added the cacheextents filter to nbdkit only for VDDK transfers, so far I have seen it knock several seconds off the transfer startup time when the importer is querying for disk extents. 

**Release note**:
```release-note
NONE
```

