### PR TITLE
Fix import populator static binding test

### DIFF
--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -177,9 +177,9 @@ func (r *ReconcilerBase) rebindPV(targetPVC, pvcPrime *corev1.PersistentVolumeCl
 	}
 
 	// Examine the claimref for the PV and see if it's still bound to PVC'
-	if !isPVBoundToPVC(pv, pvcPrime) {
+	if !IsPVBoundToPVC(pv, pvcPrime) {
 		// Something is not right if the PV is neither bound to PVC' nor target PVC
-		if !isPVBoundToPVC(pv, targetPVC) {
+		if !IsPVBoundToPVC(pv, targetPVC) {
 			klog.Errorf("PV bound to unexpected PVC: Could not rebind to target PVC '%s'", targetPVC.Name)
 		}
 		return nil

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -105,7 +105,8 @@ func checkIntreeStorageClass(pvc *corev1.PersistentVolumeClaim, sc *storagev1.St
 	return true
 }
 
-func isPVBoundToPVC(pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim) bool {
+// IsPVBoundToPVC returns true if the passed PVC and PV are bound to each other
+func IsPVBoundToPVC(pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim) bool {
 	claimRef := pv.Spec.ClaimRef
 	return claimRef.Name == pvc.Name && claimRef.Namespace == pvc.Namespace && claimRef.UID == pvc.UID
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pull Request fixes a race condition in a test that checks for static binding in the import populator. We shouldn't worry about the PVC' being created in that case since the target PVC will be bound immediately afterward.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

