### PR TITLE
[release-1.49] Queue DataVolumes referred to in "populatedFor" PVC annotations

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -1131,7 +1129,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			By("Verifying Pending without PVC")
 			Eventually(func() cdiv1.DataVolumePhase {
-				dv, _ := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				dv, err := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return dv.Status.Phase
 			}, timeout, pollingInterval).Should(Equal(cdiv1.Pending))
@@ -1141,23 +1139,21 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			By("Create PVC")
 			annotations := map[string]string{"cdi.kubevirt.io/storage.populatedFor": dataVolumeName}
-			pvcDef := utils.NewPVCDefinition(dataVolumeName, "100m", annotations, nil)
-			pvcDef.OwnerReferences = append(pvcDef.OwnerReferences,
-				*metav1.NewControllerRef(dataVolume, schema.GroupVersionKind{
-					Group:   cdiv1.SchemeGroupVersion.Group,
-					Version: cdiv1.SchemeGroupVersion.Version,
-					Kind:    "DataVolume",
-				}))
-			_, err = f.CreateBoundPVCFromDefinition(pvcDef)
+			pvc := utils.NewPVCDefinition(dataVolumeName, "100m", annotations, nil)
+			pvc, err = f.CreateBoundPVCFromDefinition(pvc)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying Succeed with PVC Bound")
-			Eventually(func() cdiv1.DataVolumePhase {
-				dv, _ := f.CdiClient.CdiV1beta1().DataVolumes(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return dv.Status.Phase
-			}, timeout, pollingInterval).Should(Equal(cdiv1.Succeeded))
+			err = utils.WaitForDataVolumePhase(f.CdiClient, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
 
+			By("Verifying PVC owned by DV")
+			Eventually(func() bool {
+				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				pvcOwner := metav1.GetControllerOf(pvc)
+				return pvcOwner != nil && pvcOwner.Kind == "DataVolume" && pvcOwner.Name == dataVolume.Name
+			}, timeout, pollingInterval).Should(BeTrue())
 		})
 
 		It("[test_id:4961]should handle a pre populated PVC", func() {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


https://bugzilla.redhat.com/show_bug.cgi?id=2149669

**Special notes for your reviewer**:

Manual backport of #2373

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix DataVolume/PVC restore - don't require PVC initially owned by DataVolume
```

