### PR TITLE
Don't go further in reconcile loop after cleanup finished successfully

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -260,8 +260,9 @@ func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, pr
 	if dv.DeletionTimestamp != nil {
 		log.Info("DataVolume marked for deletion, cleaning up")
 		if cleanup != nil {
-			err := cleanup(syncRes)
-			return syncRes, err
+			if err := cleanup(syncRes); err != nil {
+				return syncRes, err
+			}
 		}
 		syncRes.result = &reconcile.Result{}
 		return syncRes, nil


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Right now if cleanup finishes successfully we just keep going on in the reconcile loop, 
even though deletion timestamp is set.
Results in nil ptr when doing cross ns smart clone:
```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1543ec1]
 
goroutine 1133 [running]:
kubevirt.io/containerized-data-importer/pkg/controller/datavolume.(*PvcCloneReconciler).selectCloneStrategy(0xc001a69768, 0xc0050e65a0, 0x0)
        /remote-source/app/pkg/controller/datavolume/pvc-clone-controller.go:489 +0x81
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

