### PR TITLE
fix issue #2391 When clone dv from an existing pvc use smart clone, s…

### DIFF
--- a/pkg/controller/smart-clone-controller.go
+++ b/pkg/controller/smart-clone-controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -228,7 +229,14 @@ func (r *SmartCloneReconciler) reconcileSnapshot(log logr.Logger, snapshot *snap
 	if err := setAnnOwnedByDataVolume(newPvc, dataVolume); err != nil {
 		return reconcile.Result{}, err
 	}
-
+	//passing annotations from the target DV to the matching target PVC
+	if len(dataVolume.GetAnnotations()) > 0 {
+		for k, v := range dataVolume.GetAnnotations() {
+			if !strings.Contains(k, common.CDIAnnKey) {
+				newPvc.Annotations[k] = v
+			}
+		}
+	}
 	if snapshot.Spec.Source.PersistentVolumeClaimName != nil {
 		event := &DataVolumeEvent{
 			eventType: corev1.EventTypeNormal,

--- a/pkg/controller/smart-clone-controller_test.go
+++ b/pkg/controller/smart-clone-controller_test.go
@@ -211,6 +211,8 @@ var _ = Describe("All smart clone tests", func() {
 		It("Should create PVC if snapshot ready", func() {
 			dv := newCloneDataVolume("test-dv")
 			q, _ := resource.ParseQuantity("500Mi")
+			// Set annotation on DV which we can verify on PVC later
+			dv.GetAnnotations()["test"] = "test-value"
 			snapshot := createSnapshotVolume(dv.Name, dv.Namespace, nil)
 			snapshot.Spec.Source = snapshotv1.VolumeSnapshotSource{
 				PersistentVolumeClaimName: &[]string{"source"}[0],
@@ -231,7 +233,8 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Labels[common.AppKubernetesVersionLabel]).To(Equal("v0.0.0-tests"))
 			Expect(pvc.Labels[common.KubePersistentVolumeFillingUpSuppressLabelKey]).To(Equal(common.KubePersistentVolumeFillingUpSuppressLabelValue))
-
+			// Verify PVC's annotation
+			Expect(pvc.GetAnnotations()["test"]).To(Equal("test-value"))
 			event := <-reconciler.recorder.(*record.FakeRecorder).Events
 			Expect(event).To(ContainSubstring("Creating PVC for smart-clone is in progress"))
 		})


### PR DESCRIPTION
…ome ann of dv can't be inherited by the new pvc.

Signed-off-by: zhuanlan <zhuanlan_yewu@cmss.chinamobile.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fix issue#2391: When clone dv from an existing pvc use smart clone, some ann of dv can't be inherited by the new pvc. #2391

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2391

**Special notes for your reviewer**:
Although my code works, but I think these code may not meet the logic of reconcile and need to be improved.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Pass annotations from DV to PVC when smart cloning.
```

