### PR TITLE
pkg/controller/util.go: Add runAsUser only to Pods with volume mounts

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1268,8 +1268,8 @@ func SetRestrictedSecurityContext(podSpec *v1.PodSpec) {
 			}
 			container.SecurityContext.AllowPrivilegeEscalation = pointer.BoolPtr(false)
 			container.SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
-			container.SecurityContext.RunAsUser = pointer.Int64(common.QemuSubGid)
 			if len(container.VolumeMounts) > 0 {
+				container.SecurityContext.RunAsUser = pointer.Int64(common.QemuSubGid)
 				hasVolumeMounts = true
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes SetRestrictedSecurityContext so that runAsUser is only added to pods that use VolumeMounts, similar to adding SecurityContext.FSGroup. This fixes the creation of Pods without volume mounts and less privileged ServiceAccounts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2437

**Special notes for your reviewer**:

This seems to fix the issue in #2437, but are there potentially any unwanted side effects to this?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

