### PR TITLE
FormatReader should support ISO file

### DIFF
--- a/pkg/image/filefmt.go
+++ b/pkg/image/filefmt.go
@@ -10,10 +10,10 @@ import (
 )
 
 // MaxExpectedHdrSize defines the Size of buffer used to read file headers.
-// Note: this is the size of tar's header. If a larger number is used the tar unarchive operation
+// Note: this is the size of iso's header. If a larger number is used the tar unarchive operation
 //
 //	creates the destination file too large, by the difference between this const and 512.
-const MaxExpectedHdrSize = 512
+const MaxExpectedHdrSize = 32774
 
 // Headers provides a map for header info, key is file format, eg. "gz" or "tar", value is metadata describing the layout for this hdr
 type Headers map[string]Header
@@ -75,6 +75,13 @@ var knownHeaders = Headers{
 	"vhdx": Header{
 		Format:      "vhdx",
 		magicNumber: []byte("vhdxfile"),
+		SizeOff:     0,
+		SizeLen:     0,
+	},
+	"iso": Header{
+		Format:      "iso",
+		magicNumber: []byte("CD001"),
+		mgOffset:    0x8001,
 		SizeOff:     0,
 		SizeLen:     0,
 	},

--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -196,6 +196,9 @@ func (fr *FormatReaders) fileFormatSelector(hdr *image.Header) {
 	case "vhdx":
 		r = nil
 		fr.Convert = true
+	case "iso":
+		r = nil
+		fr.Convert = true
 	}
 	if err == nil && r != nil {
 		fr.appendReader(rdrTypM[fFmt], r)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

HTTP Datasource can't handle s3 presigned URL for ISO file

Fixes #2737

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
FormatReader support ISO fileheader
```

