### PR TITLE
Enable HonorWaitForFirstConsumer by default

### DIFF
--- a/doc/waitforfirstconsumer-storage-handling.md
+++ b/doc/waitforfirstconsumer-storage-handling.md
@@ -33,10 +33,10 @@ This will force the scheduling of a CDI worker pod and immediately bind the PVC.
 
 This is useful for use cases that do not require binding to a particular node (like uploading a golden image to the cluster).      
 
-## Configuration - Opt in
+## Configuration
 
 To be fully compatible with any external tools that may already use CDI, this new feature has to be enabled by 
-the feature gate: `HonorWaitForFirstConsumer`. It is available in the `CDI` custom resource, under spec.config (see [cdi-config doc](cdi-config.md)).
+the feature gate: `HonorWaitForFirstConsumer`. In the released `cdi-cr` it is enabled by default. To disable it remove the feature gate in the `CDI` custom resource, under spec.config (see [cdi-config doc](cdi-config.md)).
 
 A Snippet below shows CDI resource with `HonorWaitForFirstConsumer` enabled.
 ```

--- a/manifests/templates/release/cdi-cr.yaml.in
+++ b/manifests/templates/release/cdi-cr.yaml.in
@@ -3,6 +3,9 @@ kind: CDI
 metadata:
   name: {{.CrName}}
 spec:
+  config:
+    featureGates:
+    - HonorWaitForFirstConsumer
   imagePullPolicy: {{.PullPolicy}}
   infra:
     nodeSelector:


### PR DESCRIPTION
Modified template that generates CDI cr to honor
wait for first consumer for the release manifest

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable HonorWaitForFirstConsumer by default on release manifest
```

