### PR TITLE
Enable additional linters to golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,4 +4,3 @@ linters:
   disable:
   - errcheck # TODO: part of default linters. Fix warnings and remove this line # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
   - ineffassign # TODO: part of default linters. Fix warnings and remove this line # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
-  - staticcheck # TODO: part of default linters. Fix warnings and remove this line # (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,4 +5,3 @@ linters:
   - errcheck # TODO: part of default linters. Fix warnings and remove this line # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
   - ineffassign # TODO: part of default linters. Fix warnings and remove this line # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
   - staticcheck # TODO: part of default linters. Fix warnings and remove this line # (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
-  - typecheck # TODO: part of default linters. Fix warnings and remove this line #: Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,4 +3,3 @@ linters:
   # - ginkgolinter # TODO: enable and fix warnings # enforces standards of using ginkgo and gomega
   disable:
   - errcheck # TODO: part of default linters. Fix warnings and remove this line # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
-  - ineffassign # TODO: part of default linters. Fix warnings and remove this line # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -76,7 +76,7 @@ func createHTTPClient(clientKey, clientCert, serverCert []byte) *http.Client {
 		Certificates: []tls.Certificate{clientKeyPair},
 		RootCAs:      caCertPool,
 	}
-	tlsConfig.BuildNameToCertificate()
+	tlsConfig.BuildNameToCertificate() //nolint:staticcheck  // todo: BuildNameToCertificate() is deprecated - check this
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: transport}

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -107,6 +107,10 @@ func main() {
 	imageSize, _ := util.ParseEnvVar(common.ImporterImageSize, false)
 	filesystemOverhead, _ := strconv.ParseFloat(os.Getenv(common.FilesystemOverheadVar), 64)
 	preallocation, err := strconv.ParseBool(os.Getenv(common.Preallocation))
+	if err != nil {
+		klog.Errorf(`the %s environment variable is with a wrong value "%s"; should be "true" or "false"`, common.Preallocation, os.Getenv(common.Preallocation))
+		os.Exit(1)
+	}
 
 	volumeMode := v1.PersistentVolumeBlock
 	if _, err := os.Stat(common.WriteBlockPath); os.IsNotExist(err) {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -250,7 +250,7 @@ func (app *cdiAPIApp) getTLSConfig() (*tls.Config, error) {
 			return fmt.Errorf("no valid subject specified")
 		},
 	}
-	tlsConfig.BuildNameToCertificate()
+	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // todo: BuildNameToCertificate() is deprecated - check this
 
 	return tlsConfig, nil
 }

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Auth config tests", func() {
 
 		cdiConfig.Spec.TLSSecurityProfile = nil
 		// Should roll us back to 'Intermediate' profile (default) instead of the initial 'Old'
-		cdiConfig, err = cdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), cdiConfig, metav1.UpdateOptions{})
+		_, err = cdiClient.CdiV1beta1().CDIConfigs().Update(context.TODO(), cdiConfig, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// behavior of this changed in 16.4 used to wait then check so now explicitly waiting

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -438,7 +438,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).To(HaveOccurred())

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -123,10 +123,12 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
 		Expect(sourcePod).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
 		By("Verifying no source pod exists")
 		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		By("Verifying the PVC now has a source pod name")
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, testPvc)
@@ -152,6 +154,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
@@ -201,6 +204,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
@@ -306,6 +310,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
@@ -326,6 +331,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
@@ -354,7 +360,8 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		sourcePod.Status.Phase = corev1.PodSucceeded
 		err = reconciler.client.Update(context.TODO(), sourcePod)
 		Expect(err).ToNot(HaveOccurred())
-		sourcePod, err = reconciler.findCloneSourcePod(testPvc)
+		_, err = reconciler.findCloneSourcePod(testPvc)
+		Expect(err).ToNot(HaveOccurred())
 
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).ToNot(HaveOccurred())
@@ -431,6 +438,7 @@ var _ = Describe("Clone controller reconcile loop", func() {
 		reconciler.shortTokenValidator.(*cc.FakeValidator).Params["targetName"] = "testPvc1"
 		By("Verifying no source pod exists")
 		sourcePod, err := reconciler.findCloneSourcePod(testPvc)
+		Expect(err).To(HaveOccurred())
 		Expect(sourcePod).To(BeNil())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "default"}})
 		Expect(err).To(HaveOccurred())
@@ -701,7 +709,7 @@ func createCloneReconciler(objects ...runtime.Object) *CloneReconciler {
 	cdiv1.AddToScheme(s)
 	rec := record.NewFakeRecorder(1)
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// Create a ReconcileMemcached object with the scheme and fake client.
 	return &CloneReconciler{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1111,11 +1111,12 @@ func CreateStorageClassWithProvisioner(name string, annotations, labels map[stri
 // CreateClient creates a fake client
 func CreateClient(objs ...runtime.Object) client.Client {
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
-	corev1.AddToScheme(s)
-	storagev1.AddToScheme(s)
-	ocpconfigv1.AddToScheme(s)
-	return fake.NewFakeClientWithScheme(s, objs...)
+	_ = cdiv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	_ = storagev1.AddToScheme(s)
+	_ = ocpconfigv1.Install(s)
+
+	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 }
 
 // ErrQuotaExceeded checked is the error is of exceeded quota

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -92,6 +92,7 @@ var _ = Describe("CDIConfig Controller reconcile loop", func() {
 	DescribeTable("Should set proxyURL to override if no ingress or route exists", func(authority bool) {
 		reconciler, cdiConfig := createConfigReconciler(createConfigMap(operator.ConfigMapName, testNamespace))
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{})
+		Expect(err).ToNot(HaveOccurred())
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: reconciler.configName}, cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
 		override := "www.override-something.org.tt.test"
@@ -126,6 +127,7 @@ var _ = Describe("CDIConfig Controller reconcile loop", func() {
 			),
 		)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{})
+		Expect(err).ToNot(HaveOccurred())
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: reconciler.configName}, cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
 		override := "www.override-something.org.tt.test"
@@ -888,7 +890,7 @@ func createConfigReconciler(objects ...runtime.Object) (*CDIConfigReconciler, *c
 	objs = append(objs, cdi)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// Create a ReconcileMemcached object with the scheme and fake client.
 	r := &CDIConfigReconciler{

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -544,6 +544,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			timestamp := time.Now().Format(time.RFC3339)
 			cron.Annotations[AnnNextCronTime] = timestamp
 			err = reconciler.client.Update(context.TODO(), cron)
+			Expect(err).ToNot(HaveOccurred())
 
 			_, err = reconciler.Reconcile(context.TODO(), cronReq)
 			Expect(err).ToNot(HaveOccurred())
@@ -692,11 +693,11 @@ func createDataImportCronReconcilerWithoutConfig(objects ...runtime.Object) *Dat
 	objs = append(objs, objects...)
 
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
-	imagev1.AddToScheme(s)
-	extv1.AddToScheme(s)
+	_ = cdiv1.AddToScheme(s)
+	_ = imagev1.Install(s)
+	_ = extv1.AddToScheme(s)
 
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	rec := record.NewFakeRecorder(1)
 	r := &DataImportCronReconciler{
 		client:         cl,

--- a/pkg/controller/datasource-controller_test.go
+++ b/pkg/controller/datasource-controller_test.go
@@ -143,7 +143,7 @@ func createDataSourceReconciler(objects ...runtime.Object) *DataSourceReconciler
 	s := scheme.Scheme
 	cdiv1.AddToScheme(s)
 	snapshotv1.AddToScheme(s)
-	cl := fake.NewFakeClientWithScheme(s, objects...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
 	r := &DataSourceReconciler{
 		client: cl,
 		scheme: s,

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -797,7 +797,7 @@ func (r *ReconcilerBase) updateConditions(dataVolume *cdiv1.DataVolume, pvc *cor
 		anno = make(map[string]string)
 	}
 
-	readyStatus := corev1.ConditionUnknown
+	var readyStatus corev1.ConditionStatus
 	switch dataVolume.Status.Phase {
 	case cdiv1.Succeeded:
 		readyStatus = corev1.ConditionTrue

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -926,7 +926,7 @@ func updateProgressUsingPod(dataVolumeCopy *cdiv1.DataVolume, pod *corev1.Pod) e
 			return err
 		}
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/datavolume/external-population-controller_test.go
+++ b/pkg/controller/datavolume/external-population-controller_test.go
@@ -355,7 +355,7 @@ func createPopulatorReconcilerWithoutConfig(objects ...runtime.Object) *Populato
 	objs = append(objs, MakeEmptyCDICR())
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1417,7 +1417,7 @@ func createImportReconcilerWithoutConfig(objects ...runtime.Object) *ImportRecon
 	objs = append(objs, MakeEmptyCDICR())
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -855,6 +855,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSize, err := inflateSizeWithOverhead(reconciler.client, int64(100), pvcSpec)
+			Expect(err).ToNot(HaveOccurred())
 			expectedSizeInt64, _ := expectedSize.AsInt64()
 
 			// Checks
@@ -885,6 +886,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			pvcSpec, err := renderPvcSpec(reconciler.client, reconciler.recorder, reconciler.log, dv)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSize, err := inflateSizeWithOverhead(reconciler.client, int64(100), pvcSpec)
+			Expect(err).ToNot(HaveOccurred())
 			expectedSizeInt64, _ := expectedSize.AsInt64()
 
 			// Checks
@@ -973,7 +975,7 @@ func createCloneReconcilerWithoutConfig(objects ...runtime.Object) *PvcCloneReco
 	objs = append(objs, MakeEmptyCDICR())
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/controller/datavolume/smart-clone-controller_test.go
+++ b/pkg/controller/datavolume/smart-clone-controller_test.go
@@ -321,7 +321,7 @@ func createSmartCloneReconciler(objects ...runtime.Object) *SmartCloneReconciler
 	}
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(1)
 	// Create a ReconcileMemcached object with the scheme and fake client.

--- a/pkg/controller/datavolume/snapshot-clone-controller_test.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller_test.go
@@ -253,7 +253,7 @@ func createSnapshotCloneReconcilerWithoutConfig(objects ...runtime.Object) *Snap
 	objs = append(objs, MakeEmptyCDICR())
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -93,7 +93,7 @@ func createUploadReconcilerWithoutConfig(objects ...runtime.Object) *UploadRecon
 	objs = append(objs, MakeEmptyCDICR())
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -113,9 +113,9 @@ func createDataVolumeWithStorageAPI(name, ns string, source *cdiv1.DataVolumeSou
 func createClient(objs ...runtime.Object) client.Client {
 	// Register cdi types with the runtime scheme.
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
+	_ = cdiv1.AddToScheme(s)
 	// Register other types with the runtime scheme.
-	ocpconfigv1.AddToScheme(s)
+	_ = ocpconfigv1.Install(s)
 	// Create a fake client to mock API calls.
-	return fake.NewFakeClientWithScheme(s, objs...)
+	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 }

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -121,6 +121,9 @@ func NewImportController(mgr manager.Manager, log logr.Logger, importerImage, pu
 		Scheme: mgr.GetScheme(),
 		Mapper: mgr.GetRESTMapper(),
 	})
+	if err != nil {
+		return nil, err
+	}
 	client := mgr.GetClient()
 	reconciler := &ImportReconciler{
 		client:          client,

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1014,7 +1014,7 @@ func createImportReconciler(objects ...runtime.Object) *ImportReconciler {
 
 	// Register cdi types with the runtime scheme.
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
+	_ = cdiv1.AddToScheme(s)
 
 	objs = append(objs, cc.MakeEmptyCDICR())
 
@@ -1025,7 +1025,7 @@ func createImportReconciler(objects ...runtime.Object) *ImportReconciler {
 	objs = append(objs, cdiConfig)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// Increase this if you have more than one event that fires.
 	rec := record.NewFakeRecorder(1)

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -342,10 +342,10 @@ func createStorageProfileReconciler(objects ...runtime.Object) *StorageProfileRe
 	objs = append(objs, cdiConfig)
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
+	_ = cdiv1.AddToScheme(s)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// Create a ReconcileMemcached object with the scheme and fake client.
 	r := &StorageProfileReconciler{

--- a/pkg/controller/transfer/controller_test.go
+++ b/pkg/controller/transfer/controller_test.go
@@ -62,7 +62,7 @@ func createReconciler(objects ...client.Object) *transfer.ObjectTransferReconcil
 	for _, obj := range objects {
 		runtimeObjects = append(runtimeObjects, obj)
 	}
-	cl := fake.NewFakeClientWithScheme(s, runtimeObjects...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(runtimeObjects...).Build()
 
 	return &transfer.ObjectTransferReconciler{
 		Client:   cl,

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -459,6 +459,7 @@ var _ = Describe("reconcilePVC loop", func() {
 				profileType = profile.Type
 				cdiConfig.Spec.TLSSecurityProfile = profile
 				err = reconciler.client.Update(context.TODO(), cdiConfig)
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			_, err = reconciler.reconcilePVC(reconciler.log, testPvc, isClone)
@@ -616,10 +617,10 @@ func createUploadReconciler(objects ...runtime.Object) *UploadReconciler {
 	objs = append(objs, cdiConfig)
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
-	cdiv1.AddToScheme(s)
+	_ = cdiv1.AddToScheme(s)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	rec := record.NewFakeRecorder(10)
 

--- a/pkg/feature-gates/feature-gates_test.go
+++ b/pkg/feature-gates/feature-gates_test.go
@@ -83,7 +83,7 @@ func createFeatureGatesAndClient(objects ...runtime.Object) (FeatureGates, clien
 	cdiv1.AddToScheme(s)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// Create a NewFeatureGates with fake client.
 	return NewFeatureGates(cl), cl

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -154,8 +154,7 @@ func (hs *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
 			return ProcessingPhaseError, err
 		}
 		size, err := util.GetAvailableSpace(path)
-		if size <= int64(0) {
-			//Path provided is invalid.
+		if err != nil || size <= 0 {
 			return ProcessingPhaseError, ErrInvalidPath
 		}
 		err = util.StreamDataToFile(hs.readers.TopReader(), file)

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Http client", func() {
 		systemCAs, err := x509.SystemCertPool()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(len(activeCAs.Subjects())).Should(Equal(len(systemCAs.Subjects()) + 1))
+		Expect(len(activeCAs.Subjects())).Should(Equal(len(systemCAs.Subjects()) + 1)) //nolint:staticcheck // todo: Subjects() is deprecated - check this
 	})
 
 })

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -556,6 +556,9 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 	var reader io.ReadCloser
 	if extentsFeature {
 		req, err := http.NewRequest("GET", transferURL+"/extents", nil)
+		if err != nil {
+			return nil, uint64(0), it, conn, err
+		}
 		req = req.WithContext(ctx)
 
 		resp, err := client.Do(req)
@@ -589,6 +592,9 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 		}
 	} else {
 		req, err := http.NewRequest("GET", transferURL, nil)
+		if err != nil {
+			return nil, uint64(0), it, conn, errors.Wrap(err, "Sending request failed")
+		}
 		req = req.WithContext(ctx)
 
 		resp, err := client.Do(req)

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Imageio client preparation", func() {
 	It("should load the cert", func() {
 		activeCAs, err := loadCA(tempDir)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(activeCAs.Subjects())).Should(Equal(1))
+		Expect(len(activeCAs.Subjects())).Should(Equal(1)) // nolint:staticcheck // todo: Subjects() is deprecated - check this
 	})
 
 	It("should return error if dir is empty", func() {
@@ -549,6 +549,7 @@ var _ = Describe("Imageio extents", func() {
 		ticketTime := time.Now()
 		time.Sleep(1 * time.Millisecond)
 		err = source.renewExtentsTicket(it.MustId(), extentsReader)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(renewalTime.Equal(ticketTime)).To(BeFalse())
 	})
 

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -340,7 +340,9 @@ func (vmware *VMwareClient) FindDiskInSnapshotTree(snapshots []types.VirtualMach
 		if disk := vmware.FindDiskInSnapshot(snapshot.Snapshot, fileName); disk != nil {
 			return disk
 		}
-		return vmware.FindDiskInSnapshotTree(snapshot.ChildSnapshotList, fileName)
+		if disk := vmware.FindDiskInSnapshotTree(snapshot.ChildSnapshotList, fileName); disk != nil {
+			return disk
+		}
 	}
 	return nil
 }
@@ -717,7 +719,8 @@ func (sink *VDDKFileSink) ZeroRange(offset uint64, length uint32) error {
 	if sink.isBlock { // Try to punch a hole in block device destination
 		err = punch(offset, length)
 	} else {
-		info, err := sink.file.Stat()
+		var info os.FileInfo
+		info, err = sink.file.Stat()
 		if err != nil {
 			klog.Errorf("Unable to stat destination file: %v", err)
 		} else { // Filesystem

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -142,6 +142,7 @@ var _ = Describe("VDDK data source", func() {
 
 	It("VDDK delta copy should return immediately if there are no changed blocks", func() {
 		dp, err := NewVDDKDataSource("", "", "", "", "", "", "checkpoint-1", "checkpoint-2", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
 		dp.ChangedBlocks = &types.DiskChangeInfo{
 			StartOffset: 0,
 			Length:      0,
@@ -154,6 +155,7 @@ var _ = Describe("VDDK data source", func() {
 
 	It("VDDK full copy should successfully copy the same bytes passed in", func() {
 		dp, err := NewVDDKDataSource("", "", "", "", "", "", "", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
 		dp.Size = 40 << 20
 		sourceBytes := bytes.Repeat([]byte{0x55}, int(dp.Size))
 		replaceExport := currentExport
@@ -180,6 +182,7 @@ var _ = Describe("VDDK data source", func() {
 
 		// Copy base disk ("snapshot 1")
 		snap1, err := NewVDDKDataSource("", "", "", "", "", "", "checkpoint-1", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
 		snap1.Size = 40 << 20
 		sourceBytes := bytes.Repeat([]byte{0x55}, int(snap1.Size))
 		replaceExport := currentExport
@@ -203,6 +206,7 @@ var _ = Describe("VDDK data source", func() {
 
 		// Write some data to the first snapshot, then copy the delta from difference between the two snapshots
 		snap2, err := NewVDDKDataSource("", "", "", "", "", "", "checkpoint-1", "checkpoint-2", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
 		snap2.Size = 40 << 20
 		copy(sourceBytes[1024:2048], bytes.Repeat([]byte{0xAA}, 1024))
 		snap2.ChangedBlocks = &types.DiskChangeInfo{

--- a/pkg/keys/keystore_test.go
+++ b/pkg/keys/keystore_test.go
@@ -93,7 +93,7 @@ func checkAction(expected, actual core.Action) {
 	}
 
 	switch a := actual.(type) {
-	case core.CreateAction:
+	case core.CreateActionImpl:
 		e, _ := expected.(core.CreateAction)
 		expObject := e.GetObject()
 		object := a.GetObject()
@@ -102,7 +102,7 @@ func checkAction(expected, actual core.Action) {
 			Fail(fmt.Sprintf("Action %s %s has wrong object\nDiff:\n %s",
 				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expObject, object)))
 		}
-	case core.UpdateAction:
+	case core.UpdateActionImpl:
 		e, _ := expected.(core.UpdateAction)
 		expObject := e.GetObject()
 		object := a.GetObject()

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -315,7 +315,7 @@ func reconcileHandleOldVersion(args *callbacks.ReconcileCallbackArgs) error {
 	desiredVersion := newestVersion(desiredCrd)
 
 	if olderVersionsExist(desiredVersion, currentCrd) {
-		desiredCrd = restoreOlderVersions(currentCrd, desiredCrd)
+		restoreOlderVersions(currentCrd, desiredCrd)
 		if !desiredIsStorage(desiredVersion, currentCrd) {
 			// Let kubernetes add it
 			return nil

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1568,7 +1568,7 @@ func createClient(objs ...client.Object) client.Client {
 	for _, obj := range objs {
 		runtimeObjs = append(runtimeObjs, obj)
 	}
-	return fakeClient.NewFakeClientWithScheme(scheme.Scheme, runtimeObjs...)
+	return fakeClient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(runtimeObjs...).Build()
 }
 
 func createCDI(name, uid string) *cdiv1.CDI {

--- a/pkg/system/prlimit_test.go
+++ b/pkg/system/prlimit_test.go
@@ -209,7 +209,7 @@ func doFaker(args []string) {
 }
 
 func doSpinner(args []string) {
-	for {
+	for { //nolint:staticcheck
 
 	}
 }
@@ -220,7 +220,7 @@ func doHog(args []string) {
 	for i := 0; i < (1 << 20); i++ {
 		bytes := make([]byte, 1024)
 		rand.Read(bytes)
-		arrays = append(arrays, bytes)
+		arrays = append(arrays, bytes) //nolint:staticcheck
 	}
 }
 

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -150,7 +150,7 @@ func (c *clientCreator) CreateClient() (*http.Client, error) {
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
 	}
-	tlsConfig.BuildNameToCertificate()
+	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // todo: BuildNameToCertificate() is deprecated - check this
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: transport, Timeout: proxyRequestTimeout}, nil

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -82,7 +82,7 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
 	}
-	tlsConfig.BuildNameToCertificate()
+	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO: handle this deprecation
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: transport}

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -3266,7 +3266,7 @@ func EnableGcAndAnnotateLegacyDv(f *framework.Framework, dvName, dvNamespace str
 
 	By("Add true DeleteAfterCompletion annotation to DV")
 	controller.AddAnnotation(dv, controller.AnnDeleteAfterCompletion, "true")
-	dv, err = f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Update(context.TODO(), dv, metav1.UpdateOptions{})
+	_, err = f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Update(context.TODO(), dv, metav1.UpdateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	VerifyGC(f, dvName, dvNamespace, false, nil)
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -70,10 +70,11 @@ var _ = Describe("ALL Operator tests", func() {
 					oldVer := cdiCrd.Spec.Versions[0].DeepCopy()
 					oldVer.Name = "v1alpha1"
 					cdiCrd.Spec.Versions[0].Storage = false
-					oldVer.Storage = false
+					oldVer.Storage = true
 					cdiCrd.Spec.Versions = append(cdiCrd.Spec.Versions, *oldVer)
 
-					cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), cdiCrd, metav1.UpdateOptions{})
+					_, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), cdiCrd, metav1.UpdateOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
 					By("Restoring CRD with newer version as storage")
 					cdiCrd, err = f.ExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "cdis.cdi.kubevirt.io", metav1.GetOptions{})

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Aggregated role in-action tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		dv := utils.NewDataVolumeWithHTTPImport("test-"+user, "1Gi", "http://nonexistant.url")
-		dv, err = cdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Create(context.TODO(), dv, metav1.CreateOptions{})
+		_, err = cdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Create(context.TODO(), dv, metav1.CreateOptions{})
 		Expect(err).To(HaveOccurred())
 
 		dvl, err := cdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})

--- a/tests/transfer_test.go
+++ b/tests/transfer_test.go
@@ -285,7 +285,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 			}
 
 			defer deleteTransfer(ot.Name)
-			ot = doTransfer(ot)
+			doTransfer(ot)
 
 			targetHash = getHash(f.Namespace, dataVolume.Name)
 			Expect(sourceMD5).To(Equal(targetHash))
@@ -360,7 +360,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 					}
 
 					defer deleteTransfer(ot.Name)
-					ot = doTransfer(ot)
+					doTransfer(ot)
 
 					tn := sourceName
 					if targetName != nil {
@@ -470,7 +470,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			rq.Spec.Hard[corev1.ResourceRequestsStorage] = *resource.NewQuantity(bq, resource.DecimalSI)
-			rq, err = f.K8sClient.CoreV1().ResourceQuotas(targetNs.Name).Update(context.TODO(), rq, metav1.UpdateOptions{})
+			_, err = f.K8sClient.CoreV1().ResourceQuotas(targetNs.Name).Update(context.TODO(), rq, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {

--- a/tools/util/marshaller.go
+++ b/tools/util/marshaller.go
@@ -43,13 +43,16 @@ func MarshallObject(obj interface{}, writer io.Writer) error {
 		return err
 	}
 
-	// remove status and metadata.creationTimestamp
 	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(r.Object, "spec", "template", "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(r.Object, "status")
 
-	// remove timestamp and status from deployments in CSV objects
 	deployments, exists, err := unstructured.NestedSlice(r.Object, "spec", "install", "spec", "deployments")
+	if err != nil {
+		return err
+	}
+	// remove timestamp and status from deployments in CSV objects
+	// remove status and metadata.creationTimestamp
 	if exists {
 		for _, obj := range deployments {
 			deployment := obj.(map[string]interface{})


### PR DESCRIPTION
Enable the following linters and fix their findings:
* `typecheck` - Like the front-end of a Go compiler, parses and type-checks Go code [no findings]
* `staticcheck` - (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [many findings]
* `ineffassign` - Detects when assignments to existing variables are not used [1 finding]

***Note***: *Some findings were not fixed, as they need to be handled by the CDI team. These findings are disabled by the `nolint` comment + `TODO`*

```release-note
None
```

