### PR TITLE
use basic auth in nbdkit

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -85,10 +85,16 @@ func NewNbdkit(plugin NbdkitPlugin, nbdkitPidFile string) *Nbdkit {
 }
 
 // NewNbdkitCurl creates a new Nbdkit instance with the curl plugin
-func NewNbdkitCurl(nbdkitPidFile, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
+func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
 	var pluginArgs []string
 	var redactArgs []string
 	args := []string{"-r"}
+	if user != "" {
+		pluginArgs = append(pluginArgs, "user="+user)
+	}
+	if password != "" {
+		pluginArgs = append(pluginArgs, "password="+password)
+	}
 	if certDir != "" {
 		pluginArgs = append(pluginArgs, fmt.Sprintf("cainfo=%s/%s", certDir, "tls.crt"))
 	}
@@ -384,7 +390,7 @@ func (n *Nbdkit) validatePlugin() error {
 type mockNbdkit struct{}
 
 // NewMockNbdkitCurl creates a mock nbdkit curl plugin for testing
-func NewMockNbdkitCurl(nbdkitPidFile, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
+func NewMockNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
 	return &mockNbdkit{}
 }
 

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -102,9 +102,6 @@ func NewHTTPDataSource(endpoint, accessKey, secKey, certDir string, contentType 
 		return nil, err
 	}
 
-	if accessKey != "" && secKey != "" {
-		ep.User = url.UserPassword(accessKey, secKey)
-	}
 	httpSource := &HTTPDataSource{
 		ctx:              ctx,
 		cancel:           cancel,
@@ -115,7 +112,7 @@ func NewHTTPDataSource(endpoint, accessKey, secKey, certDir string, contentType 
 		brokenForQemuImg: brokenForQemuImg,
 		contentLength:    contentLength,
 	}
-	httpSource.n = createNbdkitCurl(nbdkitPid, certDir, nbdkitSocket, extraHeaders, secretExtraHeaders)
+	httpSource.n = createNbdkitCurl(nbdkitPid, accessKey, secKey, certDir, nbdkitSocket, extraHeaders, secretExtraHeaders)
 	// We know this is a counting reader, so no need to check.
 	countingReader := httpReader.(*util.CountingReader)
 	go httpSource.pollProgress(countingReader, 10*time.Minute, time.Second)

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -78,17 +78,6 @@ var _ = Describe("Http data source", func() {
 		Expect(strings.Contains(err.Error(), "unable to parse endpoint")).To(BeTrue())
 	})
 
-	It("endpoint User object should be set when accessKey and secKey are not blank", func() {
-		image := ts.URL + "/" + cirrosFileName
-		dp, err = NewHTTPDataSource(image, "user", "password", "", cdiv1.DataVolumeKubeVirt)
-		Expect(err).NotTo(HaveOccurred())
-		user := dp.endpoint.User
-		Expect("user").To(Equal(user.Username()))
-		pw, set := user.Password()
-		Expect("password").To(Equal(pw))
-		Expect(set).To(BeTrue())
-	})
-
 	It("NewHTTPDataSource should fail when called with an invalid certdir", func() {
 		image := ts.URL + "/" + cirrosFileName
 		_, err = NewHTTPDataSource(image, "", "", "/invaliddir", cdiv1.DataVolumeKubeVirt)


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use http basic auth with nbdkit.  Currently encoding the user/password in the url and that is strongly discouraged and not universally compatible

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2338

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

