### PR TITLE
Fix DataImportCron PVC timestamping

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -422,6 +422,7 @@ func (r *DataImportCronReconciler) getImportState(ctx context.Context, cron *cdi
 
 func (r *DataImportCronReconciler) updatePvc(ctx context.Context, cron *cdiv1.DataImportCron, pvc *corev1.PersistentVolumeClaim) error {
 	pvcCopy := pvc.DeepCopy()
+	cc.AddAnnotation(pvc, AnnLastUseTime, time.Now().UTC().Format(time.RFC3339Nano))
 	r.setDataImportCronResourceLabels(cron, pvc)
 	if !reflect.DeepEqual(pvc, pvcCopy) {
 		if err := r.client.Update(ctx, pvc); err != nil {
@@ -567,8 +568,7 @@ func (r *DataImportCronReconciler) createImportDataVolume(ctx context.Context, d
 			return err
 		}
 	} else {
-		cc.AddAnnotation(pvc, AnnLastUseTime, time.Now().Format(time.RFC3339Nano))
-		if err := r.client.Update(ctx, pvc); err != nil {
+		if err := r.updatePvc(ctx, dataImportCron, pvc); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
DataImportCron PVC garbage collection is LRU-based, so it's broken when PVCs are not timestamped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes bz #2165793

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix DataImportCron PVC timestamping
```

