### PR TITLE
Fix race condition in upload-controller to keep PVC annotations after a clone error

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -195,10 +195,6 @@ const (
 	CloneWithoutSource = "CloneWithoutSource"
 	// MessageCloneWithoutSource reports that the source PVC of a clone doesn't exists (message)
 	MessageCloneWithoutSource = "The source PVC doesn't exist"
-	// RunningConditionToFalse reports that a DataVolume's running condition changed to false without specifying more information (reason)
-	RunningConditionToFalse = "RunningConditionToFalse"
-	// MessageRunningConditionToFalse reports that a DataVolume's running condition changed to false without specifying more information (message)
-	MessageRunningConditionToFalse = "Running condition changed to false: For more information, check events in the DataVolume's PVC or request access to cdi-deploy logs from your sysadmin"
 
 	// AnnCSICloneRequest annotation associates object with CSI Clone Request
 	AnnCSICloneRequest = "cdi.kubevirt.io/CSICloneRequest"

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -246,11 +246,10 @@ func (r *UploadReconciler) reconcilePVC(log logr.Logger, pvc *corev1.PersistentV
 		return reconcile.Result{}, err
 	}
 
-	podPhase := pod.Status.Phase
-	anno[AnnPodPhase] = string(podPhase)
-	anno[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
-
-	setAnnotationsFromPodWithPrefix(anno, pod, AnnRunningCondition)
+	// Update the annotations in the PVC to reflect the current state of the upload
+	if err := r.updateUploadAnnotations(pvc, anno, pod, isCloneTarget); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	if !reflect.DeepEqual(pvc, pvcCopy) {
 		if err := r.updatePVC(pvcCopy); err != nil {
@@ -480,6 +479,58 @@ func (r *UploadReconciler) deleteService(namespace, serviceName string) error {
 		}
 	}
 
+	return nil
+}
+
+// checkIfCloneFailed inspects clone-related annotations and pods to diagnose if the cloning process has failed
+func (r *UploadReconciler) checkIfCloneFailed(pvc *corev1.PersistentVolumeClaim, isCloneTarget bool) (bool, error) {
+	isCloneRequest, sourceNamespace, _ := ParseCloneRequestAnnotation(pvc)
+	if !isCloneRequest || !isCloneTarget {
+		return false, nil
+	}
+
+	// Clone finished succesfully
+	if pvc.Annotations[AnnCloneOf] == "true" {
+		return false, nil
+	}
+	// Clone source pod not ready
+	sourcePodName, ok := pvc.Annotations[AnnCloneSourcePod]
+	if !ok {
+		return false, nil
+	}
+
+	pod := &corev1.Pod{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: sourcePodName, Namespace: sourceNamespace}, pod); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return true, err
+		}
+		// We assume the clone has failed when the pod doesn't exist, the cloning process hasn't finished and the PVC's running condition is false
+		if pvc.Annotations[AnnRunningCondition] == "false" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// updateUploadAnnotations updates annotations without overwritting previous conditions or states
+func (r *UploadReconciler) updateUploadAnnotations(pvc *corev1.PersistentVolumeClaim, anno map[string]string, pod *v1.Pod, isCloneTarget bool) error {
+	// First we check if the clone failed to avoid changing the running condition back to true
+	cloneFailed, err := r.checkIfCloneFailed(pvc, isCloneTarget)
+	if err != nil {
+		return err
+	}
+
+	if cloneFailed {
+		return nil
+	}
+
+	// Update PVC with upload annotations
+	podPhase := pod.Status.Phase
+	anno[AnnPodPhase] = string(podPhase)
+	anno[AnnPodReady] = strconv.FormatBool(isPodReady(pod))
+
+	setAnnotationsFromPodWithPrefix(anno, pod, AnnRunningCondition)
 	return nil
 }
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -574,55 +574,7 @@ var _ = Describe("Update PVC", func() {
 })
 
 var _ = Describe("updateUploadAnnotations", func() {
-	It("Should not update the annotations if the clone has failed", func() {
-		testPvc := createPvc("testPvc", "default", map[string]string{}, nil)
-		// Add annotations to mock the failed clone
-		testPvc.Annotations[cloneRequestAnnotation] = "default/sourcePvc"
-		testPvc.Annotations[AnnRunningCondition] = "false"
-		testPvc.Annotations[AnnCloneSourcePod] = ""
-		reconciler := createUploadReconciler(testPvc)
-
-		pvcCopy := testPvc.DeepCopy()
-
-		err := reconciler.updateUploadAnnotations(testPvc, pvcCopy.Annotations, nil, true)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testPvc.Annotations).To(Equal(pvcCopy.Annotations))
-	})
-
-	It("Should update the annotations if the clone has succeeded / is in progress", func() {
-		testPvc := createPvc("testPvc", "default", map[string]string{}, nil)
-		// Add annotations to mock the succeeded clone
-		testPvc.Annotations[cloneRequestAnnotation] = "default/sourcePvc"
-		testPvc.Annotations[AnnCloneOf] = "true"
-		pod := createUploadPod(testPvc)
-		pod.Status = corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			ContainerStatuses: []corev1.ContainerStatus{
-				{
-					RestartCount: 2,
-					LastTerminationState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: 1,
-							Message:  "I went poof",
-							Reason:   "Explosion",
-						},
-					},
-				},
-			},
-		}
-		reconciler := createUploadReconciler(testPvc, pod)
-
-		pvcCopy := testPvc.DeepCopy()
-
-		err := reconciler.updateUploadAnnotations(testPvc, pvcCopy.Annotations, pod, true)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(pvcCopy.Annotations[AnnPodRestarts]).To(Equal("2"))
-		Expect(pvcCopy.GetAnnotations()[AnnRunningCondition]).To(Equal("false"))
-		Expect(pvcCopy.GetAnnotations()[AnnRunningConditionMessage]).To(BeEmpty())
-		Expect(pvcCopy.GetAnnotations()[AnnRunningConditionReason]).To(BeEmpty())
-	})
-
-	It("Should update the annotations if the PVC is not clone target", func() {
+	It("Should update the annotations", func() {
 		testPvc := createPvc("testPvc", "default", map[string]string{}, nil)
 		pod := createUploadPod(testPvc)
 		pod.Status = corev1.PodStatus{
@@ -636,12 +588,10 @@ var _ = Describe("updateUploadAnnotations", func() {
 				},
 			},
 		}
-		reconciler := createUploadReconciler(testPvc, pod)
 
 		pvcCopy := testPvc.DeepCopy()
 
-		err := reconciler.updateUploadAnnotations(testPvc, pvcCopy.Annotations, pod, false)
-		Expect(err).ToNot(HaveOccurred())
+		updateUploadAnnotations(testPvc, pvcCopy.Annotations, pod, false)
 		Expect(pvcCopy.Annotations[AnnPodRestarts]).To(Equal("1"))
 		Expect(pvcCopy.GetAnnotations()[AnnRunningCondition]).To(Equal("true"))
 		Expect(pvcCopy.GetAnnotations()[AnnRunningConditionMessage]).To(Equal(""))

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1193,6 +1193,8 @@ func handleFailedPod(err error, podName string, pvc *v1.PersistentVolumeClaim, r
 	recorder.Event(pvc, v1.EventTypeWarning, reason, msg)
 
 	AddAnnotation(pvc, AnnRunningCondition, "false")
+	AddAnnotation(pvc, AnnRunningConditionReason, "")
+	AddAnnotation(pvc, AnnRunningConditionMessage, "")
 	AddAnnotation(pvc, AnnPodPhase, string(v1.PodFailed))
 	if err := c.Update(context.TODO(), pvc); err != nil {
 		return err

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1188,13 +1188,20 @@ func handleFailedPod(err error, podName string, pvc *v1.PersistentVolumeClaim, r
 	// Error handling to fine-tune the event with pertinent info
 	if errQuotaExceeded(err) {
 		reason = ErrExceededQuota
-	} // TODO: Add more error cases
+	}
 
 	recorder.Event(pvc, v1.EventTypeWarning, reason, msg)
 
-	AddAnnotation(pvc, AnnRunningCondition, "false")
-	AddAnnotation(pvc, AnnRunningConditionReason, "")
-	AddAnnotation(pvc, AnnRunningConditionMessage, "")
+	if isCloneSourcePod := createCloneSourcePodName(pvc) == podName; isCloneSourcePod {
+		AddAnnotation(pvc, AnnSourceRunningCondition, "false")
+		AddAnnotation(pvc, AnnSourceRunningConditionReason, reason)
+		AddAnnotation(pvc, AnnSourceRunningConditionMessage, msg)
+	} else {
+		AddAnnotation(pvc, AnnRunningCondition, "false")
+		AddAnnotation(pvc, AnnRunningConditionReason, reason)
+		AddAnnotation(pvc, AnnRunningConditionMessage, msg)
+	}
+
 	AddAnnotation(pvc, AnnPodPhase, string(v1.PodFailed))
 	if err := c.Update(context.TODO(), pvc); err != nil {
 		return err

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1845,8 +1845,15 @@ var _ = Describe("all clone tests", func() {
 				return log
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
+			expectedCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeRunning,
+				Status:  v1.ConditionFalse,
+				Message: fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv"),
+				Reason:  controller.ErrExceededQuota,
+			}
+
 			By("Verify target DV has 'false' as running condition")
-			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
+			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, expectedCondition)
 
 			By("Check the expected event")
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv")
@@ -1887,8 +1894,15 @@ var _ = Describe("all clone tests", func() {
 				return log
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
+			expectedCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeRunning,
+				Status:  v1.ConditionFalse,
+				Message: fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv"),
+				Reason:  controller.ErrExceededQuota,
+			}
+
 			By("Verify target DV has 'false' as running condition")
-			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
+			utils.WaitForConditions(f, targetDV.Name, f.Namespace.Name, timeout, pollingInterval, expectedCondition)
 
 			By("Check the expected event")
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv")
@@ -1960,17 +1974,24 @@ var _ = Describe("all clone tests", func() {
 				return log
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
+			podName := fmt.Sprintf("%s-source-pod", targetPvc.GetUID())
+			expectedCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeRunning,
+				Status:  v1.ConditionFalse,
+				Message: fmt.Sprintf(controller.MessageErrStartingPod, podName),
+				Reason:  controller.ErrExceededQuota,
+			}
+
 			By("Verify target DV has 'false' as running condition")
-			utils.WaitForConditions(f, targetDV.Name, targetNs.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
+			utils.WaitForConditions(f, targetDV.Name, targetNs.Name, timeout, pollingInterval, expectedCondition)
 
 			By("Check the expected event")
-			podName := fmt.Sprintf("%s-source-pod", targetPvc.GetUID())
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, podName)
 			f.ExpectEvent(targetNs.Name).Should(ContainSubstring(msg))
 			f.ExpectEvent(targetNs.Name).Should(ContainSubstring(controller.ErrExceededQuota))
 		})
 
-		It("Should fail clone data across namespaces, if target namespace doesn't have enough quota", func() {
+		It("[test_id:9076]Should fail clone data across namespaces, if target namespace doesn't have enough quota", func() {
 			err := f.UpdateCdiConfigResourceLimits(int64(0), int64(512*1024*1024), int64(1), int64(512*1024*1024))
 			Expect(err).NotTo(HaveOccurred())
 			pvcDef := utils.NewPVCDefinition(sourcePVCName, "500M", nil, nil)
@@ -2003,8 +2024,15 @@ var _ = Describe("all clone tests", func() {
 				return strings.Trim(log, " ")
 			}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
 
+			expectedCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeRunning,
+				Status:  v1.ConditionFalse,
+				Message: fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv"),
+				Reason:  controller.ErrExceededQuota,
+			}
+
 			By("Verify target DV has 'false' as running condition")
-			utils.WaitForConditions(f, targetDV.Name, targetNs.Name, timeout, pollingInterval, &cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: v1.ConditionFalse})
+			utils.WaitForConditions(f, targetDV.Name, targetNs.Name, timeout, pollingInterval, expectedCondition)
 
 			By("Check the expected event")
 			msg := fmt.Sprintf(controller.MessageErrStartingPod, "cdi-upload-target-dv")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

## What this PR does / why we need it

When a pod fails after the error handling added in https://github.com/kubevirt/containerized-data-importer/pull/2335, some annotations (running condition, pod phase...) are updated in the affected PVC to let other controllers know.
    
However, due to a lack of synchronization between some controllers, a race condition could happen where, if a pod is successfully created just after a pod fails in a different controller, the annotations set in the error handling would just be updated inappropriately.

This PR updates the upload controller so it checks for clone errors before updating the annotations.

## How to replicate

The described race condition has been only replicable under particular conditions, namely, a cross-namespace clone where the source namespace doesn't have enough quota to create the source-clone pod.

Once the source-clone pod fails due to quota, the upload pod in the target namespace keeps running after being successfully created, updating the annotations set after the previous failure.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

