### PR TITLE
Adapt operator_test to cover OpenShift

### DIFF
--- a/tests/framework/nodeplacement.go
+++ b/tests/framework/nodeplacement.go
@@ -22,13 +22,22 @@ var (
 // The values chosen are valid, but the pod will likely not be schedulable.
 func (f *Framework) TestNodePlacementValues() sdkapi.NodePlacement {
 	nodes, _ := f.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+
+	nodeName := nodes.Items[0].Name
+	for _, node := range nodes.Items {
+		if _, hasLabel := node.Labels["node-role.kubernetes.io/worker"]; hasLabel {
+			nodeName = node.Name
+			break
+		}
+	}
+
 	affinityTestValue = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 				NodeSelectorTerms: []v1.NodeSelectorTerm{
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
-							{Key: "kubernetes.io/hostname", Operator: v1.NodeSelectorOpIn, Values: []string{nodes.Items[0].Name}},
+							{Key: "kubernetes.io/hostname", Operator: v1.NodeSelectorOpIn, Values: []string{nodeName}},
 						},
 					},
 				},

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -274,10 +274,7 @@ var _ = Describe("ALL Operator tests", func() {
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				Expect(err).ToNot(HaveOccurred())
 
-				cdiPods, err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{})
-
-				Expect(err).ToNot(HaveOccurred(), "failed listing cdi pods")
-				Expect(len(cdiPods.Items)).To(BeNumerically(">", 0), "no cdi pods found")
+				cdiPods = getCDIPods(f)
 			})
 
 			AfterEach(func() {
@@ -298,9 +295,7 @@ var _ = Describe("ALL Operator tests", func() {
 
 				By("Waiting for there to be as many CDI pods as before")
 				Eventually(func() bool {
-					newCdiPods, err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred(), "failed getting CDI pods")
-
+					newCdiPods = getCDIPods(f)
 					By(fmt.Sprintf("number of cdi pods: %d\n new number of cdi pods: %d\n", len(cdiPods.Items), len(newCdiPods.Items)))
 					return len(cdiPods.Items) == len(newCdiPods.Items)
 				}, 5*time.Minute, 2*time.Second).Should(BeTrue())
@@ -420,7 +415,7 @@ var _ = Describe("ALL Operator tests", func() {
 			})
 
 			It("[test_id:4986]should remove/install CDI a number of times successfully", func() {
-				for i := 0; i < 10; i++ {
+				for i := 0; i < 5; i++ {
 					err := f.CdiClient.CdiV1beta1().CDIs().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					ensureCDI()
@@ -444,6 +439,11 @@ var _ = Describe("ALL Operator tests", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return pod.Status.Phase == corev1.PodRunning
 				}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+
+				if us := cr.Spec.UninstallStrategy; us != nil && *us == cdiv1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist {
+					err = utils.DeleteDataVolume(f.CdiClient, dv.Namespace, dv.Name)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Deleting CDI")
 				err = f.CdiClient.CdiV1beta1().CDIs().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
@@ -1041,7 +1041,7 @@ var _ = Describe("ALL Operator tests", func() {
 
 				Eventually(func() int {
 					return getMetricValue("kubevirt_cdi_cr_ready")
-				}, 1*time.Minute, 1*time.Second).Should(BeNumerically("==", 1))
+				}, 2*time.Minute, 1*time.Second).Should(BeNumerically("==", 1))
 			})
 
 			It("[test_id:7965] StorageProfile incomplete metric expected value when creating an incomplete profile", func() {
@@ -1236,6 +1236,8 @@ var _ = Describe("ALL Operator tests", func() {
 				serverSecretNames := []string{"cdi-apiserver-server-cert", "cdi-uploadproxy-server-cert"}
 
 				ts := time.Now()
+				// Time comparison here is in seconds, so make sure there is an interval
+				time.Sleep(time.Second)
 
 				Eventually(func() bool {
 					cr := getCDI(f)
@@ -1363,6 +1365,8 @@ var _ = Describe("ALL Operator tests", func() {
 				prioClass := ""
 				if cr.Spec.PriorityClass != nil {
 					prioClass = string(*cr.Spec.PriorityClass)
+				} else if utils.IsOpenshift(f.K8sClient) {
+					prioClass = osUserCrit.Name
 				}
 				// Deployment
 				verifyPodPriorityClass(cdiDeploymentPodPrefix, string(prioClass), common.CDILabelSelector)
@@ -1400,6 +1404,9 @@ var _ = Describe("ALL Operator tests", func() {
 			})
 
 			It("should use openshift priority class if not set and available", func() {
+				if utils.IsOpenshift(f.K8sClient) {
+					Skip("This test is not needed in OpenShift")
+				}
 				getCDI(f)
 				_, err := f.K8sClient.SchedulingV1().PriorityClasses().Create(context.TODO(), osUserCrit, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1416,7 +1423,11 @@ var _ = Describe("ALL Operator tests", func() {
 })
 
 func getCDIPods(f *framework.Framework) *corev1.PodList {
-	cdiPods, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{})
+	By("Getting CDI pods")
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "storage"}}
+	cdiPods, err := f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	})
 	Expect(err).ToNot(HaveOccurred(), "failed listing cdi pods")
 	Expect(len(cdiPods.Items)).To(BeNumerically(">", 0), "no cdi pods found")
 	return cdiPods
@@ -1508,9 +1519,7 @@ func waitCDI(f *framework.Framework, cr *cdiv1.CDI, cdiPods *corev1.PodList) {
 
 	By("Waiting for there to be as many CDI pods as before")
 	Eventually(func() bool {
-		newCdiPods, err = f.K8sClient.CoreV1().Pods(f.CdiInstallNs).List(context.TODO(), metav1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred(), "failed getting CDI pods")
-
+		newCdiPods = getCDIPods(f)
 		By(fmt.Sprintf("number of cdi pods: %d\n new number of cdi pods: %d\n", len(cdiPods.Items), len(newCdiPods.Items)))
 		return len(cdiPods.Items) == len(newCdiPods.Items)
 	}, 5*time.Minute, 2*time.Second).Should(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:
Until recently, operator_test destructive tests were executed in CDI CI k8s lane, but they were rarely executed D/S on OpenShift cluster. To allow executing it D/S on a regular basis, as a follow-up to #2577, we fix a few test issues encountered on OpenShift cluster:
-Fix affinity to use a worker node instead of the first one
-Check only the storage-labeled pods, instead of all the pods in cdi namespace
-Check CDI UninstallStrategy to decide wheter to delete DVs beore deleting CDI
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

