### PR TITLE
[release-v1.55] Annotate DIC-created DV for immediate binding

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -930,7 +930,7 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	dv.Name = dataVolumeName
 	dv.Namespace = cron.Namespace
 	r.setDataImportCronResourceLabels(cron, dv)
-	passCronAnnotationToDv(cron, dv, AnnImmediateBinding)
+	AddAnnotation(dv, AnnImmediateBinding, "true")
 	passCronAnnotationToDv(cron, dv, AnnPodRetainAfterCompletion)
 	return dv
 }

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Import Proxy tests", func() {
 
 			By(fmt.Sprintf("Create new DataImportCron %s, url %s", cronName, *reg.URL))
 			dic := utils.NewDataImportCron(cronName, "5Gi", scheduleEveryMinute, dataSourceName, 1, reg)
-			dic.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+			controller.AddAnnotation(dic, controller.AnnPodRetainAfterCompletion, "true")
 			retentionPolicy := cdiv1.DataImportCronRetainNone
 			dic.Spec.RetentionPolicy = &retentionPolicy
 

--- a/tests/utils/dataimportcron.go
+++ b/tests/utils/dataimportcron.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"kubevirt.io/containerized-data-importer/pkg/controller"
 )
 
 // NewDataImportCron initializes a DataImportCron struct
@@ -14,9 +13,6 @@ func NewDataImportCron(name, size, schedule, dataSource string, importsToKeep in
 	return &cdiv1.DataImportCron{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
-			Annotations: map[string]string{
-				controller.AnnImmediateBinding: "true",
-			},
 		},
 		Spec: cdiv1.DataImportCronSpec{
 			Template: cdiv1.DataVolume{


### PR DESCRIPTION
Manual backport of #2650

**What this PR does / why we need it**:
If the storage class binding mode is WaitForFirstConsumer, and the annotation was not explicitly added to the DIC DV template, the created DV will get stuck in WFFC phase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [bz #2180801](https://bugzilla.redhat.com/show_bug.cgi?id=2180801)

**Special notes for your reviewer**:

**Release note**:
```release-note
Annotate DataImportCron-created DataVolumes for immediate binding, so they will not get stuck in WaitForFirstConsumer phase.
```