### PR TITLE
Wait for podman stop to successfully stop rsync container

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -50,11 +50,11 @@ ${CDI_CRI} run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $D
 
 echo "Starting rsyncd"
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --restart always --security-opt label=disable $DISABLE_SECCOMP --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
-    ${CDI_CRI} stop ${RSYNC_CID_CDI} >/dev/null 2>&1 &
-    ${CDI_CRI} rm -f ${RSYNC_CID_CDI} >/dev/null 2>&1 &
+    ${CDI_CRI} stop --time 1 ${RSYNC_CID_CDI} >/dev/null 2>&1
+    ${CDI_CRI} rm -f ${RSYNC_CID_CDI} >/dev/null 2>&1
 }
 trap finish EXIT
 


### PR DESCRIPTION

Signed-off-by: Brian Carey <bcarey@redhat.com>

**What this PR does / why we need it**:
`bazel-docker.sh` is run numerous times during the large e2e jobs. Each
time the script is run a temporary rsync container is started. If one of
these rsync containers is not cleaned up correctly it can lead to rsync
daemon failuresi[1] when e2e jobs are run with podman.

`podman stop`[2] attempts to stop a container using `SIGTERM` if this fails
within the default 10 seconds a `SIGKILL` is used to forceably stop the
container. Previously the script was not waiting for the container to be
successfully stopped.

Also updating the wait before the `SIGKILL` to 1 second.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/2446/pull-containerized-data-importer-e2e-destructive/1582345804016783360#1:build-log.txt%3A1951
[2] https://docs.podman.io/en/latest/markdown/podman-stop.1.html#description

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @awels 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

