### PR TITLE
Don't use nbdkit for xz or gz

### DIFF
--- a/doc/scratch-space.md
+++ b/doc/scratch-space.md
@@ -12,10 +12,9 @@ If none of those exist, then CDI will be unable to create scratch space. This me
 
 Operations that require scratch space are:
 
-| Type | Reason|
-|------|-------|
-| Registry imports | In order to import from registry container images, CDI has to first download the image to a scratch space, extract the layers to find the image file, and then pass that image file to QEMU-IMG for conversion to a raw disk |
-| Upload image | Because QEMU-IMG does not accept inputs from stdin yet, we cannot stream the upload directly to QEMU-IMG, so we have to save the upload to a scratch space first and then pass it to QEMU-IMG for conversion |
-| Http imports from unsupported server source for nbdkit | CDI uses ndbkit curl to stream the source content. However, nbdkit curl plugin cannot fetch the source when the server doesn't support accept ranges, or HTTP HEAD requests (for example, S3 servers). For those cases, the scratch space is still required|
-| Http imports of custom certificates | nbdkit handles custom certificates differently. To avoid breaking users we keep using a Go client that requires scratch space|
-
+| Type                                                   | Reason                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry imports                                       | In order to import from registry container images, CDI has to first download the image to a scratch space, extract the layers to find the image file, and then pass that image file to QEMU-IMG for conversion to a raw disk                                |
+| Upload image                                           | Because QEMU-IMG does not accept inputs from stdin yet, we cannot stream the upload directly to QEMU-IMG, so we have to save the upload to a scratch space first and then pass it to QEMU-IMG for conversion                                                |
+| Http imports from unsupported server source for nbdkit | CDI uses ndbkit curl to stream the source content. However, nbdkit curl plugin cannot fetch the source when the server doesn't support accept ranges, or HTTP HEAD requests (for example, S3 servers). For those cases, the scratch space is still required |
+| Http imports of non raw files with custom certificates | nbdkit handles custom certificates differently. To avoid breaking users we keep using a Go client that requires scratch space                                                                                                                               |

--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -54,13 +54,14 @@ var knownHeaders = Headers{
 	},
 	"vdi": Header{
 		Format:      "vdi",
-		magicNumber: []byte("<<< Oracle VM"),
+		magicNumber: []byte{0x7F, 0x10, 0xDA, 0xBE},
+		mgOffset:    0x40,
 		SizeOff:     0,
 		SizeLen:     0,
 	},
 	"vhd": Header{
 		Format:      "vhd",
-		magicNumber: []byte("connectix"),
+		magicNumber: []byte("conectix"),
 		SizeOff:     0,
 		SizeLen:     0,
 	},

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -20,6 +20,7 @@ import (
 const (
 	nbdVddkLibraryPath    = "/opt/vmware-vix-disklib-distrib"
 	startupTimeoutSeconds = 15
+	defaultUserAgent      = "cdi-nbdkit-importer"
 )
 
 type nbdkitOperations struct {
@@ -90,6 +91,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	var pluginArgs []string
 	var redactArgs []string
 	args := []string{"-r"}
+	pluginArgs = append(pluginArgs, fmt.Sprintf("header=User-Agent: %s", defaultUserAgent))
 	if user != "" {
 		pluginArgs = append(pluginArgs, "user="+user)
 	}

--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -25,11 +25,9 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	"github.com/ulikunitz/xz"
-
-	"k8s.io/klog/v2"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ulikunitz/xz"
+	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -109,12 +109,12 @@ var _ = Describe("Http data source", func() {
 		table.Entry("return TransferTarget with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseTransferDataDir, diskimageArchiveData, false),
 	)
 
-	It("calling info with raw image should return TransferDataFile", func() {
+	It("calling info with raw gz image should return TransferDataFile", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		newPhase, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(newPhase))
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(newPhase))
 	})
 
 	table.DescribeTable("calling transfer should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, scratchPath string, want []byte, wantErr bool) {
@@ -160,7 +160,7 @@ var _ = Describe("Http data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(result))
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
 	})
 
 	It("TransferFile should succeed when writing to valid file and reading raw xz", func() {
@@ -168,7 +168,7 @@ var _ = Describe("Http data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseConvert).To(Equal(result))
+		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
 	})
 
 	It("should get extra headers on creation of new HTTP data source", func() {

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -477,14 +477,14 @@ func wasPodProxied(imgURL, podIP, userAgent, proxyLog string) bool {
 	for _, line := range strings.Split(strings.TrimSuffix(proxyLog, "\n"), "\n") {
 		matched := lineMatcher.FindStringSubmatch(line)
 		if len(matched) > 1 {
-			matchedUrl, _ := url.Parse(matched[2])
+			matchedURL, _ := url.Parse(matched[2])
 			matchedSrc := matched[3]
 			matchedUserAgent := matched[4]
-			if matchedUrl.Hostname() == u.Hostname() &&
+			if matchedURL.Hostname() == u.Hostname() &&
 				strings.HasPrefix(matchedSrc, podIP+":") &&
 				matchedUserAgent == userAgent {
 				fmt.Fprintf(GinkgoWriter, "INFO: Matched: %q, %q, %q, %q, %q, %q [%s]\n",
-					matchedUrl, imgURL, matchedSrc, podIP, matchedUserAgent, userAgent, line)
+					matchedURL, imgURL, matchedSrc, podIP, matchedUserAgent, userAgent, line)
 				res = true
 				break
 			}


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Nbdkit is not a good fit for gz because it downloads/unzips the file to tempdir.

It is also not a good fit for xz, as discussed in #2288.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2288

https://bugzilla.redhat.com/show_bug.cgi?id=2089391

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NBDKit no longer used for .gz or .xz files
```

