### PR TITLE
Stop forcing preallocation on block imports

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -111,8 +111,6 @@ func main() {
 	volumeMode := v1.PersistentVolumeBlock
 	if _, err := os.Stat(common.WriteBlockPath); os.IsNotExist(err) {
 		volumeMode = v1.PersistentVolumeFilesystem
-	} else {
-		preallocation = true
 	}
 
 	// With writeback cache mode it's possible that the process will exit before all writes have been commited to storage.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request enables deactivating preallocation on block imports.

### The bug

Due to what seemed like a [bug](https://github.com/kubevirt/containerized-data-importer/issues/1980#issuecomment-940238434) in qemu-img, we started forcing preallocation on block imports as an arbitrary way to skip that specific error. This behavior was introduced in https://github.com/kubevirt/containerized-data-importer/pull/2001. After several updates in qemu and related dependencies, the bug is no longer reproducible. 

After some research, we've found a [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1872633)  that seems to solve an oddly similar case. The described bugs and fixes are:
-  A race in the kernel solved in commit https://github.com/torvalds/linux/commit/767630c63bb23acf022adb265574996ca39a4645  (v5.11).
- QEMU not being able to handle the previous bug. This was addressed here https://github.com/qemu/qemu/commit/ece4fa9152ea37c7ebd158af330e3b20e33cf385  (v5.2.0).
- " An optimization for grossly unaligned writes that qemu-img convert does".

As a last important note, CDI 1.40 (the one used in the original [issue](https://github.com/kubevirt/containerized-data-importer/issues/1980#issuecomment-940238434)) included qemu 5.1.0, the version where the bug described in the previous bugzilla was reproduced. 

### Conclusions

Knowing this, we can draw some conclusions:
- Always preallocating block imports is an arbitrary behavior that shouldn't be forced unless explicitly necessary.
- The original bug is not CDI-related. 
- Since the bug is no longer reproducible and several related fixes are present in our current qemu binaries, we can conclude that is safe to revert the behavior introduced in https://github.com/kubevirt/containerized-data-importer/pull/2001.

**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2168165

**Special notes for your reviewer**:
https://github.com/kubevirt/kubevirt/pull/6942 should also be reverted once this PR is merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop forcing preallocation on block imports
```

