### PR TITLE
Set ttl for completed cron jobs

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -857,6 +857,7 @@ func (r *DataImportCronReconciler) newCronJob(cron *cdiv1.DataImportCron) (*batc
 			Schedule:                   cron.Spec.Schedule,
 			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
 			SuccessfulJobsHistoryLimit: pointer.Int32(1),
+			FailedJobsHistoryLimit:     pointer.Int32(1),
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
@@ -868,7 +869,8 @@ func (r *DataImportCronReconciler) newCronJob(cron *cdiv1.DataImportCron) (*batc
 							Volumes:                       volumes,
 						},
 					},
-					BackoffLimit: pointer.Int32(2),
+					BackoffLimit:            pointer.Int32(2),
+					TTLSecondsAfterFinished: pointer.Int32(10),
 				},
 			},
 		},

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -271,10 +271,13 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(cronjob.Spec.SuccessfulJobsHistoryLimit).To(Equal(pointer.Int32(1)))
-			Expect(cronjob.Spec.FailedJobsHistoryLimit).To(BeNil())
+			Expect(cronjob.Spec.FailedJobsHistoryLimit).To(Equal(pointer.Int32(1)))
 
-			jobTemplateSpec := cronjob.Spec.JobTemplate.Spec.Template.Spec
-			containers := jobTemplateSpec.Containers
+			jobTemplateSpec := cronjob.Spec.JobTemplate.Spec
+			Expect(jobTemplateSpec.TTLSecondsAfterFinished).To(Equal(pointer.Int32(10)))
+
+			jobPodTemplateSpec := jobTemplateSpec.Template.Spec
+			containers := jobPodTemplateSpec.Containers
 			Expect(containers).To(HaveLen(1))
 
 			env := containers[0].Env
@@ -283,7 +286,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(BeEmpty())
 
 			Expect(containers[0].VolumeMounts).To(HaveLen(0))
-			Expect(jobTemplateSpec.Volumes).To(HaveLen(0))
+			Expect(jobPodTemplateSpec.Volumes).To(HaveLen(0))
 		})
 
 		It("Should update CronJob on reconcile", func() {


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Keeping the last completed or failed job and pod for a while is needed for both functional tests and debugging. Since the ttl was not set, the jobs were not automatically deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [bz 2158608](https://bugzilla.redhat.com/show_bug.cgi?id=2158608)

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: Failed/successful pods associated with DataImportCron Jobs need to be cleaned up
```

