### PR TITLE
Grab target PVC early on to avoid false status updates

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -256,6 +256,10 @@ func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, pr
 	}
 	syncRes.dv = dv
 	syncRes.dvMutated = dv.DeepCopy()
+	syncRes.pvc, err = r.getPVC(dv)
+	if err != nil {
+		return syncRes, err
+	}
 
 	if dv.DeletionTimestamp != nil {
 		log.Info("DataVolume marked for deletion, cleaning up")
@@ -273,10 +277,6 @@ func (r ReconcilerBase) sync(log logr.Logger, req reconcile.Request, cleanup, pr
 		}
 	}
 
-	syncRes.pvc, err = r.getPVC(dv)
-	if err != nil {
-		return syncRes, err
-	}
 	if syncRes.pvc != nil {
 		if err := r.garbageCollect(syncRes, log); err != nil {
 			return syncRes, err


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Now that we update status in the end of a loop regardless of err,
it is important that we have the PVC in place for that.
Otherwise, if we fail at cleanup/prepare, syncRes.pvc is nil,
and we get false status updates like the following:
```bash
NAMESPACE   NAME               PHASE                             PROGRESS   RESTARTS
default     cloned-target-dv   Succeeded                         N/A                   23s
default     cloned-target-dv   Pending                           N/A                   23s
default     cloned-target-dv   Pending                           N/A                   23s
default     cloned-target-dv   Pending                           N/A                   23s
NAMESPACE   NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
golden-ns   golden-snap-source   Bound    pvc-63ed1368-9f84-44ce-8b4b-7e9e3c4574f4   8Gi        RWO            rook-ceph-block   5m59s
(Target got deleted)
```
This results in a nasty bug where the target PVC simply disappears in cross ns clones.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: target PVC disappears after cross namespace clone 
```

