### PR TITLE
Document CRI config that allows non-root containers usage of block devices

### DIFF
--- a/doc/block_cri_ownership_config.md
+++ b/doc/block_cri_ownership_config.md
@@ -1,0 +1,24 @@
+# device_ownership_from_security_context CRI configurable
+
+## Introduction
+Unlike volumes with fsGroup, devices have no official notion of deviceGroup/deviceUser that the CRI runtimes (or kubelet) would be able to use.  
+This makes it problematic for our workloads to populate block devices, and has manifested itself in the form of [this](https://github.com/kubevirt/containerized-data-importer/issues/2433#issuecomment-1287277907) community issue.
+
+## Solution
+As explained in the source below, a solution that is seamless to end-users was chosen by the k8s community, without getting the device plugin vendors involved.  
+The selected approach was to re-use `runAsUser` and `runAsGroup` for devices, with an opt-in config entry for the CRI (`device_ownership_from_security_context`) that ensures no existing deployment breaks.  
+To use CDI, it is advised to opt-in.  
+For containerd:
+```toml
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = true
+```
+CRI-O:
+```toml
+[crio.runtime]
+device_ownership_from_security_context = true
+```
+
+## Source
+https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -435,8 +435,10 @@ Lastly, it is worth mentioning that the detection and automation of  storage par
 for example, using [pvc](#pvc-source) allows to ommit the storage size, while for others is still mandatory. We encourage to check the docs for each individual source for more information.
 
 ### Block Volume Mode
-You can import, clone and upload a disk image to a raw block persistent volume.
-This is done by assigning the value 'Block' to the PVC volumeMode field in the DataVolume yaml.
+You can import, clone and upload a disk image to a raw block persistent volume, though,  
+Some CRIs need manual configuration to allow our rootless workload pods to utilize block devices, see [Configure CRI ownership from security context](block_cri_ownership_config.md).  
+
+Block disk image operations are initiated by assigning the value 'Block' to the PVC volumeMode field in the DataVolume yaml.
 The following is an example to import disk image to a raw block volume:
 ```yaml
 apiVersion: cdi.kubevirt.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Document CRI config that allows non-root containers usage of block devices

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

