### PR TITLE
Apply retry filter to ndkit conversions

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -100,6 +100,8 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	for _, header := range extraHeaders {
 		pluginArgs = append(pluginArgs, fmt.Sprintf("header=%s", header))
 	}
+	// Don't do exponential retry, the container restart will be exponential
+	pluginArgs = append(pluginArgs, "retry-exponential=no")
 	for _, header := range secretExtraHeaders {
 		redactArgs = append(redactArgs, fmt.Sprintf("header=%s", header))
 	}
@@ -111,6 +113,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 		redactArgs: redactArgs,
 		Socket:     socket,
 	}
+	// Should be last filter
 	n.AddFilter(NbdkitRetryFilter)
 	return n
 }

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -289,6 +289,7 @@ func (o *qemuOperations) CreateBlankImage(dest string, size resource.Quantity, p
 	err = os.Chmod(dest, 0660)
 	if err != nil {
 		err = errors.Wrap(err, "Unable to change permissions of target file")
+		return err
 	}
 
 	return nil

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -301,7 +301,7 @@ var _ = Describe("Create blank image", func() {
 		size := convertQuantityToQemuSize(quantity)
 		replaceExecFunction(mockExecFunction("", "", nil, "create", "-f", "raw", "image", size), func() {
 			err = CreateBlankImage("image", quantity, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no such file or directory"))
 		})
 	})
 
@@ -322,7 +322,7 @@ var _ = Describe("Create blank image", func() {
 		size := convertQuantityToQemuSize(quantity)
 		replaceExecFunction(mockExecFunctionStrict("", "", nil, "create", "-f", "raw", "image", size, "-o", "preallocation=falloc"), func() {
 			err = CreateBlankImage("image", quantity, true)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no such file or directory"))
 		})
 	})
 
@@ -332,7 +332,7 @@ var _ = Describe("Create blank image", func() {
 		size := convertQuantityToQemuSize(quantity)
 		replaceExecFunction(mockExecFunctionStrict("", "", nil, "create", "-f", "raw", "image", size), func() {
 			err = CreateBlankImage("image", quantity, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no such file or directory"))
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reduce the number of pod retries when there are failures in downloading images. Instead retry
inside the pod. This implements suggestion from https://github.com/kubevirt/containerized-data-importer/issues/2561.
Also fix some linter warnings in same package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: use retry filter in inline streaming conversion with qcow2 http endpoints.
```

