### PR TITLE
Clean up when dv is gone in addition to deletionTimestamp

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -250,14 +250,14 @@ func (r ReconcilerBase) syncCommon(log logr.Logger, req reconcile.Request, clean
 func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, prepare dataVolumeSyncResultFunc) (*dataVolumeSyncResult, error) {
 	syncRes := &dataVolumeSyncResult{}
 	dv, err := r.getDataVolume(req.NamespacedName)
-	if dv == nil || err != nil {
+	if err != nil {
 		syncRes.result = &reconcile.Result{}
 		return syncRes, err
 	}
 	syncRes.dv = dv
 	syncRes.dvMutated = dv.DeepCopy()
 
-	if dv.DeletionTimestamp != nil {
+	if syncRes.dv == nil || dv.DeletionTimestamp != nil {
 		log.Info("DataVolume marked for deletion, cleaning up")
 		if cleanup != nil {
 			err := cleanup(syncRes)


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Not sure how we do cleanup of a DV that is deleted mid-way without this?
`cleanupTransfer` for example seems to only happen if phase is succeeded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

