### PR TITLE
[release-v1.55] Add topolvm.io and cinder to known provisioners (#2530) (#2507)

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -64,6 +64,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.trident.netapp.io/ontap-san": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
 	// topolvm
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
+	"topolvm.io":         createTopoLVMCapabilities(),
 	// OpenStack Cinder
 	"cinder.csi.openstack.org": createCinderVolumeCapabilities(),
 }

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -64,6 +64,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.trident.netapp.io/ontap-san": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
 	// topolvm
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
+	// OpenStack Cinder
+	"cinder.csi.openstack.org": createCinderVolumeCapabilities(),
 }
 
 // Get finds and returns a predefined StorageCapabilities for a given StorageClass
@@ -210,6 +212,13 @@ func createOpenStorageVolumeCapabilities() []StorageCapabilities {
 func createOpenStorageSharedVolumeCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+	}
+}
+
+func createCinderVolumeCapabilities() []StorageCapabilities {
+	return []StorageCapabilities{
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
 		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
 	}
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2158521

**Release note**:
```release-note
BugFix: storage profile missing defaults for LVMS "topolvm.io" provisioner and for cinder provisioner
```

