### PR TITLE
expand upon #2721

### DIFF
--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -62,7 +62,7 @@ const (
 	CsiClone
 )
 
-const sourceInUseRequeueSeconds = time.Duration(5 * time.Second)
+const sourceInUseRequeueDuration = time.Duration(5 * time.Second)
 
 const pvcCloneControllerName = "datavolume-pvc-clone-controller"
 
@@ -320,7 +320,7 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 				if syncRes.result == nil {
 					syncRes.result = &reconcile.Result{}
 				}
-				syncRes.result.RequeueAfter = sourceInUseRequeueSeconds
+				syncRes.result.RequeueAfter = sourceInUseRequeueDuration
 				return syncRes,
 					r.syncCloneStatusPhase(&syncRes, cdiv1.CloneScheduled, nil)
 			}
@@ -524,7 +524,7 @@ func (r *PvcCloneReconciler) reconcileCsiClonePvc(log logr.Logger,
 	if readyToClone, err := r.isSourceReadyToClone(datavolume, CsiClone); err != nil {
 		return reconcile.Result{}, err
 	} else if !readyToClone {
-		return reconcile.Result{Requeue: true},
+		return reconcile.Result{RequeueAfter: sourceInUseRequeueDuration},
 			r.syncCloneStatusPhase(syncRes, cdiv1.CloneScheduled, nil)
 	}
 
@@ -625,7 +625,7 @@ func (r *PvcCloneReconciler) reconcileSmartClonePvc(log logr.Logger,
 		if readyToClone, err := r.isSourceReadyToClone(datavolume, SmartClone); err != nil {
 			return reconcile.Result{}, err
 		} else if !readyToClone {
-			return reconcile.Result{Requeue: true},
+			return reconcile.Result{RequeueAfter: sourceInUseRequeueDuration},
 				r.syncCloneStatusPhase(syncState, cdiv1.CloneScheduled, nil)
 		}
 

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -196,7 +196,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			reconciler = createCloneReconciler(sc, sp, dv, pvc, snapClass, podFunc(dv), createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
 			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Requeue).To(BeTrue())
+			Expect(result.RequeueAfter).To(Equal(sourceInUseRequeueDuration))
 			By("Checking events recorded")
 			close(reconciler.recorder.(*record.FakeRecorder).Events)
 			found := false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

expand upon #2721

Need to replace requeue bool with requeue duration in a couple other spots.  Also linter did not like the name of duration variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This will all be replaced soon (hopefully) with populatior integration, but adding this anyway just in case we don't make code freeze

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

