### PR TITLE
Preserve permissions on extract

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -203,11 +203,12 @@ func StreamDataToFile(r io.Reader, fileName string) error {
 // using the specified io.Reader to the specified destination.
 func UnArchiveTar(reader io.Reader, destDir string) error {
 	klog.V(1).Infof("begin untar to %s...\n", destDir)
-	untar := exec.Command("/usr/bin/tar", "--no-same-owner", "-xvC", destDir)
+	untar := exec.Command("/usr/bin/tar", "--preserve-permissions", "--no-same-owner", "-xvC", destDir)
 	untar.Stdin = reader
 	var outBuf, errBuf bytes.Buffer
 	untar.Stdout = &outBuf
 	untar.Stderr = &errBuf
+	klog.V(1).Infof("running untar cmd: %v\n", untar.Args)
 	err := untar.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On external testing lanes using NFS static PVs, lots of failures show that we lose `chmod 660` when untarring.
Let's attempt to keep the permissions.

On CSI storage we probably get reasonable chmod&chown on spin up stage, but not on regular NFS:
https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-csi-drivers-to-declare-support-for-fsgroup-based-permissions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

