### PR TITLE
Another attempt to stabilize storage profile metric tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -795,6 +795,9 @@ var _ = Describe("ALL Operator tests", func() {
 				cdiPods                *corev1.PodList
 				numAddedStorageClasses int
 				originalMetricVal      int
+
+				metricPollingInterval = 5 * time.Second
+				metricPollingTimeout  = 5 * time.Minute
 			)
 
 			f := framework.NewFramework("alert-tests")
@@ -866,7 +869,7 @@ var _ = Describe("ALL Operator tests", func() {
 
 				Eventually(func() int {
 					return getMetricValue("kubevirt_cdi_incomplete_storageprofiles_total")
-				}, 2*time.Minute, 1*time.Second).Should(BeNumerically("==", originalMetricVal))
+				}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", originalMetricVal))
 			})
 
 			createUnknownStorageClass := func(name, provisioner string) *storagev1.StorageClass {
@@ -1043,7 +1046,7 @@ var _ = Describe("ALL Operator tests", func() {
 				expectedIncomplete := originalMetricVal + numAddedStorageClasses
 				Eventually(func() int {
 					return getMetricValue("kubevirt_cdi_incomplete_storageprofiles_total")
-				}, 2*time.Minute, 1*time.Second).Should(BeNumerically("==", expectedIncomplete))
+				}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", expectedIncomplete))
 
 				By("Fix profiles to be complete and test metric value equals original")
 				for i := 0; i < numAddedStorageClasses; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Seems CDI delete&recreate in tests before 7965 makes things a little slower
(Prometheus resources recreating may add it's own overhead, for example)
Let's wait a little longer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

