### PR TITLE
Queue DataVolumes referred to in "populatedFor" annotations

### DIFF
--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -409,10 +409,31 @@ func addDatavolumeControllerWatches(mgr manager.Manager, datavolumeController co
 	if err := datavolumeController.Watch(&source.Kind{Type: &cdiv1.DataVolume{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
-	if err := datavolumeController.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
-		OwnerType:    &cdiv1.DataVolume{},
-		IsController: true,
-	}); err != nil {
+	if err := datavolumeController.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(
+		func(obj client.Object) []reconcile.Request {
+			var result []reconcile.Request
+			owner := metav1.GetControllerOf(obj)
+			if owner != nil && owner.Kind == "DataVolume" {
+				result = append(result, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: obj.GetNamespace(),
+						Name:      owner.Name,
+					},
+				})
+			}
+			populatedFor := obj.GetAnnotations()[AnnPopulatedFor]
+			if populatedFor != "" {
+				result = append(result, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: obj.GetNamespace(),
+						Name:      populatedFor,
+					},
+				})
+			}
+			// it is okay if result contains the same entry twice, will be deduplicated by caller
+			return result
+		},
+	)); err != nil {
 		return err
 	}
 	if err := datavolumeController.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1149,6 +1149,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 
+			cdi, err := controller.GetActiveCDI(f.CrClient)
+			Expect(err).ToNot(HaveOccurred())
+
+			if cdi.Spec.Config.DataVolumeTTLSeconds != nil {
+				return
+			}
+
 			By("Verifying PVC owned by DV")
 			Eventually(func() bool {
 				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This issue came up in testing backup/restore with Kasten k10.  Should queue DataVolumes referred to in "populatedFor" annotations.  Without this change, a "prePopulated" DV created before a "populatedFor" DV will be pending forever if the PVC is not owned by the DV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

