### PR TITLE
Check docker first

### DIFF
--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -18,10 +18,10 @@ determine_cri_bin() {
     elif [ "${KUBEVIRTCI_RUNTIME-}" = "docker" ]; then
         echo docker
     else
-        if podman ps >/dev/null 2>&1; then
-            echo "podman"
-        elif docker ps >/dev/null 2>&1; then
+        if docker ps >/dev/null 2>&1; then
             echo docker
+        elif podman ps >/dev/null 2>&1; then
+            echo podman
         else
             echo ""
         fi


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Our CRI detection cod was looking for podman first then docker. If you have both installed it would find podman first and set that. Even if you preferred docker (need to properly configure podman).

This switches the check to look for docker first then podman. If you want to use podman you can set the KUBEVIRTCI_RUNTIME env variable to podman

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

