### PR TITLE
[release-v1.56] Add Dell EMC, HPE & Hitachi to known provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -37,6 +37,14 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"linstor.csi.linbit.com": createLinstorCapabilities(),
 	// dell-unity-csi
 	"csi-unity.dellemc.com": createDellUnityCapabilities(),
+	// PowerFlex
+	"csi-vxflexos.dellemc.com": createDellPowerCapabilities(),
+	// PowerScale
+	"csi-isilon.dellemc.com": createDellPowerCapabilities(),
+	// PowerMax
+	"csi-powermax.dellemc.com": createDellPowerCapabilities(),
+	// PowerStore
+	"csi-powerstore.dellemc.com": createDellPowerCapabilities(),
 	// storageos
 	"kubernetes.io/storageos": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
 	"storageos":               {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
@@ -53,6 +61,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// GCE Persistent Disk
 	"kubernetes.io/gce-pd":  {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
 	"pd.csi.storage.gke.io": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
+	// HPE
+	"csi.hpe.com": createRWOBlockAndFilesystemCapabilities(),
 	// Portworx in-tree CSI
 	"kubernetes.io/portworx-volume/shared": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
 	"kubernetes.io/portworx-volume":        {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
@@ -68,7 +78,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
 	"topolvm.io":         createTopoLVMCapabilities(),
 	// OpenStack Cinder
-	"cinder.csi.openstack.org": createCinderVolumeCapabilities(),
+	"cinder.csi.openstack.org": createRWOBlockAndFilesystemCapabilities(),
 	// OpenStack manila
 	"manila.csi.openstack.org": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
 }
@@ -218,6 +228,14 @@ func createDellUnityCapabilities() []StorageCapabilities {
 	}
 }
 
+func createDellPowerCapabilities() []StorageCapabilities {
+	return []StorageCapabilities{
+		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
+		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+	}
+}
+
 func createTopoLVMCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
@@ -241,7 +259,7 @@ func createOpenStorageSharedVolumeCapabilities() []StorageCapabilities {
 	}
 }
 
-func createCinderVolumeCapabilities() []StorageCapabilities {
+func createRWOBlockAndFilesystemCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
 		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -18,21 +18,31 @@ type StorageCapabilities struct {
 	VolumeMode v1.PersistentVolumeMode
 }
 
+const (
+	rwo = v1.ReadWriteOnce
+	rox = v1.ReadOnlyMany
+	rwx = v1.ReadWriteMany
+
+	block = v1.PersistentVolumeBlock
+	file  = v1.PersistentVolumeFilesystem
+)
+
 // CapabilitiesByProvisionerKey defines default capabilities for different storage classes
 var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// hostpath-provisioner
-	"kubevirt.io.hostpath-provisioner": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"kubevirt.io/hostpath-provisioner": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"kubevirt.io.hostpath-provisioner": {{rwo, file}},
+	"kubevirt.io/hostpath-provisioner": {{rwo, file}},
 	// nfs-csi
-	"nfs.csi.k8s.io": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"nfs.csi.k8s.io": {{rwx, file}},
+	"k8s-sigs.io/nfs-subdir-external-provisioner": {{rwx, file}},
 	// ceph-rbd
 	"kubernetes.io/rbd":                  createRbdCapabilities(),
 	"rbd.csi.ceph.com":                   createRbdCapabilities(),
 	"rook-ceph.rbd.csi.ceph.com":         createRbdCapabilities(),
 	"openshift-storage.rbd.csi.ceph.com": createRbdCapabilities(),
 	// ceph-fs
-	"cephfs.csi.ceph.com":                   {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"openshift-storage.cephfs.csi.ceph.com": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"cephfs.csi.ceph.com":                   {{rwx, file}},
+	"openshift-storage.cephfs.csi.ceph.com": {{rwx, file}},
 	// LINSTOR
 	"linstor.csi.linbit.com": createLinstorCapabilities(),
 	// dell-unity-csi
@@ -46,41 +56,45 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// PowerStore
 	"csi-powerstore.dellemc.com": createDellPowerCapabilities(),
 	// storageos
-	"kubernetes.io/storageos": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"storageos":               {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"kubernetes.io/storageos": {{rwo, file}},
+	"storageos":               {{rwo, file}},
 	//AWSElasticBlockStore
-	"kubernetes.io/aws-ebs": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
-	"ebs.csi.aws.com":       {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
+	"kubernetes.io/aws-ebs": {{rwo, block}},
+	"ebs.csi.aws.com":       {{rwo, block}},
 	// AWSFIle is done by a pod
 	//Azure disk
-	"kubernetes.io/azure-disk": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
-	"disk.csi.azure.com":       {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
+	"kubernetes.io/azure-disk": {{rwo, block}},
+	"disk.csi.azure.com":       {{rwo, block}},
 	//Azure file
-	"kubernetes.io/azure-file": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"file.csi.azure.com":       {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"kubernetes.io/azure-file": {{rwx, file}},
+	"file.csi.azure.com":       {{rwx, file}},
 	// GCE Persistent Disk
-	"kubernetes.io/gce-pd":  {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
-	"pd.csi.storage.gke.io": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
+	"kubernetes.io/gce-pd":  {{rwo, block}},
+	"pd.csi.storage.gke.io": {{rwo, block}},
+	// Hitachi
+	"hspc.csi.hitachi.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// HPE
 	"csi.hpe.com": createRWOBlockAndFilesystemCapabilities(),
 	// Portworx in-tree CSI
-	"kubernetes.io/portworx-volume/shared": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"kubernetes.io/portworx-volume":        {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"kubernetes.io/portworx-volume/shared": {{rwx, file}},
+	"kubernetes.io/portworx-volume":        {{rwo, file}},
 	// Portworx CSI
 	"pxd.openstorage.org/shared": createOpenStorageSharedVolumeCapabilities(),
 	"pxd.openstorage.org":        createOpenStorageVolumeCapabilities(),
 	"pxd.portworx.com/shared":    createOpenStorageSharedVolumeCapabilities(),
 	"pxd.portworx.com":           createOpenStorageVolumeCapabilities(),
 	// Trident
-	"csi.trident.netapp.io/ontap-nas": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
-	"csi.trident.netapp.io/ontap-san": {{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock}},
+	"csi.trident.netapp.io/ontap-nas": {{rwx, file}},
+	"csi.trident.netapp.io/ontap-san": {{rwo, block}},
 	// topolvm
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
 	"topolvm.io":         createTopoLVMCapabilities(),
 	// OpenStack Cinder
 	"cinder.csi.openstack.org": createRWOBlockAndFilesystemCapabilities(),
 	// OpenStack manila
-	"manila.csi.openstack.org": {{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeFilesystem}},
+	"manila.csi.openstack.org": {{rwx, file}},
+	// ovirt csi
+	"csi.ovirt.org": createRWOBlockAndFilesystemCapabilities(),
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
@@ -200,48 +214,44 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 
 func createRbdCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwx, block},
+		{rwo, block},
+		{rwo, file},
 	}
 }
 
 func createLinstorCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
-		{AccessMode: v1.ReadOnlyMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadOnlyMany, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwx, block},
+		{rwo, block},
+		{rwo, file},
+		{rox, block},
+		{rox, file},
 	}
 }
 
 func createDellUnityCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
-		{AccessMode: v1.ReadOnlyMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadOnlyMany, VolumeMode: v1.PersistentVolumeFilesystem},
-		{AccessMode: v1.ReadWriteOncePod, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOncePod, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwx, block},
+		{rwo, block},
+		{rwo, file},
+		{rox, block},
+		{rox, file},
 	}
 }
 
 func createDellPowerCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwx, block},
+		{rwo, block},
+		{rwo, file},
 	}
 }
 
 func createTopoLVMCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
-		{AccessMode: v1.ReadWriteOncePod, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOncePod, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwo, block},
+		{rwo, file},
 	}
 }
 
@@ -254,14 +264,14 @@ func createOpenStorageVolumeCapabilities() []StorageCapabilities {
 
 func createOpenStorageSharedVolumeCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteMany, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwx, block},
+		{rwo, file},
 	}
 }
 
 func createRWOBlockAndFilesystemCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeBlock},
-		{AccessMode: v1.ReadWriteOnce, VolumeMode: v1.PersistentVolumeFilesystem},
+		{rwo, block},
+		{rwo, file},
 	}
 }


### PR DESCRIPTION
Manual backport of #2710 #2717
bz #2208838

**What this PR does / why we need it**:
Add StorageProfile default ClaimPropertySets (StorageCapabilities) for the provisioners.

**Release note**:
```release-note
Add Dell EMC PowerFlex/Scale/Max/Store, HPE and Hitachi to known provisioners
```