### PR TITLE
skip nbdkit for all raw/iso image imports

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -316,6 +316,12 @@ func (dp *DataProcessor) resize() (ProcessingPhase, error) {
 			return ProcessingPhaseError, errors.Wrap(err, "Unable to change permissions of target file")
 		}
 	}
+	if isBlockDev && dp.preallocation && !dp.preallocationApplied {
+		// don't love this but it's actually true
+		// should only get here when importing a raw/iso file
+		klog.V(1).Info("preallocation indirectly applied by downloading via golang http client")
+		dp.preallocationApplied = true
+	}
 
 	return ProcessingPhaseComplete, nil
 }

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -130,14 +130,11 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 	if hs.contentType == cdiv1.DataVolumeArchive {
 		return ProcessingPhaseTransferDataDir, nil
 	}
-	if hs.readers.Convert {
-		if hs.brokenForQemuImg || hs.readers.Archived || hs.customCA != "" {
-			return ProcessingPhaseTransferScratch, nil
-		}
-	} else {
-		if hs.readers.Archived || hs.customCA != "" {
-			return ProcessingPhaseTransferDataFile, nil
-		}
+	if !hs.readers.Convert {
+		return ProcessingPhaseTransferDataFile, nil
+	}
+	if hs.brokenForQemuImg || hs.readers.Archived || hs.customCA != "" {
+		return ProcessingPhaseTransferScratch, nil
 	}
 	hs.url, _ = url.Parse(fmt.Sprintf("nbd+unix:///?socket=%s", nbdkitSocket))
 	if err = hs.n.StartNbdkit(hs.endpoint.String()); err != nil {

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreIso,
 				isHTTPS:       false,
 				withBasicAuth: false,
-				userAgent:     nbdKitUserAgent,
+				userAgent:     golangUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso.gz import dv with a proxied server (http)", importProxyTestArguments{
 				name:          "dv-import-http-proxy",
@@ -223,7 +223,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreQcow2,
 				isHTTPS:       false,
 				withBasicAuth: true,
-				userAgent:     nbdKitUserAgent,
+				userAgent:     golangUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
 				name:          "dv-import-http-proxy-auth",
@@ -232,7 +232,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreIso,
 				isHTTPS:       false,
 				withBasicAuth: true,
-				userAgent:     nbdKitUserAgent,
+				userAgent:     golangUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso.gz import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
 				name:          "dv-import-http-proxy-auth",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

I don't think there's any benefit to using nbdkit to proxy raw/iso images.  At this point, I believe it is mostly useful when "qemu-img convert" is required because the http client in qemu-img has issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2737

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
skip nbdkit for all raw/iso image imports
```

