### PR TITLE
Remove v1alpha1 version from CDI CRD

### DIFF
--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -51,6 +51,7 @@ func addReconcileCallbacks(r *ReconcileCDI) {
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCreatePrometheusInfra)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileRemainingRelationshipLabels)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteSecrets)
+	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCDICRD)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileInitializeCRD)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileSetConfigAuthority)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileHandleOldVersion)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -192,9 +192,9 @@ func (r *ReconcileCDI) SetController(controller controller.Controller) {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCDI) Reconcile(_ context.Context, request reconcile.Request) (reconcile.Result, error) {
-	operatorVersion := r.namespacedArgs.OperatorVersion
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling CDI")
+	reqLogger.Info("Reconciling CDI CR")
+	operatorVersion := r.namespacedArgs.OperatorVersion
 	cr := &cdiv1.CDI{}
 	crKey := client.ObjectKey{Namespace: "", Name: request.NamespacedName.Name}
 	err := r.client.Get(context.TODO(), crKey, cr)

--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -306,7 +306,7 @@ func reconcileCDICRD(args *callbacks.ReconcileCallbackArgs) error {
 		return nil
 	}
 	deployment := args.CurrentObject.(*appsv1.Deployment)
-	if !isControllerDeployment(deployment) || !sdk.CheckDeploymentReady(deployment) {
+	if !isControllerDeployment(deployment) {
 		return nil
 	}
 

--- a/pkg/operator/controller/reconciler-hooks.go
+++ b/pkg/operator/controller/reconciler-hooks.go
@@ -22,6 +22,10 @@ func (r *ReconcileCDI) watch() error {
 		return err
 	}
 
+	if err := r.watchCDICRD(); err != nil {
+		return err
+	}
+
 	if err := r.watchPrometheusResources(); err != nil {
 		return err
 	}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -62,7 +62,60 @@ var _ = Describe("ALL Operator tests", func() {
 					}, 5*time.Minute, 1*time.Second).Should(Equal(originalReplicaVal))
 				})
 
-				It("Alpha versions of CRD are removed, even if objects previously existed", func() {
+				It("Alpha version of CDI CRD is removed even if it was briefly a storage version", func() {
+					By("Scaling down CDI operator")
+					originalReplicaVal = scaleDeployment(f, deploymentName, 0)
+					Eventually(func() bool {
+						_, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, deploymentName, common.CDILabelSelector)
+						if !errors.IsNotFound(err) {
+							return false
+						}
+						return true
+					}, 20*time.Second, 1*time.Second).Should(BeTrue())
+
+					By("Appending v1alpha1 version as stored version")
+					cdiCrd, err := f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "cdis.cdi.kubevirt.io", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					oldVer := cdiCrd.Spec.Versions[0].DeepCopy()
+					oldVer.Name = "v1alpha1"
+					cdiCrd.Spec.Versions[0].Storage = false
+					oldVer.Storage = false
+					cdiCrd.Spec.Versions = append(cdiCrd.Spec.Versions, *oldVer)
+
+					cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), cdiCrd, metav1.UpdateOptions{})
+
+					By("Restoring CRD with newer version as storage")
+					cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "cdis.cdi.kubevirt.io", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					// This is done because due to the way CRDs are applied,
+					// the scenario where alpha is the "storage: true" isn't
+					// possible - so the code doesn't handle it.
+					for i, ver := range cdiCrd.Spec.Versions {
+						if ver.Name == "v1alpha1" {
+							cdiCrd.Spec.Versions[i].Storage = false
+						} else {
+							cdiCrd.Spec.Versions[i].Storage = true
+						}
+					}
+					cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), cdiCrd, metav1.UpdateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Scaling up CDI operator")
+					scaleDeployment(f, deploymentName, originalReplicaVal)
+					By("Eventually, CDI will restore v1beta1 to be the only stored version")
+					Eventually(func() bool {
+						cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "cdis.cdi.kubevirt.io", metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						for _, ver := range cdiCrd.Spec.Versions {
+							if !(ver.Name == "v1beta1" && ver.Storage == true) {
+								return false
+							}
+						}
+						return true
+					}, 1*time.Minute, 2*time.Second).Should(BeTrue())
+				})
+
+				It("Alpha versions of datavolume CRD are removed, even if objects previously existed", func() {
 					By("Scaling down CDI operator")
 					originalReplicaVal = scaleDeployment(f, deploymentName, 0)
 					Eventually(func() bool {


### PR DESCRIPTION
This is the last CRD of CDI that still has v1alpha1 version.
We left it because it appears in release YAMLs, and we want update through applying YAMLs to just work.

**What this PR does / why we need it**:
Technical debt left over from #2407.
We needed more complicated work to watch the CDI CRD.
This CRD is created by the release YAMLs and not owned by the controller, therefore we need custom watch code for it that isn't from controller-lifecycle-operator-sdk.

**Special notes for your reviewer**:
I've checked early in reconcile whether this is a CDI CRD and not a CDI CR - not sure how to integrate it with controller-lifecycle-operator-sdk. Not sure whether needing Update() is normal.
Perhaps it's not too bad as we already know we'll remove this code in under a year (once we've released a version or more with this PR).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
At runtime, remove v1alpha1 version from CDI CRD, the last CRD that had it.
The release YAMLs still contain the alpha version, but it will be removed at runtime.
We plan to remove the version from the release YAML in the future (after a few versions), but as long as you update through intermediate versions, it will just work without errors.
```

