### PR TITLE
Fix failure to resize when the request image size is specified in milli- scale.

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -402,7 +402,7 @@ func (dp *DataProcessor) calculateTargetSize() int64 {
 		targetQuantity = &minQuantity
 	}
 	klog.V(1).Infof("Target size %s.\n", targetQuantity.String())
-	targetSize, _ := targetQuantity.AsInt64()
+	targetSize := targetQuantity.Value()
 	return targetSize
 }
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -534,7 +534,7 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
-				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "2Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDataVolume)


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed this when cloning block->file system to a slightly larger (1Gi -> 1.1Gi) DV.
Unclear whether this happens in some more scenarios, I'm surprised this problem wasn't reported by others.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix failure to resize when the request image size is specified in milli- scale.
```

