### PR TITLE
Update git config to mark rsync directory as safe

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -48,6 +48,8 @@ fi
 echo "Making sure output directory exists..."
 ${CDI_CRI} run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --rm --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} mkdir -p /root/go/src/kubevirt.io/containerized-data-importer/_out
 
+${CDI_CRI} run -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --rm --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} git config --global --add safe.directory /root/go/src/kubevirt.io/containerized-data-importer
+
 echo "Starting rsyncd"
 # Start an rsyncd instance and make sure it gets stopped after the script exits
 RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --cap-add SYS_CHROOT --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to avoid
```
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```
we add `git config --global --add safe.directory /root/go/src/kubevirt.io/containerized-data-importer` in the builder container to tell git that the ownership not matching is not a problem and the rsync can work normally

buildvcs adds version information to the built binaries, would be lost if we directly add `-buildvcs=false` to the build command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

