### PR TITLE
Create PVC if possible even if the StorageClass is missing

### DIFF
--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -122,7 +122,7 @@ func UpdateReadyCondition(conditions []cdiv1.DataVolumeCondition, status corev1.
 	return updateCondition(conditions, cdiv1.DataVolumeReady, status, message, reason)
 }
 
-func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, reason string) []cdiv1.DataVolumeCondition {
+func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, message, reason string) []cdiv1.DataVolumeCondition {
 	if pvc != nil {
 		pvcCondition := getPVCCondition(pvc.GetAnnotations())
 		switch pvc.Status.Phase {
@@ -149,10 +149,13 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 			conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 		}
 	} else {
+		if message == "" {
+			message = "No PVC found"
+		}
 		if reason == "" {
 			reason = cc.NotFound
 		}
-		conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionUnknown, "No PVC found", reason)
+		conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionUnknown, message, reason)
 		conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 	}
 	return conditions

--- a/pkg/controller/datavolume/conditions_test.go
+++ b/pkg/controller/datavolume/conditions_test.go
@@ -135,7 +135,7 @@ var _ = Describe("updateReadyCondition", func() {
 var _ = Describe("updateBoundCondition", func() {
 	It("should create condition if it doesn't exist", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
-		conditions = updateBoundCondition(conditions, nil, "")
+		conditions = updateBoundCondition(conditions, nil, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -147,7 +147,7 @@ var _ = Describe("updateBoundCondition", func() {
 	It("should create condition with reason if it doesn't exist", func() {
 		reason := "exceeded quota"
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
-		conditions = updateBoundCondition(conditions, nil, reason)
+		conditions = updateBoundCondition(conditions, nil, "", reason)
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -156,11 +156,23 @@ var _ = Describe("updateBoundCondition", func() {
 		Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
 	})
 
+	It("should create condition with message if one passed", func() {
+		message := "message"
+		conditions := make([]cdiv1.DataVolumeCondition, 0)
+		conditions = updateBoundCondition(conditions, nil, message, "")
+		Expect(len(conditions)).To(Equal(2))
+		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
+		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
+		Expect(condition.Message).To(Equal(message))
+		Expect(condition.Reason).To(Equal(NotFound))
+		Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
+	})
+
 	It("should be bound if PVC bound", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, nil, nil)
 		pvc.Status.Phase = corev1.ClaimBound
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(1))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -173,7 +185,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "true"}, nil)
 		pvc.Status.Phase = corev1.ClaimBound
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(1))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -186,7 +198,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: "not bound", AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
 		pvc.Status.Phase = corev1.ClaimBound
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -204,7 +216,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, nil, nil)
 		pvc.Status.Phase = corev1.ClaimPending
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -222,7 +234,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "true"}, nil)
 		pvc.Status.Phase = corev1.ClaimPending
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -241,7 +253,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, map[string]string{AnnBoundCondition: "false", AnnBoundConditionReason: reason, AnnBoundConditionMessage: "scratch PVC not bound"}, nil)
 		pvc.Status.Phase = corev1.ClaimPending
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
@@ -259,7 +271,7 @@ var _ = Describe("updateBoundCondition", func() {
 		conditions := make([]cdiv1.DataVolumeCondition, 0)
 		pvc := CreatePvc("test", corev1.NamespaceDefault, nil, nil)
 		pvc.Status.Phase = corev1.ClaimLost
-		conditions = updateBoundCondition(conditions, pvc, "")
+		conditions = updateBoundCondition(conditions, pvc, "", "")
 		Expect(len(conditions)).To(Equal(2))
 		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -73,6 +73,8 @@ const (
 	dvPhaseField = "status.phase"
 
 	claimRefField = "spec.claimRef"
+
+	claimStorageClassNameField = "spec.storageClassName"
 )
 
 var httpClient *http.Client
@@ -201,6 +203,14 @@ func CreateCommonIndexes(mgr manager.Manager) error {
 			return err
 		}
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &corev1.PersistentVolume{}, claimStorageClassNameField, func(obj client.Object) []string {
+		if pv, ok := obj.(*corev1.PersistentVolume); ok {
+			return []string{pv.Spec.StorageClassName}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -286,6 +296,30 @@ func addDataVolumeControllerCommonWatches(mgr manager.Manager, dataVolumeControl
 			}
 			for _, dv := range dvList.Items {
 				if getDataVolumeOp(mgr.GetLogger(), &dv, mgr.GetClient()) == op {
+					reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
+				}
+			}
+			return
+		},
+	),
+	); err != nil {
+		return err
+	}
+
+	// Watch for PV updates to reconcile the DVs waiting for available PV
+	if err := dataVolumeController.Watch(&source.Kind{Type: &corev1.PersistentVolume{}}, handler.EnqueueRequestsFromMapFunc(
+		func(obj client.Object) (reqs []reconcile.Request) {
+			pv := obj.(*corev1.PersistentVolume)
+			dvList := &cdiv1.DataVolumeList{}
+			if err := mgr.GetClient().List(context.TODO(), dvList, client.MatchingFields{dvPhaseField: ""}); err != nil {
+				return
+			}
+			for _, dv := range dvList.Items {
+				storage := dv.Spec.Storage
+				if storage != nil &&
+					storage.StorageClassName != nil &&
+					*storage.StorageClassName == pv.Spec.StorageClassName &&
+					getDataVolumeOp(mgr.GetLogger(), &dv, mgr.GetClient()) == op {
 					reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
 				}
 			}
@@ -411,6 +445,8 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 
 	syncState.pvcSpec, err = renderPvcSpec(r.client, r.recorder, log, dv)
 	if err != nil {
+		r.syncDataVolumeStatusPhaseWithEvent(&syncState, cdiv1.PhaseUnset, nil,
+			Event{corev1.EventTypeWarning, cc.ErrClaimNotValid, err.Error()})
 		return syncState, err
 	}
 
@@ -707,10 +743,12 @@ func (r *ReconcilerBase) updateDataVolumeStatusPhaseWithEvent(
 	dataVolumeCopy.Status.Phase = phase
 
 	reason := ""
+	message := ""
 	if pvc == nil {
 		reason = event.reason
+		message = event.message
 	}
-	r.updateConditions(dataVolumeCopy, pvc, reason)
+	r.updateConditions(dataVolumeCopy, pvc, reason, message)
 	return r.emitEvent(dataVolume, dataVolumeCopy, curPhase, dataVolume.Status.Conditions, &event)
 }
 
@@ -797,11 +835,11 @@ func (r ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPha
 
 	currentCond := make([]cdiv1.DataVolumeCondition, len(dataVolumeCopy.Status.Conditions))
 	copy(currentCond, dataVolumeCopy.Status.Conditions)
-	r.updateConditions(dataVolumeCopy, pvc, "")
+	r.updateConditions(dataVolumeCopy, pvc, "", "")
 	return result, r.emitEvent(dv, dataVolumeCopy, curPhase, currentCond, &event)
 }
 
-func (r *ReconcilerBase) updateConditions(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim, reason string) {
+func (r *ReconcilerBase) updateConditions(dataVolume *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim, reason, message string) {
 	var anno map[string]string
 
 	if dataVolume.Status.Conditions == nil {
@@ -824,8 +862,8 @@ func (r *ReconcilerBase) updateConditions(dataVolume *cdiv1.DataVolume, pvc *cor
 		readyStatus = corev1.ConditionFalse
 	}
 
-	dataVolume.Status.Conditions = updateBoundCondition(dataVolume.Status.Conditions, pvc, reason)
-	dataVolume.Status.Conditions = UpdateReadyCondition(dataVolume.Status.Conditions, readyStatus, "", reason)
+	dataVolume.Status.Conditions = updateBoundCondition(dataVolume.Status.Conditions, pvc, message, reason)
+	dataVolume.Status.Conditions = UpdateReadyCondition(dataVolume.Status.Conditions, readyStatus, message, reason)
 	dataVolume.Status.Conditions = updateRunningCondition(dataVolume.Status.Conditions, anno)
 }
 

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -694,7 +694,7 @@ func (r *PvcCloneReconciler) isSourcePVCPopulated(dv *cdiv1.DataVolume) (bool, e
 }
 
 func (r *PvcCloneReconciler) sourceInUse(dv *cdiv1.DataVolume, eventReason string) (bool, error) {
-	pods, err := cc.GetPodsUsingPVCs(r.client, dv.Spec.Source.PVC.Namespace, sets.New[string](dv.Spec.Source.PVC.Name), false)
+	pods, err := cc.GetPodsUsingPVCs(r.client, dv.Spec.Source.PVC.Namespace, sets.New(dv.Spec.Source.PVC.Name), false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -373,8 +373,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc := CreatePvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
 			reconciler = createCloneReconciler(dv, pvc, createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
 			snapclass, err := reconciler.getSnapshotClassForSmartClone(dv, dv.Spec.PVC)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to retrieve storage class"))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(snapclass).To(BeEmpty())
 		})
 

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -730,7 +730,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				{AccessModes: accessMode, VolumeMode: &BlockMode}}, &cloneStrategy)
 
 			reconciler := createCloneReconciler(dv, storageProfile, sc)
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, nil)
 			Expect(err).ToNot(HaveOccurred())
 			done, err := reconciler.detectCloneSize(syncState(dv, targetPvc, pvcSpec), HostAssistedClone)
 			Expect(err).To(HaveOccurred())
@@ -747,7 +747,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc := CreatePvcInStorageClass("test", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
 			reconciler := createCloneReconciler(dv, pvc, storageProfile, sc)
 
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			done, err := reconciler.detectCloneSize(syncState(dv, pvc, pvcSpec), HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
@@ -775,7 +775,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvc.GetAnnotations()[AnnPodPhase] = string(corev1.PodSucceeded)
 			reconciler := createCloneReconciler(dv, pvc, storageProfile, sc)
 
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			done, err := reconciler.detectCloneSize(syncState(dv, pvc, pvcSpec), HostAssistedClone)
 			Expect(err).ToNot(HaveOccurred())
@@ -811,7 +811,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Checks
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			done, err := reconciler.detectCloneSize(syncState(dv, pvc, pvcSpec), HostAssistedClone)
 			Expect(err).To(HaveOccurred())
@@ -852,7 +852,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get the expected value
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSize, err := cc.InflateSizeWithOverhead(reconciler.client, int64(100), pvcSpec)
 			Expect(err).ToNot(HaveOccurred())
@@ -883,7 +883,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			reconciler := createCloneReconciler(dv, pvc, storageProfile, sc)
 
 			// Get the expected value
-			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSize, err := cc.InflateSizeWithOverhead(reconciler.client, int64(100), pvcSpec)
 			Expect(err).ToNot(HaveOccurred())
@@ -910,7 +910,7 @@ var _ = Describe("All DataVolume Tests", func() {
 				pvc.Spec.VolumeMode = &volumeMode
 				reconciler := createCloneReconciler(dv, pvc, storageProfile, sc)
 
-				pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
+				pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv, pvc)
 				Expect(err).ToNot(HaveOccurred())
 				expectedSize := *pvc.Status.Capacity.Storage()
 				done, err := reconciler.detectCloneSize(syncState(dv, pvc, pvcSpec), selectedCloneStrategy)

--- a/pkg/controller/datavolume/smart-clone-controller.go
+++ b/pkg/controller/datavolume/smart-clone-controller.go
@@ -234,7 +234,7 @@ func (r *SmartCloneReconciler) reconcileSnapshot(log logr.Logger, snapshot *snap
 		return reconcile.Result{}, nil
 	}
 
-	targetPvcSpec, err := renderPvcSpec(r.client, r.recorder, r.log, dataVolume)
+	targetPvcSpec, err := renderPvcSpec(r.client, r.recorder, r.log, dataVolume, nil)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -45,93 +44,105 @@ const (
 )
 
 // renderPvcSpec creates a new PVC Spec based on either the dv.spec.pvc or dv.spec.storage section
-func renderPvcSpec(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume) (*v1.PersistentVolumeClaimSpec, error) {
+func renderPvcSpec(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
 	if dv.Spec.PVC != nil {
 		return dv.Spec.PVC.DeepCopy(), nil
 	} else if dv.Spec.Storage != nil {
-		return pvcFromStorage(client, recorder, log, dv)
+		return pvcFromStorage(client, recorder, log, dv, pvc)
 	}
 
 	return nil, errors.Errorf("datavolume one of {pvc, storage} field is required")
 }
 
-func pvcFromStorage(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume) (*v1.PersistentVolumeClaimSpec, error) {
-	storage := dv.Spec.Storage
-	pvcSpec := copyStorageAsPvc(log, storage)
+func pvcFromStorage(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
+	var pvcSpec *v1.PersistentVolumeClaimSpec
 
+	if pvc == nil {
+		pvcSpec = copyStorageAsPvc(log, dv.Spec.Storage)
+		if err := renderPvcSpecVolumeModeAndAccessModes(client, recorder, log, dv, pvcSpec); err != nil {
+			return nil, err
+		}
+	} else {
+		pvcSpec = pvc.Spec.DeepCopy()
+	}
+
+	if err := renderPvcSpecVolumeSize(client, dv.Spec, pvcSpec); err != nil {
+		return nil, err
+	}
+
+	return pvcSpec, nil
+}
+
+func renderPvcSpecVolumeModeAndAccessModes(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvcSpec *v1.PersistentVolumeClaimSpec) error {
 	if dv.Spec.ContentType == cdiv1.DataVolumeArchive {
 		if pvcSpec.VolumeMode != nil && *pvcSpec.VolumeMode == v1.PersistentVolumeBlock {
 			log.V(1).Info("DataVolume with ContentType Archive cannot have block volumeMode", "namespace", dv.Namespace, "name", dv.Name)
 			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid, "DataVolume with ContentType Archive cannot have block volumeMode")
-			return nil, errors.Errorf("DataVolume with ContentType Archive cannot have block volumeMode")
+			return errors.Errorf("DataVolume with ContentType Archive cannot have block volumeMode")
 		}
 		volumeMode := v1.PersistentVolumeFilesystem
 		pvcSpec.VolumeMode = &volumeMode
 	}
 
-	storageClass, err := cc.GetStorageClassByName(client, storage.StorageClassName)
+	storageClass, err := cc.GetStorageClassByName(client, dv.Spec.Storage.StorageClassName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if storageClass == nil {
-		// If SC was not found, look for PV with this SC name
-		pv, err := getPV(client, pvcSpec, dv.Name, dv.Namespace)
-		if err != nil {
-			return nil, err
-		}
-		if pv != nil {
-			pvcSpec.VolumeMode = pv.Spec.VolumeMode
-			if len(pvcSpec.AccessModes) == 0 {
-				pvcSpec.AccessModes = pv.Spec.AccessModes
-			}
+		if err := renderPvcSpecFromAvailablePv(client, pvcSpec); err != nil {
+			return err
 		}
 		// Not even default storageClass on the cluster, cannot apply the defaults, verify spec is ok
 		if len(pvcSpec.AccessModes) == 0 {
 			log.V(1).Info("Cannot set accessMode for new pvc", "namespace", dv.Namespace, "name", dv.Name)
 			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid, "DataVolume.storage spec is missing accessMode and no storageClass to choose profile")
-			return nil, errors.Errorf("DataVolume spec is missing accessMode")
+			return errors.Errorf("DataVolume spec is missing accessMode")
 		}
-	} else {
-		pvcSpec.StorageClassName = &storageClass.Name
-		// given storageClass we can apply defaults if needed
-		if (pvcSpec.VolumeMode == nil || *pvcSpec.VolumeMode == "") && (len(pvcSpec.AccessModes) == 0) {
-			accessModes, volumeMode, err := getDefaultVolumeAndAccessMode(client, storageClass)
-			if err != nil {
-				log.V(1).Info("Cannot set accessMode and volumeMode for new pvc", "namespace", dv.Namespace, "name", dv.Name, "Error", err)
-				recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid,
-					fmt.Sprintf("DataVolume.storage spec is missing accessMode and volumeMode, cannot get access mode from StorageProfile %s", getName(storageClass)))
-				return nil, err
-			}
-			pvcSpec.AccessModes = append(pvcSpec.AccessModes, accessModes...)
-			pvcSpec.VolumeMode = volumeMode
-		} else if len(pvcSpec.AccessModes) == 0 {
-			accessModes, err := getDefaultAccessModes(client, storageClass, pvcSpec.VolumeMode)
-			if err != nil {
-				log.V(1).Info("Cannot set accessMode for new pvc", "namespace", dv.Namespace, "name", dv.Name, "Error", err)
-				recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid,
-					fmt.Sprintf("DataVolume.storage spec is missing accessMode and cannot get access mode from StorageProfile %s", getName(storageClass)))
-				return nil, err
-			}
-			pvcSpec.AccessModes = append(pvcSpec.AccessModes, accessModes...)
-		} else if pvcSpec.VolumeMode == nil || *pvcSpec.VolumeMode == "" {
-			volumeMode, err := getDefaultVolumeMode(client, storageClass, pvcSpec.AccessModes)
-			if err != nil {
-				return nil, err
-			}
-			pvcSpec.VolumeMode = volumeMode
-		}
+		return nil
 	}
 
-	requestedVolumeSize, err := resolveVolumeSize(client, dv.Spec, pvcSpec)
+	pvcSpec.StorageClassName = &storageClass.Name
+	// given storageClass we can apply defaults if needed
+	if (pvcSpec.VolumeMode == nil || *pvcSpec.VolumeMode == "") && (len(pvcSpec.AccessModes) == 0) {
+		accessModes, volumeMode, err := getDefaultVolumeAndAccessMode(client, storageClass)
+		if err != nil {
+			log.V(1).Info("Cannot set accessMode and volumeMode for new pvc", "namespace", dv.Namespace, "name", dv.Name, "Error", err)
+			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid,
+				fmt.Sprintf("DataVolume.storage spec is missing accessMode and volumeMode, cannot get access mode from StorageProfile %s", getName(storageClass)))
+			return err
+		}
+		pvcSpec.AccessModes = append(pvcSpec.AccessModes, accessModes...)
+		pvcSpec.VolumeMode = volumeMode
+	} else if len(pvcSpec.AccessModes) == 0 {
+		accessModes, err := getDefaultAccessModes(client, storageClass, pvcSpec.VolumeMode)
+		if err != nil {
+			log.V(1).Info("Cannot set accessMode for new pvc", "namespace", dv.Namespace, "name", dv.Name, "Error", err)
+			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid,
+				fmt.Sprintf("DataVolume.storage spec is missing accessMode and cannot get access mode from StorageProfile %s", getName(storageClass)))
+			return err
+		}
+		pvcSpec.AccessModes = append(pvcSpec.AccessModes, accessModes...)
+	} else if pvcSpec.VolumeMode == nil || *pvcSpec.VolumeMode == "" {
+		volumeMode, err := getDefaultVolumeMode(client, storageClass, pvcSpec.AccessModes)
+		if err != nil {
+			return err
+		}
+		pvcSpec.VolumeMode = volumeMode
+	}
+
+	return nil
+}
+
+func renderPvcSpecVolumeSize(client client.Client, dvSpec cdiv1.DataVolumeSpec, pvcSpec *v1.PersistentVolumeClaimSpec) error {
+	requestedVolumeSize, err := resolveVolumeSize(client, dvSpec, pvcSpec)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if pvcSpec.Resources.Requests == nil {
 		pvcSpec.Resources.Requests = v1.ResourceList{}
 	}
 	pvcSpec.Resources.Requests[v1.ResourceStorage] = *requestedVolumeSize
-
-	return pvcSpec, nil
+	return nil
 }
 
 func getName(storageClass *storagev1.StorageClass) string {
@@ -157,35 +168,31 @@ func copyStorageAsPvc(log logr.Logger, storage *cdiv1.StorageSpec) *v1.Persisten
 	return pvcSpec
 }
 
-// Gets either the bound PV or an available satisfying PV
-func getPV(c client.Client, pvcSpec *v1.PersistentVolumeClaimSpec, pvcName, pvcNamespace string) (*corev1.PersistentVolume, error) {
+// Renders the PVC spec VolumeMode and AccessModes from an available satisfying PV
+func renderPvcSpecFromAvailablePv(c client.Client, pvcSpec *v1.PersistentVolumeClaimSpec) error {
 	if pvcSpec.StorageClassName == nil {
-		return nil, nil
+		return nil
 	}
 
 	pvList := &v1.PersistentVolumeList{}
 	fields := client.MatchingFields{claimStorageClassNameField: *pvcSpec.StorageClassName}
 	if err := c.List(context.TODO(), pvList, fields); err != nil {
-		return nil, err
+		return err
 	}
 	for _, pv := range pvList.Items {
-		if pv.Status.Phase == corev1.VolumeBound &&
-			pv.Spec.ClaimRef != nil &&
-			pv.Spec.ClaimRef.Name == pvcName &&
-			pv.Spec.ClaimRef.Namespace == pvcNamespace {
-			return &pv, nil
-		}
-	}
-	for _, pv := range pvList.Items {
-		if pv.Status.Phase == corev1.VolumeAvailable {
-			pvc := &corev1.PersistentVolumeClaim{Spec: *pvcSpec}
+		if pv.Status.Phase == v1.VolumeAvailable {
+			pvc := &v1.PersistentVolumeClaim{Spec: *pvcSpec}
 			if err := checkVolumeSatisfyClaim(&pv, pvc); err == nil {
-				return &pv, nil
+				pvcSpec.VolumeMode = pv.Spec.VolumeMode
+				if len(pvcSpec.AccessModes) == 0 {
+					pvcSpec.AccessModes = pv.Spec.AccessModes
+				}
+				return nil
 			}
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func getDefaultVolumeAndAccessMode(c client.Client, storageClass *storagev1.StorageClass) ([]v1.PersistentVolumeAccessMode, *v1.PersistentVolumeMode, error) {

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -121,13 +121,13 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		boundCondition := &cdiv1.DataVolumeCondition{
 			Type:    cdiv1.DataVolumeBound,
 			Status:  v1.ConditionUnknown,
-			Message: "No PVC found",
+			Message: "exceeded quota",
 			Reason:  cc.ErrExceededQuota,
 		}
 		readyCondition := &cdiv1.DataVolumeCondition{
 			Type:    cdiv1.DataVolumeReady,
 			Status:  v1.ConditionFalse,
-			Message: "",
+			Message: "exceeded quota",
 			Reason:  cc.ErrExceededQuota,
 		}
 		utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, readyCondition)

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -91,7 +91,7 @@ var _ = Describe("DataSource", func() {
 
 		By("Verify DV conditions")
 		utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
-			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "No PVC found", Reason: dvc.CloneWithoutSource},
+			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source pvc pvc1 doesn't exist", Reason: dvc.CloneWithoutSource},
 			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
 			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
 		f.ExpectEvent(dv.Namespace).Should(ContainSubstring(dvc.CloneWithoutSource))
@@ -239,7 +239,7 @@ var _ = Describe("DataSource", func() {
 
 			By("Verify DV conditions")
 			utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
-				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "No PVC found", Reason: dvc.CloneWithoutSource},
+				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source snapshot snap1 doesn't exist", Reason: dvc.CloneWithoutSource},
 				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
 				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
 			f.ExpectEvent(dv.Namespace).Should(ContainSubstring(dvc.CloneWithoutSource))

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -381,19 +382,21 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
 				Status:  v1.ConditionUnknown,
-				Message: "No PVC found",
+				Message: "exceeded quota",
 				Reason:  controller.ErrExceededQuota,
 			}
 			readyCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeReady,
 				Status:  v1.ConditionFalse,
-				Message: "",
+				Message: "exceeded quota",
 				Reason:  controller.ErrExceededQuota,
 			}
 			// for smart clone dv the dv can't be updated, only events will show the quota reason
 			if args.name == "dv-clone-test" && f.IsSnapshotStorageClassAvailable() {
 				expectedPhase = cdiv1.SnapshotForSmartCloneInProgress
+				boundCondition.Message = "in progress"
 				boundCondition.Reason = dvc.SnapshotForSmartCloneInProgress
+				readyCondition.Message = "in progress"
 				readyCondition.Reason = dvc.SnapshotForSmartCloneInProgress
 			}
 			waitForDvPhase(expectedPhase, dataVolume, f)
@@ -1702,7 +1705,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		createDataVolumeForImport := func(f *framework.Framework, storageSpec cdiv1.StorageSpec) *cdiv1.DataVolume {
 			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
-				dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URLRateLimit, f.CdiInstallNs))
+				dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 
 			dataVolume.Spec.Storage = &storageSpec
 
@@ -2303,6 +2306,190 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				return pvc.Spec.Resources.Requests.Storage().Cmp(expectedSize) == 0
 			}, 1*time.Minute, 2*time.Second).Should(BeTrue())
 		})
+	})
+
+	Describe("Verify that when the required storage class is missing", func() {
+		var (
+			testSc *storagev1.StorageClass
+			pvName string
+		)
+
+		testScName := "test-sc"
+
+		updatePV := func(updateFunc func(*v1.PersistentVolume)) {
+			pv, err := f.K8sClient.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			updateFunc(pv)
+			_, err = f.K8sClient.CoreV1().PersistentVolumes().Update(context.TODO(), pv, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		createPV := func(scName string) {
+			dv := utils.NewDataVolumeForBlankRawImage("blank-source", "106Mi")
+			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
+
+			err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			pvName = pvc.Spec.VolumeName
+
+			By("retaining pv")
+			updatePV(func(pv *v1.PersistentVolume) {
+				pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
+			})
+
+			err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			updatePV(func(pv *v1.PersistentVolume) {
+				pv.Spec.StorageClassName = scName
+				pv.Spec.ClaimRef = nil
+			})
+		}
+
+		createStorageClass := func(scName string) {
+			var err error
+			By(fmt.Sprintf("creating storage class %s", scName))
+			sc := utils.DefaultStorageClass.DeepCopy()
+			sc.Name = scName
+			sc.ResourceVersion = ""
+			sc.Annotations[controller.AnnDefaultStorageClass] = "false"
+			testSc, err = f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		AfterEach(func() {
+			if testSc != nil {
+				err := f.K8sClient.StorageV1().StorageClasses().Delete(context.TODO(), testScName, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				testSc = nil
+			}
+
+			if pvName != "" {
+				updatePV(func(pv *v1.PersistentVolume) {
+					pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
+				})
+				pvName = ""
+			}
+		})
+
+		table.DescribeTable("import DV using StorageSpec without AccessModes, PVC is created only when", func(scName string, scFunc func(string)) {
+			By(fmt.Sprintf("verifying no storage class %s", testScName))
+			_, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), scName, metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+
+			By(fmt.Sprintf("creating new datavolume %s with StorageClassName %s", dataVolumeName, scName))
+			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
+				dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
+			dataVolume.Spec.Storage.StorageClassName = pointer.String(scName)
+			dataVolume.Spec.Storage.AccessModes = nil
+
+			dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying event occurred")
+			f.ExpectEvent(dataVolume.Namespace).Should(And(ContainSubstring(controller.ErrClaimNotValid), ContainSubstring("DataVolume spec is missing accessMode")))
+
+			By("verifying conditions")
+			boundCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeBound,
+				Status:  v1.ConditionUnknown,
+				Message: "DataVolume spec is missing accessMode",
+				Reason:  controller.ErrClaimNotValid,
+			}
+			readyCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeReady,
+				Status:  v1.ConditionFalse,
+				Message: "DataVolume spec is missing accessMode",
+				Reason:  controller.ErrClaimNotValid,
+			}
+			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, readyCondition)
+
+			By("verifying pvc not created")
+			_, err = utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			scFunc(scName)
+
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
+
+			By("waiting for pvc bound phase")
+			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, dataVolume.Namespace, v1.ClaimBound, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for dv succeeeded")
+			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+		},
+			table.Entry("[test_id:9922]the storage class is created", testScName, createStorageClass),
+			table.Entry("[test_id:9924]PV with the SC name is created", testScName, createPV),
+			table.Entry("[test_id:9925]PV with the SC name (\"\" blank) is created", "", createPV),
+		)
+
+		newDataVolumeWithStorageSpec := func(scName string) *cdiv1.DataVolume {
+			dv := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
+				dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
+			dv.Spec.Storage.StorageClassName = pointer.String(scName)
+			return dv
+		}
+
+		newDataVolumeWithPvcSpec := func(scName string) *cdiv1.DataVolume {
+			dv := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
+			dv.Spec.PVC.StorageClassName = pointer.String(scName)
+			return dv
+		}
+
+		table.DescribeTable("import DV with AccessModes, PVC is pending until", func(scName string, scFunc func(string), dvFunc func(string) *cdiv1.DataVolume) {
+			By(fmt.Sprintf("verifying no storage class %s", testScName))
+			_, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), scName, metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvFunc(scName))
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying event occurred")
+			f.ExpectEvent(dataVolume.Namespace).Should(And(ContainSubstring("Pending"), ContainSubstring("PVC test-dv Pending")))
+
+			By("verifying conditions")
+			boundCondition := &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeBound,
+				Status:  v1.ConditionFalse,
+				Message: "PVC test-dv Pending",
+				Reason:  "Pending",
+			}
+			readyCondition := &cdiv1.DataVolumeCondition{
+				Type:   cdiv1.DataVolumeReady,
+				Status: v1.ConditionFalse,
+			}
+			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, readyCondition)
+
+			By("verifying pvc created")
+			_, err = utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			scFunc(scName)
+
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
+
+			By("waiting for pvc bound phase")
+			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, dataVolume.Namespace, v1.ClaimBound, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for dv succeeeded")
+			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+		},
+			table.Entry("[test_id:9926]the storage class is created (PvcSpec)", testScName, createStorageClass, newDataVolumeWithPvcSpec),
+			table.Entry("[test_id:9927]PV with the SC name is created (PvcSpec)", testScName, createPV, newDataVolumeWithPvcSpec),
+			table.Entry("[test_id:9928]PV with the SC name (\"\" blank) is created (PvcSpec)", "", createPV, newDataVolumeWithPvcSpec),
+			table.Entry("[test_id:9929]the storage class is created (StorageSpec)", testScName, createStorageClass, newDataVolumeWithStorageSpec),
+			table.Entry("[test_id:9930]PV with the SC name is created (StorageSpec)", testScName, createPV, newDataVolumeWithStorageSpec),
+			table.Entry("[test_id:9931]PV with the SC name (\"\" blank) is created (StorageSpec)", "", createPV, newDataVolumeWithStorageSpec),
+		)
 	})
 
 	Describe("Progress reporting on import datavolume", func() {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2421,7 +2421,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, dataVolume.Namespace, v1.ClaimBound, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("waiting for dv succeeeded")
+			By("waiting for dv succeeded")
 			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 		},
@@ -2479,7 +2479,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, dataVolume.Namespace, v1.ClaimBound, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("waiting for dv succeeeded")
+			By("waiting for dv succeeded")
 			err = utils.WaitForDataVolumePhase(f, dataVolume.Namespace, cdiv1.Succeeded, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
When `PVC` is created with `storageClassName` and the `SC` is not found, k8s looks for `PV` with the `storageClassName` for satisfying this claim. In this case k8s supports also a blank (“”, not the nil default one) `storageClassName`. To support this behavior we added:
- `DV` controller support for this flow (for both “” and non-existing `SC`)
- Condition update and event when `StorageSpec` `PVC` rendering errors and `PVC` is not created (e.g. missing both `AccessModes` and `SC`/`PV`)
- `PVC` is created even if a satisfying `SC`/`PV` doesn't exist if `spec.pvc/storage` `AccessModes` is set (otherwise k8s PVC validation fails). PVC/DV phase  will be `Pending` until a satisfying `SC`/`PV` is found
- `PV` watch to reconcile `DVs` waiting for the `PV` `storageClassName`
- `PV` `storageClassName` indexer, so we can list the relevant `PVs`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2186

**Special notes for your reviewer**:

**Release note**:
```release-note
Create PVC if possible even if the StorageClass is missing; Update DV condition fire and event on PVC rendering error
```

