### PR TITLE
[Draft] Annotate pvc for completion

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -68,6 +68,10 @@ const (
 	AnnPopulatedFor = AnnAPIGroup + "/storage.populatedFor"
 	// AnnPrePopulated is a PVC annotation telling the datavolume controller that the PVC is already populated
 	AnnPrePopulated = AnnAPIGroup + "/storage.prePopulated"
+	// AnnPopulationDone is a PVC annotation for communicating that the PVC is done populating.
+	// It differs from AnnPopulatedFor, AnnPrePopulated by being initialized to false when the PVC is created
+	// this is to eliminate races when checking this value.
+	AnnPopulationDone = AnnAPIGroup + "/storage.populationDone"
 	// AnnPriorityClassName is PVC annotation to indicate the priority class name for importer, cloner and uploader pod
 	AnnPriorityClassName = AnnAPIGroup + "/storage.pod.priorityclassname"
 	// AnnDeleteAfterCompletion is PVC annotation for deleting DV after completion

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -66,7 +66,7 @@ const (
 	AnnPodRestarts = AnnAPIGroup + "/storage.pod.restarts"
 	// AnnPopulatedFor is a PVC annotation telling the datavolume controller that the PVC is already populated
 	AnnPopulatedFor = AnnAPIGroup + "/storage.populatedFor"
-	// AnnPrePopulated is a PVC annotation telling the datavolume controller that the PVC is already populated
+	// AnnPrePopulated is a DV annotation telling the datavolume controller that the PVC is already populated
 	AnnPrePopulated = AnnAPIGroup + "/storage.prePopulated"
 	// AnnPopulationDone is a PVC annotation for communicating that the PVC is done populating.
 	// It differs from AnnPopulatedFor, AnnPrePopulated by being initialized to false when the PVC is created

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/utils/utils.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1/utils/utils.go
@@ -30,7 +30,12 @@ import (
 func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*cdiv1.DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
 	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
-		// Find the data volume:
+		populated, ok := pvc.Annotations["cdi.kubevirt.io/storage.populationDone"]
+		if ok {
+			// New CDI, we don't need to query the DV to tell if done
+			return populated == "true", nil
+		}
+		// Find the data volume, for older CDI that didn't always populate populationDone:
 		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
 		if err != nil {
 			return false, err

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/utils/utils.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/utils/utils.go
@@ -30,7 +30,12 @@ import (
 func IsPopulated(pvc *corev1.PersistentVolumeClaim, getDvFunc func(name, namespace string) (*cdiv1.DataVolume, error)) (bool, error) {
 	pvcOwner := metav1.GetControllerOf(pvc)
 	if pvcOwner != nil && pvcOwner.Kind == "DataVolume" {
-		// Find the data volume:
+		populated, ok := pvc.Annotations["cdi.kubevirt.io/storage.populationDone"]
+		if ok {
+			// New CDI, we don't need to query the DV to tell if done
+			return populated == "true", nil
+		}
+		// Find the data volume, for older CDI that didn't always populate populationDone:
 		dv, err := getDvFunc(pvcOwner.Name, pvc.Namespace)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This was inspired by two things:
- the desire to simplify backup/restore to not require custom code
- a [race seen in kubevirt's CI](https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8796/pull-kubevirt-e2e-k8s-1.24-sig-storage-root/1592810005592018944), which we can simplify ignore.

The race is explained as follows:
We try to see if the PVC is ready to be consumed. We look at the PVC, and it references a DV so we need to inspect its status.
In the meantime, garbage collection has happened, so when we look at the DV, it no longer exists.

However, it's a lot of work for the small window before a data volume is garbage collected - assuming this DV will be garbage collected. Perhaps we don't want to do this at all, and just assume from now on that datavolumes are garbage collected, or all of them will be real soon now.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Populate datavolume AnnPrePopulated, PVC AnnPopulatedFor when a DV is complete, to simplify writing backup/restore code.
Add a new annotation allowing to eliminate a race condition that resulted in IsPopulated in the CDI API sometimes returning an error
```

