### PR TITLE
Annotate DIC-created DV for immediate binding

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -943,7 +943,7 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	dv.Name = dataVolumeName
 	dv.Namespace = cron.Namespace
 	r.setDataImportCronResourceLabels(cron, dv)
-	passCronAnnotationToDv(cron, dv, cc.AnnImmediateBinding)
+	cc.AddAnnotation(dv, cc.AnnImmediateBinding, "true")
 	passCronAnnotationToDv(cron, dv, cc.AnnPodRetainAfterCompletion)
 
 	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetype)

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -319,10 +319,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			reconciler = createDataImportCronReconciler(cron)
 			verifyConditions("Before DesiredDigest is set", false, false, false, noImport, noDigest, "")
 
-			if cron.Annotations == nil {
-				cron.Annotations = make(map[string]string)
-			}
-			cron.Annotations[AnnSourceDesiredDigest] = testDigest
+			cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
 			err := reconciler.client.Update(context.TODO(), cron)
 			Expect(err).ToNot(HaveOccurred())
 			dataSource = &cdiv1.DataSource{}
@@ -340,6 +337,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*dv.Spec.Source.Registry.URL).To(Equal(testRegistryURL + "@" + testDigest))
+			Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
 
 			dv.Status.Phase = cdiv1.ImportScheduled
 			err = reconciler.client.Update(context.TODO(), dv)
@@ -407,14 +405,10 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			if cron.Annotations == nil {
-				cron.Annotations = make(map[string]string)
-			}
-
 			pvc := &corev1.PersistentVolumeClaim{}
 			lastTs := ""
 			verifyDigestUpdate := func(idx int) {
-				cron.Annotations[AnnSourceDesiredDigest] = digests[idx]
+				cc.AddAnnotation(cron, AnnSourceDesiredDigest, digests[idx])
 				err := reconciler.client.Update(context.TODO(), cron)
 				Expect(err).ToNot(HaveOccurred())
 				dataSource = &cdiv1.DataSource{}
@@ -576,6 +570,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*dv.Spec.Source.Registry.URL).To(Equal("docker://" + testDockerRef))
+			Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
 			dv.Status.Phase = cdiv1.Succeeded
 			dv.Status.Conditions = cdv.UpdateReadyCondition(dv.Status.Conditions, corev1.ConditionTrue, "", "")
 			err = reconciler.client.Update(context.TODO(), dv)

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Import Proxy tests", func() {
 
 			By(fmt.Sprintf("Create new DataImportCron %s, url %s", cronName, *reg.URL))
 			dic := utils.NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, 1, reg)
-			dic.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+			controller.AddAnnotation(dic, controller.AnnPodRetainAfterCompletion, "true")
 			retentionPolicy := cdiv1.DataImportCronRetainNone
 			dic.Spec.RetentionPolicy = &retentionPolicy
 

--- a/tests/utils/dataimportcron.go
+++ b/tests/utils/dataimportcron.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
 )
 
 // NewDataImportCron initializes a DataImportCron struct
@@ -14,9 +13,6 @@ func NewDataImportCron(name, size, schedule, dataSource string, importsToKeep in
 	return &cdiv1.DataImportCron{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
-			Annotations: map[string]string{
-				controller.AnnImmediateBinding: "true",
-			},
 		},
 		Spec: cdiv1.DataImportCronSpec{
 			Template: cdiv1.DataVolume{


### PR DESCRIPTION
**What this PR does / why we need it**:
If the storage class binding mode is WaitForFirstConsumer, and the annotation was not explicitly added to the DIC DV template, the created DV will get stuck in WFFC phase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [bz #2166394](https://bugzilla.redhat.com/show_bug.cgi?id=2166394)

**Special notes for your reviewer**:

**Release note**:
```release-note
Annotate DataImportCron-created DataVolumes for immediate binding, so they will not get stuck in WaitForFirstConsumer phase.
```

