### PR TITLE
add PendingPopulation DataVolume phase

### DIFF
--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -366,6 +366,9 @@ const (
 
 	// WaitForFirstConsumer represents a data volume with a current phase of WaitForFirstConsumer
 	WaitForFirstConsumer DataVolumePhase = "WaitForFirstConsumer"
+	// PendingPopulation represents a data volume which should be populated by
+	// the CDI populators but havn't created the pvc' yet
+	PendingPopulation DataVolumePhase = "PendingPopulation"
 
 	// Succeeded represents a DataVolumePhase of Succeeded
 	Succeeded DataVolumePhase = "Succeeded"

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -367,7 +367,7 @@ const (
 	// WaitForFirstConsumer represents a data volume with a current phase of WaitForFirstConsumer
 	WaitForFirstConsumer DataVolumePhase = "WaitForFirstConsumer"
 	// PendingPopulation represents a data volume which should be populated by
-	// the CDI populators but havn't created the pvc' yet
+	// the CDI populators but haven't created the pvc' yet
 	PendingPopulation DataVolumePhase = "PendingPopulation"
 
 	// Succeeded represents a DataVolumePhase of Succeeded


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

kubevirt/kubevirt has to be aware of/handle this phase before it can consume a version of CDI that uses populators internally.  By "handle", I mean that it is okay start the VM if a DV is in this state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

