### PR TITLE
Use container image name in server as-is

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -57,6 +58,16 @@ func waitForReadyFile() {
 		klog.Errorf("%+v", err)
 	}
 	os.Exit(1)
+}
+
+func getHTTPEp(ep string) string {
+	readyFile, err := util.ParseEnvVar(common.ImporterReadyFile, false)
+	if err == nil && len(readyFile) > 0 {
+		if imageName, err := ioutil.ReadFile(readyFile); err == nil && len(imageName) > 0 {
+			return strings.TrimSuffix(ep, common.DiskImageName) + string(imageName)
+		}
+	}
+	return ep
 }
 
 func touchDoneFile() {
@@ -231,7 +242,7 @@ func newDataSource(source string, contentType string, volumeMode v1.PersistentVo
 
 	switch source {
 	case controller.SourceHTTP:
-		ds, err := importer.NewHTTPDataSource(ep, acc, sec, certDir, cdiv1.DataVolumeContentType(contentType))
+		ds, err := importer.NewHTTPDataSource(getHTTPEp(ep), acc, sec, certDir, cdiv1.DataVolumeContentType(contentType))
 		if err != nil {
 			errorCannotConnectDataSource(err, "http")
 		}

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -62,12 +62,22 @@ func waitForReadyFile() {
 
 func getHTTPEp(ep string) string {
 	readyFile, err := util.ParseEnvVar(common.ImporterReadyFile, false)
-	if err == nil && len(readyFile) > 0 {
-		if imageName, err := ioutil.ReadFile(readyFile); err == nil && len(imageName) > 0 {
-			return strings.TrimSuffix(ep, common.DiskImageName) + string(imageName)
-		}
+	if err != nil {
+		klog.Errorf("Failed parsing env var %s: %+v", common.ImporterReadyFile, err)
+		os.Exit(1)
 	}
-	return ep
+	if len(readyFile) == 0 {
+		return ep
+	}
+	imageName, err := ioutil.ReadFile(readyFile)
+	if err != nil {
+		klog.Errorf("Failed reading file %s: %+v", readyFile, err)
+		os.Exit(1)
+	}
+	if len(imageName) == 0 {
+		return ep
+	}
+	return strings.TrimSuffix(ep, common.DiskImageName) + string(imageName)
 }
 
 func touchDoneFile() {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -124,6 +124,7 @@ exports_files(
 pkg_tar(
     name = "tinycore-tar",
     srcs = [":images/tinyCore.iso"],
+    owner = "107.107",
     package_dir = "/disk",
     strip_prefix = "/tests/images",
 )


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Don't rename it to `disk.img`, in order to support restricted security context where image uid:gid don't allow renaming it. E.g. DV/DIC with the following results image named `downloaded` with 107:107:
```
      source:
        registry:
          pullMethod: node
          url: docker://quay.io/kubevirt/cirros-container-disk-demo
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Use container image name in server as-is to support restricted security context
```

