### PR TITLE
DataImportCron dusty stuff cleanups

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -157,7 +157,6 @@ not supported, then you can use the following example to run Functional Tests.
      clusterrolebinding.rbac.authorization.k8s.io/cdi-apiserver-auth-delegator created
      serviceaccount/cdi-sa created
      deployment.apps/cdi-deployment created
-     configmap/cdi-insecure-registries created
      serviceaccount/cdi-apiserver created
      rolebinding.rbac.authorization.k8s.io/cdi-apiserver created
      role.rbac.authorization.k8s.io/cdi-apiserver created

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -200,8 +200,6 @@ const (
 
 	// DefaultResyncPeriod sets a 10 minute resync period, used in the controller pkg and the controller cmd executable
 	DefaultResyncPeriod = 10 * time.Minute
-	// InsecureRegistryConfigMap is the name of the ConfigMap for insecure registries
-	InsecureRegistryConfigMap = "cdi-insecure-registries"
 
 	// ScratchSpaceNeededExitCode is the exit code that indicates the importer pod requires scratch space to function properly.
 	ScratchSpaceNeededExitCode = 42

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -641,11 +641,11 @@ func (r *ImportReconciler) isInsecureTLS(pvc *corev1.PersistentVolumeClaim, cdiC
 	if !ok || ep == "" {
 		return false, nil
 	}
-	return IsInsecureTLS(ep, cdiConfig, r.uncachedClient, r.log)
+	return IsInsecureTLS(ep, cdiConfig, r.log)
 }
 
 // IsInsecureTLS checks if TLS security is disabled for the given endpoint
-func IsInsecureTLS(ep string, cdiConfig *cdiv1.CDIConfig, client client.Client, log logr.Logger) (bool, error) {
+func IsInsecureTLS(ep string, cdiConfig *cdiv1.CDIConfig, log logr.Logger) (bool, error) {
 	url, err := url.Parse(ep)
 	if err != nil {
 		return false, err
@@ -661,27 +661,6 @@ func IsInsecureTLS(ep string, cdiConfig *cdiv1.CDIConfig, client client.Client, 
 			return true, nil
 		}
 	}
-
-	// ConfigMap is obsoleted and supported only for upgrade. It won't be refered anymore by future releases.
-	configMapName := common.InsecureRegistryConfigMap
-	log.V(1).Info("Checking configmap for host", "configMapName", configMapName, "host URL", url.Host)
-
-	cm := &corev1.ConfigMap{}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: configMapName, Namespace: util.GetNamespace()}, cm); err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.V(1).Info("Configmap does not exist", "configMapName", configMapName)
-			return false, nil
-		}
-		return false, err
-	}
-
-	for _, value := range cm.Data {
-		log.V(1).Info("Checking host against value", "host", url.Host, "value", value)
-		if value == url.Host {
-			return true, nil
-		}
-	}
-
 	return false, nil
 }
 

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -62,10 +62,9 @@ import (
 )
 
 const (
-	version                   = "v1.5.0"
-	cdiNamespace              = "cdi"
-	configMapName             = "cdi-config"
-	insecureRegistryConfigMap = "cdi-insecure-registries"
+	version       = "v1.5.0"
+	cdiNamespace  = "cdi"
+	configMapName = "cdi-config"
 
 	normalCreateSuccess              = "Normal CreateResourceSuccess Successfully created resource"
 	normalCreateEnsured              = "Normal CreateResourceSuccess Successfully ensured"
@@ -564,40 +563,6 @@ var _ = Describe("Controller", func() {
 				Expect(conditions.IsStatusConditionFalse(args.cdi.Status.Conditions, conditions.ConditionProgressing)).To(BeTrue())
 				Expect(conditions.IsStatusConditionFalse(args.cdi.Status.Conditions, conditions.ConditionDegraded)).To(BeTrue())
 				validateEvents(args.reconciler, createReadyEventValidationMap())
-			})
-
-			It("does not modify insecure registry configmap", func() {
-				args := createArgs()
-				doReconcile(args)
-
-				cm := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      insecureRegistryConfigMap,
-						Namespace: cdiNamespace,
-					},
-				}
-
-				obj, err := getObject(args.client, cm)
-				Expect(err).ToNot(HaveOccurred())
-				cm = obj.(*corev1.ConfigMap)
-
-				if cm.Data == nil {
-					cm.Data = make(map[string]string)
-				}
-				data := cm.Data
-				data["foo.bar.com"] = ""
-
-				err = args.client.Update(context.TODO(), cm)
-				Expect(err).ToNot(HaveOccurred())
-
-				doReconcile(args)
-
-				obj, err = getObject(args.client, cm)
-				Expect(err).ToNot(HaveOccurred())
-				cm = obj.(*corev1.ConfigMap)
-
-				Expect(cm.Data).Should(Equal(data))
-				validateEvents(args.reconciler, createNotReadyEventValidationMap())
 			})
 
 			It("should be an error when creating another CDI instance", func() {
@@ -1780,7 +1745,6 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.RoleBinding cdi-deployment"] = false
 	match[normalCreateSuccess+" *v1.Role cdi-deployment"] = false
 	match[normalCreateSuccess+" *v1.Deployment cdi-deployment"] = false
-	match[normalCreateSuccess+" *v1.ConfigMap cdi-insecure-registries"] = false
 	match[normalCreateSuccess+" *v1.ServiceAccount cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.Service cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.RoleBinding cdi-uploadproxy"] = false

--- a/pkg/operator/resources/namespaced/BUILD.bazel
+++ b/pkg/operator/resources/namespaced/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,7 +52,6 @@ func createControllerResources(args *FactoryArgs) []client.Object {
 			args.ImagePullSecrets,
 			args.PriorityClassName,
 			args.InfraNodePlacement),
-		createInsecureRegConfigMap(),
 		createPrometheusService(),
 	}
 }
@@ -355,19 +353,6 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, upl
 		},
 	}
 	return deployment
-}
-
-func createInsecureRegConfigMap() *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   common.InsecureRegistryConfigMap,
-			Labels: utils.ResourceBuilder.WithCommonLabels(nil),
-		},
-	}
 }
 
 func createPrometheusService() *corev1.Service {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/log:go_default_library",
     ],
 )
 

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -393,13 +393,8 @@ func (f *Framework) RunCommandAndCaptureOutput(pvc *k8sv1.PersistentVolumeClaim,
 
 // NewPodWithPVC creates a new pod that mounts the given PVC
 func (f *Framework) NewPodWithPVC(podName, cmd string, pvc *k8sv1.PersistentVolumeClaim, readOnly bool) *k8sv1.Pod {
-	var importerImage string
+	importerImage := f.GetEnvVarValue("IMPORTER_IMAGE")
 	volumeName := naming.GetLabelNameFromResourceName(pvc.GetName())
-	for _, e := range f.ControllerPod.Spec.Containers[0].Env {
-		if e.Name == "IMPORTER_IMAGE" {
-			importerImage = e.Value
-		}
-	}
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
@@ -453,6 +448,16 @@ func (f *Framework) NewPodWithPVC(podName, cmd string, pvc *k8sv1.PersistentVolu
 
 func (f *Framework) newExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim, readOnly bool) *k8sv1.Pod {
 	return f.NewPodWithPVC(podName, "while true; do echo hello; sleep 2;done", pvc, readOnly)
+}
+
+// GetEnvVarValue gets an environmemnt variable value from the cdi-deployment container
+func (f *Framework) GetEnvVarValue(name string) (importerImage string) {
+	for _, e := range f.ControllerPod.Spec.Containers[0].Env {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
 }
 
 // CreateExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /dev/pvc. You can then use the executor utilities to

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -83,9 +83,7 @@ func main() {
 	}
 	cc.AddAnnotation(dataImportCron, controller.AnnLastCronTime, time.Now().Format(time.RFC3339))
 
-	imports := dataImportCron.Status.CurrentImports
-	if digest != "" && (imports == nil || digest != imports[0].Digest) &&
-		digest != dataImportCron.Annotations[controller.AnnSourceDesiredDigest] {
+	if digest != "" && digest != dataImportCron.Annotations[controller.AnnSourceDesiredDigest] {
 		cc.AddAnnotation(dataImportCron, controller.AnnSourceDesiredDigest, digest)
 		log.Printf("Digest updated")
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove obsoleted insecure registries ConfigMap
- Cleanup functests and add external poller test
- Remove irrelevant poller digest update check

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Remove obsoleted insecure registries ConfigMap
```

