### PR TITLE
dataimportcron: Pass dynamic credential support label

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -290,6 +290,9 @@ const (
 	// LabelDefaultPreferenceKind provides a default kind of either VirtualMachineClusterPreference or VirtualMachinePreference
 	LabelDefaultPreferenceKind = "instancetype.kubevirt.io/default-preference-kind"
 
+	// LabelDynamicCredentialSupport specifies if the OS supports updating credentials at runtime.
+	LabelDynamicCredentialSupport = "kubevirt.io/dynamic-credentials-support"
+
 	// ProgressDone this means we are DONE
 	ProgressDone = "100.0%"
 )

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -570,6 +570,8 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreference)
 	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreferenceKind)
 
+	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDynamicCredentialSupport)
+
 	sourcePVC := dataImportCron.Status.LastImportedPVC
 	populateDataSource(format, dataSource, sourcePVC)
 
@@ -1246,6 +1248,8 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetypeKind)
 	passCronLabelToDv(cron, dv, cc.LabelDefaultPreference)
 	passCronLabelToDv(cron, dv, cc.LabelDefaultPreferenceKind)
+
+	passCronLabelToDv(cron, dv, cc.LabelDynamicCredentialSupport)
 
 	return dv
 }

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -728,25 +728,20 @@ var _ = Describe("All DataImportCron Tests", func() {
 			dvName := imports[0].DataVolumeName
 			Expect(dvName).ToNot(BeEmpty())
 
-			ExpectInstancetypeLabels := func(labels map[string]string) {
-				Expect(labels).ToNot(BeEmpty())
-				Expect(labels).Should(ContainElement(cc.LabelDefaultInstancetype))
-				Expect(labels[cc.LabelDefaultInstancetype]).Should(Equal(cc.LabelDefaultInstancetype))
-				Expect(labels).Should(ContainElement(cc.LabelDefaultInstancetypeKind))
-				Expect(labels[cc.LabelDefaultInstancetypeKind]).Should(Equal(cc.LabelDefaultInstancetypeKind))
-				Expect(labels).Should(ContainElement(cc.LabelDefaultPreference))
-				Expect(labels[cc.LabelDefaultPreference]).Should(Equal(cc.LabelDefaultPreference))
-				Expect(labels).Should(ContainElement(cc.LabelDefaultPreferenceKind))
-				Expect(labels[cc.LabelDefaultPreferenceKind]).Should(Equal(cc.LabelDefaultPreferenceKind))
+			expectLabels := func(labels map[string]string) {
+				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetype, cc.LabelDefaultInstancetype))
+				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetypeKind, cc.LabelDefaultInstancetypeKind))
+				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreference, cc.LabelDefaultPreference))
+				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreferenceKind, cc.LabelDefaultPreferenceKind))
 			}
 
 			dv := &cdiv1.DataVolume{}
 			Expect(reconciler.client.Get(context.TODO(), dvKey(dvName), dv)).To(Succeed())
-			ExpectInstancetypeLabels(dv.Labels)
+			expectLabels(dv.Labels)
 
 			dataSource = &cdiv1.DataSource{}
 			Expect(reconciler.client.Get(context.TODO(), dataSourceKey(cron), dataSource)).To(Succeed())
-			ExpectInstancetypeLabels(dataSource.Labels)
+			expectLabels(dataSource.Labels)
 		})
 
 		Context("Snapshot source format", func() {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -705,7 +705,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Entry("has no tag", imageStreamName, 1),
 		)
 
-		It("should pass through defaultInstancetype and defaultPreference metadata to DataVolume and DataSource", func() {
+		It("should pass through metadata to DataVolume and DataSource", func() {
 			cron = newDataImportCron(cronName)
 			cron.Annotations[AnnSourceDesiredDigest] = testDigest
 
@@ -714,6 +714,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			cron.Labels[cc.LabelDefaultInstancetypeKind] = cc.LabelDefaultInstancetypeKind
 			cron.Labels[cc.LabelDefaultPreference] = cc.LabelDefaultPreference
 			cron.Labels[cc.LabelDefaultPreferenceKind] = cc.LabelDefaultPreferenceKind
+			cron.Labels[cc.LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createDataImportCronReconciler(cron)
 			_, err := reconciler.Reconcile(context.TODO(), cronReq)
@@ -733,6 +734,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetypeKind, cc.LabelDefaultInstancetypeKind))
 				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreference, cc.LabelDefaultPreference))
 				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreferenceKind, cc.LabelDefaultPreferenceKind))
+				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDynamicCredentialSupport, "true"))
 			}
 
 			dv := &cdiv1.DataVolume{}

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -263,10 +263,10 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(pvc.Name).To(Equal("test-dv"))
-			Expect(pvc.Labels[LabelDefaultInstancetype]).To(Equal(LabelDefaultInstancetype))
-			Expect(pvc.Labels[LabelDefaultInstancetypeKind]).To(Equal(LabelDefaultInstancetypeKind))
-			Expect(pvc.Labels[LabelDefaultPreference]).To(Equal(LabelDefaultPreference))
-			Expect(pvc.Labels[LabelDefaultPreferenceKind]).To(Equal(LabelDefaultPreferenceKind))
+			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetype, LabelDefaultInstancetype))
+			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetypeKind, LabelDefaultInstancetypeKind))
+			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreference, LabelDefaultPreference))
+			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreferenceKind, LabelDefaultPreferenceKind))
 		})
 
 		It("Should set params on a PVC from import DV.PVC", func() {

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -246,13 +246,14 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(dv.Status.Progress).To(BeEquivalentTo("13.45%"))
 		})
 
-		It("Should pass instancetype labels from DV to PVC", func() {
+		It("Should pass labels from DV to PVC", func() {
 			dv := NewImportDataVolume("test-dv")
 			dv.Labels = map[string]string{}
 			dv.Labels[LabelDefaultInstancetype] = LabelDefaultInstancetype
 			dv.Labels[LabelDefaultInstancetypeKind] = LabelDefaultInstancetypeKind
 			dv.Labels[LabelDefaultPreference] = LabelDefaultPreference
 			dv.Labels[LabelDefaultPreferenceKind] = LabelDefaultPreferenceKind
+			dv.Labels[LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createImportReconciler(dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
@@ -267,6 +268,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetypeKind, LabelDefaultInstancetypeKind))
 			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreference, LabelDefaultPreference))
 			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreferenceKind, LabelDefaultPreferenceKind))
+			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDynamicCredentialSupport, "true"))
 		})
 
 		It("Should set params on a PVC from import DV.PVC", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The label `kubevirt.io/dynamic-credentials-support` specifies if the OS supports dynamic SSH key change on a running VM.

This PR passes the label from DataImportCron to DataVolume and DataSource.


More information at: https://issues.redhat.com/browse/CNV-28212

**Release note**:
```release-note
None
```

