### PR TITLE
Fix SCC priority so it doesn't get picked for random pods

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -220,6 +220,7 @@ var _ = Describe("Controller", func() {
 				scc, err := getSCC(args.client, scc)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(scc.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
+				Expect(scc.Priority).To(BeNil())
 
 				for _, eu := range []string{"system:serviceaccount:cdi:cdi-sa"} {
 					found := false

--- a/pkg/operator/controller/scc.go
+++ b/pkg/operator/controller/scc.go
@@ -39,7 +39,8 @@ import (
 const sccName = "containerized-data-importer"
 
 func setSCC(scc *secv1.SecurityContextConstraints) {
-	scc.Priority = &[]int32{10}[0]
+	// Ensure we are just good citizens that don't want to compete against other prioritized SCCs
+	scc.Priority = nil
 	scc.RunAsUser = secv1.RunAsUserStrategyOptions{
 		Type: secv1.RunAsUserStrategyMustRunAsNonRoot,
 	}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We create our SCC with `priority: 10` (not sure why), which means that it might compete (or directly get picked up) by random pods whose service account is privileged enough to access all SCCs:
```bash
$ oc get pods -n openshift-cluster-storage-operator cluster-storage-operator-5648cb555d-zh76b  -o yaml| grep scc
    openshift.io/scc: containerized-data-importer
```
Happens because it can physically do that
```bash
$ oc get clusterrolebinding cluster-storage-operator-role -o yaml | grep cluster-admin
  name: cluster-admin
```
A nice readout about this in context of the openshift oauth pods:
https://access.redhat.com/solutions/4727461

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-22345

**Special notes for your reviewer**:
We will likely need backports of this, not sure what's the exact impact

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Priority of CDI SecurityContextConstraints is too high
```

