### PR TITLE
Add `operator_health_impact` label to CDI alerts

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -295,6 +295,7 @@ var _ = Describe("Controller", func() {
 					},
 					Labels: map[string]string{
 						"severity":                      "warning",
+						"operator_health_impact":        "critical",
 						"kubernetes_operator_part_of":   "kubevirt",
 						"kubernetes_operator_component": "containerized-data-importer",
 					},

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -43,16 +43,17 @@ import (
 )
 
 const (
-	ruleName                 = "prometheus-cdi-rules"
-	rbacName                 = "cdi-monitoring"
-	monitorName              = "service-monitor-cdi"
-	defaultMonitoringNs      = "monitoring"
-	runbookURLBasePath       = "https://kubevirt.io/monitoring/runbooks/"
-	severityAlertLabelKey    = "severity"
-	partOfAlertLabelKey      = "kubernetes_operator_part_of"
-	partOfAlertLabelValue    = "kubevirt"
-	componentAlertLabelKey   = "kubernetes_operator_component"
-	componentAlertLabelValue = common.CDILabelValue
+	ruleName                  = "prometheus-cdi-rules"
+	rbacName                  = "cdi-monitoring"
+	monitorName               = "service-monitor-cdi"
+	defaultMonitoringNs       = "monitoring"
+	runbookURLBasePath        = "https://kubevirt.io/monitoring/runbooks/"
+	severityAlertLabelKey     = "severity"
+	healthImpactAlertLabelKey = "operator_health_impact"
+	partOfAlertLabelKey       = "kubernetes_operator_part_of"
+	partOfAlertLabelValue     = "kubevirt"
+	componentAlertLabelKey    = "kubernetes_operator_component"
+	componentAlertLabelValue  = common.CDILabelValue
 )
 
 func ensurePrometheusResourcesExist(c client.Client, scheme *runtime.Scheme, owner metav1.Object) error {
@@ -150,9 +151,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "CDIOperatorDown",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "critical",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -164,9 +166,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "CDINotReady",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "critical",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -178,9 +181,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "CDIDataVolumeUnusualRestartCount",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "warning",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -192,9 +196,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "CDIStorageProfilesIncomplete",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "info",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "info",
+				healthImpactAlertLabelKey: "warning",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -206,9 +211,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "CDIDataImportCronOutdated",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "info",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "info",
+				healthImpactAlertLabelKey: "warning",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 	}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1112,6 +1112,7 @@ var _ = Describe("ALL Operator tests", func() {
 							if rule.Alert != "" {
 								Expect(rule.Labels).ToNot(BeNil())
 								checkForSeverityLabel(rule)
+								checkForHealthImpactLabel(rule)
 								checkForPartOfLabel(rule)
 								checkForComponentLabel(rule)
 							}
@@ -1484,6 +1485,12 @@ func checkForSeverityLabel(rule promv1.Rule) {
 	severity, ok := rule.Labels["severity"]
 	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have severity label", rule.Alert))
 	ExpectWithOffset(1, severity).To(BeElementOf("info", "warning", "critical"), fmt.Sprintf("%s severity label is not valid", rule.Alert))
+}
+
+func checkForHealthImpactLabel(rule promv1.Rule) {
+	operatorHealthImpact, ok := rule.Labels["operator_health_impact"]
+	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have operator_health_impact label", rule.Alert))
+	ExpectWithOffset(1, operatorHealthImpact).To(BeElementOf("none", "warning", "critical"), fmt.Sprintf("%s operator_health_impact label is not valid", rule.Alert))
 }
 
 func checkForPartOfLabel(rule promv1.Rule) {


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds to each of CDI alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires due to an issue that impacts the operator's functionality badly, and an action must be taken immediately in order to solve it.
-  `warning` indicates that the alert fires due to an issue that soon might impact the operator's functionality badly, and the user should be warned in order to solve the issue.
- `none` indicates that the alert fires due to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/CNV-18923

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

