### PR TITLE
Add restart policy for rsync container

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -50,7 +50,7 @@ ${CDI_CRI} run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $D
 
 echo "Starting rsyncd"
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --restart always --security-opt label=disable $DISABLE_SECCOMP --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
     ${CDI_CRI} stop ${RSYNC_CID_CDI} >/dev/null 2>&1 &


### PR DESCRIPTION
**What this PR does / why we need it**:
An issue appears when running the e2e CDI tests with podman[1].
The rsync container hits an error as the rsync daemon
fails to attach to the specified port. Adding a restart policy to
restart the container any time it stops allows the e2e lanes to run
successfully using podman. A similiar change was made in kubevirt/kubevirt[2].

This change is required to move the CDI repo to podman based CI[3].

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2339/rehearsal-pull-containerized-data-importer-e2e-ceph/1572199015787794432#1:build-log.txt%3A918
[2] https://github.com/kubevirt/kubevirt/pull/8388
[3] https://github.com/kubevirt/project-infra/pull/2339


Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

