### PR TITLE
Make cluster-sync more friendly for external provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ There are quite a few examples in the [example manifests](https://github.com/kub
 
 CDI includes a self contained development and test environment.  We use Docker to build, and we provide a simple way to get a test cluster up and running on your laptop. The development tools include a version of kubectl that you can use to communicate with the cluster. A wrapper script to communicate with the cluster can be invoked using ./cluster-up/kubectl.sh.
 
-```
+```bash
 $ mkdir $GOPATH/src/kubevirt.io && cd $GOPATH/src/kubevirt.io
 $ git clone https://github.com/kubevirt/containerized-data-importer && cd containerized-data-importer
 $ make cluster-up
 $ make cluster-sync
 $ ./cluster-up/kubectl.sh .....
 ```
+For development on external cluster (not provisioned by our CI),
+check out the [external provider](cluster-sync/external/README.md).
 
 ## Storage notes
 

--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -7,14 +7,14 @@ source ./cluster-up/cluster/${KUBEVIRT_PROVIDER}/provider.sh
 echo "Cleaning up ..."
 
 if [ "${CDI_CLEAN}" == "test-infra" ]; then
-  _kubectl delete all -n cdi -l cdi.kubevirt.io/testing
+  _kubectl delete all -n ${CDI_NAMESPACE} -l cdi.kubevirt.io/testing
   exit 0
 fi
 
 OPERATOR_CR_MANIFEST=./_out/manifests/release/cdi-cr.yaml
 OPERATOR_MANIFEST=./_out/manifests/release/cdi-operator.yaml
 LABELS=("operator.cdi.kubevirt.io" "cdi.kubevirt.io" "prometheus.cdi.kubevirt.io")
-NAMESPACES=(default kube-system cdi)
+NAMESPACES=(default kube-system "${CDI_NAMESPACE}")
 
 _kubectl get ot --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep objectTransfer | while read p; do
     arr=($p)
@@ -48,7 +48,7 @@ if [ -f "${OPERATOR_CR_MANIFEST}" ]; then
 	echo "Cleaning CR object ..."
     if _kubectl get crd cdis.cdi.kubevirt.io ; then
         _kubectl delete --ignore-not-found -f "${OPERATOR_CR_MANIFEST}"
-        _kubectl wait cdis.cdi.kubevirt.io/${CR_NAME} --for=delete --timeout=30s | echo "this is fine"
+        _kubectl wait cdis.cdi.kubevirt.io/${CR_NAME} --for=delete --timeout=30s || echo "this is fine"
     fi
 fi
 

--- a/cluster-sync/external/README.md
+++ b/cluster-sync/external/README.md
@@ -1,3 +1,7 @@
+# Introduction
+Sometimes one would want to setup CDI development environment on a totally external cluster (not kubevirtci).  
+We try to support this, with this document aggregating some knowledge around that.
+
 # External Kubernetes Provider
 
 This provider works with an existing Kubernetes cluster.  You'll want to configure your own
@@ -7,30 +11,28 @@ such that:
 2. We generate the manifests with the provided DOCKER_PREFIX (uses default port)
 3. Uses your configured `kubectl` and deploys your build to the existing cluster
 
-# Building images and pushing to your registry
-
-```bash
-export DOCKER_PREFIX=index.docker.io/barney_rubble
-export DOCKER_TAG=latest # defaults to `latest`
-export KUBEVIRT_PROVIDER=external
-```
-
-`make docker push`
-
 # Build and push images, create manifests and deploy CDI
 
-We use the same workflow as the ephemeral dev environment, but skip `make cluster-up`:
+We use the same workflow as the ephemeral dev environment, but skip `make cluster-up`.  
+A suggested flow:
 
 ```bash
-export DOCKER_PREFIX=index.docker.io/barney_rubble
-export DOCKER_TAG=latest # defaults to `latest`
 export KUBEVIRT_PROVIDER=external
+export PULL_POLICY=Always
+export CDI_NAMESPACE=cdi-rand-ns-name
+export KUBECONFIG=/path/to/kubeconfig
+export DOCKER_PREFIX=quay.io/username
 ```
 
 `make cluster-sync`
 
-# A note about kubernetes local-up-cluster.sh
+For tests, it is required to have a default storage class defined in the cluster.
 
+# Differences vs local
+- A note about kubernetes local-up-cluster.sh  
 The external provider isn't quite appropriate for use with the local-up-cluster.sh script used 
 in the Kubernetes source repo.  We'll need to add an additional `local` provider for this to 
 handle some of the specifics.
+- You will be prompted to login to your external registry,
+so that the credentials could be saved in a path that bazel "expects".  
+Bazel push (CDI containers/e2e testing containers) expects external registry creds to be in the docker CRI default path.


### PR DESCRIPTION
The aim of this change is to make setting up a dev environment on external cluster easier, By doing mainly 2 things:
- Bazel push (CDI containers/e2e testing containers) expects external registry creds to be in the docker CRI default path.
This seems to be half-configurable on the bazel side, except for the [actual file name](https://github.com/bazelbuild/rules_docker/blob/64827560cbbe9359294b9a14e8ac417224f6fdd2/container/go/cmd/pusher/pusher.go#L192) (which differs for podman).
Now we prompt for the credentials and save them on the expected path.
- Deploy the e2e testing manifests on external provider as well
Not sure why not do that today? probably reason dates way back

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

