### PR TITLE
Add DataImportCron CronJobs Proxy support

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/cluster-bootstrap/token/api:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -771,14 +772,25 @@ func (r *DataImportCronReconciler) newCronJob(cron *cdiv1.DataImportCron) (*batc
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}
 
+	volumes := []corev1.Volume{}
 	hasCertConfigMap := regSource.CertConfigMap != nil && *regSource.CertConfigMap != ""
 	if hasCertConfigMap {
 		vm := corev1.VolumeMount{
 			Name:      CertVolName,
 			MountPath: common.ImporterCertDir,
 		}
-		container.VolumeMounts = []corev1.VolumeMount{vm}
+		container.VolumeMounts = append(container.VolumeMounts, vm)
 		container.Command = append(container.Command, "-certdir", common.ImporterCertDir)
+		volumes = append(volumes, createConfigMapVolume(CertVolName, *regSource.CertConfigMap))
+	}
+
+	if volName, _ := GetImportProxyConfig(cdiConfig, common.ImportProxyConfigMapName); volName != "" {
+		vm := corev1.VolumeMount{
+			Name:      ProxyCertVolName,
+			MountPath: common.ImporterProxyCertDir,
+		}
+		container.VolumeMounts = append(container.VolumeMounts, vm)
+		volumes = append(volumes, createConfigMapVolume(ProxyCertVolName, volName))
 	}
 
 	if regSource.SecretRef != nil && *regSource.SecretRef != "" {
@@ -809,19 +821,8 @@ func (r *DataImportCronReconciler) newCronJob(cron *cdiv1.DataImportCron) (*batc
 	}
 
 	if insecureTLS {
-		container.Env = append(container.Env,
-			corev1.EnvVar{
-				Name:  common.InsecureTLSVar,
-				Value: "true",
-			},
-		)
+		container.Env = append(container.Env, corev1.EnvVar{Name: common.InsecureTLSVar, Value: "true"})
 	}
-
-	successfulJobsHistoryLimit := int32(0)
-	failedJobsHistoryLimit := int32(0)
-	ttlSecondsAfterFinished := int32(0)
-	backoffLimit := int32(2)
-	gracePeriodSeconds := int64(0)
 
 	cronJobName := GetCronJobName(cron)
 	cronJob := &batchv1.CronJob{
@@ -832,37 +833,24 @@ func (r *DataImportCronReconciler) newCronJob(cron *cdiv1.DataImportCron) (*batc
 		Spec: batchv1.CronJobSpec{
 			Schedule:                   cron.Spec.Schedule,
 			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
-			SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
-			FailedJobsHistoryLimit:     &failedJobsHistoryLimit,
+			SuccessfulJobsHistoryLimit: pointer.Int32(1),
+			FailedJobsHistoryLimit:     pointer.Int32(0),
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							RestartPolicy:                 corev1.RestartPolicyNever,
-							TerminationGracePeriodSeconds: &gracePeriodSeconds,
+							TerminationGracePeriodSeconds: pointer.Int64(0),
 							Containers:                    []corev1.Container{container},
 							ServiceAccountName:            common.CronJobServiceAccountName,
+							Volumes:                       volumes,
 						},
 					},
-					TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
-					BackoffLimit:            &backoffLimit,
+					TTLSecondsAfterFinished: pointer.Int32(3),
+					BackoffLimit:            pointer.Int32(2),
 				},
 			},
 		},
-	}
-
-	if hasCertConfigMap {
-		vol := corev1.Volume{
-			Name: CertVolName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: *regSource.CertConfigMap,
-					},
-				},
-			},
-		}
-		cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes = []corev1.Volume{vol}
 	}
 
 	if err := r.setJobCommon(cron, cronJob); err != nil {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -50,8 +51,12 @@ import (
 )
 
 var (
-	cronLog  = logf.Log.WithName("data-import-cron-controller-test")
-	cronName = "test-cron"
+	cronLog        = logf.Log.WithName("data-import-cron-controller-test")
+	cronName       = "test-cron"
+	httpProxy      = "test-http-proxy"
+	httpsProxy     = "test-https-proxy"
+	noProxy        = "test-no-proxy"
+	trustedCAProxy = "test-trusted-ca-proxy"
 )
 
 const (
@@ -194,14 +199,49 @@ var _ = Describe("All DataImportCron Tests", func() {
 		})
 
 		It("Should create and delete CronJob if DataImportCron is created and deleted", func() {
+			cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+			cdiConfig.Status.ImportProxy = &cdiv1.ImportProxy{
+				HTTPProxy:      &httpProxy,
+				HTTPSProxy:     &httpsProxy,
+				NoProxy:        &noProxy,
+				TrustedCAProxy: &trustedCAProxy,
+			}
+
 			cron = newDataImportCron(cronName)
-			reconciler = createDataImportCronReconciler(cron)
+			reconciler = createDataImportCronReconcilerWithoutConfig(cron, cdiConfig)
 			_, err := reconciler.Reconcile(context.TODO(), cronReq)
 			Expect(err).ToNot(HaveOccurred())
 
 			cronjob := &batchv1.CronJob{}
 			err = reconciler.client.Get(context.TODO(), cronJobKey(cron), cronjob)
 			Expect(err).ToNot(HaveOccurred())
+			containers := cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers
+			Expect(containers).To(HaveLen(1))
+
+			env := containers[0].Env
+			Expect(getEnvVar(env, common.ImportProxyHTTP)).To(Equal(httpProxy))
+			Expect(getEnvVar(env, common.ImportProxyHTTPS)).To(Equal(httpsProxy))
+			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(Equal(noProxy))
+
+			volMounts := containers[0].VolumeMounts
+			Expect(volMounts).To(HaveLen(1))
+			Expect(volMounts[0]).To(Equal(corev1.VolumeMount{
+				Name:      ProxyCertVolName,
+				MountPath: common.ImporterProxyCertDir,
+			}))
+
+			volumes := cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes
+			Expect(volumes).To(HaveLen(1))
+			Expect(volumes[0]).To(Equal(corev1.Volume{
+				Name: ProxyCertVolName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: trustedCAProxy,
+						},
+					},
+				},
+			}))
 
 			err = reconciler.client.Get(context.TODO(), cronKey, cron)
 			Expect(err).ToNot(HaveOccurred())
@@ -216,6 +256,32 @@ var _ = Describe("All DataImportCron Tests", func() {
 
 			err = reconciler.client.Get(context.TODO(), cronJobKey(cron), cronjob)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should verify CronJob container env variables are empty and no extra volume is set when proxy is not configured", func() {
+			cron = newDataImportCron(cronName)
+			reconciler = createDataImportCronReconciler(cron)
+			_, err := reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			cronjob := &batchv1.CronJob{}
+			err = reconciler.client.Get(context.TODO(), cronJobKey(cron), cronjob)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(cronjob.Spec.SuccessfulJobsHistoryLimit).To(Equal(pointer.Int32(1)))
+			Expect(cronjob.Spec.FailedJobsHistoryLimit).To(BeNil())
+
+			jobTemplateSpec := cronjob.Spec.JobTemplate.Spec.Template.Spec
+			containers := jobTemplateSpec.Containers
+			Expect(containers).To(HaveLen(1))
+
+			env := containers[0].Env
+			Expect(getEnvVar(env, common.ImportProxyHTTP)).To(BeEmpty())
+			Expect(getEnvVar(env, common.ImportProxyHTTPS)).To(BeEmpty())
+			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(BeEmpty())
+
+			Expect(containers[0].VolumeMounts).To(HaveLen(0))
+			Expect(jobTemplateSpec.Volumes).To(HaveLen(0))
 		})
 
 		It("Should update CronJob on reconcile", func() {
@@ -562,8 +628,14 @@ var _ = Describe("untagURL", func() {
 
 func createDataImportCronReconciler(objects ...runtime.Object) *DataImportCronReconciler {
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+	objs := []runtime.Object{cdiConfig}
+	objs = append(objs, objects...)
+	return createDataImportCronReconcilerWithoutConfig(objs...)
+}
+
+func createDataImportCronReconcilerWithoutConfig(objects ...runtime.Object) *DataImportCronReconciler {
 	crd := &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "dataimportcrons.cdi.kubevirt.io"}}
-	objs := []runtime.Object{cdiConfig, crd}
+	objs := []runtime.Object{crd}
 	objs = append(objs, objects...)
 
 	s := scheme.Scheme
@@ -661,4 +733,13 @@ func verifyConditionState(condType string, condState cdiv1.ConditionState, desir
 	}
 	Expect(condState.Status).To(Equal(desiredStatus))
 	Expect(condState.Reason).To(Equal(desiredReason))
+}
+
+func getEnvVar(env []corev1.EnvVar, name string) string {
+	for _, envVar := range env {
+		if envVar.Name == name {
+			return envVar.Value
+		}
+	}
+	return ""
 }

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -1171,20 +1171,8 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			Name:      CertVolName,
 			MountPath: common.ImporterCertDir,
 		}
-
-		vol := corev1.Volume{
-			Name: CertVolName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: args.podEnvVar.certConfigMap,
-					},
-				},
-			},
-		}
-
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
+		pod.Spec.Volumes = append(pod.Spec.Volumes, createConfigMapVolume(CertVolName, args.podEnvVar.certConfigMap))
 	}
 
 	if args.podEnvVar.certConfigMapProxy != "" {
@@ -1193,7 +1181,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			MountPath: common.ImporterProxyCertDir,
 		}
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, createProxyConfigMapVolume(ProxyCertVolName, args.podEnvVar.certConfigMapProxy))
+		pod.Spec.Volumes = append(pod.Spec.Volumes, createConfigMapVolume(ProxyCertVolName, args.podEnvVar.certConfigMapProxy))
 	}
 
 	for index, header := range args.podEnvVar.secretExtraHeaders {
@@ -1259,7 +1247,7 @@ func makeImporterContainerSpec(image, verbose, pullPolicy string) *corev1.Contai
 	}
 }
 
-func createProxyConfigMapVolume(certVolName, objRef string) corev1.Volume {
+func createConfigMapVolume(certVolName, objRef string) corev1.Volume {
 	return corev1.Volume{
 		Name: certVolName,
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -54,7 +54,7 @@ type RegistryDataSource struct {
 
 // NewRegistryDataSource creates a new instance of the Registry Data Source.
 func NewRegistryDataSource(endpoint, accessKey, secKey, certDir string, insecureTLS bool) *RegistryDataSource {
-	allCertDir, err := createCertificateDir(certDir)
+	allCertDir, err := CreateCertificateDir(certDir)
 	if err != nil {
 		klog.Infof("Error creating allCertDir %v", err)
 		if allCertDir != "/" {
@@ -164,7 +164,8 @@ func getImageFileName(dir string) (string, error) {
 	return filename, nil
 }
 
-func createCertificateDir(registryCertDir string) (string, error) {
+// CreateCertificateDir creates a common certificate dir
+func CreateCertificateDir(registryCertDir string) (string, error) {
 	allCerts := "/tmp/all_certs"
 	err := os.MkdirAll(allCerts, 0700)
 	if err != nil {

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -14,7 +14,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -66,7 +65,7 @@ var _ = Describe("DataImportCron", func() {
 		f.CreateBoundPVCFromDefinition(pvc)
 
 		By(fmt.Sprintf("Create new DataImportCron %s, url %s", cronName, *reg.URL))
-		cron = NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, *reg)
+		cron = utils.NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, importsToKeep, *reg)
 
 		expectedImports := int(importsToKeep)
 		if !garbageCollection {
@@ -258,7 +257,7 @@ var _ = Describe("DataImportCron", func() {
 		Expect(err).To(BeNil())
 		noSuchCM := "nosuch"
 		reg.CertConfigMap = &noSuchCM
-		cron = NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, dataSourceName, *reg)
+		cron = utils.NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, dataSourceName, importsToKeep, *reg)
 		By("Create new DataImportCron")
 		cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -334,38 +333,6 @@ var _ = Describe("DataImportCron", func() {
 		}, dataImportCronTimeout, pollingInterval).Should(BeTrue(), "cronjob first job pod was not deleted")
 	})
 })
-
-// NewDataImportCron initializes a DataImportCron struct
-func NewDataImportCron(name, size, schedule, dataSource string, source cdiv1.DataVolumeSourceRegistry) *cdiv1.DataImportCron {
-	return &cdiv1.DataImportCron{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Annotations: map[string]string{
-				controller.AnnImmediateBinding: "true",
-			},
-		},
-		Spec: cdiv1.DataImportCronSpec{
-			Template: cdiv1.DataVolume{
-				Spec: cdiv1.DataVolumeSpec{
-					Source: &cdiv1.DataVolumeSource{
-						Registry: &source,
-					},
-					PVC: &corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse(size),
-							},
-						},
-					},
-				},
-			},
-			Schedule:          schedule,
-			ManagedDataSource: dataSource,
-			ImportsToKeep:     &importsToKeep,
-		},
-	}
-}
 
 func getDataVolumeSourceRegistry(f *framework.Framework) (*cdiv1.DataVolumeSourceRegistry, error) {
 	reg := &cdiv1.DataVolumeSourceRegistry{}

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Import Proxy tests", func() {
 		clusterWideProxySpec *ocpconfigv1.ProxySpec
 		config               *cdiv1.CDIConfig
 		origSpec             *cdiv1.CDIConfigSpec
+		cron                 *cdiv1.DataImportCron
 		err                  error
 	)
 
@@ -94,13 +95,23 @@ var _ = Describe("Import Proxy tests", func() {
 	})
 
 	AfterEach(func() {
-		By("Deleting DataVolume")
-		err := utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dvName)
-		Expect(err).ToNot(HaveOccurred())
-		Eventually(func() bool {
-			_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
-			return k8serrors.IsNotFound(err)
-		}, timeout, pollingInterval).Should(BeTrue())
+		if dvName != "" {
+			By("Deleting DataVolume")
+			err := utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dvName)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() bool {
+				_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+				return k8serrors.IsNotFound(err)
+			}, timeout, pollingInterval).Should(BeTrue())
+			dvName = ""
+		}
+
+		if cron != nil {
+			By("Deleting DataImportCron")
+			err = f.CdiClient.CdiV1beta1().DataImportCrons(cron.Namespace).Delete(context.TODO(), cron.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			cron = nil
+		}
 
 		if utils.IsOpenshift(f.K8sClient) {
 			By("Reverting the cluster wide proxy spec to the original configuration")
@@ -135,8 +146,7 @@ var _ = Describe("Import Proxy tests", func() {
 			imgURL := createImgURL(args.isHTTPS, args.withBasicAuth, args.imgName, f.CdiInstallNs)
 			dvName = args.name
 
-			By("Updating CDIConfig with ImportProxy configuration")
-			updateProxy(f, proxyHTTPURL, proxyHTTPSURL, noProxy, ocpClient)
+			updateProxy(f, f.Namespace.Name, proxyHTTPURL, proxyHTTPSURL, noProxy, ocpClient)
 
 			By(fmt.Sprintf("Creating new datavolume %s", dvName))
 			dv := createHTTPDataVolume(f, dvName, args.size, imgURL, args.isHTTPS, args.withBasicAuth)
@@ -152,7 +162,7 @@ var _ = Describe("Import Proxy tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
-			verifyImporterPodInfoInProxyLogs(f, dataVolume, imgURL, args.userAgent, now, args.expected)
+			verifyImporterPodInfoInProxyLogs(f, imgURL, args.userAgent, now, args.expected)
 		},
 			Entry("succeed creating import dv with a proxied server (http)", importProxyTestArguments{
 				name:          "dv-import-http-proxy",
@@ -284,8 +294,7 @@ var _ = Describe("Import Proxy tests", func() {
 
 		DescribeTable("should proxy registry imports", func(isHTTPS, hasAuth bool) {
 			now := time.Now()
-			By("Updating CDIConfig with ImportProxy configuration")
-			updateProxy(f, "", createProxyURL(isHTTPS, hasAuth, f.CdiInstallNs), "", ocpClient)
+			updateProxy(f, f.Namespace.Name, "", createProxyURL(isHTTPS, hasAuth, f.CdiInstallNs), "", ocpClient)
 
 			By("Creating new datavolume")
 			dv := utils.NewDataVolumeWithRegistryImport("import-dv", "1Gi", fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs))
@@ -305,20 +314,110 @@ var _ = Describe("Import Proxy tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
-			verifyImporterPodInfoInProxyLogs(f, dv, *dv.Spec.Source.Registry.URL, registryUserAgent, now, BeTrue)
+			verifyImporterPodInfoInProxyLogs(f, *dv.Spec.Source.Registry.URL, registryUserAgent, now, BeTrue)
 		},
 			Entry("with http proxy, no auth", false, false),
 			Entry("with http proxy, auth", false, true),
 			Entry("with https proxy, no auth", true, false),
 			Entry("with https proxy, auth", true, true),
 		)
+
+		DescribeTable("should proxy DataImportCron CronJob poller and registry import", func(isHTTPS, hasAuth bool) {
+			const (
+				cronName            = "cron-test"
+				dataSourceName      = "datasource-test"
+				scheduleEveryMinute = "* * * * *"
+			)
+
+			now := time.Now()
+			ns := f.Namespace.Name
+			updateProxy(f, ns, "", createProxyURL(isHTTPS, hasAuth, f.CdiInstallNs), "", ocpClient)
+
+			// Copy user-ca-bundle also to cdi ns for the cronjobs
+			_, err := utils.CopyConfigMap(f.K8sClient, f.CdiInstallNs, cdiProxyCaConfigMapName, f.CdiInstallNs, trustedCaProxyConfigName, "")
+			Expect(err).ToNot(HaveOccurred())
+
+			cm, err := utils.CopyRegistryCertConfigMapDestName(f.K8sClient, ns, f.CdiInstallNs, utils.RegistryCertConfigMap)
+			Expect(err).To(BeNil())
+
+			url := fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs)
+			reg := cdiv1.DataVolumeSourceRegistry{
+				URL:           &url,
+				CertConfigMap: &cm,
+			}
+
+			By(fmt.Sprintf("Create new DataImportCron %s, url %s", cronName, *reg.URL))
+			dic := utils.NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, 1, reg)
+			dic.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+			retentionPolicy := cdiv1.DataImportCronRetainNone
+			dic.Spec.RetentionPolicy = &retentionPolicy
+
+			cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), dic, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify initial job succeeded")
+			initialJobName := controller.GetInitialJobName(cron)
+			Eventually(func() int32 {
+				job, err := f.K8sClient.BatchV1().Jobs(f.CdiInstallNs).Get(context.TODO(), initialJobName, metav1.GetOptions{})
+				if err != nil {
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+					return 0
+				}
+				return job.Status.Succeeded
+			}, timeout, pollingInterval).Should(Equal(int32(1)), "initial job is not succeeded")
+
+			By("Verify cronjob first job succeeded")
+			cronJobName := controller.GetCronJobName(cron)
+			Eventually(func() *metav1.Time {
+				cronjob, err := f.K8sClient.BatchV1().CronJobs(f.CdiInstallNs).Get(context.TODO(), cronJobName, metav1.GetOptions{})
+				if err != nil {
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+					return nil
+				}
+				if cronjob.Status.LastSuccessfulTime == nil {
+					return nil
+				}
+				return cronjob.Status.LastSuccessfulTime
+			}, timeout, pollingInterval).ShouldNot(BeNil())
+
+			By("Wait for DataImportCron UpToDate")
+			Eventually(func() bool {
+				var err error
+				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				condUpToDate := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
+				return condUpToDate != nil && condUpToDate.Status == corev1.ConditionTrue
+			}, timeout, pollingInterval).Should(BeTrue(), "Timeout waiting for DataImportCron conditions")
+
+			By("Wait for CurrentImports update")
+			dvName := ""
+			Eventually(func() string {
+				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+				dvName = cron.Status.CurrentImports[0].DataVolumeName
+				Expect(dvName).ToNot(BeEmpty())
+				return dvName
+			}, timeout, pollingInterval).ShouldNot(BeEmpty())
+
+			By("Wait for datavolume succeeded")
+			err = utils.WaitForDataVolumePhase(f, ns, cdiv1.Succeeded, dvName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking the importer pod information in the proxy log to verify if the requests were proxied")
+			verifyImporterPodInfoInProxyLogs(f, url, registryUserAgent, now, BeTrue)
+		},
+			Entry("with http proxy, no auth", false, false),
+			Entry("with http proxy, auth", false, true),
+			Entry("with https proxy, no auth", true, false),
+			Entry("with https proxy, auth", true, true),
+		)
+
 	})
 })
 
-func updateProxy(f *framework.Framework, proxyHTTPURL, proxyHTTPSURL, noProxy string, ocpClient *configclient.Clientset) {
+func updateProxy(f *framework.Framework, destNamespace, proxyHTTPURL, proxyHTTPSURL, noProxy string, ocpClient *configclient.Clientset) {
 	By("Updating CDIConfig with ImportProxy configuration")
 	if !utils.IsOpenshift(f.K8sClient) {
-		proxyCAConfigMapName, err := utils.CopyConfigMap(f.K8sClient, f.CdiInstallNs, cdiProxyCaConfigMapName, f.Namespace.Name, trustedCaProxyConfigName, "")
+		proxyCAConfigMapName, err := utils.CopyConfigMap(f.K8sClient, f.CdiInstallNs, cdiProxyCaConfigMapName, destNamespace, trustedCaProxyConfigName, "")
 		Expect(err).ToNot(HaveOccurred())
 		updateCDIConfigProxy(f, proxyHTTPURL, proxyHTTPSURL, noProxy, proxyCAConfigMapName)
 	} else {
@@ -440,7 +539,7 @@ func updateClusterWideProxyObj(ocpClient *configclient.Clientset, HTTPProxy, HTT
 }
 
 // verifyImporterPodInfoInProxyLogs verifiy if the importer pod request (method, url and impoter pod IP) appears in the proxy log
-func verifyImporterPodInfoInProxyLogs(f *framework.Framework, dataVolume *cdiv1.DataVolume, imgURL, userAgent string, since time.Time, expected func() types.GomegaMatcher) {
+func verifyImporterPodInfoInProxyLogs(f *framework.Framework, imgURL, userAgent string, since time.Time, expected func() types.GomegaMatcher) {
 	podIP := getImporterPodIP(f)
 	Eventually(func() bool {
 		return wasPodProxied(imgURL, podIP, userAgent, getProxyLog(f, since))

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -450,7 +450,7 @@ var _ = Describe("ALL Operator tests", func() {
 				Expect(err).To(BeNil())
 
 				By("Create new DataImportCron")
-				cron := NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, "ds", *reg)
+				cron := utils.NewDataImportCron("cron-test", "5Gi", scheduleEveryMinute, "ds", 1, *reg)
 				cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Create(context.TODO(), cron, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -475,7 +475,7 @@ var _ = Describe("ALL Operator tests", func() {
 					var err error
 					for i := 0; i < 100 && err == nil; i++ {
 						cronName := fmt.Sprintf("cron-test-%d", i)
-						cron := NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, "ds", *reg)
+						cron := utils.NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, "ds", 1, *reg)
 						_, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Create(context.TODO(), cron, metav1.CreateOptions{})
 					}
 				}()
@@ -951,7 +951,7 @@ var _ = Describe("ALL Operator tests", func() {
 				defer utils.RemoveInsecureRegistry(f.CrClient, *reg.URL)
 
 				for i := 1; i < numCrons+1; i++ {
-					cron := NewDataImportCron(fmt.Sprintf("cron-test-%d", i), "5Gi", scheduleOnceAYear, fmt.Sprintf("datasource-test-%d", i), *reg)
+					cron := utils.NewDataImportCron(fmt.Sprintf("cron-test-%d", i), "5Gi", scheduleOnceAYear, fmt.Sprintf("datasource-test-%d", i), 1, *reg)
 					By(fmt.Sprintf("Create new DataImportCron %s", *reg.URL))
 					cron, err = f.CdiClient.CdiV1beta1().DataImportCrons(f.Namespace.Name).Create(context.TODO(), cron, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "certs.go",
         "common.go",
         "configmaps.go",
+        "dataimportcron.go",
         "datavolume.go",
         "deployments.go",
         "fileConversion.go",

--- a/tests/utils/dataimportcron.go
+++ b/tests/utils/dataimportcron.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/controller"
+)
+
+// NewDataImportCron initializes a DataImportCron struct
+func NewDataImportCron(name, size, schedule, dataSource string, importsToKeep int32, source cdiv1.DataVolumeSourceRegistry) *cdiv1.DataImportCron {
+	return &cdiv1.DataImportCron{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				controller.AnnImmediateBinding: "true",
+			},
+		},
+		Spec: cdiv1.DataImportCronSpec{
+			Template: cdiv1.DataVolume{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						Registry: &source,
+					},
+					PVC: &corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse(size),
+							},
+						},
+					},
+				},
+			},
+			Schedule:          schedule,
+			ManagedDataSource: dataSource,
+			ImportsToKeep:     &importsToKeep,
+		},
+	}
+}

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/importer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/importer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net/http"
+	neturl "net/url"
 	"os"
 	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
@@ -64,7 +65,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to build config; kubeURL %s configPath %s: %v", kubeURL, configPath, err)
 	}
-	cfg.TLSClientConfig = rest.TLSClientConfig{Insecure: true}
+
+	// Don't proxy k8s api calls
+	cfg.Proxy = func(r *http.Request) (*neturl.URL, error) {
+		return nil, nil
+	}
 
 	cdiClient, err := cdiClientset.NewForConfig(cfg)
 	if err != nil {

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
@@ -48,19 +48,27 @@ func init() {
 }
 
 func main() {
-	digest, err := importer.GetImageDigest(url, accessKey, secretKey, certDir, insecureTLS)
+	allCertDir, err := importer.CreateCertificateDir(certDir)
 	if err != nil {
-		os.Exit(1)
+		log.Printf("Ignore common certificate dir: %v", err)
+		allCertDir = certDir
 	}
-	fmt.Println("Digest is", digest)
+
+	digest, err := importer.GetImageDigest(url, accessKey, secretKey, allCertDir, insecureTLS)
+	if err != nil {
+		log.Fatalf("Failed to get image digest: %v", err)
+	}
+	log.Printf("Digest is %s", digest)
 
 	cfg, err := clientcmd.BuildConfigFromFlags(kubeURL, configPath)
 	if err != nil {
-		log.Fatalf("Failed BuildConfigFromFlags, kubeURL %s configPath %s: %v", kubeURL, configPath, err)
+		log.Fatalf("Failed to build config; kubeURL %s configPath %s: %v", kubeURL, configPath, err)
 	}
+	cfg.TLSClientConfig = rest.TLSClientConfig{Insecure: true}
+
 	cdiClient, err := cdiClientset.NewForConfig(cfg)
 	if err != nil {
-		log.Fatalf("Failed NewForConfig: %v", err)
+		log.Fatalf("Failed to create Clientset: %v", err)
 	}
 
 	dataImportCron, err := cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Get(context.TODO(), cronName, metav1.GetOptions{})
@@ -73,9 +81,9 @@ func main() {
 	if digest != "" && (imports == nil || digest != imports[0].Digest) &&
 		digest != dataImportCron.Annotations[controller.AnnSourceDesiredDigest] {
 		controller.AddAnnotation(dataImportCron, controller.AnnSourceDesiredDigest, digest)
-		fmt.Println("Digest updated")
+		log.Printf("Digest updated")
 	} else {
-		fmt.Println("No digest update")
+		log.Printf("No digest update")
 	}
 
 	_, err = cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Update(context.TODO(), dataImportCron, metav1.UpdateOptions{})


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Use proxy certificates when creating DataImportCron CronJobs, so the pods won't fail on certificate issues when proxy is configured. `cdi-source-update-poller` was also fixed to use the proxy certificates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Add DataImportCron CronJobs Proxy support
```

