### PR TITLE
Change how we deploy the upgrade testing DVs

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -52,7 +52,7 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
 fi
 
 if [[ -n "$MULTI_UPGRADE" ]]; then
-  export UPGRADE_FROM="v1.34.2 v1.35.0 v1.37.0 v1.40.0"
+  export UPGRADE_FROM="v1.35.0 v1.37.0 v1.40.0 v1.49.0"
 fi
 
 # Don't upgrade if we are using a random CR name, otherwise the upgrade will fail

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -123,6 +123,16 @@ function wait_cdi_pods_updated {
   fi
 }
 
+function dump_upgrade_info {
+  echo "Dumping upgrade object information"
+  _kubectl get all --namespace cdi-testing-old-version-artifacts
+  _kubectl describe pvc olddv-v1alpha1 --namespace cdi-testing-old-version-artifacts
+  _kubectl describe pvc olddv-v1beta1 --namespace cdi-testing-old-version-artifacts
+  _kubectl get dv --namespace cdi-testing-old-version-artifacts -o yaml
+  _kubectl describe dv --namespace cdi-testing-old-version-artifacts
+  exit 1
+}
+
 # Setup some datavolumes in older version for testing upgrades
 # Done unconditionally to make it easier to write tests.
 function setup_for_upgrade_testing {
@@ -142,7 +152,7 @@ function setup_for_upgrade_testing {
   _kubectl wait pod -n ${CDI_NAMESPACE} --for=condition=Ready --all --timeout=${CDI_AVAILABLE_TIMEOUT}s
   _kubectl apply -f "./_out/manifests/upgrade-testing-artifacts.yaml"
   echo "Waiting for old version artifacts to come up"
-  _kubectl wait dv --namespace cdi-testing-old-version-artifacts --for=condition=Ready --all --timeout=${CDI_AVAILABLE_TIMEOUT}s
+  _kubectl wait dv --namespace cdi-testing-old-version-artifacts --for=condition=Ready --all --timeout=${CDI_AVAILABLE_TIMEOUT}s || dump_upgrade_info
 }
 
 # Start functional test HTTP server.

--- a/manifests/templates/upgrade-testing-artifacts-no-gc.yaml.in
+++ b/manifests/templates/upgrade-testing-artifacts-no-gc.yaml.in
@@ -11,6 +11,7 @@ metadata:
   namespace: cdi-testing-old-version-artifacts
   annotations:
     cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
       http:
@@ -29,6 +30,7 @@ metadata:
   namespace: cdi-testing-old-version-artifacts
   annotations:
     cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
       http:

--- a/manifests/templates/upgrade-testing-artifacts.yaml.in
+++ b/manifests/templates/upgrade-testing-artifacts.yaml.in
@@ -9,6 +9,9 @@ kind: DataVolume
 metadata:
   name: olddv-v1alpha1
   namespace: cdi-testing-old-version-artifacts
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
       http:
@@ -25,6 +28,9 @@ kind: DataVolume
 metadata:
   name: olddv-v1beta1
   namespace: cdi-testing-old-version-artifacts
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
       http:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Only deploy the upgrade test datavolumes on multi upgrade before upgrading to latest. Deploy a different set on upgrade from latest released to contents of PR. This set will have an annotation to not garbage collect the DVs. Also dump some extra information if the DVs do not become ready in time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

