### PR TITLE
Update succeeded DIC PVC labels also when no DV GC

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -314,6 +314,9 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	if dv != nil {
 		switch dv.Status.Phase {
 		case cdiv1.Succeeded:
+			if r.updatePvc(ctx, dataImportCron, pvc); err != nil {
+				return res, err
+			}
 			importSucceeded = true
 		case cdiv1.ImportScheduled:
 			updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, "Import is scheduled", scheduled)
@@ -324,14 +327,10 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, fmt.Sprintf("Import DataVolume phase %s", dvPhase), dvPhase)
 		}
 	} else if pvc != nil {
-		importSucceeded = true
-		pvcCopy := pvc.DeepCopy()
-		r.setDataImportCronResourceLabels(dataImportCron, pvc)
-		if !reflect.DeepEqual(pvc, pvcCopy) {
-			if err := r.client.Update(ctx, pvc); err != nil {
-				return res, err
-			}
+		if r.updatePvc(ctx, dataImportCron, pvc); err != nil {
+			return res, err
 		}
+		importSucceeded = true
 	} else {
 		if len(imports) > 0 {
 			dataImportCron.Status.CurrentImports = imports[1:]
@@ -395,7 +394,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	return res, nil
 }
 
-// Returns the current import DV if exists, otherwise returns the last imported PVC
+// Returns the current import DV if exists, and the last imported PVC
 func (r *DataImportCronReconciler) getImportState(ctx context.Context, cron *cdiv1.DataImportCron) (*cdiv1.DataVolume, *corev1.PersistentVolumeClaim, error) {
 	imports := cron.Status.CurrentImports
 	if len(imports) == 0 {
@@ -404,19 +403,32 @@ func (r *DataImportCronReconciler) getImportState(ctx context.Context, cron *cdi
 
 	dvName := imports[0].DataVolumeName
 	dv := &cdiv1.DataVolume{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: cron.Namespace, Name: dvName}, dv); err == nil {
-		return dv, nil, nil
-	} else if !k8serrors.IsNotFound(err) {
-		return nil, nil, err
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: cron.Namespace, Name: dvName}, dv); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, nil, err
+		}
+		dv = nil
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: cron.Namespace, Name: dvName}, pvc); err == nil {
-		return nil, pvc, nil
-	} else if !k8serrors.IsNotFound(err) {
-		return nil, nil, err
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: cron.Namespace, Name: dvName}, pvc); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, nil, err
+		}
+		pvc = nil
 	}
-	return nil, nil, nil
+	return dv, pvc, nil
+}
+
+func (r *DataImportCronReconciler) updatePvc(ctx context.Context, cron *cdiv1.DataImportCron, pvc *corev1.PersistentVolumeClaim) error {
+	pvcCopy := pvc.DeepCopy()
+	r.setDataImportCronResourceLabels(cron, pvc)
+	if !reflect.DeepEqual(pvc, pvcCopy) {
+		if err := r.client.Update(ctx, pvc); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *DataImportCronReconciler) deleteErroneousDataVolume(ctx context.Context, cron *cdiv1.DataImportCron, dv *cdiv1.DataVolume) error {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -351,6 +351,11 @@ var _ = Describe("All DataImportCron Tests", func() {
 			dv.Status.Phase = cdiv1.Succeeded
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
+
+			pvc := cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
+			err = reconciler.client.Create(context.TODO(), pvc)
+			Expect(err).ToNot(HaveOccurred())
+
 			verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready)
 
 			sourcePVC := cdiv1.DataVolumeSourcePVC{
@@ -571,6 +576,10 @@ var _ = Describe("All DataImportCron Tests", func() {
 			dv.Status.Phase = cdiv1.Succeeded
 			dv.Status.Conditions = cdv.UpdateReadyCondition(dv.Status.Conditions, corev1.ConditionTrue, "", "")
 			err = reconciler.client.Update(context.TODO(), dv)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc := cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
+			err = reconciler.client.Create(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
 			verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready)
 

--- a/pkg/controller/datavolume/controller.go
+++ b/pkg/controller/datavolume/controller.go
@@ -131,7 +131,9 @@ func addDataVolumeControllerCommonWatches(mgr manager.Manager, dataVolumeControl
 		dvKey := types.NamespacedName{Namespace: namespace, Name: name}
 		dv := &cdiv1.DataVolume{}
 		if err := mgr.GetClient().Get(context.TODO(), dvKey, dv); err != nil {
-			mgr.GetLogger().Error(err, "Failed to get DV", "dvKey", dvKey)
+			if !k8serrors.IsNotFound(err) {
+				mgr.GetLogger().Error(err, "Failed to get DV", "dvKey", dvKey)
+			}
 			return reqs
 		}
 		if getDataVolumeOp(dv) == op {

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -125,9 +125,8 @@ var _ = Describe("DataImportCron", func() {
 					By("Reset desired digest")
 					retryOnceOnErr(updateDataImportCron(f.CdiClient, ns, cronName, updateDigest(""))).Should(BeNil())
 
-					By("Delete last import PVC")
-					err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), currentImportDv, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					By("Delete last import PVC " + currentImportDv)
+					deleteDvPvc(f, currentImportDv)
 					lastImportDv = ""
 
 					By("Wait for non-empty desired digest")
@@ -198,8 +197,7 @@ var _ = Describe("DataImportCron", func() {
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue(), "DataSource was not re-created")
 
 			By("Delete last imported PVC")
-			err = f.DeletePVC(currentPvc)
-			Expect(err).To(BeNil())
+			deleteDvPvc(f, currentPvc.Name)
 			By("Verify last imported PVC was re-created")
 			Eventually(func() bool {
 				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), currentPvc.Name, metav1.GetOptions{})


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
The PVC labelling is used for `DataImportCron` controller old import `PVCs` garbage collection, keeping only the last `importsToKeep` (3 by default) imported `PVCs` per `DIC`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [bz 2156928](https://bugzilla.redhat.com/show_bug.cgi?id=2156928)

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: PVC garbage collection in DataImportCron fails when CDI DV garbage collection is disabled
```