### PR TITLE
Bump bazel version in builder

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -50,7 +50,7 @@ RUN \
 	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
 	rm -rf "${GOPATH}/pkg"
 
-ENV BAZEL_VERSION 5.2.0
+ENV BAZEL_VERSION 5.3.1
 
 COPY output-bazel-arch.sh /output-bazel-arch.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Needed to get the fix for
https://github.com/bazelbuild/rules_go/pull/3231 If we want to bump to 1.19
kubevirt already at this version with 1.19
https://github.com/kubevirt/kubevirt/commit/9e15eca23c8554a13f19cd71ff8f82052d73c35a

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

