### PR TITLE
Get rid of sync/updateStatus shared state

### DIFF
--- a/pkg/controller/datavolume/external-population-controller.go
+++ b/pkg/controller/datavolume/external-population-controller.go
@@ -85,18 +85,17 @@ func NewPopulatorController(ctx context.Context, mgr manager.Manager, log logr.L
 
 // Reconcile loop for externally populated DataVolumes
 func (r *PopulatorReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := r.log.WithValues("DataVolume", req.NamespacedName)
-	return r.updateStatus(r.sync(log, req))
+	return r.reconcile(ctx, req, r)
 }
 
 // If dataSourceRef is set (external populator), use an empty spec.Source field
-func (r *PopulatorReconciler) prepare(syncRes *dataVolumeSyncResult) error {
-	if !dvUsesVolumePopulator(syncRes.dv) {
+func (r *PopulatorReconciler) prepare(syncState *dvSyncState) error {
+	if !dvUsesVolumePopulator(syncState.dv) {
 		return errors.Errorf("undefined population source")
 	}
 	// TODO - let's revisit this
-	syncRes.dv.Spec.Source = &cdiv1.DataVolumeSource{}
-	syncRes.dvMutated.Spec.Source = &cdiv1.DataVolumeSource{}
+	syncState.dv.Spec.Source = &cdiv1.DataVolumeSource{}
+	syncState.dvMutated.Spec.Source = &cdiv1.DataVolumeSource{}
 	return nil
 }
 
@@ -194,37 +193,23 @@ func (r *PopulatorReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pv
 	return nil
 }
 
-func (r *PopulatorReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
-	syncRes, syncErr := r.syncExternalPopulation(log, req)
-	// TODO _ I think it is bad form that the datavolume is updated even in the case of error
-	if err := r.syncUpdate(log, &syncRes); err != nil {
-		syncErr = err
+func (r *PopulatorReconciler) sync(log logr.Logger, req reconcile.Request) (dvSyncResult, error) {
+	syncState, err := r.syncExternalPopulation(log, req)
+	if err == nil {
+		err = r.syncUpdate(log, &syncState)
 	}
-	return syncRes, syncErr
+	return syncState.dvSyncResult, err
 }
 
-func (r *PopulatorReconciler) syncExternalPopulation(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
-	syncRes, syncErr := r.syncCommon(log, req, nil, r.prepare)
-	if syncErr != nil || syncRes.result != nil {
-		return syncRes, syncErr
+func (r *PopulatorReconciler) syncExternalPopulation(log logr.Logger, req reconcile.Request) (dvSyncState, error) {
+	syncState, syncErr := r.syncCommon(log, req, nil, r.prepare)
+	if syncErr != nil || syncState.result != nil {
+		return syncState, syncErr
 	}
-	if err := r.handlePvcCreation(log, &syncRes, r.updateAnnotations); err != nil {
+	if err := r.handlePvcCreation(log, &syncState, r.updateAnnotations); err != nil {
 		syncErr = err
 	}
-	return syncRes, syncErr
-}
-
-func (r *PopulatorReconciler) updateStatus(syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
-	// TODO FIXME - WE SHOULD ALWAYS UPDATE STATUS
-	if syncErr != nil {
-		r.log.Info("FIXME should not return because of this", "err", syncErr)
-		return getReconcileResult(syncRes.result), syncErr
-	}
-	res, err := r.updateStatusCommon(syncRes, r.updateStatusPhase)
-	if err != nil {
-		syncErr = err
-	}
-	return res, syncErr
+	return syncState, syncErr
 }
 
 func (r *PopulatorReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -102,41 +102,26 @@ func (r *UploadReconciler) updateAnnotations(dataVolume *cdiv1.DataVolume, pvc *
 
 // Reconcile loop for the upload data volumes
 func (r *UploadReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := r.log.WithValues("DataVolume", req.NamespacedName)
-	return r.updateStatus(r.sync(log, req))
+	return r.reconcile(ctx, req, r)
 }
 
-func (r *UploadReconciler) sync(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
-	syncRes, syncErr := r.syncUpload(log, req)
-	// TODO _ I think it is bad form that the datavolume is updated even in the case of error
-	if err := r.syncUpdate(log, &syncRes); err != nil {
-		syncErr = err
+func (r *UploadReconciler) sync(log logr.Logger, req reconcile.Request) (dvSyncResult, error) {
+	syncState, err := r.syncUpload(log, req)
+	if err == nil {
+		err = r.syncUpdate(log, &syncState)
 	}
-	return syncRes, syncErr
+	return syncState.dvSyncResult, err
 }
 
-func (r *UploadReconciler) syncUpload(log logr.Logger, req reconcile.Request) (dataVolumeSyncResult, error) {
-	syncRes, syncErr := r.syncCommon(log, req, nil, nil)
-	if syncErr != nil || syncRes.result != nil {
-		return syncRes, syncErr
+func (r *UploadReconciler) syncUpload(log logr.Logger, req reconcile.Request) (dvSyncState, error) {
+	syncState, syncErr := r.syncCommon(log, req, nil, nil)
+	if syncErr != nil || syncState.result != nil {
+		return syncState, syncErr
 	}
-	if err := r.handlePvcCreation(log, &syncRes, r.updateAnnotations); err != nil {
+	if err := r.handlePvcCreation(log, &syncState, r.updateAnnotations); err != nil {
 		syncErr = err
 	}
-	return syncRes, syncErr
-}
-
-func (r *UploadReconciler) updateStatus(syncRes dataVolumeSyncResult, syncErr error) (reconcile.Result, error) {
-	// TODO FIXME - WE SHOULD ALWAYS UPDATE STATUS
-	if syncErr != nil {
-		r.log.Info("FIXME should not return because of this", "err", syncErr)
-		return getReconcileResult(syncRes.result), syncErr
-	}
-	res, err := r.updateStatusCommon(syncRes, r.updateStatusPhase)
-	if err != nil {
-		syncErr = err
-	}
-	return res, syncErr
+	return syncState, syncErr
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -55,7 +55,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			storageProfile := createStorageProfile(scName, nil, BlockMode)
 
 			r := createUploadReconciler(testDv, sc, storageProfile)
-			dvPhaseTest(r.ReconcilerBase, r.updateStatusPhase, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
+			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
 		},
 			Entry("should switch to scheduled for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadScheduled, corev1.ClaimBound, corev1.PodPending, AnnUploadRequest, "Upload into test-dv scheduled", AnnPriorityClassName, "p0-upload"),
 			Entry("should switch to uploadready for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadReady, corev1.ClaimBound, corev1.PodRunning, AnnUploadRequest, "Upload into test-dv ready", AnnPodReady, "true", AnnPriorityClassName, "p0-upload"),

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -423,3 +423,7 @@ func CheckAccessModes(claim *v1.PersistentVolumeClaim, volume *v1.PersistentVolu
 	}
 	return true
 }
+
+func getReconcileRequest(obj client.Object) reconcile.Request {
+	return reconcile.Request{NamespacedName: client.ObjectKeyFromObject(obj)}
+}

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -49,7 +49,7 @@ var _ = Describe("DataSource", func() {
 				By(fmt.Sprintf("condition state: %s, %s", cond.Status, cond.Reason))
 			}
 			return cond != nil && cond.Status == status && cond.Reason == reason
-		}, 60*time.Second, pollingInterval).Should(BeTrue())
+		}, timeout, pollingInterval).Should(BeTrue())
 		return ds
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See @mhenriks PR [comment](https://github.com/kubevirt/containerized-data-importer/pull/2559#issuecomment-1407056241):
There should be no state shared between sync() and updateStatus(). updateStatus() should stand on it's own, and come to it's own conclusions based on what it observes. It is okay if it is "late to the party" and does not observe the latest changes in sync(). It will eventually converge. This is what kubevirt does.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

