### PR TITLE
Correctly wait for resourcequota "ready" state in tests

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -462,7 +462,7 @@ func (f *Framework) CreateQuotaInSpecifiedNs(ns string, requestCPU, requestMemor
 		if err != nil {
 			return false, err
 		}
-		return len(quota.Status.Hard) == 4, nil
+		return len(quota.Status.Used) == 4, nil
 	})
 }
 
@@ -486,7 +486,14 @@ func (f *Framework) UpdateQuotaInNs(requestCPU, requestMemory, limitsCPU, limits
 	if err != nil {
 		ginkgo.Fail("Unable to set resource quota " + err.Error())
 	}
-	return err
+	return wait.PollImmediate(5*time.Second, nsDeleteTime, func() (bool, error) {
+		quota, err := f.K8sClient.CoreV1().ResourceQuotas(f.Namespace.GetName()).Get(context.TODO(), "test-quota", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "ERROR: GET ResourceQuota failed once, retrying: %v\n", err.Error())
+			return false, nil
+		}
+		return len(quota.Status.Used) == 4, nil
+	})
 }
 
 // CreateStorageQuota creates a quota to limit pvc count and cumulative storage capacity
@@ -514,7 +521,7 @@ func (f *Framework) CreateStorageQuota(numPVCs, requestStorage int64) error {
 			fmt.Fprintf(ginkgo.GinkgoWriter, "ERROR: GET ResourceQuota failed once, retrying: %v\n", err.Error())
 			return false, nil
 		}
-		return len(quota.Status.Hard) == 2, nil
+		return len(quota.Status.Used) == 2, nil
 	})
 }
 
@@ -544,7 +551,7 @@ func (f *Framework) UpdateStorageQuota(numPVCs, requestStorage int64) error {
 		}
 		requestStorageUpdated := resource.NewQuantity(requestStorage, resource.DecimalSI).Cmp(quota.Status.Hard[v1.ResourceRequestsStorage])
 		numPVCsUpdated := resource.NewQuantity(numPVCs, resource.DecimalSI).Cmp(quota.Status.Hard[v1.ResourcePersistentVolumeClaims])
-		return requestStorageUpdated+numPVCsUpdated == 0, nil
+		return len(quota.Status.Used) == 2 && requestStorageUpdated+numPVCsUpdated == 0, nil
 	})
 }
 

--- a/tests/transfer_test.go
+++ b/tests/transfer_test.go
@@ -402,7 +402,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 			Entry("with same namespace and explicit name", false, &[]string{"target-name"}[0]),
 		)
 
-		It("[posneg:negative][test_id:5734]should handle quota failure", func() {
+		It("[posneg:negative][test_id:5734]should report quota failure on dv transfer and succeed once quota is large enough", func() {
 			sq := int64(100 * 1024 * 1024)
 			bq := int64(1024 * 1024 * 1024)
 			dataVolume := createDV(f.Namespace.Name, "source-dv")
@@ -425,9 +425,17 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 					},
 				},
 			}
+			quotaUpdated := func() int {
+				quota, err := f.K8sClient.CoreV1().ResourceQuotas(targetNs.Name).Get(context.TODO(), rq.Name, metav1.GetOptions{})
+				if err != nil {
+					return -1
+				}
+				return len(quota.Status.Used)
+			}
 
 			rq, err = f.K8sClient.CoreV1().ResourceQuotas(targetNs.Name).Create(context.TODO(), rq, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			Eventually(quotaUpdated, 2*time.Minute, 2*time.Second).Should(BeNumerically("==", 1))
 
 			ot := &cdiv1.ObjectTransfer{
 				ObjectMeta: metav1.ObjectMeta{
@@ -472,6 +480,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 			rq.Spec.Hard[corev1.ResourceRequestsStorage] = *resource.NewQuantity(bq, resource.DecimalSI)
 			rq, err = f.K8sClient.CoreV1().ResourceQuotas(targetNs.Name).Update(context.TODO(), rq, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			Eventually(quotaUpdated, 2*time.Minute, 2*time.Second).Should(BeNumerically("==", 1))
 
 			Eventually(func() bool {
 				ot2, err := f.CdiClient.CdiV1beta1().ObjectTransfers().Get(context.TODO(), ot.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Apparently the correct way to understand if a quota is "ready" is to look at the keys in the `used` field.
Hopefully this eliminates error like these on test runs
```bash
persistentvolumeclaims "test-pvc" is forbidden: status unknown for quota: test-storage-quota
```

Sources:
https://github.com/kubernetes/apiserver/blob/a32e26b98aff9e1dfdf0fb8d0d49d9b56287b875/pkg/admission/plugin/resourcequota/controller.go#L473-L475 https://github.com/kubernetes/kubernetes/blob/a24aef65108bb3549c9ad31f51aab8097c640447/test/e2e/apimachinery/resource_quota.go#L2152

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

