### PR TITLE
Add manila csi to list of known provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -69,6 +69,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"topolvm.io":         createTopoLVMCapabilities(),
 	// OpenStack Cinder
 	"cinder.csi.openstack.org": createCinderVolumeCapabilities(),
+	// OpenStack manila
+	"manila.csi.openstack.org": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The manila provisioner is essentially an NFS provisioner so we can provide the appropriate defaults for that. The defaults are RWX and Filesystem

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Open Stack manila now has a complete storage profile
```

