### PR TITLE
Add cinder to known provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -64,6 +64,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.trident.netapp.io/ontap-san": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
 	// topolvm
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
+	// OpenStack Cinder
+	"cinder.csi.openstack.org": createCinderVolumeCapabilities(),
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
@@ -220,6 +222,13 @@ func createOpenStorageVolumeCapabilities() []StorageCapabilities {
 func createOpenStorageSharedVolumeCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+	}
+}
+
+func createCinderVolumeCapabilities() []StorageCapabilities {
+	return []StorageCapabilities{
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
 		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
 	}
 }


### PR DESCRIPTION
Storage classes using the provisioner 'cinder.csi.openstack.org' appear in kubernetes clusters that have been created on OpenStack infrastructure.  Although some cinder volume types can support multi-attach (ReadWriteMany), we cannot be certain of this.  Therefore, we suggest a claimPropertSet of RWO,Block.

See https://github.com/kubernetes/website/pull/34219 for more context.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

