### PR TITLE
Testing suite adjustments for testing on WFFC snapshot capable storage

### DIFF
--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -425,7 +425,6 @@ func NewDataVolumeCloneToBlockPVStorageAPI(dataVolumeName string, size string, s
 			Storage: &cdiv1.StorageSpec{
 				VolumeMode:       &volumeMode,
 				StorageClassName: &storageClassName,
-				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
 						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We have started testing LVMS (LVM Storage) recently on OKD installs:
https://github.com/openshift/lvm-operator
and identified some issues with how our testing suite plays along with that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This will need backports so we can test on older releases with WFFC snapshot capable storage

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

