### PR TITLE
Remove stack trace from PVC and DataVolume events in case of import error

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -180,7 +180,7 @@ func handleImport(
 		if err == importer.ErrRequiresScratchSpace {
 			return common.ScratchSpaceNeededExitCode
 		}
-		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %+v", err.Error()))
+		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error()))
 		if err != nil {
 			klog.Errorf("%+v", err)
 		}
@@ -310,7 +310,7 @@ func createBlankImage(imageSize string, availableDestSpace int64, preallocation 
 
 	if err != nil {
 		klog.Errorf("%+v", err)
-		message := fmt.Sprintf("Unable to create blank image: %+v", err)
+		message := fmt.Sprintf("Unable to create blank image: %v", err)
 		err = util.WriteTerminationMessage(message)
 		if err != nil {
 			klog.Errorf("%+v", err)
@@ -321,7 +321,7 @@ func createBlankImage(imageSize string, availableDestSpace int64, preallocation 
 
 func errorCannotConnectDataSource(err error, dsName string) {
 	klog.Errorf("%+v", err)
-	err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to %s data source: %+v", dsName, err))
+	err = util.WriteTerminationMessage(fmt.Sprintf("Unable to connect to %s data source: %v", dsName, err))
 	if err != nil {
 		klog.Errorf("%+v", err)
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR slightly modifies cdi-importer behavior so, when an import of any kind fails, the termination message in the pod only contains the error and not the stack trace.

This makes the events in PVCs and DataVolumes cleaner and easier to understand for users. The stack trace will still appear on the pod logs for debugging purposes.

**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2143716

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

