### PR TITLE
Allow root podman for cluster-sync

### DIFF
--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -14,12 +14,12 @@
 
 determine_cri_bin() {
     if [ "${KUBEVIRTCI_RUNTIME-}" = "podman" ]; then
-        echo "podman --remote --url=unix://${XDG_RUNTIME_DIR-}/podman/podman.sock"
+        echo podman
     elif [ "${KUBEVIRTCI_RUNTIME-}" = "docker" ]; then
         echo docker
     else
-        if curl --unix-socket "${XDG_RUNTIME_DIR-}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-            echo "podman --remote --url=unix://${XDG_RUNTIME_DIR-}/podman/podman.sock"
+        if podman ps >/dev/null 2>&1; then
+            echo "podman"
         elif docker ps >/dev/null 2>&1; then
             echo docker
         else


### PR DESCRIPTION
The current implementation only works for rootless podman check if rootless works first, if not use root podman

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

