### PR TITLE
Remove namespaced rbac for dataimportcron

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1721,8 +1721,6 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.Role cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.Deployment cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.ServiceAccount cdi-cronjob"] = false
-	match[normalCreateSuccess+" *v1.RoleBinding cdi-cronjob"] = false
-	match[normalCreateSuccess+" *v1.Role cdi-cronjob"] = false
 	match[normalCreateSuccess+" *v1.APIService v1beta1.upload.cdi.kubevirt.io"] = false
 	match[normalCreateSuccess+" *v1.APIService v1alpha1.upload.cdi.kubevirt.io"] = false
 	match[normalCreateSuccess+" *v1.ValidatingWebhookConfiguration cdi-api-datavolume-validate"] = false

--- a/pkg/operator/resources/namespaced/cronjob.go
+++ b/pkg/operator/resources/namespaced/cronjob.go
@@ -18,7 +18,6 @@ package namespaced
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
@@ -31,34 +30,9 @@ const (
 func createCronJobResources(args *FactoryArgs) []client.Object {
 	return []client.Object{
 		createCronJobServiceAccount(),
-		createCronJobRoleBinding(),
-		createCronJobRole(),
 	}
 }
 
 func createCronJobServiceAccount() *corev1.ServiceAccount {
 	return utils.ResourceBuilder.CreateServiceAccount(cronJobResourceName)
-}
-
-func createCronJobRoleBinding() *rbacv1.RoleBinding {
-	return utils.ResourceBuilder.CreateRoleBinding(cronJobResourceName, cronJobResourceName, cronJobResourceName, "")
-}
-
-func createCronJobRole() *rbacv1.Role {
-	rules := []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"dataimportcrons",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"update",
-			},
-		},
-	}
-	return utils.ResourceBuilder.CreateRole(cronJobResourceName, rules)
 }


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It seems we only need the cluster access which happens at `pkg/operator/resources/cluster/cronjob.go`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

