### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/certcreator/certsecret.go
+++ b/cluster-up/cluster/kind-1.22-sriov/certcreator/certsecret.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -65,7 +64,7 @@ func generate(hookName, namespace string) ([]byte, []byte, error) {
 func exportCertificateFile(data []byte, filePath string) error {
 	certificateFileName := fmt.Sprintf("%s.cert", filePath)
 	encodedData := []byte(base64.StdEncoding.EncodeToString(data))
-	if err := ioutil.WriteFile(certificateFileName, encodedData, 0644); err != nil {
+	if err := os.WriteFile(certificateFileName, encodedData, 0644); err != nil {
 		return fmt.Errorf("failed to write content to file %s: %v", filePath, err)
 	}
 	log.Printf("certificate exported successfully to: %s", filePath)

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -38,7 +37,7 @@ func (er *execReader) Read(p []byte) (n int, err error) {
 	n, err = er.stdout.Read(p)
 	if err == io.EOF {
 		if err2 := er.cmd.Wait(); err2 != nil {
-			errBytes, _ := ioutil.ReadAll(er.stderr)
+			errBytes, _ := io.ReadAll(er.stderr)
 			klog.Fatalf("Subprocess did not execute successfully, result is: %q\n%s", er.cmd.ProcessState.ExitCode(), string(errBytes))
 		}
 	}
@@ -86,7 +85,7 @@ func createHTTPClient(clientKey, clientCert, serverCert []byte) *http.Client {
 }
 
 func startPrometheus() {
-	certsDirectory, err := ioutil.TempDir("", "certsdir")
+	certsDirectory, err := os.MkdirTemp("", "certsdir")
 	if err != nil {
 		klog.Fatalf("Error %s creating temp dir", err)
 	}
@@ -192,7 +191,7 @@ func newTarReader(preallocation bool) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	return &execReader{cmd: cmd, stdout: stdout, stderr: ioutil.NopCloser(&stderr)}, nil
+	return &execReader{cmd: cmd, stdout: stdout, stderr: io.NopCloser(&stderr)}, nil
 }
 
 func getInputStream(preallocation bool) (rc io.ReadCloser) {

--- a/cmd/cdi-cloner/clone-source_test.go
+++ b/cmd/cdi-cloner/clone-source_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 var _ = Describe("Prometheus Endpoint", func() {
 	It("Should start prometheus endpoint", func() {
 		By("Creating cert directory, we can store self signed CAs")
-		certsDirectory, err := ioutil.TempDir("", "certsdir")
+		certsDirectory, err := os.MkdirTemp("", "certsdir")
 		Expect(err).NotTo(HaveOccurred())
 		empty, err := isDirEmpty(certsDirectory)
 		Expect(err).NotTo(HaveOccurred())

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -303,7 +302,7 @@ func deleteReadyFile() {
 }
 
 func getTokenPublicKey() *rsa.PublicKey {
-	keyBytes, err := ioutil.ReadFile(controller.TokenPublicKeyPath)
+	keyBytes, err := os.ReadFile(controller.TokenPublicKeyPath)
 	if err != nil {
 		klog.Fatalf("Error reading apiserver public key")
 	}
@@ -317,7 +316,7 @@ func getTokenPublicKey() *rsa.PublicKey {
 }
 
 func getTokenPrivateKey() *rsa.PrivateKey {
-	bytes, err := ioutil.ReadFile(controller.TokenPrivateKeyPath)
+	bytes, err := os.ReadFile(controller.TokenPrivateKeyPath)
 	if err != nil {
 		klog.Fatalf("Error reading private key")
 	}

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -15,7 +15,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -69,7 +68,7 @@ func getHTTPEp(ep string) string {
 	if len(readyFile) == 0 {
 		return ep
 	}
-	imageName, err := ioutil.ReadFile(readyFile)
+	imageName, err := os.ReadFile(readyFile)
 	if err != nil {
 		klog.Errorf("Failed reading file %s: %+v", readyFile, err)
 		os.Exit(1)
@@ -95,7 +94,7 @@ func touchDoneFile() {
 func main() {
 	defer klog.Flush()
 
-	certsDirectory, err := ioutil.TempDir("", "certsdir")
+	certsDirectory, err := os.MkdirTemp("", "certsdir")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -302,7 +301,7 @@ func (app *cdiAPIApp) uploadHandler(request *restful.Request, response *restful.
 
 	namespace := request.PathParameter("namespace")
 	defer request.Request.Body.Close()
-	body, err := ioutil.ReadAll(request.Request.Body)
+	body, err := io.ReadAll(request.Request.Body)
 	if err != nil {
 		klog.Error(err)
 		response.WriteError(http.StatusBadRequest, err)

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -23,7 +23,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -87,7 +87,7 @@ func newAdmissionHandler(a Admitter) http.Handler {
 func (h *admissionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/controller/datavolume-controller.go
+++ b/pkg/controller/datavolume-controller.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -2512,7 +2512,7 @@ func updateProgressUsingPod(dataVolumeCopy *cdiv1.DataVolume, pod *corev1.Pod) e
 			return err
 		}
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -19,7 +19,6 @@ package image
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -130,7 +129,7 @@ func convertToRaw(src, dest string, preallocate bool) error {
 	if err != nil {
 		os.Remove(dest)
 		errorMsg := "could not convert image to raw"
-		if nbdkitLog, err := ioutil.ReadFile(common.NbdkitLogPath); err == nil {
+		if nbdkitLog, err := os.ReadFile(common.NbdkitLogPath); err == nil {
 			errorMsg += " " + string(nbdkitLog)
 		}
 		return errors.Wrap(err, errorMsg)
@@ -200,7 +199,7 @@ func (o *qemuOperations) Info(url *url.URL) (*ImgInfo, error) {
 	output, err := qemuExecFunction(qemuInfoLimits, nil, "qemu-img", "info", "--output=json", url.String())
 	if err != nil {
 		errorMsg := fmt.Sprintf("%s, %s", output, err.Error())
-		if nbdkitLog, err := ioutil.ReadFile(common.NbdkitLogPath); err == nil {
+		if nbdkitLog, err := os.ReadFile(common.NbdkitLogPath); err == nil {
 			errorMsg += " " + string(nbdkitLog)
 		}
 		return nil, errors.Errorf(errorMsg)

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -17,7 +17,6 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -134,7 +133,7 @@ var _ = Describe("Convert to Raw", func() {
 	var tmpDir, destPath string
 
 	BeforeEach(func() {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), "qemutestdest")
+		tmpDir, err := os.MkdirTemp(os.TempDir(), "qemutestdest")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 		destPath = filepath.Join(tmpDir, "dest")

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -2,7 +2,6 @@ package importer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -244,7 +243,7 @@ var _ = Describe("Data Processor", func() {
 	})
 
 	It("should call Convert after Process phase", func() {
-		tmpDir, err := ioutil.TempDir("", "scratch")
+		tmpDir, err := os.MkdirTemp("", "scratch")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(tmpDir)
 
@@ -318,7 +317,7 @@ var _ = Describe("Data Processor", func() {
 	})
 
 	table.DescribeTable("should avoid cleanup before delta copies", func(dataSource DataSourceInterface, expectedCleanup bool) {
-		tmpDir, err := ioutil.TempDir("", "scratch")
+		tmpDir, err := os.MkdirTemp("", "scratch")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(tmpDir)
 
@@ -381,7 +380,7 @@ var _ = Describe("Convert", func() {
 
 var _ = Describe("Resize", func() {
 	It("Should not resize and return complete, when requestedSize is blank", func() {
-		tempDir, err := ioutil.TempDir(os.TempDir(), "dest")
+		tempDir, err := os.MkdirTemp(os.TempDir(), "dest")
 		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())
@@ -398,7 +397,7 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should not resize and return complete, when requestedSize is valid, but datadir doesn't exist (block device)", func() {
-		tempDir, err := ioutil.TempDir(os.TempDir(), "dest")
+		tempDir, err := os.MkdirTemp(os.TempDir(), "dest")
 		Expect(err).ToNot(HaveOccurred())
 
 		replaceAvailableSpaceBlockFunc(func(dataDir string) (int64, error) {
@@ -421,7 +420,7 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should resize and return complete, when requestedSize is valid, and datadir exists", func() {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), "data")
+		tmpDir, err := os.MkdirTemp(os.TempDir(), "data")
 		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())
@@ -438,7 +437,7 @@ var _ = Describe("Resize", func() {
 	})
 
 	It("Should not resize and return error, when ResizeImage fails", func() {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), "data")
+		tmpDir, err := os.MkdirTemp(os.TempDir(), "data")
 		Expect(err).ToNot(HaveOccurred())
 		url, err := url.Parse("http://fakeurl-notreal.fake")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -145,7 +144,7 @@ func (fr *FormatReaders) appendReader(rType int, x interface{}) {
 		r = io.MultiReader(r, fr.TopReader())
 	}
 	if _, ok := r.(io.Closer); !ok {
-		r = ioutil.NopCloser(r)
+		r = io.NopCloser(r)
 	}
 	fr.readers = append(fr.readers, reader{rdrType: rType, rdr: r.(io.ReadCloser)})
 }

--- a/pkg/importer/format-readers_test.go
+++ b/pkg/importer/format-readers_test.go
@@ -3,7 +3,6 @@ package importer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,7 +91,7 @@ var _ = Describe("Format Readers", func() {
 	)
 
 	It("should not crash on no progress reader", func() {
-		stringReader := ioutil.NopCloser(strings.NewReader("This is a test string"))
+		stringReader := io.NopCloser(strings.NewReader("This is a test string"))
 		testReader, err := NewFormatReaders(stringReader, uint64(0))
 		// Not passing a real string, so the header checking will fail.
 		Expect(err).To(HaveOccurred())

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -211,20 +210,20 @@ func createCertPool(certDir string) (*x509.CertPool, error) {
 	}
 
 	// append the user-provided trusted CA certificates bundle when making egress connections using proxy
-	if files, err := ioutil.ReadDir(common.ImporterProxyCertDir); err == nil {
+	if files, err := os.ReadDir(common.ImporterProxyCertDir); err == nil {
 		for _, file := range files {
 			if file.IsDir() || file.Name()[0] == '.' {
 				continue
 			}
 			fp := path.Join(common.ImporterProxyCertDir, file.Name())
-			if certs, err := ioutil.ReadFile(fp); err == nil {
+			if certs, err := os.ReadFile(fp); err == nil {
 				certPool.AppendCertsFromPEM(certs)
 			}
 		}
 	}
 
 	// append server CA certificates
-	files, err := ioutil.ReadDir(certDir)
+	files, err := os.ReadDir(certDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error listing files in %s", certDir)
 	}
@@ -238,7 +237,7 @@ func createCertPool(certDir string) (*x509.CertPool, error) {
 
 		klog.Infof("Attempting to get certs from %s", fp)
 
-		certs, err := ioutil.ReadFile(fp)
+		certs, err := os.ReadFile(fp)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading file %s", fp)
 		}
@@ -470,7 +469,7 @@ func getExtraHeadersFromSecrets() ([]string, error) {
 			return nil
 		}
 
-		header, err := ioutil.ReadFile(filePath)
+		header, err := os.ReadFile(filePath)
 		if err != nil {
 			return errors.Wrapf(err, "Error reading headers from %s", filePath)
 		}

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -51,7 +50,7 @@ var _ = Describe("Http data source", func() {
 		By("[BeforeEach] Creating test server")
 		ts = createTestServer(imageDir)
 		dp = nil
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})
@@ -140,7 +139,7 @@ var _ = Describe("Http data source", func() {
 				fileStat, err := file.Stat()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(int64(len(want))).To(Equal(fileStat.Size()))
-				resultBuffer, err := ioutil.ReadAll(file)
+				resultBuffer, err := io.ReadAll(file)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
 			}
@@ -181,7 +180,7 @@ var _ = Describe("Http data source", func() {
 			if firstExists && secondExists {
 				response, err := ts.Client().Get(ts.URL + "/" + r.RequestURI)
 				Expect(err).NotTo(HaveOccurred())
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				w.Write(body)
 			} else {
@@ -201,7 +200,7 @@ var _ = Describe("Http client", func() {
 	BeforeEach(func() {
 		var err error
 
-		tempDir, err = ioutil.TempDir("/tmp", "cert-test")
+		tempDir, err = os.MkdirTemp("/tmp", "cert-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		keyPair, err := triple.NewCA("datastream.cdi.kubevirt.io")
@@ -209,7 +208,7 @@ var _ = Describe("Http client", func() {
 
 		certBytes := cert.EncodeCertPEM(keyPair.Cert)
 
-		err = ioutil.WriteFile(path.Join(tempDir, "tls.crt"), certBytes, 0644)
+		err = os.WriteFile(path.Join(tempDir, "tls.crt"), certBytes, 0644)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -417,7 +416,7 @@ var _ = Describe("http pollprogress", func() {
 			cancel: cancel,
 		}
 		By("Creating string reader we can test just the poll progress part")
-		stringReader := ioutil.NopCloser(strings.NewReader("This is a test string"))
+		stringReader := io.NopCloser(strings.NewReader("This is a test string"))
 		endlessReader := EndlessReader{
 			Reader: stringReader,
 		}
@@ -448,7 +447,7 @@ func readFile(fileName string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	result, err := ioutil.ReadAll(f)
+	result, err := io.ReadAll(f)
 	return result, err
 }
 

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -878,7 +878,7 @@ func loadCA(certDir string) (*x509.CertPool, error) {
 	if certDir == "" {
 		return nil, errors.New("Error CA not provided")
 	}
-	files, err := ioutil.ReadDir(certDir)
+	files, err := os.ReadDir(certDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error listing files in %s", certDir)
 	}
@@ -893,7 +893,7 @@ func loadCA(certDir string) (*x509.CertPool, error) {
 
 		klog.Infof("Attempting to get certs from %s", fp)
 
-		certs, err := ioutil.ReadFile(fp)
+		certs, err := os.ReadFile(fp)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading file %s", fp)
 		}

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -214,7 +214,7 @@ var _ = Describe("Imageio pollprogress", func() {
 			cancel: cancel,
 		}
 		By("Creating string reader we can test just the poll progress part")
-		stringReader := ioutil.NopCloser(strings.NewReader("This is a test string"))
+		stringReader := io.NopCloser(strings.NewReader("This is a test string"))
 		endlessReader := EndlessReader{
 			Reader: stringReader,
 		}
@@ -602,7 +602,7 @@ var _ = Describe("Imageio extents", func() {
 		Expect(phase).To(Equal(ProcessingPhaseTransferDataFile))
 		err = source.StreamExtents(extentsReader, destination)
 		Expect(err).ToNot(HaveOccurred())
-		data, err := ioutil.ReadFile(destination)
+		data, err := os.ReadFile(destination)
 		Expect(err).ToNot(HaveOccurred())
 		extentData := createTestExtentData()
 		comparison := bytes.Compare(data, extentData)
@@ -879,7 +879,7 @@ func createErrMockOvirtClient(ep string, accessKey string, secKey string) (Conne
 func createCert() string {
 	var err error
 
-	tempDir, err := ioutil.TempDir("/tmp", "cert-test")
+	tempDir, err := os.MkdirTemp("/tmp", "cert-test")
 	Expect(err).ToNot(HaveOccurred())
 
 	keyPair, err := triple.NewCA("datastream.cdi.kubevirt.io")
@@ -888,7 +888,7 @@ func createCert() string {
 	certBytes := bytes.Buffer{}
 	pem.Encode(&certBytes, &pem.Block{Type: cert.CertificateBlockType, Bytes: keyPair.Cert.Raw})
 
-	err = ioutil.WriteFile(path.Join(tempDir, "tls.crt"), certBytes.Bytes(), 0644)
+	err = os.WriteFile(path.Join(tempDir, "tls.crt"), certBytes.Bytes(), 0644)
 	Expect(err).ToNot(HaveOccurred())
 
 	return tempDir

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package importer
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -129,7 +128,7 @@ func getImageFileName(dir string) (string, error) {
 		return "", errors.Errorf("image directory does not exist")
 	}
 
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		klog.Errorf("Error reading directory")
 		return "", errors.Wrapf(err, "image file does not exist in image directory")

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -1,7 +1,6 @@
 package importer
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +20,7 @@ var _ = Describe("Registry data source", func() {
 	var ds *RegistryDataSource
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})

--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -1,7 +1,7 @@
 package importer
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,7 +24,7 @@ var _ = Describe("S3 data source", func() {
 
 	BeforeEach(func() {
 		newClientFunc = createMockS3Client
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})
@@ -122,7 +122,7 @@ var _ = Describe("S3 data source", func() {
 			fileStat, err := file.Stat()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(int64(len(want))).To(Equal(fileStat.Size()))
-			resultBuffer, err := ioutil.ReadAll(file)
+			resultBuffer, err := io.ReadAll(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
 			Expect(file.Name()).To(Equal(sd.GetURL().String()))

--- a/pkg/importer/transport_test.go
+++ b/pkg/importer/transport_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package importer
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ var _ = Describe("Registry Importer", func() {
 	var err error
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -1,7 +1,7 @@
 package importer
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,7 +26,7 @@ var _ = Describe("Upload data source", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})
@@ -102,7 +102,7 @@ var _ = Describe("Upload data source", func() {
 			fileStat, err := file.Stat()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(int64(len(want))).To(Equal(fileStat.Size()))
-			resultBuffer, err := ioutil.ReadAll(file)
+			resultBuffer, err := io.ReadAll(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reflect.DeepEqual(resultBuffer, want)).To(BeTrue())
 			Expect(file.Name()).To(Equal(ud.GetURL().String()))
@@ -171,7 +171,7 @@ var _ = Describe("Async Upload data source", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "scratch")
+		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -1,7 +1,6 @@
 package importer
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/signal"
@@ -30,7 +29,7 @@ func ParseEndpoint(endpt string) (*url.URL, error) {
 // CleanDir cleans the contents of a directory including its sub directories, but does NOT remove the
 // directory itself.
 func CleanDir(dest string) error {
-	dir, err := ioutil.ReadDir(dest)
+	dir, err := os.ReadDir(dest)
 	if err != nil {
 		klog.Errorf("Unable read directory to clean: %s, %v", dest, err)
 		return err

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -2,7 +2,6 @@ package importer
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -58,7 +57,7 @@ var _ = Describe("Stream Data To File", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "stream")
+		tmpDir, err = os.MkdirTemp("", "stream")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})
@@ -91,7 +90,7 @@ var _ = Describe("Clean dir", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "stream")
+		tmpDir, err = os.MkdirTemp("", "stream")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 	})
@@ -110,12 +109,12 @@ var _ = Describe("Clean dir", func() {
 		Expect(err).NotTo(HaveOccurred())
 		_, err = os.Create(filepath.Join(tmpDir, "newfile2"))
 		Expect(err).NotTo(HaveOccurred())
-		dir, err := ioutil.ReadDir(tmpDir)
+		dir, err := os.ReadDir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(2).To(Equal(len(dir)))
 		err = CleanDir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
-		dir, err = ioutil.ReadDir(tmpDir)
+		dir, err = os.ReadDir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(0).To(Equal(len(dir)))
 	})

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -925,7 +924,7 @@ func (vs *VDDKDataSource) Info() (ProcessingPhase, error) {
 // Close closes any readers or other open resources.
 func (vs *VDDKDataSource) Close() error {
 	if vddkVersion != "" || vddkHost != "" {
-		existingbytes, _ := ioutil.ReadFile(common.PodTerminationMessageFile)
+		existingbytes, _ := os.ReadFile(common.PodTerminationMessageFile)
 		existing := string(existingbytes)
 		if existing != "" {
 			existing += "; "

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -215,7 +214,7 @@ func (app *uploadServerApp) createUploadServer() (*http.Server, error) {
 	}
 
 	if app.tlsKey != "" && app.tlsCert != "" {
-		certDir, err := ioutil.TempDir("", "uploadserver-tls")
+		certDir, err := os.MkdirTemp("", "uploadserver-tls")
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating cert dir")
 		}
@@ -223,12 +222,12 @@ func (app *uploadServerApp) createUploadServer() (*http.Server, error) {
 		app.keyFile = filepath.Join(certDir, "tls.key")
 		app.certFile = filepath.Join(certDir, "tls.crt")
 
-		err = ioutil.WriteFile(app.keyFile, []byte(app.tlsKey), 0600)
+		err = os.WriteFile(app.keyFile, []byte(app.tlsKey), 0600)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating key file")
 		}
 
-		err = ioutil.WriteFile(app.certFile, []byte(app.tlsCert), 0600)
+		err = os.WriteFile(app.certFile, []byte(app.tlsCert), 0600)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating cert file")
 		}
@@ -504,5 +503,5 @@ func newContentReader(stream io.ReadCloser, contentType string) io.ReadCloser {
 }
 
 func newSnappyReadCloser(stream io.ReadCloser) io.ReadCloser {
-	return ioutil.NopCloser(snappy.NewReader(stream))
+	return io.NopCloser(snappy.NewReader(stream))
 }

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -29,10 +29,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -162,9 +162,9 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	certFixturePath := path.Join(fixtureDirectory, baseName+".crt")
 	keyFixturePath := path.Join(fixtureDirectory, baseName+".key")
 	if len(fixtureDirectory) > 0 {
-		cert, err := ioutil.ReadFile(certFixturePath)
+		cert, err := os.ReadFile(certFixturePath)
 		if err == nil {
-			key, err := ioutil.ReadFile(keyFixturePath)
+			key, err := os.ReadFile(keyFixturePath)
 			if err == nil {
 				return cert, key, nil
 			}
@@ -249,10 +249,10 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	}
 
 	if len(fixtureDirectory) > 0 {
-		if err := ioutil.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write cert fixture to %s: %v", certFixturePath, err)
 		}
-		if err := ioutil.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write key fixture to %s: %v", certFixturePath, err)
 		}
 	}

--- a/pkg/util/cert/fetcher/certfetcher.go
+++ b/pkg/util/cert/fetcher/certfetcher.go
@@ -3,7 +3,7 @@ package fetcher
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -27,12 +27,12 @@ type FileCertFetcher struct {
 
 // KeyBytes returns key bytes
 func (f *FileCertFetcher) KeyBytes() ([]byte, error) {
-	return ioutil.ReadFile(f.KeyFileName)
+	return os.ReadFile(f.KeyFileName)
 }
 
 // CertBytes returns cert bytes
 func (f *FileCertFetcher) CertBytes() ([]byte, error) {
-	return ioutil.ReadFile(f.CertFileName)
+	return os.ReadFile(f.CertFileName)
 }
 
 // MemCertFetcher reads certs from files

--- a/pkg/util/prometheus/prometheus.go
+++ b/pkg/util/prometheus/prometheus.go
@@ -3,8 +3,8 @@ package prometheus
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"time"
 
@@ -97,13 +97,13 @@ func StartPrometheusEndpoint(certsDirectory string) {
 	}
 
 	certFile := path.Join(certsDirectory, "tls.crt")
-	if err = ioutil.WriteFile(certFile, certBytes, 0600); err != nil {
+	if err = os.WriteFile(certFile, certBytes, 0600); err != nil {
 		klog.Error("Error writing cert file")
 		return
 	}
 
 	keyFile := path.Join(certsDirectory, "tls.key")
-	if err = ioutil.WriteFile(keyFile, keyBytes, 0600); err != nil {
+	if err = os.WriteFile(keyFile, keyBytes, 0600); err != nil {
 		klog.Error("Error writing key file")
 		return
 	}

--- a/pkg/util/prometheus/prometheus_test.go
+++ b/pkg/util/prometheus/prometheus_test.go
@@ -3,7 +3,6 @@ package prometheus
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -35,10 +34,10 @@ func init() {
 var _ = Describe("Timed update", func() {
 
 	It("Should start and stop when finished", func() {
-		r := ioutil.NopCloser(bytes.NewReader([]byte("hello world")))
+		r := io.NopCloser(bytes.NewReader([]byte("hello world")))
 		progressReader := NewProgressReader(r, uint64(11), progress, ownerUID)
 		progressReader.StartTimedUpdate()
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -66,7 +65,7 @@ func GetNamespace() string {
 }
 
 func getNamespace(path string) string {
-	if data, err := ioutil.ReadFile(path); err == nil {
+	if data, err := os.ReadFile(path); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns
 		}
@@ -254,7 +253,7 @@ func WriteTerminationMessageToFile(file, message string) error {
 	// Only write the first line of the message.
 	scanner := bufio.NewScanner(strings.NewReader(message))
 	if scanner.Scan() {
-		err := ioutil.WriteFile(file, []byte(scanner.Text()), os.ModeAppend)
+		err := os.WriteFile(file, []byte(scanner.Text()), os.ModeAppend)
 		if err != nil {
 			return errors.Wrap(err, "could not create termination message file")
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -121,7 +120,7 @@ var _ = Describe("Copy files", func() {
 	var err error
 
 	BeforeEach(func() {
-		destTmp, err = ioutil.TempDir("", "dest")
+		destTmp, err = os.MkdirTemp("", "dest")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -162,7 +161,7 @@ var _ = Describe("Zero out ranges in files", func() {
 	BeforeEach(func() {
 		var err error
 
-		testFile, err = ioutil.TempFile("", "test")
+		testFile, err = os.CreateTemp("", "test")
 		Expect(err).ToNot(HaveOccurred())
 		written, err := testFile.Write(testData)
 		Expect(err).ToNot(HaveOccurred())
@@ -184,7 +183,7 @@ var _ = Describe("Zero out ranges in files", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = testFile.Close()
 		Expect(err).ToNot(HaveOccurred())
-		data, err := ioutil.ReadFile(testFile.Name())
+		data, err := os.ReadFile(testFile.Name())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(data)).To(Equal(len(testData)))
 		comparison := bytes.Compare(data[start:end], bytes.Repeat([]byte{0}, length))
@@ -203,7 +202,7 @@ var _ = Describe("Zero out ranges in files", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = testFile.Close()
 		Expect(err).ToNot(HaveOccurred())
-		data, err := ioutil.ReadFile(testFile.Name())
+		data, err := os.ReadFile(testFile.Name())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(data)).To(Equal(len(testData) + length))
 		comparison := bytes.Compare(data[:len(testData)], testData)

--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -404,7 +403,7 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 })
 
 func yamlFiletoStruct(fileName string, o *map[string]interface{}) error {
-	yamlFile, err := ioutil.ReadFile(fileName)
+	yamlFile, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -422,7 +421,7 @@ func structToYamlFile(fileName string, o interface{}) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(fileName, yamlOutput, 0644)
+	err = os.WriteFile(fileName, yamlOutput, 0644)
 	if err != nil {
 		return err
 	}

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -504,7 +504,7 @@ var _ = Describe("[rfe_id:1118][crit:high][vendor:cnv-qe@redhat.com][level:compo
 				if err == nil {
 					defer resp.Body.Close()
 					if resp.StatusCode == http.StatusOK {
-						bodyBytes, err := ioutil.ReadAll(resp.Body)
+						bodyBytes, err := io.ReadAll(resp.Body)
 						Expect(err).NotTo(HaveOccurred())
 						match := importRegExp.FindStringSubmatch(string(bodyBytes))
 						if match != nil {
@@ -1005,7 +1005,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 				var result map[string]interface{}
 				resp := f.MakePrometheusHTTPRequest("query?query=kubevirt_cdi_import_dv_unusual_restartcount_total>0")
 				defer resp.Body.Close()
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return false
 				}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -795,7 +795,7 @@ var _ = Describe("ALL Operator tests", func() {
 					var result map[string]interface{}
 					resp := f.MakePrometheusHTTPRequest("query?query=" + endpoint)
 					defer resp.Body.Close()
-					bodyBytes, err := ioutil.ReadAll(resp.Body)
+					bodyBytes, err := io.ReadAll(resp.Body)
 					if err != nil {
 						return false
 					}
@@ -884,7 +884,7 @@ var _ = Describe("ALL Operator tests", func() {
 					resp := f.MakePrometheusHTTPRequest("alerts")
 					defer resp.Body.Close()
 					// Make sure alert appears and is firing
-					bodyBytes, err := ioutil.ReadAll(resp.Body)
+					bodyBytes, err := io.ReadAll(resp.Body)
 					if err != nil {
 						return false
 					}

--- a/tests/utils/certs.go
+++ b/tests/utils/certs.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -72,11 +71,11 @@ func CreateCertForTestService(namespace, serviceName, configMapName, certDir, ce
 		}
 	}
 
-	if err = ioutil.WriteFile(path.Join(certDir, certFileName), certBytes, 0644); err != nil {
+	if err = os.WriteFile(path.Join(certDir, certFileName), certBytes, 0644); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(path.Join(certDir, keyFileName), keyBytes, 0600); err != nil {
+	if err = os.WriteFile(path.Join(certDir, keyFileName), keyBytes, 0600); err != nil {
 		return err
 	}
 

--- a/tools/cdi-containerimage-server/main.go
+++ b/tools/cdi-containerimage-server/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -23,7 +22,7 @@ func printFiles(dir string) error {
 }
 
 func getImageFilename(dir string) (string, error) {
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +55,7 @@ func main() {
 		log.Fatalf("Failed listening on %s err: %v", addr, err)
 	}
 
-	if err := ioutil.WriteFile(*readyFile, []byte(imageFilename), 0666); err != nil {
+	if err := os.WriteFile(*readyFile, []byte(imageFilename), 0666); err != nil {
 		log.Fatalf("Failed creating \"ready\" file: %v", err)
 	}
 	defer os.Remove(*readyFile)

--- a/tools/cdi-func-test-proxy/main.go
+++ b/tools/cdi-func-test-proxy/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -190,7 +189,7 @@ func newResponse(r *http.Request, contentType string, status int, body string) *
 	resp.Status = http.StatusText(status)
 	buf := bytes.NewBufferString(body)
 	resp.ContentLength = int64(buf.Len())
-	resp.Body = ioutil.NopCloser(buf)
+	resp.Body = io.NopCloser(buf)
 	return resp
 }
 

--- a/tools/crd-generator/crd-generator.go
+++ b/tools/crd-generator/crd-generator.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,7 +21,7 @@ func main() {
 
 	flag.Parse()
 
-	files, err := ioutil.ReadDir(*dirname)
+	files, err := os.ReadDir(*dirname)
 	if err != nil {
 		panic(fmt.Errorf("error occurred reading directory, %v", err))
 	}

--- a/tools/manifest-generator/manifest-generator.go
+++ b/tools/manifest-generator/manifest-generator.go
@@ -14,7 +14,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -116,7 +115,7 @@ func generateFromFile(templFile string) {
 	// Read generated manifests and populate templated manifest
 	genDir := *genManifestsPath
 	data.GeneratedManifests = make(map[string]string)
-	manifests, err := ioutil.ReadDir(genDir)
+	manifests, err := os.ReadDir(genDir)
 	if err != nil {
 		klog.Fatalf("Failed to read directory %s: %v", genDir, err)
 	}
@@ -125,7 +124,7 @@ func generateFromFile(templFile string) {
 		if manifest.IsDir() {
 			continue
 		}
-		b, err := ioutil.ReadFile(filepath.Join(genDir, manifest.Name()))
+		b, err := os.ReadFile(filepath.Join(genDir, manifest.Name()))
 		if err != nil {
 			klog.Fatalf("Failed to read file %s: %v", templFile, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (`os.ReadDir` returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo` and it is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

Code refactoring only, no user facing changes.

```release-note
NONE
```

