### PR TITLE
Improve importer controller code readability

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -324,16 +324,14 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 				return reconcile.Result{Requeue: true}, nil
 			}
 
-			if _, ok := pvc.Annotations[AnnImportPod]; ok {
-				// Create importer pod, make sure the PVC owns it.
-				if err := r.createImporterPod(pvc); err != nil {
-					return reconcile.Result{}, err
-				}
-			} else {
-				// Create importer pod name annotation and store in PVC
-				if err := r.initPvcAnnotations(pvc, log); err != nil {
-					return reconcile.Result{}, err
-				}
+			// Create importer pod name annotation and store in PVC
+			if err := r.initPvcAnnotations(pvc, log); err != nil {
+				return reconcile.Result{}, err
+			}
+
+			// Create importer pod, make sure the PVC owns it.
+			if err := r.createImporterPod(pvc); err != nil {
+				return reconcile.Result{}, err
 			}
 		}
 	} else {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -330,8 +330,8 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 					return reconcile.Result{}, err
 				}
 			} else {
-				// Create importer pod Name and store in PVC?
-				if err := r.initPvcPodName(pvc, log); err != nil {
+				// Create importer pod name annotation and store in PVC
+				if err := r.initPvcAnnotations(pvc, log); err != nil {
 					return reconcile.Result{}, err
 				}
 			}
@@ -359,7 +359,7 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 	return reconcile.Result{}, nil
 }
 
-func (r *ImportReconciler) initPvcPodName(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
+func (r *ImportReconciler) initPvcAnnotations(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
 	currentPvcCopy := pvc.DeepCopyObject()
 
 	log.V(1).Info("Init pod name on PVC")

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -619,8 +619,8 @@ var _ = Describe("Update PVC from POD", func() {
 	It("Should mark PVC as waiting for VDDK configmap, if not already present", func() {
 		pvc := createPvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{AnnEndpoint: testEndPoint, AnnImportPod: "testpod", AnnSource: SourceVDDK}, nil, corev1.ClaimPending)
 		reconciler = createImportReconciler(pvc)
-		err := reconciler.createImporterPod(pvc)
-		By("Checking importer pod creation returned an error")
+		err := reconciler.initPvcAnnotations(pvc, reconciler.log)
+		By("Checking pvc annotation initialization returned an error")
 		Expect(err).To(HaveOccurred())
 		By("Checking pvc annotations have been updated")
 		resPvc := &corev1.PersistentVolumeClaim{}


### PR DESCRIPTION
rename initPvcPodName to initPvcAnnotations as it initializes the scratch space annotation as well.
Make this code unconditional - the function is harmless to re-run, so we don't need a secondary check for this.
Also, we can get away with not needing to re-run the reconcile loop because we update the pvc object reference.

Reduces indentation/complexity.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

