### PR TITLE
Align DV controllers with kubevirt sync/updateStatus model

### DIFF
--- a/pkg/controller/datavolume/clone-controller.go
+++ b/pkg/controller/datavolume/clone-controller.go
@@ -365,6 +365,17 @@ func (r CloneReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pvc *co
 }
 
 func (r CloneReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeCloneSyncResult, error) {
+	syncRes, syncErr := r.syncClone(log, req)
+	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
+		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
+			r.log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
+			syncErr = err
+		}
+	}
+	return syncRes, syncErr
+}
+
+func (r CloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (dataVolumeCloneSyncResult, error) {
 	var syncRes dataVolumeCloneSyncResult
 
 	cleanup := func() error {

--- a/pkg/controller/datavolume/clone-controller.go
+++ b/pkg/controller/datavolume/clone-controller.go
@@ -366,11 +366,8 @@ func (r CloneReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pvc *co
 
 func (r CloneReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeCloneSyncResult, error) {
 	syncRes, syncErr := r.syncClone(log, req)
-	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
-		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
-			r.log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
-			syncErr = err
-		}
+	if err := r.syncUpdateMeta(log, syncRes.dataVolumeSyncResult); err != nil {
+		syncErr = err
 	}
 	return syncRes, syncErr
 }

--- a/pkg/controller/datavolume/clone-controller.go
+++ b/pkg/controller/datavolume/clone-controller.go
@@ -154,6 +154,27 @@ const (
 	CsiClone
 )
 
+type statusPhaseSync struct {
+	phase cdiv1.DataVolumePhase
+	pvc   *corev1.PersistentVolumeClaim
+	event Event
+}
+
+type finalizerOp int
+
+const (
+	nop finalizerOp = iota
+	addFinalizer
+	removeFinalizer
+)
+
+type dataVolumeCloneSyncResult struct {
+	dataVolumeSyncResult
+	phaseSync *statusPhaseSync
+	strategy  cloneStrategy
+	finOp     finalizerOp
+}
+
 // ErrInvalidTermMsg reports that the termination message from the size-detection pod doesn't exists or is not a valid quantity
 var ErrInvalidTermMsg = fmt.Errorf("The termination message from the size-detection pod is not-valid")
 
@@ -277,7 +298,6 @@ func addCloneWithoutSourceWatch(mgr manager.Manager, datavolumeController contro
 	}
 
 	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &cdiv1.DataVolume{}, sourcePvcField, func(obj client.Object) []string {
-		//FIXME: what about sourceRef?
 		if source := obj.(*cdiv1.DataVolume).Spec.Source; source != nil {
 			if pvc := source.PVC; pvc != nil {
 				ns := cc.GetNamespace(pvc.Namespace, obj.GetNamespace())
@@ -319,26 +339,25 @@ func addCloneWithoutSourceWatch(mgr manager.Manager, datavolumeController contro
 }
 
 // Reconcile loop for the clone data volumes
-// Unlike the base class sync call, for clone we pass cleanup and prepare
 func (r CloneReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := r.log.WithValues("DataVolume", req.NamespacedName)
-	res, syncErr := r.sync(log, req, r.cleanup, r.prepare)
-	return r.updateStatus(log, res, syncErr)
+	return r.updateStatus(r.sync(log, req))
 }
 
-func (r CloneReconciler) prepare(dv *cdiv1.DataVolume) error {
+func (r CloneReconciler) prepare(syncRes *dataVolumeCloneSyncResult) error {
+	dv := syncRes.dv
 	if err := r.populateSourceIfSourceRef(dv); err != nil {
 		return err
 	}
 	if isCrossNamespaceClone(dv) && dv.Status.Phase == cdiv1.Succeeded {
-		if err := r.cleanup(dv); err != nil {
+		if err := r.cleanup(syncRes); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r CloneReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, annotations map[string]string) error {
+func (r CloneReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error {
 	if dataVolume.Spec.Source.PVC == nil {
 		return errors.Errorf("no source set for clone datavolume")
 	}
@@ -350,52 +369,49 @@ func (r CloneReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, annotat
 	if !ok {
 		return errors.Errorf("no clone token")
 	}
-	annotations[cc.AnnCloneToken] = token
-	annotations[cc.AnnCloneRequest] = sourceNamespace + "/" + dataVolume.Spec.Source.PVC.Name
+	pvc.Annotations[cc.AnnCloneToken] = token
+	pvc.Annotations[cc.AnnCloneRequest] = sourceNamespace + "/" + dataVolume.Spec.Source.PVC.Name
 	return nil
 }
 
-func (r CloneReconciler) updateStatus(log logr.Logger, syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
-	if syncErr != nil {
-		return reconcile.Result{}, syncErr
-	}
-	if syncRes.res != nil {
-		return *syncRes.res, nil
-	}
-	//FIXME: pass syncRes instead of args
-	return r.reconcileClone(log, syncRes.dv, syncRes.pvc, syncRes.pvcSpec, getTransferName(syncRes.dv))
-}
+func (r CloneReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeCloneSyncResult, error) {
+	var syncRes dataVolumeCloneSyncResult
 
-func getTransferName(dv *cdiv1.DataVolume) string {
-	return fmt.Sprintf("cdi-tmp-%s", dv.UID)
-}
+	cleanup := func() error {
+		return r.cleanup(&syncRes)
+	}
+	prepare := func() error {
+		return r.prepare(&syncRes)
+	}
+	syncErr := r.syncCommon(log, req, &(syncRes.dataVolumeSyncResult), cleanup, prepare)
+	if syncErr != nil || syncRes.result != nil {
+		return syncRes, syncErr
+	}
 
-func (r *CloneReconciler) reconcileClone(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	transferName string) (reconcile.Result, error) {
+	pvc := syncRes.pvc
+	pvcSpec := syncRes.pvcSpec
+	datavolume := syncRes.dv
+	transferName := getTransferName(syncRes.dv)
 
 	// Get the most appropiate clone strategy
 	selectedCloneStrategy, err := r.selectCloneStrategy(datavolume, pvcSpec)
 	if err != nil {
-		return reconcile.Result{}, err
+		return syncRes, err
 	}
-
-	setCloneType := cloneTypeModifier(selectedCloneStrategy)
+	syncRes.strategy = selectedCloneStrategy
 
 	pvcPopulated := pvcIsPopulated(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
 
 	if pvcPopulated || prePopulated {
-		return r.reconcileDataVolumeStatus(datavolume, pvc, setCloneType, r.updateStatusPhase)
+		return syncRes, nil
 	}
 
 	// Check if source PVC exists and do proper validation before attempting to clone
-	if done, err := r.validateCloneAndSourcePVC(datavolume); err != nil {
-		return reconcile.Result{}, err
+	if done, err := r.validateCloneAndSourcePVC(&syncRes); err != nil {
+		return syncRes, err
 	} else if !done {
-		return reconcile.Result{}, nil
+		return syncRes, nil
 	}
 
 	if selectedCloneStrategy == SmartClone {
@@ -405,18 +421,19 @@ func (r *CloneReconciler) reconcileClone(log logr.Logger,
 	// If the target's size is not specified, we can extract that value from the source PVC
 	targetRequest, hasTargetRequest := pvcSpec.Resources.Requests[corev1.ResourceStorage]
 	if !hasTargetRequest || targetRequest.IsZero() {
-		done, err := r.detectCloneSize(datavolume, pvc, pvcSpec, selectedCloneStrategy)
+		done, err := r.detectCloneSize(syncRes)
 		if err != nil {
-			return reconcile.Result{}, err
+			return syncRes, err
 		} else if !done {
 			// Check if the source PVC is ready to be cloned
 			if readyToClone, err := r.isSourceReadyToClone(datavolume, selectedCloneStrategy); err != nil {
-				return reconcile.Result{}, err
+				return syncRes, err
 			} else if !readyToClone {
-				return reconcile.Result{Requeue: true},
-					r.updateCloneStatusPhase(cdiv1.CloneScheduled, datavolume, nil, selectedCloneStrategy)
+				syncRes.result.Requeue = true
+				return syncRes,
+					r.syncCloneStatusPhase(&syncRes, cdiv1.CloneScheduled, nil)
 			}
-			return reconcile.Result{}, nil
+			return syncRes, nil
 		}
 	}
 
@@ -424,27 +441,29 @@ func (r *CloneReconciler) reconcileClone(log logr.Logger,
 		if selectedCloneStrategy == SmartClone {
 			snapshotClassName, err := r.getSnapshotClassForSmartClone(datavolume, pvcSpec)
 			if err != nil {
-				return reconcile.Result{}, err
+				return syncRes, err
 			}
-			return r.reconcileSmartClonePvc(log, datavolume, pvcSpec, transferName, snapshotClassName)
+			res, err := r.reconcileSmartClonePvc(log, &syncRes, transferName, snapshotClassName)
+			syncRes.result = &res
+			return syncRes, err
 		}
 		if selectedCloneStrategy == CsiClone {
 			csiDriverAvailable, err := r.storageClassCSIDriverExists(pvcSpec.StorageClassName)
 			if err != nil && !k8serrors.IsNotFound(err) {
-				return reconcile.Result{}, err
+				return syncRes, err
 			}
 			if !csiDriverAvailable {
 				// err csi clone not possible
 				storageClass, err := cc.GetStorageClassByName(r.client, pvcSpec.StorageClassName)
 				if err != nil {
-					return reconcile.Result{}, err
+					return syncRes, err
 				}
 				noCsiDriverMsg := "CSI Clone configured, failed to look for CSIDriver - target storage class could not be found"
 				if storageClass != nil {
 					noCsiDriverMsg = fmt.Sprintf("CSI Clone configured, but no CSIDriver available for %s", storageClass.Name)
 				}
-				return reconcile.Result{},
-					r.updateDataVolumeStatusPhaseWithEvent(cdiv1.CloneScheduled, datavolume, pvc, setCloneType,
+				return syncRes,
+					r.syncDataVolumeStatusPhaseWithEvent(&syncRes, cdiv1.CloneScheduled, pvc,
 						Event{
 							eventType: corev1.EventTypeWarning,
 							reason:    ErrUnableToClone,
@@ -452,48 +471,50 @@ func (r *CloneReconciler) reconcileClone(log logr.Logger,
 						})
 			}
 
-			return r.reconcileCsiClonePvc(log, datavolume, pvcSpec, transferName)
+			res, err := r.reconcileCsiClonePvc(log, &syncRes, transferName)
+			syncRes.result = &res
+			return syncRes, err
 		}
 
-		newPvc, err := r.createPvcForDatavolume(datavolume, pvcSpec, nil)
+		newPvc, err := r.createPvcForDatavolume(datavolume, pvcSpec, r.updateAnnotations)
 		if err != nil {
 			if cc.ErrQuotaExceeded(err) {
-				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, datavolume, nil, setCloneType,
+				r.syncDataVolumeStatusPhaseWithEvent(&syncRes, cdiv1.Pending, nil,
 					Event{
 						eventType: corev1.EventTypeWarning,
 						reason:    cc.ErrExceededQuota,
 						message:   err.Error(),
 					})
 			}
-			return reconcile.Result{}, err
+			return syncRes, err
 		}
 		pvc = newPvc
 	}
 
 	shouldBeMarkedWaitForFirstConsumer, err := r.shouldBeMarkedWaitForFirstConsumer(pvc)
 	if err != nil {
-		return reconcile.Result{}, err
+		return syncRes, err
 	}
 
 	switch selectedCloneStrategy {
 	case HostAssistedClone:
 		if err := r.ensureExtendedToken(pvc); err != nil {
-			return reconcile.Result{}, err
+			return syncRes, err
 		}
 	case CsiClone:
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:
 			if err := r.setCloneOfOnPvc(pvc); err != nil {
-				return reconcile.Result{}, err
+				return syncRes, err
 			}
 		case corev1.ClaimPending:
 			r.log.V(3).Info("ClaimPending CSIClone")
 			if !shouldBeMarkedWaitForFirstConsumer {
-				return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CSICloneInProgress, datavolume, pvc, selectedCloneStrategy)
+				return syncRes, r.syncCloneStatusPhase(&syncRes, cdiv1.CSICloneInProgress, pvc)
 			}
 		case corev1.ClaimLost:
-			return reconcile.Result{},
-				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Failed, datavolume, pvc, setCloneType,
+			return syncRes,
+				r.syncDataVolumeStatusPhaseWithEvent(&syncRes, cdiv1.Failed, pvc,
 					Event{
 						eventType: corev1.EventTypeWarning,
 						reason:    ErrClaimLost,
@@ -503,11 +524,32 @@ func (r *CloneReconciler) reconcileClone(log logr.Logger,
 		fallthrough
 	case SmartClone:
 		if !shouldBeMarkedWaitForFirstConsumer {
-			return r.finishClone(log, datavolume, pvc, pvcSpec, transferName, selectedCloneStrategy)
+			res, err := r.finishClone(log, &syncRes, transferName)
+			syncRes.result = &res
+			return syncRes, err
+
 		}
 	}
 
-	return r.reconcileDataVolumeStatus(datavolume, pvc, setCloneType, r.updateStatusPhase)
+	return syncRes, syncErr
+}
+
+func (r CloneReconciler) updateStatus(syncRes dataVolumeCloneSyncResult, syncErr error) (reconcile.Result, error) {
+	modifier := getModifier(syncRes)
+	ps := syncRes.phaseSync
+	if ps != nil {
+		syncErr = r.updateDataVolumeStatusPhaseWithEvent(ps.phase, syncRes.dv, ps.pvc, modifier, ps.event)
+	}
+	if syncErr != nil {
+		return reconcile.Result{}, syncErr
+	}
+	if syncRes.result != nil {
+		return *syncRes.result, nil
+	}
+	if ps != nil {
+		return reconcile.Result{}, nil
+	}
+	return r.updateStatusCommon(syncRes.dataVolumeSyncResult, modifier, r.updateStatusPhase)
 }
 
 func (r CloneReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
@@ -628,17 +670,18 @@ func (r *CloneReconciler) selectCloneStrategy(datavolume *cdiv1.DataVolume, pvcS
 }
 
 func (r *CloneReconciler) reconcileCsiClonePvc(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
+	syncRes *dataVolumeCloneSyncResult,
 	transferName string) (reconcile.Result, error) {
 
 	log = log.WithName("reconcileCsiClonePvc")
+	datavolume := syncRes.dv
+	pvcSpec := syncRes.pvcSpec
 	pvcName := datavolume.Name
 
 	if isCrossNamespaceClone(datavolume) {
 		pvcName = transferName
 
-		result, err := r.doCrossNamespaceClone(log, datavolume, pvcSpec, pvcName, false, CsiClone)
+		result, err := r.doCrossNamespaceClone(log, syncRes, pvcName, false, CsiClone)
 		if result != nil {
 			return *result, err
 		}
@@ -669,7 +712,7 @@ func (r *CloneReconciler) reconcileCsiClonePvc(log logr.Logger,
 		return reconcile.Result{}, err
 	} else if !readyToClone {
 		return reconcile.Result{Requeue: true},
-			r.updateCloneStatusPhase(cdiv1.CloneScheduled, datavolume, nil, CsiClone)
+			r.syncCloneStatusPhase(syncRes, cdiv1.CloneScheduled, nil)
 	}
 
 	log.Info("Creating PVC for datavolume")
@@ -684,7 +727,7 @@ func (r *CloneReconciler) reconcileCsiClonePvc(log logr.Logger,
 		}
 		if err := r.client.Create(context.TODO(), cloneTargetPvc); err != nil && !k8serrors.IsAlreadyExists(err) {
 			if cc.ErrQuotaExceeded(err) {
-				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, datavolume, nil, cloneTypeModifier(CsiClone),
+				r.syncDataVolumeStatusPhaseWithEvent(syncRes, cdiv1.Pending, nil,
 					Event{
 						eventType: corev1.EventTypeWarning,
 						reason:    cc.ErrExceededQuota,
@@ -711,25 +754,19 @@ func (r *CloneReconciler) reconcileCsiClonePvc(log logr.Logger,
 		}
 	}
 
-	return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CSICloneInProgress, datavolume, nil, CsiClone)
+	return reconcile.Result{}, r.syncCloneStatusPhase(syncRes, cdiv1.CSICloneInProgress, nil)
 }
 
 // When the clone is finished some additional actions may be applied
 // like namespaceTransfer Cleanup or size expansion
-func (r *CloneReconciler) finishClone(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	transferName string,
-	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
-
+func (r *CloneReconciler) finishClone(log logr.Logger, syncRes *dataVolumeCloneSyncResult, transferName string) (reconcile.Result, error) {
 	//DO Nothing, not yet ready
-	if pvc.Annotations[cc.AnnCloneOf] != "true" {
+	if syncRes.pvc.Annotations[cc.AnnCloneOf] != "true" {
 		return reconcile.Result{}, nil
 	}
 
 	// expand for non-namespace case
-	return r.expandPvcAfterClone(log, datavolume, pvc, pvcSpec, selectedCloneStrategy)
+	return r.expandPvcAfterClone(log, syncRes, cdiv1.Succeeded, false)
 }
 
 func (r *CloneReconciler) setCloneOfOnPvc(pvc *corev1.PersistentVolumeClaim) error {
@@ -745,43 +782,24 @@ func (r *CloneReconciler) setCloneOfOnPvc(pvc *corev1.PersistentVolumeClaim) err
 	return nil
 }
 
-func (r *CloneReconciler) expandPvcAfterClone(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
-
-	return r.expandPvcAfterCloneFunc(log, datavolume, pvc, pvcSpec, false, selectedCloneStrategy, cdiv1.Succeeded)
-}
-
 // temporary pvc is used when the clone src and tgt are in two distinct namespaces
-func (r *CloneReconciler) expandTmpPvcAfterClone(
+func (r *CloneReconciler) expandPvcAfterClone(
 	log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	tmpPVC *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	selectedCloneStrategy cloneStrategy) (reconcile.Result, error) {
+	syncRes *dataVolumeCloneSyncResult,
+	nextPhase cdiv1.DataVolumePhase,
+	isTemp bool) (reconcile.Result, error) {
 
-	return r.expandPvcAfterCloneFunc(log, datavolume, tmpPVC, pvcSpec, true, selectedCloneStrategy, cdiv1.NamespaceTransferInProgress)
-}
+	datavolume := syncRes.dv
+	pvc := syncRes.pvc
 
-func (r *CloneReconciler) expandPvcAfterCloneFunc(
-	log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	isTemp bool,
-	selectedCloneStrategy cloneStrategy,
-	nextPhase cdiv1.DataVolumePhase) (reconcile.Result, error) {
-
-	done, err := r.expand(log, datavolume, pvc, pvcSpec)
+	done, err := r.expand(log, syncRes)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if !done {
 		return reconcile.Result{Requeue: true},
-			r.updateCloneStatusPhase(cdiv1.ExpansionInProgress, datavolume, pvc, selectedCloneStrategy)
+			r.syncCloneStatusPhase(syncRes, cdiv1.ExpansionInProgress, pvc)
 	}
 
 	if isTemp {
@@ -793,13 +811,18 @@ func (r *CloneReconciler) expandPvcAfterCloneFunc(
 		}
 	}
 
-	return reconcile.Result{}, r.updateCloneStatusPhase(nextPhase, datavolume, pvc, selectedCloneStrategy)
+	return reconcile.Result{}, r.syncCloneStatusPhase(syncRes, nextPhase, pvc)
 }
 
-func cloneTypeModifier(selectedCloneStrategy cloneStrategy) modifyFunc {
-	return func(datavolume *cdiv1.DataVolume) {
-		if selectedCloneStrategy != NoClone {
-			cc.AddAnnotation(datavolume, annCloneType, cloneStrategyToCloneType(selectedCloneStrategy))
+func getModifier(syncRes dataVolumeCloneSyncResult) modifyFunc {
+	return func(dv *cdiv1.DataVolume) {
+		if syncRes.strategy != NoClone {
+			cc.AddAnnotation(dv, annCloneType, cloneStrategyToCloneType(syncRes.strategy))
+		}
+		if syncRes.finOp == addFinalizer {
+			cc.AddFinalizer(dv, crossNamespaceFinalizer)
+		} else if syncRes.finOp == removeFinalizer {
+			cc.RemoveFinalizer(dv, crossNamespaceFinalizer)
 		}
 	}
 }
@@ -817,16 +840,16 @@ func cloneStrategyToCloneType(selectedCloneStrategy cloneStrategy) string {
 }
 
 func (r *CloneReconciler) reconcileSmartClonePvc(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
+	syncRes *dataVolumeCloneSyncResult,
 	transferName string,
 	snapshotClassName string) (reconcile.Result, error) {
 
+	datavolume := syncRes.dv
 	pvcName := datavolume.Name
 
 	if isCrossNamespaceClone(datavolume) {
 		pvcName = transferName
-		result, err := r.doCrossNamespaceClone(log, datavolume, pvcSpec, pvcName, true, SmartClone)
+		result, err := r.doCrossNamespaceClone(log, syncRes, pvcName, true, SmartClone)
 		if result != nil {
 			return *result, err
 		}
@@ -857,7 +880,7 @@ func (r *CloneReconciler) reconcileSmartClonePvc(log logr.Logger,
 			return reconcile.Result{}, err
 		} else if !readyToClone {
 			return reconcile.Result{Requeue: true},
-				r.updateCloneStatusPhase(cdiv1.CloneScheduled, datavolume, nil, SmartClone)
+				r.syncCloneStatusPhase(syncRes, cdiv1.CloneScheduled, nil)
 		}
 
 		targetPvc := &corev1.PersistentVolumeClaim{}
@@ -876,7 +899,7 @@ func (r *CloneReconciler) reconcileSmartClonePvc(log logr.Logger,
 		}
 	}
 
-	return reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.SnapshotForSmartCloneInProgress, datavolume, nil, SmartClone)
+	return reconcile.Result{}, r.syncCloneStatusPhase(syncRes, cdiv1.SnapshotForSmartCloneInProgress, nil)
 }
 
 func newSnapshot(dataVolume *cdiv1.DataVolume, snapshotName, snapshotClassName string) *snapshotv1.VolumeSnapshot {
@@ -918,20 +941,20 @@ func newSnapshot(dataVolume *cdiv1.DataVolume, snapshotName, snapshotClassName s
 }
 
 func (r *CloneReconciler) doCrossNamespaceClone(log logr.Logger,
-	datavolume *cdiv1.DataVolume,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
+	syncRes *dataVolumeCloneSyncResult,
 	pvcName string,
 	returnWhenCloneInProgress bool,
 	selectedCloneStrategy cloneStrategy) (*reconcile.Result, error) {
 
-	initialized, err := r.initTransfer(log, datavolume, pvcName)
+	datavolume := syncRes.dv
+	initialized, err := r.initTransfer(log, syncRes, pvcName)
 	if err != nil {
 		return &reconcile.Result{}, err
 	}
 
 	// get reconciled again v soon
 	if !initialized {
-		return &reconcile.Result{}, r.updateCloneStatusPhase(cdiv1.CloneScheduled, datavolume, nil, selectedCloneStrategy)
+		return &reconcile.Result{}, r.syncCloneStatusPhase(syncRes, cdiv1.CloneScheduled, nil)
 	}
 
 	tmpPVC := &corev1.PersistentVolumeClaim{}
@@ -941,7 +964,7 @@ func (r *CloneReconciler) doCrossNamespaceClone(log logr.Logger,
 			return &reconcile.Result{}, err
 		}
 	} else if tmpPVC.Annotations[cc.AnnCloneOf] == "true" {
-		result, err := r.expandTmpPvcAfterClone(log, datavolume, tmpPVC, pvcSpec, selectedCloneStrategy)
+		result, err := r.expandPvcAfterClone(log, syncRes, cdiv1.NamespaceTransferInProgress, true)
 		return &result, err
 	} else {
 		// AnnCloneOf != true, so cloneInProgress
@@ -978,17 +1001,14 @@ func (r *CloneReconciler) sourceInUse(dv *cdiv1.DataVolume, eventReason string) 
 	return len(pods) > 0, nil
 }
 
-func (r *CloneReconciler) initTransfer(log logr.Logger, dv *cdiv1.DataVolume, name string) (bool, error) {
+func (r *CloneReconciler) initTransfer(log logr.Logger, syncRes *dataVolumeCloneSyncResult, name string) (bool, error) {
 	initialized := true
+	dv := syncRes.dv
 
 	log.Info("Initializing transfer")
 
 	if !cc.HasFinalizer(dv, crossNamespaceFinalizer) {
-		cc.AddFinalizer(dv, crossNamespaceFinalizer)
-		if err := r.updateDataVolume(dv); err != nil {
-			return false, err
-		}
-
+		syncRes.finOp = addFinalizer
 		initialized = false
 	}
 
@@ -1041,7 +1061,8 @@ func (r *CloneReconciler) initTransfer(log logr.Logger, dv *cdiv1.DataVolume, na
 	return initialized, nil
 }
 
-func (r CloneReconciler) cleanup(dv *cdiv1.DataVolume) error {
+func (r CloneReconciler) cleanup(syncRes *dataVolumeCloneSyncResult) error {
+	dv := syncRes.dv
 	transferName := getTransferName(dv)
 	if !cc.HasFinalizer(dv, crossNamespaceFinalizer) {
 		return nil
@@ -1107,11 +1128,7 @@ func (r CloneReconciler) cleanup(dv *cdiv1.DataVolume) error {
 		return fmt.Errorf("waiting for ObjectTransfer %s to delete", transferName)
 	}
 
-	cc.RemoveFinalizer(dv, crossNamespaceFinalizer)
-	if err := r.updateDataVolume(dv); err != nil {
-		return err
-	}
-
+	syncRes.finOp = removeFinalizer
 	return nil
 }
 
@@ -1119,15 +1136,13 @@ func expansionPodName(pvc *corev1.PersistentVolumeClaim) string {
 	return "cdi-expand-" + string(pvc.UID)
 }
 
-func (r *CloneReconciler) expand(log logr.Logger,
-	dv *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	targetSpec *corev1.PersistentVolumeClaimSpec) (bool, error) {
+func (r *CloneReconciler) expand(log logr.Logger, syncRes *dataVolumeCloneSyncResult) (bool, error) {
+	pvc := syncRes.pvc
 	if pvc.Status.Phase != corev1.ClaimBound {
 		return false, fmt.Errorf("cannot expand volume in %q phase", pvc.Status.Phase)
 	}
 
-	requestedSize, hasRequested := targetSpec.Resources.Requests[corev1.ResourceStorage]
+	requestedSize, hasRequested := syncRes.pvcSpec.Resources.Requests[corev1.ResourceStorage]
 	currentSize, hasCurrent := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 	actualSize, hasActual := pvc.Status.Capacity[corev1.ResourceStorage]
 	if !hasRequested || !hasCurrent || !hasActual {
@@ -1180,7 +1195,7 @@ func (r *CloneReconciler) expand(log logr.Logger,
 
 	if !podExists {
 		var err error
-		pod, err = r.createExpansionPod(pvc, dv, podName)
+		pod, err = r.createExpansionPod(pvc, syncRes.dv, podName)
 		// Check if pod has failed and, in that case, record an event with the error
 		if podErr := cc.HandleFailedPod(err, podName, pvc, r.recorder, r.client); podErr != nil {
 			return false, podErr
@@ -1410,7 +1425,7 @@ func (r *CloneReconciler) advancedClonePossible(dataVolume *cdiv1.DataVolume, ta
 		return false, err
 	}
 
-	return r.validateAdvancedCloneSizeCompatible(dataVolume, sourcePvc, targetStorageSpec)
+	return r.validateAdvancedCloneSizeCompatible(sourcePvc, targetStorageSpec)
 }
 
 func (r *CloneReconciler) validateSameStorageClass(
@@ -1470,7 +1485,6 @@ func getStorageVolumeMode(c client.Client, dataVolume *cdiv1.DataVolume, storage
 }
 
 func (r *CloneReconciler) validateAdvancedCloneSizeCompatible(
-	dataVolume *cdiv1.DataVolume,
 	sourcePvc *corev1.PersistentVolumeClaim,
 	targetStorageSpec *corev1.PersistentVolumeClaimSpec) (bool, error) {
 	srcStorageClass := &storagev1.StorageClass{}
@@ -1584,7 +1598,7 @@ func (r *CloneReconciler) newVolumeClonePVC(dv *cdiv1.DataVolume,
 		pvcNamespace = dv.Spec.Source.PVC.Namespace
 	}
 
-	pvc, err := r.newPersistentVolumeClaim(dv, targetPvcSpec, pvcNamespace, pvcName)
+	pvc, err := r.newPersistentVolumeClaim(dv, targetPvcSpec, pvcNamespace, pvcName, r.updateAnnotations)
 	if err != nil {
 		return nil, err
 	}
@@ -1608,12 +1622,9 @@ func (r *CloneReconciler) newVolumeClonePVC(dv *cdiv1.DataVolume,
 	return pvc, nil
 }
 
-func (r *CloneReconciler) updateCloneStatusPhase(phase cdiv1.DataVolumePhase,
-	dataVolume *cdiv1.DataVolume,
-	pvc *corev1.PersistentVolumeClaim,
-	selectedCloneStrategy cloneStrategy) error {
-
+func (r *CloneReconciler) syncCloneStatusPhase(syncRes *dataVolumeCloneSyncResult, phase cdiv1.DataVolumePhase, pvc *corev1.PersistentVolumeClaim) error {
 	var event Event
+	dataVolume := syncRes.dv
 
 	switch phase {
 	case cdiv1.CloneScheduled:
@@ -1642,10 +1653,11 @@ func (r *CloneReconciler) updateCloneStatusPhase(phase cdiv1.DataVolumePhase,
 		event.message = fmt.Sprintf(MessageCloneSucceeded, dataVolume.Spec.Source.PVC.Namespace, dataVolume.Spec.Source.PVC.Name, dataVolume.Namespace, dataVolume.Name)
 	}
 
-	return r.updateDataVolumeStatusPhaseWithEvent(phase, dataVolume, pvc, cloneTypeModifier(selectedCloneStrategy), event)
+	return r.syncDataVolumeStatusPhaseWithEvent(syncRes, phase, pvc, event)
 }
 
-// If sourceRef is set, populate spec.Source with data from the DataSource
+// If SourceRef is set, populate spec.Source with data from the DataSource
+// Note that when the controller actually updates the DV (updateDataVolume), we nil out spec.Source when SourceRef is set
 func (r *CloneReconciler) populateSourceIfSourceRef(dv *cdiv1.DataVolume) error {
 	if dv.Spec.SourceRef == nil {
 		return nil
@@ -1683,12 +1695,13 @@ func (r *CloneReconciler) getPreferredCloneStrategyForStorageClass(storageClass 
 }
 
 // validateCloneAndSourcePVC checks if the source PVC of a clone exists and does proper validation
-func (r *CloneReconciler) validateCloneAndSourcePVC(datavolume *cdiv1.DataVolume) (bool, error) {
+func (r *CloneReconciler) validateCloneAndSourcePVC(syncRes *dataVolumeCloneSyncResult) (bool, error) {
+	datavolume := syncRes.dv
 	sourcePvc, err := r.findSourcePvc(datavolume)
 	if err != nil {
 		// Clone without source
 		if k8serrors.IsNotFound(err) {
-			r.updateDataVolumeStatusPhaseWithEvent(datavolume.Status.Phase, datavolume, nil, cloneTypeModifier(NoClone),
+			r.syncDataVolumeStatusPhaseWithEvent(syncRes, datavolume.Status.Phase, nil,
 				Event{
 					eventType: corev1.EventTypeWarning,
 					reason:    CloneWithoutSource,
@@ -1706,6 +1719,18 @@ func (r *CloneReconciler) validateCloneAndSourcePVC(datavolume *cdiv1.DataVolume
 	}
 
 	return true, nil
+}
+
+func (r *CloneReconciler) syncDataVolumeStatusPhaseWithEvent(
+	syncRes *dataVolumeCloneSyncResult,
+	phase cdiv1.DataVolumePhase,
+	pvc *corev1.PersistentVolumeClaim,
+	event Event) error {
+	if syncRes.phaseSync != nil {
+		return fmt.Errorf("phaseSync is already set")
+	}
+	syncRes.phaseSync = &statusPhaseSync{phase: phase, pvc: pvc, event: event}
+	return nil
 }
 
 // isSourceReadyToClone handles the reconciling process of a clone when the source PVC is not ready
@@ -1742,14 +1767,9 @@ func (r *CloneReconciler) isSourceReadyToClone(
 }
 
 // detectCloneSize obtains and assigns the original PVC's size when cloning using an empty storage value
-func (r *CloneReconciler) detectCloneSize(
-	dv *cdiv1.DataVolume,
-	targetPvc *corev1.PersistentVolumeClaim,
-	pvcSpec *corev1.PersistentVolumeClaimSpec,
-	cloneType cloneStrategy) (bool, error) {
-
+func (r *CloneReconciler) detectCloneSize(syncRes dataVolumeCloneSyncResult) (bool, error) {
 	var targetSize int64
-	sourcePvc, err := r.findSourcePvc(dv)
+	sourcePvc, err := r.findSourcePvc(syncRes.dv)
 	if err != nil {
 		return false, err
 	}
@@ -1760,14 +1780,14 @@ func (r *CloneReconciler) detectCloneSize(
 	// collects the size of the original virtual image with 'qemu-img'.
 	// If another strategy is used or the original PVC's volume mode
 	// is "block", we simply extract the value from the original PVC's spec.
-	if cloneType == HostAssistedClone &&
+	if syncRes.strategy == HostAssistedClone &&
 		cc.GetVolumeMode(sourcePvc) == corev1.PersistentVolumeFilesystem &&
 		cc.GetContentType(sourcePvc) == string(cdiv1.DataVolumeKubeVirt) {
 		var available bool
 		// If available, we first try to get the virtual size from previous iterations
 		targetSize, available = getSizeFromAnnotations(sourcePvc)
 		if !available {
-			targetSize, err = r.getSizeFromPod(targetPvc, sourcePvc, dv)
+			targetSize, err = r.getSizeFromPod(syncRes.pvc, sourcePvc, syncRes.dv)
 			if err != nil {
 				return false, err
 			} else if targetSize == 0 {
@@ -1783,16 +1803,16 @@ func (r *CloneReconciler) detectCloneSize(
 	// if the source's size ends up being larger due to overhead differences
 	// TODO: Fix this in next PR that uses actual size also in validation
 	if sourceCapacity.CmpInt64(targetSize) == 1 {
-		dv.Annotations[cc.AnnPermissiveClone] = "true"
+		syncRes.dv.Annotations[cc.AnnPermissiveClone] = "true"
 	}
 
 	// Parse size into a 'Quantity' struct and, if needed, inflate it with filesystem overhead
-	targetCapacity, err := inflateSizeWithOverhead(r.client, targetSize, pvcSpec)
+	targetCapacity, err := inflateSizeWithOverhead(r.client, targetSize, syncRes.pvcSpec)
 	if err != nil {
 		return false, err
 	}
 
-	pvcSpec.Resources.Requests[corev1.ResourceStorage] = targetCapacity
+	syncRes.pvcSpec.Resources.Requests[corev1.ResourceStorage] = targetCapacity
 	return true, nil
 }
 
@@ -2052,4 +2072,8 @@ func isCrossNamespaceClone(dv *cdiv1.DataVolume) bool {
 // isPodComplete returns true if a pod is in 'Succeeded' phase, false if not
 func isPodComplete(pod *v1.Pod) bool {
 	return pod != nil && pod.Status.Phase == v1.PodSucceeded
+}
+
+func getTransferName(dv *cdiv1.DataVolume) string {
+	return fmt.Sprintf("cdi-tmp-%s", dv.UID)
 }

--- a/pkg/controller/datavolume/clone-controller_test.go
+++ b/pkg/controller/datavolume/clone-controller_test.go
@@ -607,6 +607,8 @@ var _ = Describe("All DataVolume Tests", func() {
 
 			syncRes := dataVolumeCloneSyncResult{dataVolumeSyncResult: dataVolumeSyncResult{dv: dv, dvCopy: dv.DeepCopy(), pvc: pvc, pvcSpec: dv.Spec.PVC.DeepCopy()}}
 			reconciler.annotate(syncRes.dvCopy, syncRes.pvc)
+			objMeta := syncRes.dvCopy.ObjectMeta.DeepCopy()
+			syncRes.dv.ObjectMeta = *objMeta
 			result, err := reconciler.updateStatus(syncRes, nil)
 			Expect(err).ToNot(HaveOccurred())
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)

--- a/pkg/controller/datavolume/clone-controller_test.go
+++ b/pkg/controller/datavolume/clone-controller_test.go
@@ -606,6 +606,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			reconciler = createCloneReconciler(dv, pvc, storageProfile, sc)
 
 			syncRes := dataVolumeCloneSyncResult{dataVolumeSyncResult: dataVolumeSyncResult{dv: dv, dvCopy: dv.DeepCopy(), pvc: pvc, pvcSpec: dv.Spec.PVC.DeepCopy()}}
+			reconciler.annotate(syncRes.dvCopy, syncRes.pvc)
 			result, err := reconciler.updateStatus(syncRes, nil)
 			Expect(err).ToNot(HaveOccurred())
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)

--- a/pkg/controller/datavolume/controller.go
+++ b/pkg/controller/datavolume/controller.go
@@ -292,6 +292,9 @@ func (r ReconcilerBase) syncUpdateMeta(log logr.Logger, syncRes dataVolumeSyncRe
 			r.log.Error(err, "Unable to sync update dv meta", "name", syncRes.dvCopy.Name)
 			return err
 		}
+		// Needed for emitEvent() DeepEqual check
+		objMeta := syncRes.dvCopy.ObjectMeta.DeepCopy()
+		syncRes.dv.ObjectMeta = *objMeta
 	}
 	return nil
 }
@@ -579,7 +582,7 @@ func (r *ReconcilerBase) emitFailureConditionEvent(dataVolume *cdiv1.DataVolume,
 }
 
 func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, event *Event) error {
-	if !reflect.DeepEqual(dataVolume.ObjectMeta, dataVolume.ObjectMeta) {
+	if !reflect.DeepEqual(dataVolume.ObjectMeta, dataVolumeCopy.ObjectMeta) {
 		return fmt.Errorf("meta update is not allowed in updateStatus phase")
 	}
 	// Only update the object if something actually changed in the status.

--- a/pkg/controller/datavolume/garbagecollect.go
+++ b/pkg/controller/datavolume/garbagecollect.go
@@ -112,6 +112,7 @@ func (r *ReconcilerBase) detachPvcDeleteDv(syncRes *dataVolumeSyncResult) error 
 	}
 	syncRes.result = &reconcile.Result{}
 	syncRes.dv = nil
+	syncRes.dvCopy = nil
 	return nil
 }
 

--- a/pkg/controller/datavolume/garbagecollect.go
+++ b/pkg/controller/datavolume/garbagecollect.go
@@ -107,7 +107,11 @@ func (r *ReconcilerBase) detachPvcDeleteDv(syncRes *dataVolumeSyncResult) error 
 	if err := r.updatePVC(syncRes.pvc); err != nil {
 		return err
 	}
-	syncRes.gc = true
+	if err := r.client.Delete(context.TODO(), syncRes.dv); err != nil {
+		return err
+	}
+	syncRes.result = &reconcile.Result{}
+	syncRes.dv = nil
 	return nil
 }
 

--- a/pkg/controller/datavolume/garbagecollect.go
+++ b/pkg/controller/datavolume/garbagecollect.go
@@ -112,7 +112,7 @@ func (r *ReconcilerBase) detachPvcDeleteDv(syncRes *dataVolumeSyncResult) error 
 	}
 	syncRes.result = &reconcile.Result{}
 	syncRes.dv = nil
-	syncRes.dvCopy = nil
+	syncRes.dvMutated = nil
 	return nil
 }
 

--- a/pkg/controller/datavolume/garbagecollect.go
+++ b/pkg/controller/datavolume/garbagecollect.go
@@ -32,30 +32,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *ReconcilerBase) garbageCollect(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim, log logr.Logger) (*reconcile.Result, error) {
+func (r *ReconcilerBase) garbageCollect(syncRes *dataVolumeSyncResult, log logr.Logger) error {
+	dataVolume := syncRes.dv
 	if dataVolume.Status.Phase != cdiv1.Succeeded {
-		return nil, nil
+		return nil
 	}
 	cdiConfig := &cdiv1.CDIConfig{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: common.ConfigName}, cdiConfig); err != nil {
-		return nil, err
+		return err
 	}
 	dvTTL := cc.GetDataVolumeTTLSeconds(cdiConfig)
 	if dvTTL < 0 {
 		log.Info("Garbage Collection is disabled")
-		return nil, nil
+		return nil
 	}
 	if allowed, err := r.isGarbageCollectionAllowed(dataVolume, log); !allowed || err != nil {
-		return nil, err
+		return err
 	}
 	// Current DV still has TTL, so reconcile will return with the needed RequeueAfter
 	if delta := getDeltaTTL(dataVolume, dvTTL); delta > 0 {
-		return &reconcile.Result{RequeueAfter: delta}, nil
+		syncRes.result = &reconcile.Result{RequeueAfter: delta}
+		return nil
 	}
-	if err := r.detachPvcDeleteDv(pvc, dataVolume); err != nil {
-		return nil, err
+	if err := r.detachPvcDeleteDv(syncRes); err != nil {
+		return err
 	}
-	return &reconcile.Result{}, nil
+	return nil
 }
 
 func (r *ReconcilerBase) isGarbageCollectionAllowed(dv *cdiv1.DataVolume, log logr.Logger) (bool, error) {
@@ -99,15 +101,13 @@ func (r *ReconcilerBase) canUpdateFinalizers(ownerRef metav1.OwnerReference) (bo
 	return ssar.Status.Allowed, nil
 }
 
-func (r *ReconcilerBase) detachPvcDeleteDv(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) error {
-	updatePvcOwnerRefs(pvc, dv)
-	delete(pvc.Annotations, cc.AnnPopulatedFor)
-	if err := r.updatePVC(pvc); err != nil {
+func (r *ReconcilerBase) detachPvcDeleteDv(syncRes *dataVolumeSyncResult) error {
+	updatePvcOwnerRefs(syncRes.pvc, syncRes.dv)
+	delete(syncRes.pvc.Annotations, cc.AnnPopulatedFor)
+	if err := r.updatePVC(syncRes.pvc); err != nil {
 		return err
 	}
-	if err := r.client.Delete(context.TODO(), dv); err != nil {
-		return err
-	}
+	syncRes.gc = true
 	return nil
 }
 

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -211,6 +211,17 @@ func (r ImportReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 }
 
 func (r ImportReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
+	syncRes, syncErr := r.syncImport(log, req)
+	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
+		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
+			log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
+			syncErr = err
+		}
+	}
+	return syncRes, syncErr
+}
+
+func (r ImportReconciler) syncImport(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
 	var syncRes dataVolumeSyncResult
 	syncErr := r.syncCommon(log, req, &syncRes, nil, nil)
 	if syncErr != nil || syncRes.result != nil {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -26,9 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
@@ -115,7 +113,15 @@ func addDataVolumeImportControllerWatches(mgr manager.Manager, datavolumeControl
 	return nil
 }
 
-func (r ImportReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, annotations map[string]string) error {
+func (r ImportReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error {
+	annotations := pvc.Annotations
+
+	if checkpoint := r.getNextCheckpoint(dataVolume, pvc); checkpoint != nil {
+		annotations[cc.AnnCurrentCheckpoint] = checkpoint.Current
+		annotations[cc.AnnPreviousCheckpoint] = checkpoint.Previous
+		annotations[cc.AnnFinalCheckpoint] = strconv.FormatBool(checkpoint.IsFinal)
+	}
+
 	if dataVolume.Spec.Source.HTTP != nil {
 		annotations[cc.AnnEndpoint] = dataVolume.Spec.Source.HTTP.URL
 		annotations[cc.AnnSource] = cc.SourceHTTP
@@ -198,58 +204,56 @@ func (r ImportReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, annota
 	return errors.Errorf("no source set for import datavolume")
 }
 
-func (r ImportReconciler) updateStatus(log logr.Logger, syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
-	if syncErr != nil {
-		return reconcile.Result{}, syncErr
-	}
-	if syncRes.res != nil {
-		return *syncRes.res, nil
-	}
-	//FIXME: pass syncRes instead of args
-	if err := r.reconcileDataVolumePVC(log, syncRes.dv, &syncRes.pvc, syncRes.pvcSpec); err != nil {
-		return reconcile.Result{}, err
-	}
-	return r.reconcileDataVolumeStatus(syncRes.dv, syncRes.pvc, nil, r.updateStatusPhase)
-
+// Reconcile loop for the import data volumes
+func (r ImportReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("DataVolume", req.NamespacedName)
+	return r.updateStatus(r.sync(log, req))
 }
 
-func (r *ImportReconciler) reconcileDataVolumePVC(log logr.Logger, dv *cdiv1.DataVolume, pvc **corev1.PersistentVolumeClaim, pvcSpec *v1.PersistentVolumeClaimSpec) error {
-	if _, dvPrePopulated := dv.Annotations[cc.AnnPrePopulated]; dvPrePopulated {
-		return nil
+func (r ImportReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
+	var syncRes dataVolumeSyncResult
+	syncErr := r.syncCommon(log, req, &syncRes, nil, nil)
+	if syncErr != nil || syncRes.result != nil {
+		return syncRes, syncErr
 	}
-	if *pvc == nil {
-		newPvc, err := r.createPvcForDatavolume(dv, pvcSpec, r.updateCheckpoint)
-		if err != nil {
-			if cc.ErrQuotaExceeded(err) {
-				r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, dv, nil, nil,
-					Event{
-						eventType: corev1.EventTypeWarning,
-						reason:    cc.ErrExceededQuota,
-						message:   err.Error(),
-					})
-			}
-			return err
-		}
-		*pvc = newPvc
-		return nil
-	}
-	if cc.GetSource(*pvc) == cc.SourceVDDK {
-		changed, err := r.getVddkAnnotations(dv, *pvc)
-		if err != nil {
-			return err
-		}
-		if changed {
-			err = r.client.Get(context.TODO(), types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}, dv)
-			if err != nil {
-				return err
-			}
+	if syncRes.pvc == nil {
+		if _, dvPrePopulated := syncRes.dv.Annotations[cc.AnnPrePopulated]; !dvPrePopulated {
+			syncRes.pvc, syncErr = r.createPvcForDatavolume(syncRes.dv, syncRes.pvcSpec, r.updateAnnotations)
 		}
 	}
+	if syncRes.pvc != nil && syncErr == nil {
+		syncErr = r.maybeSetPvcMultiStageAnnotation(syncRes.pvc, syncRes.dv)
 
-	if err := r.maybeSetMultiStageAnnotation(*pvc, dv); err != nil {
-		return err
 	}
-	return nil
+	return syncRes, syncErr
+}
+
+func (r ImportReconciler) updateStatus(syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
+	if syncErr != nil {
+		if cc.ErrQuotaExceeded(syncErr) {
+			r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, syncRes.dv, nil, nil,
+				Event{
+					eventType: corev1.EventTypeWarning,
+					reason:    cc.ErrExceededQuota,
+					message:   syncErr.Error(),
+				})
+		}
+		return reconcile.Result{}, syncErr
+	}
+	if syncRes.result != nil {
+		return *syncRes.result, nil
+	}
+	modifier := func(dv *cdiv1.DataVolume) {
+		if syncRes.pvc != nil && cc.GetSource(syncRes.pvc) == cc.SourceVDDK {
+			if vddkHost := syncRes.pvc.Annotations[cc.AnnVddkHostConnection]; vddkHost != "" {
+				cc.AddAnnotation(dv, cc.AnnVddkHostConnection, vddkHost)
+			}
+			if vddkVersion := syncRes.pvc.Annotations[cc.AnnVddkVersion]; vddkVersion != "" {
+				cc.AddAnnotation(dv, cc.AnnVddkVersion, vddkVersion)
+			}
+		}
+	}
+	return r.updateStatusCommon(syncRes, modifier, r.updateStatusPhase)
 }
 
 func (r ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
@@ -325,40 +329,15 @@ func (r ImportReconciler) updatesMultistageImportSucceeded(pvc *corev1.Persisten
 		// Single stage of a multi-stage import
 		dataVolumeCopy.Status.Phase = cdiv1.Paused
 		// Advances annotations to next checkpoint
-		if err := r.setMultistageImportAnnotations(dataVolumeCopy, pvc); err != nil {
+		if err := r.setPvcMultistageImportAnnotations(dataVolumeCopy, pvc); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *ImportReconciler) updateCheckpoint(datavolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) {
-	checkpoint := r.getNextCheckpoint(datavolume, pvc)
-	if checkpoint != nil {
-		pvc.ObjectMeta.Annotations[cc.AnnCurrentCheckpoint] = checkpoint.Current
-		pvc.ObjectMeta.Annotations[cc.AnnPreviousCheckpoint] = checkpoint.Previous
-		pvc.ObjectMeta.Annotations[cc.AnnFinalCheckpoint] = strconv.FormatBool(checkpoint.IsFinal)
-	}
-}
-
-func (r *ImportReconciler) getVddkAnnotations(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) (bool, error) {
-	var dataVolumeCopy = dataVolume.DeepCopy()
-	if vddkHost := pvc.Annotations[cc.AnnVddkHostConnection]; vddkHost != "" {
-		cc.AddAnnotation(dataVolumeCopy, cc.AnnVddkHostConnection, vddkHost)
-	}
-	if vddkVersion := pvc.Annotations[cc.AnnVddkVersion]; vddkVersion != "" {
-		cc.AddAnnotation(dataVolumeCopy, cc.AnnVddkVersion, vddkVersion)
-	}
-
-	// only update if something has changed
-	if !reflect.DeepEqual(dataVolume, dataVolumeCopy) {
-		return true, r.updateDataVolume(dataVolumeCopy)
-	}
-	return false, nil
-}
-
 // Sets the annotation if pvc needs it, and does not have it yet
-func (r *ImportReconciler) maybeSetMultiStageAnnotation(pvc *corev1.PersistentVolumeClaim, datavolume *cdiv1.DataVolume) error {
+func (r *ImportReconciler) maybeSetPvcMultiStageAnnotation(pvc *corev1.PersistentVolumeClaim, datavolume *cdiv1.DataVolume) error {
 	if pvc.Status.Phase == corev1.ClaimBound {
 		// If a PVC already exists with no multi-stage annotations, check if it
 		// needs them set (if not already finished with an import).
@@ -366,7 +345,7 @@ func (r *ImportReconciler) maybeSetMultiStageAnnotation(pvc *corev1.PersistentVo
 		multiStageAnnotationsSet := metav1.HasAnnotation(pvc.ObjectMeta, cc.AnnCurrentCheckpoint)
 		multiStageAlreadyDone := metav1.HasAnnotation(pvc.ObjectMeta, cc.AnnMultiStageImportDone)
 		if multiStageImport && !multiStageAnnotationsSet && !multiStageAlreadyDone {
-			err := r.setMultistageImportAnnotations(datavolume, pvc)
+			err := r.setPvcMultistageImportAnnotations(datavolume, pvc)
 			if err != nil {
 				return err
 			}
@@ -376,7 +355,7 @@ func (r *ImportReconciler) maybeSetMultiStageAnnotation(pvc *corev1.PersistentVo
 }
 
 // Set the PVC annotations related to multi-stage imports so that they point to the next checkpoint to copy.
-func (r *ImportReconciler) setMultistageImportAnnotations(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error {
+func (r *ImportReconciler) setPvcMultistageImportAnnotations(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error {
 	pvcCopy := pvc.DeepCopy()
 
 	// Only mark this checkpoint complete if it was completed by the current pod.

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -212,34 +212,33 @@ func (r ImportReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 
 func (r ImportReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
 	syncRes, syncErr := r.syncImport(log, req)
-	if err := r.syncUpdateMeta(log, syncRes); err != nil {
+	if err := r.syncUpdateMeta(log, &syncRes); err != nil {
 		syncErr = err
 	}
 	return syncRes, syncErr
 }
 
 func (r ImportReconciler) syncImport(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
-	var syncRes dataVolumeSyncResult
-	syncErr := r.syncCommon(log, req, &syncRes, nil, nil)
+	syncRes, syncErr := r.syncCommon(log, req, nil, nil)
 	if syncErr != nil || syncRes.result != nil {
-		return syncRes, syncErr
+		return *syncRes, syncErr
 	}
 	if syncRes.pvc == nil {
-		if _, dvPrePopulated := syncRes.dvCopy.Annotations[cc.AnnPrePopulated]; !dvPrePopulated {
-			syncRes.pvc, syncErr = r.createPvcForDatavolume(syncRes.dvCopy, syncRes.pvcSpec, r.updateAnnotations)
+		if _, dvPrePopulated := syncRes.dvMutated.Annotations[cc.AnnPrePopulated]; !dvPrePopulated {
+			syncRes.pvc, syncErr = r.createPvcForDatavolume(syncRes.dvMutated, syncRes.pvcSpec, r.updateAnnotations)
 		}
 	}
 	if syncRes.pvc != nil && syncErr == nil {
-		r.setVddkAnnotations(syncRes)
-		syncErr = r.maybeSetPvcMultiStageAnnotation(syncRes.pvc, syncRes.dvCopy)
+		r.setVddkAnnotations(*syncRes)
+		syncErr = r.maybeSetPvcMultiStageAnnotation(syncRes.pvc, syncRes.dvMutated)
 	}
-	return syncRes, syncErr
+	return *syncRes, syncErr
 }
 
 func (r ImportReconciler) updateStatus(syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
 	if syncErr != nil {
 		if cc.ErrQuotaExceeded(syncErr) {
-			err := r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, syncRes.dv, syncRes.dvCopy, nil,
+			err := r.updateDataVolumeStatusPhaseWithEvent(cdiv1.Pending, syncRes.dv, syncRes.dvMutated, nil,
 				Event{
 					eventType: corev1.EventTypeWarning,
 					reason:    cc.ErrExceededQuota,
@@ -314,10 +313,10 @@ func (r ImportReconciler) setVddkAnnotations(syncRes dataVolumeSyncResult) {
 		return
 	}
 	if vddkHost := syncRes.pvc.Annotations[cc.AnnVddkHostConnection]; vddkHost != "" {
-		cc.AddAnnotation(syncRes.dvCopy, cc.AnnVddkHostConnection, vddkHost)
+		cc.AddAnnotation(syncRes.dvMutated, cc.AnnVddkHostConnection, vddkHost)
 	}
 	if vddkVersion := syncRes.pvc.Annotations[cc.AnnVddkVersion]; vddkVersion != "" {
-		cc.AddAnnotation(syncRes.dvCopy, cc.AnnVddkVersion, vddkVersion)
+		cc.AddAnnotation(syncRes.dvMutated, cc.AnnVddkVersion, vddkVersion)
 	}
 }
 

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -212,11 +212,8 @@ func (r ImportReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 
 func (r ImportReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
 	syncRes, syncErr := r.syncImport(log, req)
-	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
-		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
-			log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
-			syncErr = err
-		}
+	if err := r.syncUpdateMeta(log, syncRes); err != nil {
+		syncErr = err
 	}
 	return syncRes, syncErr
 }

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1516,5 +1516,5 @@ func createStorageClassWithBindingMode(name string, annotations map[string]strin
 }
 
 func createSyncResult(dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) dataVolumeSyncResult {
-	return dataVolumeSyncResult{dv: dv, dvCopy: dv.DeepCopy(), pvc: pvc}
+	return dataVolumeSyncResult{dv: dv, dvMutated: dv.DeepCopy(), pvc: pvc}
 }

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -788,7 +788,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.Status.Phase = current
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, nil, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 
 			dv = &cdiv1.DataVolume{}
@@ -831,7 +832,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -873,7 +875,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -918,7 +921,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -957,7 +961,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1004,7 +1009,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, reconciler.updateStatusPhase)
+			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1266,7 +1272,7 @@ var _ = Describe("All DataVolume Tests", func() {
 })
 
 func dvPhaseTest(reconciler ReconcilerBase, updateStatusPhase updateStatusPhaseFunc, testDv runtime.Object, current, expected cdiv1.DataVolumePhase, pvcPhase corev1.PersistentVolumeClaimPhase, podPhase corev1.PodPhase, ann, expectedEvent string, extraAnnotations ...string) {
-	_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+	_, err := reconciler.Reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 	Expect(err).ToNot(HaveOccurred())
 	dv := &cdiv1.DataVolume{}
 	err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1287,7 +1293,8 @@ func dvPhaseTest(reconciler ReconcilerBase, updateStatusPhase updateStatusPhaseF
 		pvc.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
 	}
 
-	_, err = reconciler.reconcileDataVolumeStatus(dv, pvc, nil, updateStatusPhase)
+	syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
+	_, err = reconciler.updateStatusCommon(syncRes, nil, updateStatusPhase)
 	Expect(err).ToNot(HaveOccurred())
 
 	dv = &cdiv1.DataVolume{}

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -788,8 +788,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.Status.Phase = current
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, nil), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 
 			dv = &cdiv1.DataVolume{}
@@ -832,8 +831,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -875,8 +873,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -921,8 +918,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.Status.Phase = corev1.ClaimPending
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -961,8 +957,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1009,8 +1004,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
-			syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-			_, err = reconciler.updateStatusCommon(syncRes, nil, reconciler.updateStatusPhase)
+			_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), reconciler.updateStatusPhase)
 			Expect(err).ToNot(HaveOccurred())
 			dv = &cdiv1.DataVolume{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
@@ -1293,8 +1287,7 @@ func dvPhaseTest(reconciler ReconcilerBase, updateStatusPhase updateStatusPhaseF
 		pvc.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
 	}
 
-	syncRes := dataVolumeSyncResult{dv: dv, pvc: pvc}
-	_, err = reconciler.updateStatusCommon(syncRes, nil, updateStatusPhase)
+	_, err = reconciler.updateStatusCommon(createSyncResult(dv, pvc), updateStatusPhase)
 	Expect(err).ToNot(HaveOccurred())
 
 	dv = &cdiv1.DataVolume{}
@@ -1520,4 +1513,8 @@ func createStorageClassWithBindingMode(name string, annotations map[string]strin
 			Annotations: annotations,
 		},
 	}
+}
+
+func createSyncResult(dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) dataVolumeSyncResult {
+	return dataVolumeSyncResult{dv: dv, dvCopy: dv.DeepCopy(), pvc: pvc}
 }

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -19,7 +19,6 @@ package datavolume
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -109,11 +108,8 @@ func (r UploadReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 
 func (r UploadReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
 	syncRes, syncErr := r.syncUpload(log, req)
-	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
-		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
-			log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
-			syncErr = err
-		}
+	if err := r.syncUpdateMeta(log, syncRes); err != nil {
+		syncErr = err
 	}
 	return syncRes, syncErr
 }

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -19,6 +19,7 @@ package datavolume
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -107,6 +108,17 @@ func (r UploadReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 }
 
 func (r UploadReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
+	syncRes, syncErr := r.syncUpload(log, req)
+	if !reflect.DeepEqual(syncRes.dv, syncRes.dvCopy) {
+		if err := r.updateDataVolume(syncRes.dvCopy); err != nil {
+			log.Error(err, "Unable to sync update dv", "name", syncRes.dvCopy.Name)
+			syncErr = err
+		}
+	}
+	return syncRes, syncErr
+}
+
+func (r UploadReconciler) syncUpload(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
 	var syncRes dataVolumeSyncResult
 	syncErr := r.syncCommon(log, req, &syncRes, nil, nil)
 	if syncErr != nil || syncRes.result != nil {

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
@@ -344,4 +345,11 @@ func setAnnOwnedByDataVolume(dest, obj metav1.Object) error {
 	dest.GetAnnotations()[AnnOwnedByDataVolume] = key
 
 	return nil
+}
+
+func getReconcileResult(result *reconcile.Result) reconcile.Result {
+	if result != nil {
+		return *result
+	}
+	return reconcile.Result{}
 }


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>


**What this PR does / why we need it**:
Follow the model of controllers in kubevirt where `sync()` does the "work" of the controller (creating other resources, etc). The `sync()` for import/upload is just creating the pvc resource. For clones, it is more complicated depending on clone type and if cross-namespace or not. After `sync()`, `updateStatus()` is called, even if `sync()` returns an error. `updateStatus()` is conscious of all steps performed in `sync()` and updates the status of the reconciled resource based on what can be observed. The only k8s resource it creates/updates is the `DataVolume`. This split is especially nice for resources with status subresource enabled, which should be one of the ultimate goals of DV controllers refactor work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

