### PR TITLE
Add the readahead filter to curl requests

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -50,6 +50,7 @@ const (
 	NbdkitGzipFilter         NbdkitFilter = "gzip"
 	NbdkitRetryFilter        NbdkitFilter = "retry"
 	NbdkitCacheExtentsFilter NbdkitFilter = "cacheextents"
+	NbdkitReadAheadFilter    NbdkitFilter = "readahead"
 )
 
 // Nbdkit represents struct for an nbdkit instance
@@ -113,6 +114,9 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 		redactArgs: redactArgs,
 		Socket:     socket,
 	}
+	// QEMU generally reads through the extents in order, making the readahead
+	// filter quite appropriate.
+	n.AddFilter(NbdkitReadAheadFilter)
 	// Should be last filter
 	n.AddFilter(NbdkitRetryFilter)
 	return n


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently importing QCoW files over HTTP takes an extremely long time. This is due to `qemu-img convert` launching a lot of small reads against the `nbd-kit curl` plugin. To speed this up, add the readahead filter since QEMU roughly reads through the input disk images in order, so a majority of reads are pre-fetch hits.

On my machine this reduces a Ubuntu cloud image import from 90 minutes to 1 minute.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2358 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add readahead filter when importing files over HTTP.
```

