### PR TITLE
DataVolume: Check that DataVolumeSource is provided before checking DataVolumeSourcePVC

### DIFF
--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -488,7 +488,8 @@ func validateStorageSize(spec *cdiv1.DataVolumeSpec, field *k8sfield.Path) (*met
 
 	// The storage size of a DataVolume can only be empty when two conditios are met:
 	//	1. The 'Storage' spec API is used, which allows for additional logic in CDI.
-	//	2. The 'PVC' source is used, so the original size can be extracted from the source.
+	//	2. The 'PVC' source or SourceRef is used, so the original size can be extracted from the source.
+	isClone := spec.SourceRef != nil || (spec.Source != nil && spec.Source.PVC != nil)
 	if pvcSize, ok := resources.Requests["storage"]; ok {
 		if pvcSize.IsZero() || pvcSize.Value() < 0 {
 			cause := metav1.StatusCause{
@@ -498,7 +499,7 @@ func validateStorageSize(spec *cdiv1.DataVolumeSpec, field *k8sfield.Path) (*met
 			}
 			return &cause, false
 		}
-	} else if spec.Storage == nil || spec.Source.PVC == nil {
+	} else if spec.Storage == nil || !isClone {
 		cause := metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s size is missing", name),


### PR DESCRIPTION
**What this PR does / why we need it**:

This change avoids the following valid `DataSource` and `DataVolume`
definitions from causing a panic within the `DataVolume` validation
webhook by ensuring `dv.spec.source` is at least provided before
checking `dv.spec.source.pvc`:

```
---
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataSource
metadata:
  name: cirros
spec:
  source:
    pvc:
      name: cirros
      namespace: default
---
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  name: cirros-dv
spec:
  storage: {}
  sourceRef:
    kind: DataSource
    name: cirros
    namespace: default
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2502

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

