### PR TITLE
Respect bind.immediate annotation by not attempting fancy clones

### DIFF
--- a/pkg/controller/common/BUILD.bazel
+++ b/pkg/controller/common/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/client/clientset/versioned/scheme:go_default_library",
         "//pkg/common:go_default_library",
+        "//pkg/feature-gates:go_default_library",
         "//pkg/token:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -938,7 +938,7 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	dv.Name = dataVolumeName
 	dv.Namespace = cron.Namespace
 	r.setDataImportCronResourceLabels(cron, dv)
-	passCronAnnotationToDv(cron, dv, AnnImmediateBinding)
+	passCronAnnotationToDv(cron, dv, cc.AnnImmediateBinding)
 	passCronAnnotationToDv(cron, dv, cc.AnnPodRetainAfterCompletion)
 
 	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetype)

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -453,6 +453,15 @@ func (r *PvcCloneReconciler) selectCloneStrategy(datavolume *cdiv1.DataVolume, p
 	if err != nil {
 		return NoClone, err
 	}
+	if bindingMode != nil && *bindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+		waitForFirstConsumerEnabled, err := cc.IsWaitForFirstConsumerEnabled(datavolume, r.featureGates)
+		if err != nil {
+			return NoClone, err
+		}
+		if !waitForFirstConsumerEnabled {
+			return HostAssistedClone, nil
+		}
+	}
 
 	if preferredCloneStrategy != nil && *preferredCloneStrategy == cdiv1.CloneStrategyCsiClone {
 		csiClonePossible, err := r.advancedClonePossible(datavolume, pvcSpec)

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -306,6 +306,15 @@ func (r *SnapshotCloneReconciler) evaluateFallBackToHostAssistedNeeded(datavolum
 	if err != nil {
 		return true, err
 	}
+	if bindingMode != nil && *bindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+		waitForFirstConsumerEnabled, err := cc.IsWaitForFirstConsumerEnabled(datavolume, r.featureGates)
+		if err != nil {
+			return true, err
+		}
+		if !waitForFirstConsumerEnabled {
+			return true, nil
+		}
+	}
 
 	// Storage classes do not match means we can only do dumb cloning
 	if snapshot.Spec.VolumeSnapshotClassName == nil || *snapshot.Spec.VolumeSnapshotClassName == "" {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -170,8 +170,7 @@ func (r *ImportReconciler) shouldReconcilePVC(pvc *corev1.PersistentVolumeClaim,
 		return false, nil
 	}
 
-	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
-	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, r.featureGates)
+	waitForFirstConsumerEnabled, err := cc.IsWaitForFirstConsumerEnabled(pvc, r.featureGates)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -116,10 +116,10 @@ var _ = Describe("Test PVC annotations status", func() {
 		r := createImportReconciler()
 		r.featureGates = &FakeFeatureGates{honorWaitForFirstConsumerEnabled: true}
 		testPvc := createPendingPvc("testPvc1", "default", map[string]string{
-			cc.AnnPodPhase:      string(corev1.PodPending),
-			cc.AnnEndpoint:      testEndPoint,
-			cc.AnnSource:        cc.SourceHTTP,
-			AnnImmediateBinding: "true",
+			cc.AnnPodPhase:         string(corev1.PodPending),
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnSource:           cc.SourceHTTP,
+			cc.AnnImmediateBinding: "true",
 		}, nil)
 		Expect(r.shouldReconcilePVC(testPvc, importLog)).To(BeTrue())
 	})
@@ -127,10 +127,10 @@ var _ = Describe("Test PVC annotations status", func() {
 		r := createImportReconciler()
 		r.featureGates = &FakeFeatureGates{honorWaitForFirstConsumerEnabled: false}
 		testPvc := createPendingPvc("testPvc1", "default", map[string]string{
-			cc.AnnPodPhase:      string(corev1.PodPending),
-			cc.AnnEndpoint:      testEndPoint,
-			cc.AnnSource:        cc.SourceHTTP,
-			AnnImmediateBinding: "true",
+			cc.AnnPodPhase:         string(corev1.PodPending),
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnSource:           cc.SourceHTTP,
+			cc.AnnImmediateBinding: "true",
 		}, nil)
 		Expect(r.shouldReconcilePVC(testPvc, importLog)).To(BeTrue())
 	})

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -155,8 +155,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 }
 
 func (r *UploadReconciler) shouldReconcile(isUpload bool, isCloneTarget bool, pvc *v1.PersistentVolumeClaim, log logr.Logger) (bool, error) {
-	_, isImmediateBindingRequested := pvc.Annotations[AnnImmediateBinding]
-	waitForFirstConsumerEnabled, err := isWaitForFirstConsumerEnabled(isImmediateBindingRequested, r.featureGates)
+	waitForFirstConsumerEnabled, err := cc.IsWaitForFirstConsumerEnabled(pvc, r.featureGates)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -39,7 +39,6 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 
@@ -52,9 +51,6 @@ const (
 
 	// AnnOwnerRef is used when owner is in a different namespace
 	AnnOwnerRef = cc.AnnAPIGroup + "/storage.ownerRef"
-
-	// AnnImmediateBinding provides a const to indicate whether immediate binding should be performed on the PV (overrides global config)
-	AnnImmediateBinding = cc.AnnAPIGroup + "/storage.bind.immediate.requested"
 
 	// PodRunningReason is const that defines the pod was started as a reason
 	PodRunningReason = "Pod is running"
@@ -89,17 +85,6 @@ func checkPVC(pvc *v1.PersistentVolumeClaim, annotation string, log logr.Logger)
 	}
 
 	return true
-}
-
-func isWaitForFirstConsumerEnabled(isImmediateBindingRequested bool, gates featuregates.FeatureGates) (bool, error) {
-	// when PVC requests immediateBinding it cannot honor wffc logic
-	pvcHonorWaitForFirstConsumer := !isImmediateBindingRequested
-	globalHonorWaitForFirstConsumer, err := gates.HonorWaitForFirstConsumerEnabled()
-	if err != nil {
-		return false, err
-	}
-
-	return pvcHonorWaitForFirstConsumer && globalHonorWaitForFirstConsumer, nil
 }
 
 // - when the SkipWFFCVolumesEnabled is true, the CDI controller will only handle BOUND the PVC

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -26,7 +26,6 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	cont "kubevirt.io/containerized-data-importer/pkg/controller"
 	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 	"kubevirt.io/containerized-data-importer/pkg/token"
@@ -823,7 +822,7 @@ var _ = Describe("all clone tests", func() {
 				Entry("[test_id:8490]Filesystem to filesystem(empty storage size)", v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem),
 			)
 
-			Context("WaitForFirstConsumer status with advanced cloning methods", func() {
+			Context("WaitForFirstConsumer with advanced cloning methods", func() {
 				var wffcStorageClass *storagev1.StorageClass
 
 				BeforeEach(func() {
@@ -859,7 +858,7 @@ var _ = Describe("all clone tests", func() {
 					if wffcStorageClass != nil {
 						dataVolume.Spec.Storage.StorageClassName = &wffcStorageClass.Name
 					}
-					dataVolume.Annotations[cont.AnnImmediateBinding] = "true"
+					dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 					dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 					Expect(err).ToNot(HaveOccurred())
 					By("Waiting for import to be completed")
@@ -888,6 +887,49 @@ var _ = Describe("all clone tests", func() {
 					By("Wait for target DV Succeeded phase")
 					err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, targetDataVolume.Name)
 					Expect(err).ToNot(HaveOccurred())
+
+					By("Verify content")
+					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(same).To(BeTrue())
+					By("Deleting verifier pod")
+					err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should fall back to host assisted if immediate bind requested for smart/CSI clones", func() {
+					volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+
+					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+					dataVolume.Spec.Storage.VolumeMode = &volumeMode
+					if wffcStorageClass != nil {
+						dataVolume.Spec.Storage.StorageClassName = &wffcStorageClass.Name
+					}
+					dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
+					dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+					Expect(err).ToNot(HaveOccurred())
+					By("Waiting for import to be completed")
+					err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, dataVolume.Name)
+					Expect(err).ToNot(HaveOccurred())
+					sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+					if wffcStorageClass != nil {
+						targetDV.Spec.Storage.StorageClassName = &wffcStorageClass.Name
+					}
+					targetDV.Annotations[controller.AnnImmediateBinding] = "true"
+					targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
+					Expect(err).ToNot(HaveOccurred())
+					targetPvc, err := utils.WaitForPVC(f.K8sClient, targetDataVolume.Namespace, targetDataVolume.Name)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Wait for target DV Succeeded phase")
+					err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, targetDataVolume.Name)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(targetPvc.Annotations[controller.AnnCloneRequest]).To(Equal(fmt.Sprintf("%s/%s", sourcePvc.Namespace, sourcePvc.Name)))
+					Expect(targetPvc.Spec.DataSource).To(BeNil())
+					Expect(targetPvc.Spec.DataSourceRef).To(BeNil())
 
 					By("Verify content")
 					same, err := f.VerifyTargetPVCContentMD5(f.Namespace, targetPvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
@@ -2695,7 +2737,7 @@ var _ = Describe("all clone tests", func() {
 					pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(targetNs.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					suffix := "-host-assisted-source-pvc"
-					Expect(pvc.Annotations[controller.AnnCloneRequest]).To(ContainSubstring(suffix))
+					Expect(pvc.Annotations[controller.AnnCloneRequest]).To(HaveSuffix(suffix))
 					Expect(pvc.Spec.DataSource).To(BeNil())
 					Expect(pvc.Spec.DataSourceRef).To(BeNil())
 				}
@@ -2717,6 +2759,56 @@ var _ = Describe("all clone tests", func() {
 				Entry("with block single clone", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 1, false),
 				Entry("with block multiple clones", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 5, false),
 			)
+		})
+
+		Context("Immediate bind requested", func() {
+			var wffcStorageClass *storagev1.StorageClass
+
+			BeforeEach(func() {
+				sc, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), utils.DefaultStorageClass.GetName(), metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				wffcStorageClass = sc
+				if sc.VolumeBindingMode == nil || *sc.VolumeBindingMode == storagev1.VolumeBindingImmediate {
+					sc, err = f.CreateWFFCVariationOfStorageClass(sc)
+					Expect(err).ToNot(HaveOccurred())
+					wffcStorageClass = sc
+					Eventually(func() bool {
+						_, err := f.CdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), wffcStorageClass.Name, metav1.GetOptions{})
+						return err == nil
+					}, time.Minute, time.Second).Should(BeTrue())
+				}
+			})
+
+			It("should fall back to host assisted if immediate bind requested", func() {
+				var err error
+
+				size := "1Gi"
+				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				dvName := "clone-from-snap"
+				createSnapshot(size, &wffcStorageClass.Name, volumeMode)
+
+				dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(dvName, size, snapshot.Namespace, snapshot.Name, &wffcStorageClass.Name, &volumeMode)
+				By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
+				dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
+				dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, snapshot.Namespace, dataVolume)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for clone to be completed")
+				err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
+				Expect(err).ToNot(HaveOccurred())
+				By("Check host assisted clone is taking place")
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				suffix := "-host-assisted-source-pvc"
+				Expect(pvc.Annotations[controller.AnnCloneRequest]).To(HaveSuffix(suffix))
+				Expect(pvc.Spec.DataSource).To(BeNil())
+				Expect(pvc.Spec.DataSourceRef).To(BeNil())
+
+				By("Verify content")
+				same, err := f.VerifyTargetPVCContentMD5(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileMD5, utils.UploadFileSize)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(same).To(BeTrue())
+			})
 		})
 
 		Context("Clone without a source snapshot", func() {

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -13,6 +13,7 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
+	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
@@ -80,7 +81,7 @@ var _ = Describe("DataSource", func() {
 
 		By("Create clone DV with SourceRef pointing the DataSource")
 		dv := utils.NewDataVolumeWithSourceRef("clone-dv", "1Gi", ds.Namespace, ds.Name)
-		dv.Annotations[controller.AnnImmediateBinding] = "true"
+		dv.Annotations[cc.AnnImmediateBinding] = "true"
 		Expect(dv).ToNot(BeNil())
 		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -172,10 +172,6 @@ var _ = Describe("DataSource", func() {
 	})
 })
 
-// Delete PVC if DV was GCed, otherwise delete both
 func deleteDvPvc(f *framework.Framework, pvcName string) {
-	err := utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, pvcName)
-	Expect(err).ToNot(HaveOccurred())
-	err = utils.DeletePVC(f.K8sClient, f.Namespace.Name, pvcName)
-	Expect(err).ToNot(HaveOccurred())
+	utils.CleanupDvPvc(f.K8sClient, f.CdiClient, f.Namespace.Name, pvcName)
 }

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2314,8 +2314,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Cleaning up")
-			err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume.Name)
-			Expect(err).ToNot(HaveOccurred())
+			utils.CleanupDvPvc(f.K8sClient, f.CdiClient, f.Namespace.Name, dataVolume.Name)
 			Eventually(func() bool {
 				_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				return k8serrors.IsNotFound(err)
@@ -2413,8 +2412,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Cleaning up")
-			err = utils.DeleteDataVolume(f.CdiClient, f.Namespace.Name, dataVolume.Name)
-			Expect(err).ToNot(HaveOccurred())
+			utils.CleanupDvPvc(f.K8sClient, f.CdiClient, f.Namespace.Name, dataVolume.Name)
 			Eventually(func() bool {
 				_, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				return k8serrors.IsNotFound(err)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -24,7 +24,6 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	cont "kubevirt.io/containerized-data-importer/pkg/controller"
 	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -1624,7 +1623,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			dataVolume := utils.NewCloningDataVolume(dataVolumeName, "10Mi", sourcePvc)
 			dataVolume.Spec.PVC = nil
 			dataVolume.Spec.Storage = &storageSpec
-			dataVolume.Annotations[cont.AnnImmediateBinding] = "true"
+			dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 
 			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -2388,7 +2387,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			size := "1Gi"
 
 			dataVolume := dvFunc(dvName, size, url())
-			dataVolume.Annotations[cont.AnnImmediateBinding] = "true"
+			dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -32,7 +32,6 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	cont "kubevirt.io/containerized-data-importer/pkg/controller"
 	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/tests"
 	"kubevirt.io/containerized-data-importer/tests/framework"
@@ -320,7 +319,7 @@ var _ = Describe("[Istio] Namespace sidecar injection", func() {
 		dataVolume := utils.NewDataVolumeWithHTTPImport("istio-sidecar-injection-test", "100Mi", tinyCoreIsoExternalURL)
 		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
 		// We set the Immediate Binding annotation to true, to eliminate creation of the consumer pod, which will also fail due to the Istio sidecar.
-		dataVolume.Annotations[cont.AnnImmediateBinding] = "true"
+		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		dataVolume.Annotations[controller.AnnPodSidecarInjection] = "true"
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
@@ -348,7 +347,7 @@ var _ = Describe("[Istio] Namespace sidecar injection", func() {
 	It("[test_id:6492] Should successfully import with namespace sidecar injection enabled and default sidecar.istio.io/inject", func() {
 		dataVolume := utils.NewDataVolumeWithHTTPImport("istio-sidecar-injection-test", "100Mi", tinyCoreIsoExternalURL)
 		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
-		dataVolume.Annotations[cont.AnnImmediateBinding] = "true"
+		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     deps = [
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/common:go_default_library",
-        "//pkg/controller:go_default_library",
         "//pkg/controller/common:go_default_library",
         "//pkg/controller/datavolume:go_default_library",
         "//pkg/image:go_default_library",

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -113,7 +113,7 @@ func IsHostpathProvisioner() bool {
 	if DefaultStorageClass == nil {
 		return false
 	}
-	return DefaultStorageClass.Provisioner == "kubevirt.io/hostpath-provisioner"
+	return DefaultStorageClass.Provisioner == "kubevirt.io.hostpath-provisioner"
 }
 
 // GetTestNamespaceList returns a list of namespaces that have been created by the functional tests.

--- a/tests/utils/dataimportcron.go
+++ b/tests/utils/dataimportcron.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	controller "kubevirt.io/containerized-data-importer/pkg/controller"
+	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
 )
 
 // NewDataImportCron initializes a DataImportCron struct


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`bind.immediate` is an annotation that says we should bypass "real" WFFC behavior by simply starting our worker pods
wherever.
Prior to this, we were only honoring it for import/upload/host-assisted clone, but we should definitely do the same for
opt out of other fancy clone methods when it is specified:
- CSI clone
- Smart clone
- Clone from snapshot source

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Respect bind.immediate annotation on fancy clones by falling back to host assisted
```

