### PR TITLE
Delete old version DVs with DIC GC

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -804,7 +804,7 @@ func (r *DataImportCronReconciler) garbageCollectOldImports(ctx context.Context,
 		maxImports = int(*cron.Spec.ImportsToKeep)
 	}
 
-	if err := r.garbageCollectPVCs(ctx, cron.Namespace, selector, maxImports); err != nil {
+	if err := r.garbageCollectPVCs(ctx, cron.Namespace, cron.Name, selector, maxImports); err != nil {
 		return err
 	}
 	if err := r.garbageCollectSnapshots(ctx, cron.Namespace, selector, maxImports); err != nil {
@@ -814,7 +814,7 @@ func (r *DataImportCronReconciler) garbageCollectOldImports(ctx context.Context,
 	return nil
 }
 
-func (r *DataImportCronReconciler) garbageCollectPVCs(ctx context.Context, namespace string, selector labels.Selector, maxImports int) error {
+func (r *DataImportCronReconciler) garbageCollectPVCs(ctx context.Context, namespace, cronName string, selector labels.Selector, maxImports int) error {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 
 	if err := r.client.List(ctx, pvcList, &client.ListOptions{Namespace: namespace, LabelSelector: selector}); err != nil {
@@ -828,6 +828,27 @@ func (r *DataImportCronReconciler) garbageCollectPVCs(ctx context.Context, names
 			r.log.Info("Deleting dv/pvc", "name", pvc.Name, "pvc.uid", pvc.UID)
 			if err := r.deleteDvPvc(ctx, pvc.Name, pvc.Namespace); err != nil {
 				return err
+			}
+		}
+	}
+
+	dvList := &cdiv1.DataVolumeList{}
+	if err := r.client.List(ctx, dvList, &client.ListOptions{Namespace: namespace, LabelSelector: selector}); err != nil {
+		return err
+	}
+
+	if len(dvList.Items) > maxImports {
+		for _, dv := range dvList.Items {
+			pvc := &corev1.PersistentVolumeClaim{}
+			if err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: dv.Name}, pvc); err != nil {
+				return err
+			}
+
+			if pvc.Labels[common.DataImportCronLabel] != cronName {
+				r.log.Info("Deleting old version dv/pvc", "name", pvc.Name, "pvc.uid", pvc.UID)
+				if err := r.deleteDvPvc(ctx, dv.Name, dv.Namespace); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -443,6 +443,7 @@ var _ = Describe("DataImportCron", func() {
 		if format == cdiv1.DataImportCronSourceFormatSnapshot && !f.IsSnapshotStorageClassAvailable() {
 			Skip("Volumesnapshot support needed to test DataImportCron with Volumesnapshot sources")
 		}
+		const oldDvName = "old-version-dv"
 
 		configureStorageProfileResultingFormat(format)
 
@@ -478,9 +479,33 @@ var _ = Describe("DataImportCron", func() {
 
 		switch format {
 		case cdiv1.DataImportCronSourceFormatPvc:
+			By(fmt.Sprintf("Create labeled DataVolume %s for old DVs garbage collection test", oldDvName))
+			dv := utils.NewDataVolumeWithRegistryImport(oldDvName, "5Gi", "")
+			dv.Spec.Source.Registry = reg
+			dv.Labels = map[string]string{common.DataImportCronLabel: cronName}
+			cc.AddAnnotation(dv, cc.AnnDeleteAfterCompletion, "false")
+			dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, ns, dv)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for import completion")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
+			err = utils.WaitForDataVolumePhase(f, ns, cdiv1.Succeeded, dv.Name)
+			Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
+
+			By(fmt.Sprintf("Verify PVC was created %s", dv.Name))
+			pvc, err := utils.WaitForPVC(f.K8sClient, ns, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+			By(fmt.Sprintf("Verify DataImportCronLabel is passed to the PVC: %s", pvc.Labels[common.DataImportCronLabel]))
+			Expect(pvc.Labels[common.DataImportCronLabel]).To(Equal(cronName))
+
+			pvc.Labels[common.DataImportCronLabel] = ""
+			By("Update DataImportCron label to be empty in the PVC")
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
 			pvcList, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pvcList.Items).To(HaveLen(garbageSources))
+			Expect(pvcList.Items).To(HaveLen(garbageSources + 1))
 		case cdiv1.DataImportCronSourceFormatSnapshot:
 			snapshots := &snapshotv1.VolumeSnapshotList{}
 			err := f.CrClient.List(context.TODO(), snapshots, &client.ListOptions{Namespace: ns})
@@ -506,6 +531,12 @@ var _ = Describe("DataImportCron", func() {
 		By("Check garbage collection")
 		switch format {
 		case cdiv1.DataImportCronSourceFormatPvc:
+			By("Check old DV garbage collection")
+			Eventually(func() error {
+				_, err := f.CdiClient.CdiV1beta1().DataVolumes(ns).Get(context.TODO(), oldDvName, metav1.GetOptions{})
+				return err
+			}, dataImportCronTimeout, pollingInterval).Should(Satisfy(errors.IsNotFound), "Garbage collection failed cleaning old DV")
+
 			pvcList := &corev1.PersistentVolumeClaimList{}
 			Eventually(func() int {
 				pvcList, err = f.K8sClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{})
@@ -551,7 +582,7 @@ var _ = Describe("DataImportCron", func() {
 			Expect(found).To(BeTrue())
 		}
 	},
-		Entry("[test_id:7406] with PVC sources", cdiv1.DataImportCronSourceFormatPvc),
+		Entry("[test_id:7406] with PVC & DV sources", cdiv1.DataImportCronSourceFormatPvc),
 		Entry("[test_id:10033] with snapshot sources", cdiv1.DataImportCronSourceFormatSnapshot),
 	)
 


### PR DESCRIPTION
Signed-off-by: Ido Aharon <iaharon@redhat.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the old versions, the garbage collection label was added to DV only. In the new version, the GC looks for this label in the PVC, so it does not find it and does not delete the DV's from the old versions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes bz #2209969

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Delete old version DV's with DIC garbage collector
```

