### PR TITLE
Update to include mount for containers dir in bazel-docker.sh

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -109,6 +109,11 @@ else
     volumes="-v ${BUILDER_VOLUME}:/root:rw,z,exec"
 fi
 
+if [ ${CI} == "true" ]; then
+    mkdir -p "$HOME/containers"
+    volumes="$volumes -v ${HOME}/containers:/root/containers:ro,z"
+fi
+
 if [ -n "$DOCKER_CA_CERT_FILE" ]; then
     volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

The quay registry credentials are no longer available when trying to push images using the podman based bootstrap[1]. This is due to the bootstrap image now symlinking .docker/config.json to containers/auth.json [2]. bazel-push expects the registry credentials to exist under .docker/config.json but the symlink is broken as the containers directory is not also mounted into the builder container.

This update mounts the container directory into the builder container so that the symlink can work again. This is required to run any prowjobs that publish images with the new bootstrap image. 

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-containerized-data-importer-push-nightly-ARM64/1594685597958541312 
[2] https://github.com/kubevirt/project-infra/pull/2319


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @awels @akalenyu 

**Release note**:
```release-note
NONE
```

