### PR TITLE
Bump lifecycle-operator-sdk to aggregate deployment conditions on CDI CR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	kubevirt.io/containerized-data-importer-api v0.0.0
-	kubevirt.io/controller-lifecycle-operator-sdk v0.2.4
+	kubevirt.io/controller-lifecycle-operator-sdk v0.2.5
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 	kubevirt.io/qe-tools v0.1.6
 	libguestfs.org/libnbd v1.11.5

--- a/go.sum
+++ b/go.sum
@@ -2045,8 +2045,8 @@ k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-kubevirt.io/controller-lifecycle-operator-sdk v0.2.4 h1:H+VDfGgc85S6MsstwXxCtiwTfOnD/QMtO8m/zGM5Thg=
-kubevirt.io/controller-lifecycle-operator-sdk v0.2.4/go.mod h1:JlY8c5nFxNZCo3ns1pFqstPJbjgBFh6+9FuL2/5cDfk=
+kubevirt.io/controller-lifecycle-operator-sdk v0.2.5 h1:3rMW6BF4rN7+MphXRaRBR5Zio3P4i6CYlVD7bnNf+yM=
+kubevirt.io/controller-lifecycle-operator-sdk v0.2.5/go.mod h1:JlY8c5nFxNZCo3ns1pFqstPJbjgBFh6+9FuL2/5cDfk=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/qe-tools v0.1.6 h1:S6z9CATmgV2/z9CWetij++Rhu7l/Z4ObZqerLdNMo0Y=

--- a/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/reconciler/BUILD.bazel
+++ b/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/reconciler/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
-        "//vendor/github.com/openshift/custom-resource-status/conditions/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/util.go
+++ b/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/util.go
@@ -170,6 +170,28 @@ func CheckDeploymentReady(deployment *appsv1.Deployment) bool {
 	return true
 }
 
+func CheckDeploymentRequiresIntervention(deployment *appsv1.Deployment) bool {
+	var progressing, available bool
+	if cond := GetDeploymentCondition(deployment.Status, appsv1.DeploymentAvailable); cond != nil && cond.Status == v1.ConditionTrue {
+		available = true
+	}
+	if cond := GetDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing); cond != nil && cond.Status == v1.ConditionTrue {
+		progressing = true
+	}
+
+	return !progressing && !available
+}
+
+func GetDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
 func NewDefaultInstance(obj client.Object) client.Object {
 	typ := reflect.ValueOf(obj).Elem().Type()
 	return reflect.New(typ).Interface().(client.Object)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1363,7 +1363,7 @@ kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/utils
 kubevirt.io/containerized-data-importer-api/pkg/apis/upload
 kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1
-# kubevirt.io/controller-lifecycle-operator-sdk v0.2.4
+# kubevirt.io/controller-lifecycle-operator-sdk v0.2.5
 ## explicit; go 1.14
 kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk
 kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/callbacks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, we just dangle in Deploying phase when things go badly,
although the deployment conditions API provides more information such as `Progressing=false` that we can use to better capture the status of install.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://github.com/kubevirt/controller-lifecycle-operator-sdk/pull/23

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Aggregate failed workload conditions into CR
```

