### PR TITLE
Revert infra_label for CDI alerts

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -296,7 +296,6 @@ var _ = Describe("Controller", func() {
 						"severity":                      "warning",
 						"kubernetes_operator_part_of":   "kubevirt",
 						"kubernetes_operator_component": "containerized-data-importer",
-						"infra_alert":                   "true",
 					},
 				}
 

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -53,7 +53,6 @@ const (
 	partOfAlertLabelValue    = "kubevirt"
 	componentAlertLabelKey   = "kubernetes_operator_component"
 	componentAlertLabelValue = common.CDILabelValue
-	infraAlertLabelKey       = "infra_alert"
 )
 
 func ensurePrometheusResourcesExist(c client.Client, scheme *runtime.Scheme, owner metav1.Object) error {
@@ -154,7 +153,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -169,7 +167,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -184,7 +181,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -199,7 +195,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "info",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -214,7 +209,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "info",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 	}


### PR DESCRIPTION
Reverts [#2314](https://github.com/kubevirt/containerized-data-importer/pull/2314). The design is not yet agreed as a standard for all operators alerts, so this label won't be used for now.

Signed-off-by: assafad <aadmi@redhat.com>

```release-note
None
```

