### PR TITLE
Add omitempty to DataSourceStatus.source

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5439,9 +5439,6 @@
    "v1beta1.DataSourceStatus": {
     "description": "DataSourceStatus provides the most recently observed status of the DataSource",
     "type": "object",
-    "required": [
-     "source"
-    ],
     "properties": {
      "conditions": {
       "type": "array",

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -23826,7 +23826,6 @@ func schema_pkg_apis_core_v1beta1_DataSourceStatus(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5773,8 +5773,6 @@ spec:
                     - namespace
                     type: object
                 type: object
-            required:
-            - source
             type: object
         required:
         - spec

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -444,7 +444,7 @@ type DataSourceSource struct {
 // DataSourceStatus provides the most recently observed status of the DataSource
 type DataSourceStatus struct {
 	// Source is the current source of the data referenced by the DataSource
-	Source     DataSourceSource      `json:"source"`
+	Source     DataSourceSource      `json:"source,omitempty"`
 	Conditions []DataSourceCondition `json:"conditions,omitempty" optional:"true"`
 }
 


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Making this new status field required in the JSON, breaks API backward compatibility, so omitempty is added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

