### PR TITLE
[release-v1.50] manual cherry-pick PR #2333

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -483,6 +483,12 @@ func (r *DatavolumeReconciler) Reconcile(_ context.Context, req reconcile.Reques
 		return reconcile.Result{}, err
 	}
 
+	if isCrossNamespaceClone(datavolume) && datavolume.Status.Phase == cdiv1.Succeeded {
+		if err := r.cleanupTransfer(log, datavolume, transferName); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	pvcPopulated := false
 	// Get the pvc with the name specified in DataVolume.spec
 	pvc := &corev1.PersistentVolumeClaim{}
@@ -613,7 +619,7 @@ func (r *DatavolumeReconciler) reconcileClone(log logr.Logger,
 		}
 	}
 
-	if !prePopulated && !pvcPopulated {
+	if !prePopulated {
 		if pvc == nil {
 			if selectedCloneStrategy == SmartClone {
 				snapshotClassName, _ := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
@@ -655,8 +661,10 @@ func (r *DatavolumeReconciler) reconcileClone(log logr.Logger,
 
 		switch selectedCloneStrategy {
 		case HostAssistedClone:
-			if err := r.ensureExtendedToken(pvc); err != nil {
-				return reconcile.Result{}, err
+			if !pvcPopulated {
+				if err := r.ensureExtendedToken(pvc); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		case CsiClone:
 			switch pvc.Status.Phase {
@@ -677,7 +685,9 @@ func (r *DatavolumeReconciler) reconcileClone(log logr.Logger,
 			}
 			fallthrough
 		case SmartClone:
-			return r.finishClone(log, datavolume, pvc, pvcSpec, transferName, selectedCloneStrategy)
+			if !pvcPopulated {
+				return r.finishClone(log, datavolume, pvc, pvcSpec, transferName, selectedCloneStrategy)
+			}
 		}
 	}
 
@@ -882,15 +892,6 @@ func (r *DatavolumeReconciler) finishClone(log logr.Logger,
 	pvcSpec *corev1.PersistentVolumeClaimSpec,
 	transferName string,
 	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
-
-	if isCrossNamespaceClone(datavolume) && datavolume.Status.Phase == cdiv1.Succeeded {
-		if err := r.cleanupTransfer(log, datavolume, transferName); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		// done, done
-		return reconcile.Result{}, nil
-	}
 
 	//DO Nothing, not yet ready
 	if pvc.Annotations[AnnCloneOf] != "true" {
@@ -1355,7 +1356,7 @@ func (r *DatavolumeReconciler) cleanupTransfer(log logr.Logger, dv *cdiv1.DataVo
 		return nil
 	}
 
-	log.Info("Doing cleanup")
+	log.V(1).Info("Doing cleanup")
 
 	if dv.DeletionTimestamp != nil && dv.Status.Phase != cdiv1.Succeeded {
 		// delete all potential PVCs that may not have owner refs

--- a/pkg/controller/smart-clone-controller.go
+++ b/pkg/controller/smart-clone-controller.go
@@ -191,6 +191,10 @@ func (r *SmartCloneReconciler) reconcileSnapshot(log logr.Logger, snapshot *snap
 		WithValues("snapshot.Namespace", snapshot.Namespace).
 		Info("Reconciling snapshot")
 
+	if snapshot.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	dataVolume, err := r.getDataVolume(snapshot)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/smart-clone-controller_test.go
+++ b/pkg/controller/smart-clone-controller_test.go
@@ -164,6 +164,20 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("Should do nothing if snapshot deleted", func() {
+			reconciler := createSmartCloneReconciler()
+			snapshot := createSnapshotVolume("test-dv", metav1.NamespaceDefault, nil)
+			ts := metav1.Now()
+			snapshot.DeletionTimestamp = &ts
+			_, err := reconciler.reconcileSnapshot(reconciler.log, snapshot)
+			Expect(err).ToNot(HaveOccurred())
+
+			nn := types.NamespacedName{Namespace: snapshot.Namespace, Name: snapshot.Name}
+			err = reconciler.client.Get(context.TODO(), nn, &corev1.PersistentVolumeClaim{})
+			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("Should delete snapshot if DataVolume deleted", func() {
 			dv := newCloneDataVolume("test-dv")
 			ts := metav1.Now()

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -16,6 +16,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2183,18 +2184,44 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 
 	validateCloneType(f, dv)
 
+	sns := dv.Spec.Source.PVC.Namespace
+	if sns == "" {
+		sns = dv.Namespace
+	}
+
 	switch utils.GetCloneType(f.CdiClient, dv) {
 	case "snapshot":
-		sns := dv.Spec.Source.PVC.Namespace
-		if sns == "" {
-			sns = dv.Namespace
-		}
-
 		snapshots := &snapshotv1.VolumeSnapshotList{}
 		err = f.CrClient.List(context.TODO(), snapshots, &client.ListOptions{Namespace: sns})
 		Expect(err).ToNot(HaveOccurred())
 		for _, s := range snapshots.Items {
 			Expect(s.DeletionTimestamp).ToNot(BeNil())
+		}
+		fallthrough
+	case "csivolumeclone":
+		if sns != dv.Namespace {
+			tmpName := fmt.Sprintf("cdi-tmp-%s", dv.UID)
+			tmpPvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(sns).Get(context.TODO(), tmpName, metav1.GetOptions{})
+			if err != nil {
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			} else {
+				Expect(tmpPvc.DeletionTimestamp).ToNot(BeNil())
+			}
+
+			Eventually(func() []string {
+				tmp, err := f.CdiClient.CdiV1beta1().DataVolumes(targetNs.Name).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return tmp.Finalizers
+			}, 90*time.Second, 2*time.Second).Should(BeEmpty())
+
+			Eventually(func() bool {
+				ot, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), tmpName, metav1.GetOptions{})
+				if err != nil {
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+					return true
+				}
+				return ot.DeletionTimestamp != nil
+			}, 90*time.Second, 2*time.Second).Should(BeTrue())
 		}
 	case "network":
 		s, err := f.K8sClient.CoreV1().Secrets(f.CdiInstallNs).Get(context.TODO(), "cdi-api-signing-key", metav1.GetOptions{})


### PR DESCRIPTION
* fix issue #2323: Cross namespace smart clone leaving tmp PVC and ObjectTransfer around

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

* wait for objecttransfers to be cleaned up in clone tests

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

* attempt to address test failures

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

* move cross namespace cleanup code

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

* move cleanup transfer call until after dataSource is resolved

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

