### PR TITLE
Enable DataVolume garbage collection by default

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4961,7 +4961,7 @@
     "type": "object",
     "properties": {
      "dataVolumeTTLSeconds": {
-      "description": "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected.",
+      "description": "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. The default is 0 sec. To disable GC use -1.",
       "type": "integer",
       "format": "int32"
      },

--- a/doc/cdi-config.md
+++ b/doc/cdi-config.md
@@ -16,7 +16,7 @@ CDI configuration in specified by administrators in the `spec.config` of the `CD
 | preallocation            | nil           | Preallocation setting to use unless a per-dataVolume value is set                                                                                                                                                            |
 | importProxy              | nil           | The proxy configuration to be used by the importer pod when accessing a http data source. When the ImportProxy is empty, the Cluster Wide-Proxy (Openshift) configurations are used. ImportProxy has four parameters: `ImportProxy.HTTPProxy` that defines the proxy http url, the `ImportProxy.HTTPSProxy` that determines the roxy https url, and the `ImportProxy.NoProxy` which enforce that a list of hostnames and/or CIDRs will be not proxied, and finally, the `ImportProxy.TrustedCAProxy`, the ConfigMap name of an user-provided trusted certificate authority (CA) bundle to be added to the importer pod CA bundle. |
 | insecureRegistries       | nil           | List of TLS disabled registries. |
-| dataVolumeTTLSeconds     | nil           | Time after DataVolume completion it can be garbage collected. |
+| dataVolumeTTLSeconds     | nil           | Time in seconds after DataVolume completion it can be garbage collected. The default is 0 sec. To disable GC use -1. |
 | tlsSecurityProfile       | nil           | Used by operators to apply cluster-wide TLS security settings to operands. |
 
 filesystemOverhead configuration:
@@ -37,6 +37,10 @@ kubectl patch cdi cdi  --type='json' -p='[{ "op" : "add" , "path" : "/spec/confi
 - Configure global value
 ```bash
 kubectl patch cdi cdi  --type='json' -p='[{ "op" : "add" , "path" : "/spec/config/filesystemOverhead/global" , "value" : "0.0" }]'
+```
+To configure dataVolumeTTLSeconds (e.g. disable DataVolume garbage collection)
+```bash
+kubectl patch cdi cdi --patch '{"spec": {"config": {"dataVolumeTTLSeconds": "-1"}}}' --type merge
 ```
 ## Getting
 

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -6,7 +6,7 @@ Data Volumes(DV) are an abstraction on top of Persistent Volume Claims(PVC) and 
 Why is this an improvement over simply looking at the state annotation created and managed by CDI? Data Volumes provide a versioned API that other projects like [Kubevirt](https://github.com/kubevirt/kubevirt) can integrate with. This way those projects can rely on an API staying the same for a particular version and have guarantees about what that API will look like. Any changes to the API will result in a new version of the API.
 
 ### Garbage collection of successfully completed DataVolumes
-Once the PVC population process is completed, its corresponding DV has no use, so it is better garbage collected.
+Once the PVC population process is completed, its corresponding DV has no use, so it is garbage collected by default.
 
 Some GC motivations:
 * Keeping the DV around after the fact sometimes confuses users, thinking they should modify the DV to have the matching PVC react. For example, resizing PVC seems to confuse users because they see the DV.
@@ -14,7 +14,7 @@ Some GC motivations:
 * Restore a backed up VM without the need to recreate the DataVolume is much simpler.
 * Replicate a workload to another cluster without the need to mutate the PVC and DV with special annotations in order for them to behave as expected in the new cluster.
 
-GC can be dynamically configured in [CDIConfig](cdi-config.md), so we recommend users not to assume the DV exists after completion. When the desired PVC exists, but its DV does not exist, it means that the PVC was successfully populated and the DV was garbage collected. To prevent a DV from being garbage collected, it should be annotated with:
+GC can be configured in [CDIConfig](cdi-config.md), so users cannot assume the DV exists after completion. When the desired PVC exists, but its DV does not exist, it means that the PVC was successfully populated and the DV was garbage collected. To prevent a DV from being garbage collected, it should be annotated with:
 ```yaml
 cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 ```

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -22974,7 +22974,7 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 					},
 					"dataVolumeTTLSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected.",
+							Description: "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. The default is 0 sec. To disable GC use -1.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
     ],
 )

--- a/pkg/apiserver/webhooks/datavolume-mutate.go
+++ b/pkg/apiserver/webhooks/datavolume-mutate.go
@@ -111,7 +111,7 @@ func (wh *dataVolumeMutatingWebhook) Admit(ar admissionv1.AdmissionReview) *admi
 		if err != nil {
 			return toAdmissionResponseError(err)
 		}
-		if config.Spec.DataVolumeTTLSeconds != nil {
+		if controller.GetDataVolumeTTLSeconds(config) >= 0 {
 			if modifiedDataVolume.Annotations == nil {
 				modifiedDataVolume.Annotations = make(map[string]string)
 			}

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -2207,7 +2207,8 @@ spec:
                 properties:
                   dataVolumeTTLSeconds:
                     description: DataVolumeTTLSeconds is the time in seconds after
-                      DataVolume completion it can be garbage collected.
+                      DataVolume completion it can be garbage collected. The default
+                      is 0 sec. To disable GC use -1.
                     format: int32
                     type: integer
                   featureGates:
@@ -4624,7 +4625,8 @@ spec:
             properties:
               dataVolumeTTLSeconds:
                 description: DataVolumeTTLSeconds is the time in seconds after DataVolume
-                  completion it can be garbage collected.
+                  completion it can be garbage collected. The default is 0 sec. To
+                  disable GC use -1.
                 format: int32
                 type: integer
               featureGates:

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -261,7 +261,7 @@ type DataVolumeStatus struct {
 	Conditions   []DataVolumeCondition `json:"conditions,omitempty" optional:"true"`
 }
 
-//DataVolumeList provides the needed parameters to do request a list of Data Volumes from the system
+// DataVolumeList provides the needed parameters to do request a list of Data Volumes from the system
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type DataVolumeList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -359,7 +359,7 @@ const DataVolumeCloneSourceSubresource = "source"
 // see https://github.com/kubernetes/code-generator/issues/59
 // +genclient:nonNamespaced
 
-//StorageProfile provides a CDI specific recommendation for storage parameters
+// StorageProfile provides a CDI specific recommendation for storage parameters
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -373,7 +373,7 @@ type StorageProfile struct {
 	Status StorageProfileStatus `json:"status,omitempty"`
 }
 
-//StorageProfileSpec defines specification for StorageProfile
+// StorageProfileSpec defines specification for StorageProfile
 type StorageProfileSpec struct {
 	// CloneStrategy defines the preferred method for performing a CDI clone
 	CloneStrategy *CDICloneStrategy `json:"cloneStrategy,omitempty"`
@@ -381,7 +381,7 @@ type StorageProfileSpec struct {
 	ClaimPropertySets []ClaimPropertySet `json:"claimPropertySets,omitempty"`
 }
 
-//StorageProfileStatus provides the most recently observed status of the StorageProfile
+// StorageProfileStatus provides the most recently observed status of the StorageProfile
 type StorageProfileStatus struct {
 	// The StorageClass name for which capabilities are defined
 	StorageClass *string `json:"storageClass,omitempty"`
@@ -405,7 +405,7 @@ type ClaimPropertySet struct {
 	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode,omitempty" protobuf:"bytes,6,opt,name=volumeMode,casttype=PersistentVolumeMode"`
 }
 
-//StorageProfileList provides the needed parameters to request a list of StorageProfile from the system
+// StorageProfileList provides the needed parameters to request a list of StorageProfile from the system
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type StorageProfileList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -685,7 +685,7 @@ type CDIStatus struct {
 	sdkapi.Status `json:",inline"`
 }
 
-//CDIList provides the needed parameters to do request a list of CDIs from the system
+// CDIList provides the needed parameters to do request a list of CDIs from the system
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CDIList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -713,12 +713,12 @@ type CDIConfig struct {
 	Status CDIConfigStatus `json:"status,omitempty"`
 }
 
-//Percent is a string that can only be a value between [0,1)
+// Percent is a string that can only be a value between [0,1)
 // (Note: we actually rely on reconcile to reject invalid values)
 // +kubebuilder:validation:Pattern=`^(0(?:\.\d{1,3})?|1)$`
 type Percent string
 
-//FilesystemOverhead defines the reserved size for PVCs with VolumeMode: Filesystem
+// FilesystemOverhead defines the reserved size for PVCs with VolumeMode: Filesystem
 type FilesystemOverhead struct {
 	// Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
 	Global Percent `json:"global,omitempty"`
@@ -726,7 +726,7 @@ type FilesystemOverhead struct {
 	StorageClass map[string]Percent `json:"storageClass,omitempty"`
 }
 
-//CDIConfigSpec defines specification for user configuration
+// CDIConfigSpec defines specification for user configuration
 type CDIConfigSpec struct {
 	// Override the URL used when uploading to a DataVolume
 	UploadProxyURLOverride *string `json:"uploadProxyURLOverride,omitempty"`
@@ -745,14 +745,14 @@ type CDIConfigSpec struct {
 	Preallocation *bool `json:"preallocation,omitempty"`
 	// InsecureRegistries is a list of TLS disabled registries
 	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
-	// DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected.
+	// DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. The default is 0 sec. To disable GC use -1.
 	// +optional
 	DataVolumeTTLSeconds *int32 `json:"dataVolumeTTLSeconds,omitempty"`
 	// TLSSecurityProfile is used by operators to apply cluster-wide TLS security settings to operands.
 	TLSSecurityProfile *ocpconfigv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
 }
 
-//CDIConfigStatus provides the most recently observed status of the CDI Config resource
+// CDIConfigStatus provides the most recently observed status of the CDI Config resource
 type CDIConfigStatus struct {
 	// The calculated upload proxy URL
 	UploadProxyURL *string `json:"uploadProxyURL,omitempty"`
@@ -769,7 +769,7 @@ type CDIConfigStatus struct {
 	Preallocation bool `json:"preallocation,omitempty"`
 }
 
-//CDIConfigList provides the needed parameters to do request a list of CDIConfigs from the system
+// CDIConfigList provides the needed parameters to do request a list of CDIConfigs from the system
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CDIConfigList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -779,7 +779,7 @@ type CDIConfigList struct {
 	Items []CDIConfig `json:"items"`
 }
 
-//ImportProxy provides the information on how to configure the importer pod proxy.
+// ImportProxy provides the information on how to configure the importer pod proxy.
 type ImportProxy struct {
 	// HTTPProxy is the URL http://<username>:<pswd>@<ip>:<port> of the import proxy for HTTP requests.  Empty means unset and will not result in the import pod env var.
 	// +optional

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -363,7 +363,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
-		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected.\n+optional",
+		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. The default is 0 sec. To disable GC use -1.\n+optional",
 		"tlsSecurityProfile":       "TLSSecurityProfile is used by operators to apply cluster-wide TLS security settings to operands.",
 	}
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1160,10 +1160,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			cdi, err := controller.GetActiveCDI(f.CrClient)
+			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-
-			if cdi.Spec.Config.DataVolumeTTLSeconds != nil {
+			if controller.GetDataVolumeTTLSeconds(config) >= 0 {
 				return
 			}
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -191,8 +191,6 @@ var _ = Describe("DataVolume Garbage Collection", func() {
 		err      error
 		config   *cdiv1.CDIConfig
 		origSpec *cdiv1.CDIConfigSpec
-		ttl0     = int32(0)
-		ttl10    = int32(10)
 	)
 
 	BeforeEach(func() {
@@ -231,7 +229,7 @@ var _ = Describe("DataVolume Garbage Collection", func() {
 		tests.EnableGcAndAnnotateLegacyDv(f, dvName, ns)
 	}
 
-	DescribeTable("Should", func(ttl *int32, annDeleteAfterCompletion string, verifyGCFunc, additionalTestFunc func(dvName string), verifyContent bool) {
+	DescribeTable("Should", func(ttl int, annDeleteAfterCompletion string, verifyGCFunc, additionalTestFunc func(dvName string), verifyContent bool) {
 		tests.SetConfigTTL(f, ttl)
 
 		dv := utils.NewDataVolumeWithHTTPImport("gc-test", "100Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
@@ -267,11 +265,11 @@ var _ = Describe("DataVolume Garbage Collection", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 	},
-		Entry("[test_id:8562] garbage collect dv after completion when TTL is 0", &ttl0, "", verifyGC, nil, true),
-		Entry("[test_id:8563] not garbage collect dv after completion when TTL is disabled", nil, "", verifyDisabledGC, nil, false),
-		Entry("[test_id:8564] garbage collect dv after completion when TTL is 10s", &ttl10, "", verifyGC, nil, true),
-		Entry("[test_id:8568] Add DeleteAfterCompletion annotation to a legacy DV", nil, "", verifyDisabledGC, enableGcAndAnnotateLegacyDv, true),
-		Entry("[test_id:8688] not garbage collect dv after completion when DeleteAfterCompletion is false", &ttl0, "false", verifyNoGC, nil, false),
+		Entry("[test_id:8562] garbage collect dv after completion when TTL is 0", 0, "", verifyGC, nil, true),
+		Entry("[test_id:8563] not garbage collect dv after completion when TTL is disabled", -1, "", verifyDisabledGC, nil, false),
+		Entry("[test_id:8564] garbage collect dv after completion when TTL is 10s", 10, "", verifyGC, nil, true),
+		Entry("[test_id:8568] Add DeleteAfterCompletion annotation to a legacy DV", -1, "", verifyDisabledGC, enableGcAndAnnotateLegacyDv, true),
+		Entry("[test_id:8688] not garbage collect dv after completion when DeleteAfterCompletion is false", 0, "false", verifyNoGC, nil, false),
 	)
 })
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -617,7 +618,7 @@ var _ = Describe("ALL Operator tests", func() {
 				originalReplicaVal := *cdiDeployment.Spec.Replicas
 
 				By("Overwrite number of replicas with originalVal + 1")
-				cdiDeployment.Spec.Replicas = &[]int32{originalReplicaVal + 1}[0]
+				cdiDeployment.Spec.Replicas = pointer.Int32(originalReplicaVal + 1)
 				_, err = f.K8sClient.AppsV1().Deployments(f.CdiInstallNs).Update(context.TODO(), cdiDeployment, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -823,7 +824,7 @@ var _ = Describe("ALL Operator tests", func() {
 				operatorDeployment, err := f.K8sClient.AppsV1().Deployments(f.CdiInstallNs).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				originalReplicas := operatorDeployment.Spec.Replicas
-				operatorDeployment.Spec.Replicas = &[]int32{0}[0]
+				operatorDeployment.Spec.Replicas = pointer.Int32(0)
 				_, err = f.K8sClient.AppsV1().Deployments(f.CdiInstallNs).Update(context.TODO(), operatorDeployment, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() bool {

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -33,6 +33,11 @@ var _ = Describe("[Upgrade]", func() {
 
 	table.DescribeTable("[rfe_id:5493]DV status.name is populated after upgrade", func(dvName string) {
 		dv, err := f.CdiClient.CdiV1beta1().DataVolumes(oldVersionArtifactsNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})
+		if apierrs.IsNotFound(err) {
+			_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(oldVersionArtifactsNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return
+		}
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dv.Status.ClaimName).To(Equal(dvName))
 	},

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1063,7 +1063,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			tests.EnableGcAndAnnotateLegacyDv(f, dvName, ns)
 		}
 
-		DescribeTable("Should", func(ttl *int32, verifyGCFunc, additionalTestFunc func(dvName string)) {
+		DescribeTable("Should", func(ttl int, verifyGCFunc, additionalTestFunc func(dvName string)) {
 			tests.SetConfigTTL(f, ttl)
 
 			dvName := "upload-dv"
@@ -1115,8 +1115,8 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				additionalTestFunc(dv.Name)
 			}
 		},
-			Entry("[test_id:8566] garbage collect dvs after completion when TTL is 0", &[]int32{0}[0], verifyGC, nil),
-			Entry("[test_id:8570] Add DeleteAfterCompletion annotation to a legacy DV", nil, verifyDisabledGC, enableGcAndAnnotateLegacyDv),
+			Entry("[test_id:8566] garbage collect dvs after completion when TTL is 0", 0, verifyGC, nil),
+			Entry("[test_id:8570] Add DeleteAfterCompletion annotation to a legacy DV", -1, verifyDisabledGC, enableGcAndAnnotateLegacyDv),
 		)
 	})
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -671,8 +671,8 @@ func WaitForDataVolumePhaseWithTimeout(ci ClientsIface, namespace string, phase 
 		if err != nil {
 			return err
 		}
-		if ttl := cfg.Spec.DataVolumeTTLSeconds; ttl != nil {
-			return WaitForDataVolumeGC(ci, namespace, dataVolumeName, *ttl, dataVolumePhaseTime)
+		if ttl := controller.GetDataVolumeTTLSeconds(cfg); ttl >= 0 {
+			return WaitForDataVolumeGC(ci, namespace, dataVolumeName, ttl, dataVolumePhaseTime)
 		}
 	}
 	err := wait.PollImmediate(dataVolumePollInterval, timeout, func() (bool, error) {


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
It's time to enable DataVolume garbage collection by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
On the next kubevirt-bot Bump kubevirtci PR (with bump-cdi), it will fail on all kubevirtci lanes with tests referring DVs, as the tests IsDataVolumeGC() looks at CDIConfig Spec.DataVolumeTTLSeconds and assumes default is disabled. This should be fixed there.

**Release note**:
```release-note
Enable DataVolume garbage collection by default
```

