### PR TITLE
Fix bazel build command

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -109,7 +109,7 @@ else
     volumes="-v ${BUILDER_VOLUME}:/root:rw,z,exec"
 fi
 
-if [ ${CI} == "true" ]; then
+if [ "${CI}" = "true" ]; then
     mkdir -p "$HOME/containers"
     volumes="$volumes -v ${HOME}/containers:/root/containers:ro,z"
 fi


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Bazel build was generating error due to the way the comparison was. This fixes the problem.
Without this if you run make bazel-build it will generate an error on the comparison.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

