### PR TITLE
Pass DV labels to PVC

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -314,6 +314,7 @@ type dvController interface {
 	updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error
 }
 
+<<<<<<< HEAD
 func (r *ReconcilerBase) reconcile(ctx context.Context, req reconcile.Request, dvc dvController) (reconcile.Result, error) {
 	log := r.log.WithValues("DataVolume", req.NamespacedName)
 	syncRes, syncErr := dvc.sync(log, req)
@@ -340,6 +341,11 @@ func (r *ReconcilerBase) syncCommon(log logr.Logger, req reconcile.Request, clea
 func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, cleanup, prepare dvSyncStateFunc) (dvSyncState, error) {
 	syncState := dvSyncState{}
 	dv, err := r.getDataVolume(req.NamespacedName)
+=======
+func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, prepare dataVolumeSyncResultFunc) (*dataVolumeSyncResult, error) {
+	syncRes := &dataVolumeSyncResult{}
+	dv, err := getDataVolume(r.client, req.NamespacedName)
+>>>>>>> 67bd1f823 (Rebase and add utests)
 	if dv == nil || err != nil {
 		syncState.result = &reconcile.Result{}
 		return syncState, err
@@ -551,9 +557,9 @@ func (r *ReconcilerBase) getPVC(key types.NamespacedName) (*corev1.PersistentVol
 	return pvc, nil
 }
 
-func (r *ReconcilerBase) getDataVolume(key types.NamespacedName) (*cdiv1.DataVolume, error) {
+func getDataVolume(c client.Client, key types.NamespacedName) (*cdiv1.DataVolume, error) {
 	dv := &cdiv1.DataVolume{}
-	if err := r.client.Get(context.TODO(), key, dv); err != nil {
+	if err := c.Get(context.TODO(), key, dv); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -960,21 +960,6 @@ func buildHTTPClient() *http.Client {
 	return httpClient
 }
 
-func passDataVolumeInstancetypeLabelstoPVC(dataVolumeLabels, pvcLabels map[string]string) map[string]string {
-	instancetypeLabels := []string{
-		cc.LabelDefaultInstancetype,
-		cc.LabelDefaultInstancetypeKind,
-		cc.LabelDefaultPreference,
-		cc.LabelDefaultPreferenceKind,
-	}
-	for _, label := range instancetypeLabels {
-		if dvLabel, hasLabel := dataVolumeLabels[label]; hasLabel {
-			pvcLabels[label] = dvLabel
-		}
-	}
-	return pvcLabels
-}
-
 // newPersistentVolumeClaim creates a new PVC for the DataVolume resource.
 // It also sets the appropriate OwnerReferences on the resource
 // which allows handleObject to discover the DataVolume resource
@@ -986,7 +971,9 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 	if util.ResolveVolumeMode(targetPvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
 		labels[common.KubePersistentVolumeFillingUpSuppressLabelKey] = common.KubePersistentVolumeFillingUpSuppressLabelValue
 	}
-	labels = passDataVolumeInstancetypeLabelstoPVC(dataVolume.GetLabels(), labels)
+	for k, v := range dataVolume.Labels {
+		labels[k] = v
+	}
 
 	annotations := make(map[string]string)
 	for k, v := range dataVolume.ObjectMeta.Annotations {

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -314,7 +314,6 @@ type dvController interface {
 	updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error
 }
 
-<<<<<<< HEAD
 func (r *ReconcilerBase) reconcile(ctx context.Context, req reconcile.Request, dvc dvController) (reconcile.Result, error) {
 	log := r.log.WithValues("DataVolume", req.NamespacedName)
 	syncRes, syncErr := dvc.sync(log, req)
@@ -341,15 +340,6 @@ func (r *ReconcilerBase) syncCommon(log logr.Logger, req reconcile.Request, clea
 func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, cleanup, prepare dvSyncStateFunc) (dvSyncState, error) {
 	syncState := dvSyncState{}
 	dv, err := r.getDataVolume(req.NamespacedName)
-=======
-func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, prepare dataVolumeSyncResultFunc) (*dataVolumeSyncResult, error) {
-	syncRes := &dataVolumeSyncResult{}
-<<<<<<< HEAD
-	dv, err := getDataVolume(r.client, req.NamespacedName)
->>>>>>> 67bd1f823 (Rebase and add utests)
-=======
-	dv, err := r.getDataVolume(req.NamespacedName)
->>>>>>> 3f19b15ae (Transferring annotations in smart clone and passing dv instead of client)
 	if dv == nil || err != nil {
 		syncState.result = &reconcile.Result{}
 		return syncState, err

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -344,8 +344,12 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 =======
 func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, prepare dataVolumeSyncResultFunc) (*dataVolumeSyncResult, error) {
 	syncRes := &dataVolumeSyncResult{}
+<<<<<<< HEAD
 	dv, err := getDataVolume(r.client, req.NamespacedName)
 >>>>>>> 67bd1f823 (Rebase and add utests)
+=======
+	dv, err := r.getDataVolume(req.NamespacedName)
+>>>>>>> 3f19b15ae (Transferring annotations in smart clone and passing dv instead of client)
 	if dv == nil || err != nil {
 		syncState.result = &reconcile.Result{}
 		return syncState, err
@@ -557,9 +561,9 @@ func (r *ReconcilerBase) getPVC(key types.NamespacedName) (*corev1.PersistentVol
 	return pvc, nil
 }
 
-func getDataVolume(c client.Client, key types.NamespacedName) (*cdiv1.DataVolume, error) {
+func (r *ReconcilerBase) getDataVolume(key types.NamespacedName) (*cdiv1.DataVolume, error) {
 	dv := &cdiv1.DataVolume{}
-	if err := c.Get(context.TODO(), key, dv); err != nil {
+	if err := r.client.Get(context.TODO(), key, dv); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -472,7 +472,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.GetAnnotations()[AnnSource] = "invalid phase should not copy"
 			dv.GetAnnotations()[AnnPodNetwork] = "data-network"
 			dv.GetAnnotations()[AnnPodSidecarInjection] = "false"
-			dv.Labels = map[string]string{"test": "test-label"}
+			dv.SetLabels(make(map[string]string))
+			dv.GetLabels()["test"] = "test-label"
 			reconciler = createImportReconciler(dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -464,7 +464,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize.Value()))
 		})
 
-		It("Should pass annotation from DV to created a PVC on a DV", func() {
+		It("Should pass annotations and labels from DV to created PVC", func() {
 			dv := NewImportDataVolume("test-dv")
 			dv.SetAnnotations(make(map[string]string))
 			dv.GetAnnotations()["test-ann-1"] = "test-value-1"
@@ -472,6 +472,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.GetAnnotations()[AnnSource] = "invalid phase should not copy"
 			dv.GetAnnotations()[AnnPodNetwork] = "data-network"
 			dv.GetAnnotations()[AnnPodSidecarInjection] = "false"
+			dv.Labels = map[string]string{"test": "test-label"}
 			reconciler = createImportReconciler(dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
@@ -486,6 +487,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.GetAnnotations()[AnnPodNetwork]).To(Equal("data-network"))
 			Expect(pvc.GetAnnotations()[AnnPodSidecarInjection]).To(Equal("false"))
 			Expect(pvc.GetAnnotations()[AnnPriorityClassName]).To(Equal("p0"))
+			Expect(pvc.Labels["test"]).To(Equal("test-label"))
 		})
 
 		It("Should pass annotation from DV with S3 source to created a PVC on a DV", func() {

--- a/pkg/controller/datavolume/smart-clone-controller_test.go
+++ b/pkg/controller/datavolume/smart-clone-controller_test.go
@@ -212,8 +212,10 @@ var _ = Describe("All smart clone tests", func() {
 		It("Should create PVC if snapshot ready", func() {
 			dv := newCloneDataVolume("test-dv")
 			q, _ := resource.ParseQuantity("500Mi")
-			// Set annotation on DV which we can verify on PVC later
-			dv.GetAnnotations()["test"] = "test-value"
+			// Set annotation and label on DV which we can verify on PVC later
+			dv.Annotations["test"] = "test-value"
+			dv.Labels = map[string]string{"test": "test-label"}
+
 			snapshot := createSnapshotVolume(dv.Name, dv.Namespace, nil)
 			snapshot.Spec.Source = snapshotv1.VolumeSnapshotSource{
 				PersistentVolumeClaimName: &[]string{"source"}[0],
@@ -234,8 +236,9 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Labels[common.AppKubernetesVersionLabel]).To(Equal("v0.0.0-tests"))
 			Expect(pvc.Labels[common.KubePersistentVolumeFillingUpSuppressLabelKey]).To(Equal(common.KubePersistentVolumeFillingUpSuppressLabelValue))
+			Expect(pvc.Labels["test"]).To(Equal("test-label"))
 			// Verify PVC's annotation
-			Expect(pvc.GetAnnotations()["test"]).To(Equal("test-value"))
+			Expect(pvc.Annotations["test"]).To(Equal("test-value"))
 			event := <-reconciler.recorder.(*record.FakeRecorder).Events
 			Expect(event).To(ContainSubstring("Creating PVC for smart-clone is in progress"))
 		})

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -488,7 +488,7 @@ func (r *SnapshotCloneReconciler) getStorageClassCorrespondingToSnapClass(driver
 }
 
 func (r *SnapshotCloneReconciler) makePvcFromSnapshot(pvcName string, dv *cdiv1.DataVolume, snapshot *snapshotv1.VolumeSnapshot, targetPvcSpec *corev1.PersistentVolumeClaimSpec) (*corev1.PersistentVolumeClaim, error) {
-	newPvc, err := newPvcFromSnapshot(r.client, pvcName, snapshot, targetPvcSpec)
+	newPvc, err := newPvcFromSnapshot(dv, pvcName, snapshot, targetPvcSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -488,7 +488,7 @@ func (r *SnapshotCloneReconciler) getStorageClassCorrespondingToSnapClass(driver
 }
 
 func (r *SnapshotCloneReconciler) makePvcFromSnapshot(pvcName string, dv *cdiv1.DataVolume, snapshot *snapshotv1.VolumeSnapshot, targetPvcSpec *corev1.PersistentVolumeClaimSpec) (*corev1.PersistentVolumeClaim, error) {
-	newPvc, err := newPvcFromSnapshot(pvcName, snapshot, targetPvcSpec)
+	newPvc, err := newPvcFromSnapshot(r.client, pvcName, snapshot, targetPvcSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2875,8 +2875,14 @@ func doFileBasedCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolume
 	}
 	// Create targetPvc in new NS.
 	targetDV := utils.NewCloningDataVolume(targetDv, targetSize[0], srcPVCDef)
-	targetDV.Labels = map[string]string{"test-label-1": "test-label-key-1"}
-	targetDV.Annotations = map[string]string{"test-annotation-1": "test-annotation-key-1"}
+	if targetDV.GetLabels() == nil {
+		targetDV.SetLabels(make(map[string]string))
+	}
+	if targetDV.GetAnnotations() == nil {
+		targetDV.SetAnnotations(make(map[string]string))
+	}
+	targetDV.Labels["test-label-1"] = "test-label-key-1"
+	targetDV.Annotations["test-annotation-1"] = "test-annotation-key-1"
 
 	dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -281,11 +281,13 @@ var _ = Describe("all clone tests", func() {
 			DescribeTable("[test_id:1355]Should clone data across different namespaces", func(targetSize string) {
 				pvcDef := utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
 				pvcDef.Namespace = f.Namespace.Name
+
 				sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, fillCommand+testFile+"; chmod 660 "+testBaseDir+testFile)
 				targetNs, err := f.CreateNamespace(f.NsPrefix, map[string]string{
 					framework.NsPrefixLabel: f.NsPrefix,
 				})
 				Expect(err).NotTo(HaveOccurred())
+
 				f.AddNamespaceToDelete(targetNs)
 				doFileBasedCloneTest(f, pvcDef, targetNs, "target-dv", targetSize)
 			},
@@ -2654,6 +2656,8 @@ var _ = Describe("all clone tests", func() {
 
 			for i = 0; i < repeat; i++ {
 				dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(fmt.Sprintf("clone-from-snap-%d", i), size, snapshot.Namespace, snapshot.Name, nil, &volumeMode)
+				dataVolume.Labels = map[string]string{"test-label-1": "test-label-value-1"}
+				dataVolume.Annotations = map[string]string{"test-annotation-1": "test-annotation-value-1"}
 				By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
 				dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -2671,6 +2675,9 @@ var _ = Describe("all clone tests", func() {
 				Expect(ok).To(BeFalse())
 				Expect(pvc.Spec.DataSource.Kind).To(Equal("VolumeSnapshot"))
 				Expect(pvc.Spec.DataSourceRef.Kind).To(Equal("VolumeSnapshot"))
+				// All labels and annotations passed
+				Expect(pvc.Labels["test-label-1"]).To(Equal("test-label-value-1"))
+				Expect(pvc.Annotations["test-annotation-1"]).To(Equal("test-annotation-value-1"))
 			}
 
 			By("Verify MD5 on one of the DVs")
@@ -2868,6 +2875,9 @@ func doFileBasedCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolume
 	}
 	// Create targetPvc in new NS.
 	targetDV := utils.NewCloningDataVolume(targetDv, targetSize[0], srcPVCDef)
+	targetDV.Labels = map[string]string{"test-label-1": "test-label-key-1"}
+	targetDV.Annotations = map[string]string{"test-annotation-1": "test-annotation-key-1"}
+
 	dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -2888,6 +2898,10 @@ func doFileBasedCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolume
 
 	es := resource.MustParse(targetSize[0])
 	Expect(es.Cmp(*targetPvc.Status.Capacity.Storage()) <= 0).To(BeTrue())
+
+	// All labels and annotations passed
+	Expect(targetPvc.Labels["test-label-1"]).To(Equal("test-label-key-1"))
+	Expect(targetPvc.Annotations["test-annotation-1"]).To(Equal("test-annotation-key-1"))
 }
 
 func doInUseCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolumeClaim, targetNs *v1.Namespace, targetDv string) {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1134,6 +1134,31 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			table.Entry("[test_id:8045]for clone DataVolume", createCloneDataVolume, fillCommand),
 		)
 
+		table.DescribeTable("Should pass all DV labels and annotations to the PVC", func(dvFunc func(string, string, string) *cdiv1.DataVolume, url string) {
+			dataVolume := dvFunc("pass-all-labels-dv", "1Gi", url)
+			dataVolume.Labels = map[string]string{"test-label-1": "test-label-1", "test-label-2": "test-label-2"}
+			dataVolume.Annotations = map[string]string{"test-annotation-1": "test-annotation-1", "test-annotation-2": "test-annotation-2"}
+
+			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			// verify PVC was created
+			By("verifying pvc was created and is Bound")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			// All labels and annotations passed
+			Expect(pvc.Labels["test-label-1"]).To(Equal("test-label-1"))
+			Expect(pvc.Labels["test-label-2"]).To(Equal("test-label-2"))
+			Expect(pvc.Annotations["test-annotation-1"]).To(Equal("test-annotation-1"))
+			Expect(pvc.Annotations["test-annotation-2"]).To(Equal("test-annotation-2"))
+		},
+			table.Entry("for import DataVolume", utils.NewDataVolumeWithHTTPImport, tinyCoreIsoURL()),
+			table.Entry("for upload DataVolume", createUploadDataVolume, tinyCoreIsoURL()),
+			table.Entry("for clone DataVolume", createCloneDataVolume, fillCommand),
+		)
+
 		It("Should handle a pre populated DV", func() {
 			By(fmt.Sprintf("initializing dataVolume marked as prePopulated %s", dataVolumeName))
 			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", cirrosURL())


### PR DESCRIPTION
Signed-off-by: Ido Aharon <iaharon@redhat.com>

**What this PR does / why we need it**:
Pass all the DataVolume labels to its created PVC. It's fixing the current behavior which passes only specific labels, aligning it with DV annotations passing to the PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2533 

**Special notes for your reviewer**:

**Release note**:
```release-note
Pass all the DataVolume labels to its created PVC
```