### PR TITLE
[release-v1.55] Update succeeded DIC PVC labels also when no DV GC

### DIFF
--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -349,6 +349,11 @@ var _ = Describe("All DataImportCron Tests", func() {
 			dv.Status.Phase = cdiv1.Succeeded
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
+
+			pvc := createPvc(dv.Name, dv.Namespace, nil, nil)
+			err = reconciler.client.Create(context.TODO(), pvc)
+			Expect(err).ToNot(HaveOccurred())
+
 			verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready)
 
 			sourcePVC := cdiv1.DataVolumeSourcePVC{
@@ -569,6 +574,10 @@ var _ = Describe("All DataImportCron Tests", func() {
 			dv.Status.Phase = cdiv1.Succeeded
 			dv.Status.Conditions = updateReadyCondition(dv.Status.Conditions, corev1.ConditionTrue, "", "")
 			err = reconciler.client.Update(context.TODO(), dv)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc := createPvc(dv.Name, dv.Namespace, nil, nil)
+			err = reconciler.client.Create(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
 			verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready)
 

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -125,9 +125,8 @@ var _ = Describe("DataImportCron", func() {
 					By("Reset desired digest")
 					retryOnceOnErr(updateDataImportCron(f.CdiClient, ns, cronName, updateDigest(""))).Should(BeNil())
 
-					By("Delete last import PVC")
-					err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), currentImportDv, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					By("Delete last import PVC " + currentImportDv)
+					deleteDvPvc(f, currentImportDv)
 					lastImportDv = ""
 
 					By("Wait for non-empty desired digest")
@@ -198,8 +197,7 @@ var _ = Describe("DataImportCron", func() {
 			}, dataImportCronTimeout, pollingInterval).Should(BeTrue(), "DataSource was not re-created")
 
 			By("Delete last imported PVC")
-			err = f.DeletePVC(currentPvc)
-			Expect(err).To(BeNil())
+			deleteDvPvc(f, currentPvc.Name)
 			By("Verify last imported PVC was re-created")
 			Eventually(func() bool {
 				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), currentPvc.Name, metav1.GetOptions{})


### PR DESCRIPTION
Manual backport of #2539

Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
The PVC labelling is used for `DataImportCron` controller old import `PVCs` garbage collection, keeping only the last `importsToKeep` (3 by default) imported `PVCs` per `DIC`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [bz 2156928](https://bugzilla.redhat.com/show_bug.cgi?id=2156928)

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: PVC garbage collection in DataImportCron fails when CDI DV garbage collection is disabled
```