### PR TITLE
Make buildcmd choice a tunable

### DIFF
--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -45,7 +45,7 @@ ARCHITECTURE="${BUILD_ARCH:-$(uname -m)}"
 HOST_ARCHITECTURE="$(uname -m)"
 CDI_CRI="$(determine_cri_bin)"
 if [ "${CDI_CRI}" = "docker" ]; then
-   CDI_CONTAINER_BUILDCMD="docker"
+   CDI_CONTAINER_BUILDCMD=${CDI_CONTAINER_BUILDCMD:-docker}
 else
-   CDI_CONTAINER_BUILDCMD="buildah"
+   CDI_CONTAINER_BUILDCMD=${CDI_CONTAINER_BUILDCMD:-buildah}
 fi

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -61,6 +61,7 @@ RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/downl
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ADD entrypoint.sh /entrypoint.sh
+
 ADD entrypoint-bazel.sh /entrypoint-bazel.sh
 
 COPY rsyncd.conf /etc/rsyncd.conf


### PR DESCRIPTION
To be merged after https://github.com/kubevirt/project-infra/pull/2301
This PR is intended so our CI can override the build command chosen and use buildah despite otherwise being docker-based at the moment.
This allows us to build arm64 builder images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Once we change the default builder, we can call #2211 fixed.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

