### PR TITLE
[release-v1.43] Allow dynamic linked build for non bazel build (#2753)

### DIFF
--- a/hack/build/build-go.sh
+++ b/hack/build/build-go.sh
@@ -54,10 +54,14 @@ elif [ "${go_opt}" == "build" ]; then
         outLink=${BIN_DIR}/${BIN_NAME}
         rm -f ${outFile}
         rm -f ${outLink}
+        static_flag=""
+        if [ "$tgt" == "tools/cdi-containerimage-server" ]; then
+          static_flag="static"
+        fi
         (
             cd $tgt
             # Only build executables for linux amd64
-            GOOS=linux GOARCH=amd64 go build -o ${outFile} -ldflags '-extldflags "static"' -ldflags "$(cdi::version::ldflags)"
+            GOOS=linux GOARCH=amd64 go build -o ${outFile} -tags strictfipsruntime -ldflags '-extldflags $static_flag' -ldflags "$(cdi::version::ldflags)"
 
             ln -sf ${outFile} ${outLink}
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The current script always passes the static ldflag to the compiler which will result in a static binary. We would like to be able to build dynamic libraries instead.

cdi-containerimage-server has to be static because we are copying it into the context of a container disk container which is most likely based on a scratch container and has no libraries for us to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

