### PR TITLE
Fix 'ocp4-moderate-routes-protected-by-tls' Compliance failure

### DIFF
--- a/pkg/operator/controller/route.go
+++ b/pkg/operator/controller/route.go
@@ -89,8 +89,9 @@ func ensureUploadProxyRouteExists(logger logr.Logger, c client.Client, scheme *r
 				Name: uploadProxyServiceName,
 			},
 			TLS: &routev1.TLSConfig{
-				Termination:              routev1.TLSTerminationReencrypt,
-				DestinationCACertificate: string(cert),
+				Termination:                   routev1.TLSTerminationReencrypt,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				DestinationCACertificate:      string(cert),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Oren Cohen <ocohen@redhat.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
According to:
https://github.com/ComplianceAsCode/content/blob/master/applications/openshift/networking/routes_protected_by_tls/rule.yml
The `ocp4-moderate` profile of the compliance operator expects that all Routes on the cluster should have either `None` or `Redirect` setting under their `.spec.tls.insecureEdgeTerminationPolicy`.
We chose `Redirect`, to be aligned with all other default routes on an OCP cluster, and not to fail HTTP requests but redirect them to HTTPS requests.
This PR adds the expected field to the `cdi-uploadproxy` route deployed by CDI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2110562

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix ocp4-moderate-routes-protected-by-tls compliance check fail for cdi-uploadproxy.
```

