### PR TITLE
Allow restoreSize to be 0, and use request size if 0

### DIFF
--- a/pkg/controller/datavolume/smart-clone-controller_test.go
+++ b/pkg/controller/datavolume/smart-clone-controller_test.go
@@ -18,6 +18,7 @@ package datavolume
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -243,6 +244,66 @@ var _ = Describe("All smart clone tests", func() {
 			Expect(event).To(ContainSubstring("Creating PVC for smart-clone is in progress"))
 		})
 	})
+
+	createSnapshotWithRestoreSize := func(size int64) *snapshotv1.VolumeSnapshot {
+		snapshot := createSnapshotVolume("snapshot", "default", nil)
+		snapshot.Status.RestoreSize = resource.NewQuantity(size, resource.BinarySI)
+		return snapshot
+	}
+
+	createCloneDataVolumeWithRequestSizePvc := func(size int64) *cdiv1.DataVolume {
+		dv := createCloneDataVolume("testDv", "default", "snapshot", "default")
+		sizeQuantity := resource.NewQuantity(size, resource.BinarySI)
+		dv.Spec.PVC = &corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *sizeQuantity,
+				},
+			},
+		}
+		return dv
+	}
+
+	createCloneDataVolumeWithRequestSizeStorage := func(size int64) *cdiv1.DataVolume {
+		dv := createCloneDataVolume("testDv", "default", "snapshot", "default")
+		sizeQuantity := resource.NewQuantity(size, resource.BinarySI)
+		dv.Spec.Storage = &cdiv1.StorageSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *sizeQuantity,
+				},
+			},
+		}
+		return dv
+	}
+
+	table.DescribeTable("newPvcFromSnapshot should return proper size", func(dv *cdiv1.DataVolume, snapshot *snapshotv1.VolumeSnapshot, expectedSize int64, expectedError error) {
+		targetPvcSpec := &corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		}
+		pvc, err := newPvcFromSnapshot(dv, "targetPvc", snapshot, targetPvcSpec)
+		if expectedError == nil {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc).ToNot(BeNil())
+			Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(expectedSize))
+		} else {
+			Expect(err).To(Equal(expectedError))
+		}
+	},
+		table.Entry("with nil restoreSize", createCloneDataVolume("testDv", "default", "snapshot", "default"), createSnapshotVolume("snapshot", "default", nil), int64(0), fmt.Errorf("snapshot has no RestoreSize")),
+		table.Entry("with 0 restoreSize, and no dv size", createCloneDataVolume("testDv", "default", "snapshot", "default"), createSnapshotWithRestoreSize(int64(0)), int64(0), fmt.Errorf("unable to determine restore size of PVC")),
+		table.Entry("with negative restoreSize, and no dv size", createCloneDataVolume("testDv", "default", "snapshot", "default"), createSnapshotWithRestoreSize(int64(-1024)), int64(0), fmt.Errorf("snapshot has no RestoreSize")),
+		table.Entry("with 0 restoreSize, and set dv pvc size", createCloneDataVolumeWithRequestSizePvc(int64(1024)), createSnapshotWithRestoreSize(int64(0)), int64(1024), nil),
+		table.Entry("with negative restoreSize, and set dv pvc size", createCloneDataVolumeWithRequestSizePvc(int64(10240)), createSnapshotWithRestoreSize(int64(-10240)), int64(0), fmt.Errorf("snapshot has no RestoreSize")),
+		table.Entry("with postive restoreSize, and set larger dv pvc size", createCloneDataVolumeWithRequestSizePvc(int64(102400)), createSnapshotWithRestoreSize(int64(1024)), int64(1024), nil),
+		table.Entry("with 0 restoreSize, and set dv size storage", createCloneDataVolumeWithRequestSizeStorage(int64(2048)), createSnapshotWithRestoreSize(int64(0)), int64(2048), nil),
+		table.Entry("with negative restoreSize, and set dv size storage", createCloneDataVolumeWithRequestSizeStorage(int64(20480)), createSnapshotWithRestoreSize(int64(-20480)), int64(0), fmt.Errorf("snapshot has no RestoreSize")),
+		table.Entry("with postive restoreSize, and set larger dv size storage", createCloneDataVolumeWithRequestSizeStorage(int64(204800)), createSnapshotWithRestoreSize(int64(2048)), int64(2048), nil),
+	)
 })
 
 func createSmartCloneReconciler(objects ...runtime.Object) *SmartCloneReconciler {
@@ -304,6 +365,24 @@ func createSnapshotVolume(name, namespace string, owner *metav1.OwnerReference) 
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue,
 				common.CDIComponentLabel: common.SmartClonerCDILabel,
+			},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{},
+	}
+}
+
+func createCloneDataVolume(name, namespace, pvcName, pvcNamespace string) *cdiv1.DataVolume {
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			Source: &cdiv1.DataVolumeSource{
+				PVC: &cdiv1.DataVolumeSourcePVC{
+					Name:      pvcName,
+					Namespace: pvcNamespace,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some CSI provisioner when making volume snapshots don't set the restore size because it is hard to figure out the value or the actual stored size on the storage is 0 (Copy on Write). There was a strict check in place in case of CSI drivers not allowing a restore to a size other than the restoreSize of the snapshot.

This makes the check more lenient that when we encounter a 0 size restoreSize, we can assume we can use the requested size value in the pvc

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2679 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed failing snapshot clone if CSI driver set 0 to restoreSize of volumeSnapshot
```

