### PR TITLE
Allow ImmediateBinding annotation when using populators

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -722,7 +722,7 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 	}
 
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
-	setPodPvcAnnotations(pod, targetPvc)
+	cc.SetPvcAllowedAnnotations(pod, targetPvc)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	return pod
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1337,6 +1337,18 @@ func IsWaitForFirstConsumerEnabled(obj metav1.Object, gates featuregates.Feature
 	return pvcHonorWaitForFirstConsumer && globalHonorWaitForFirstConsumer, nil
 }
 
+// AddImmediateBindingAnnotationIfWFFCDisabled adds the immediateBinding annotation if wffc feature gate is disabled
+func AddImmediateBindingAnnotationIfWFFCDisabled(obj metav1.Object, gates featuregates.FeatureGates) error {
+	globalHonorWaitForFirstConsumer, err := gates.HonorWaitForFirstConsumerEnabled()
+	if err != nil {
+		return err
+	}
+	if !globalHonorWaitForFirstConsumer {
+		AddAnnotation(obj, AnnImmediateBinding, "")
+	}
+	return nil
+}
+
 // GetRequiredSpace calculates space required taking file system overhead into account
 func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
 	// the `image` has to be aligned correctly, so the space requested has to be aligned to

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -648,6 +648,12 @@ func GetPreallocation(ctx context.Context, client client.Client, preallocation *
 	return cdiconfig.Status.Preallocation
 }
 
+// ImmediateBindingRequested returns if an object has the ImmediateBinding annotation
+func ImmediateBindingRequested(obj metav1.Object) bool {
+	_, isImmediateBindingRequested := obj.GetAnnotations()[AnnImmediateBinding]
+	return isImmediateBindingRequested
+}
+
 // GetPriorityClass gets PVC priority class
 func GetPriorityClass(pvc *corev1.PersistentVolumeClaim) string {
 	anno := pvc.GetAnnotations()
@@ -1327,7 +1333,7 @@ func GetCloneSourceInfo(dv *cdiv1.DataVolume) (sourceType, sourceName, sourceNam
 // IsWaitForFirstConsumerEnabled tells us if we should respect "real" WFFC behavior or just let our worker pods randomly spawn
 func IsWaitForFirstConsumerEnabled(obj metav1.Object, gates featuregates.FeatureGates) (bool, error) {
 	// when PVC requests immediateBinding it cannot honor wffc logic
-	_, isImmediateBindingRequested := obj.GetAnnotations()[AnnImmediateBinding]
+	isImmediateBindingRequested := ImmediateBindingRequested(obj)
 	pvcHonorWaitForFirstConsumer := !isImmediateBindingRequested
 	globalHonorWaitForFirstConsumer, err := gates.HonorWaitForFirstConsumerEnabled()
 	if err != nil {

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1885,3 +1885,21 @@ func OwnedByDataVolume(obj metav1.Object) bool {
 	owner := metav1.GetControllerOf(obj)
 	return owner != nil && owner.Kind == "DataVolume"
 }
+
+// SetPvcAllowedAnnotations applies PVC annotations on the given obj
+func SetPvcAllowedAnnotations(obj metav1.Object, pvc *corev1.PersistentVolumeClaim) {
+	allowedAnnotations := map[string]string{
+		AnnPodNetwork:              "",
+		AnnPodSidecarInjection:     AnnPodSidecarInjectionDefault,
+		AnnPodMultusDefaultNetwork: ""}
+	for ann, def := range allowedAnnotations {
+		val, ok := pvc.Annotations[ann]
+		if !ok && def != "" {
+			val = def
+		}
+		if val != "" {
+			klog.V(1).Info("Applying PVC annotation", "Name", obj.GetName(), ann, val)
+			AddAnnotation(obj, ann, val)
+		}
+	}
+}

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -191,6 +191,9 @@ func (r *CloneReconcilerBase) updatePVCForPopulation(dataVolume *cdiv1.DataVolum
 	if err := addCloneToken(dataVolume, pvc); err != nil {
 		return err
 	}
+	if err := cc.AddImmediateBindingAnnotationIfWFFCDisabled(pvc, r.featureGates); err != nil {
+		return err
+	}
 	if isCrossNamespaceClone(dataVolume) {
 		_, _, sourcNamespace := cc.GetCloneSourceInfo(dataVolume)
 		cc.AddAnnotation(pvc, populators.AnnDataSourceNamespace, sourcNamespace)

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1150,8 +1150,9 @@ func (r *ReconcilerBase) shouldBeMarkedPendingPopulation(pvc *corev1.PersistentV
 		return false, err
 	}
 	nodeName := pvc.Annotations[cc.AnnSelectedNode]
+	_, immediateBindingRequested := pvc.Annotations[cc.AnnImmediateBinding]
 
-	return wffc && nodeName == "", nil
+	return wffc && nodeName == "" && !immediateBindingRequested, nil
 }
 
 // handlePvcCreation works as a wrapper for non-clone PVC creation and error handling
@@ -1200,33 +1201,11 @@ func (r *ReconcilerBase) shouldUseCDIPopulator(syncState *dvSyncState) (bool, er
 		log.Info("Not using CDI populators, currently we don't support populators with retainAfterCompletion annotation")
 		return false, nil
 	}
-	// currently populators don't support immediate bind annotation so don't use populators in that case
-	if forceBind := dv.Annotations[cc.AnnImmediateBinding]; forceBind == "true" {
-		log.Info("Not using CDI populators, currently we don't support populators with bind immediate annotation")
-		return false, nil
-	}
 	// currently we don't support populator with import source of VDDK or Imageio
 	// or clone either from PVC nor snapshot
 	if dv.Spec.Source.Imageio != nil ||
 		dv.Spec.Source.VDDK != nil {
 		log.Info("Not using CDI populators, currently we don't support populators with Imageio/VDDk source")
-		return false, nil
-	}
-
-	wffc, err := r.storageClassWaitForFirstConsumer(syncState.pvcSpec.StorageClassName)
-	if err != nil {
-		return false, err
-	}
-
-	honorWaitForFirstConsumerEnabled, err := r.featureGates.HonorWaitForFirstConsumerEnabled()
-	if err != nil {
-		return false, err
-	}
-	// currently since we don't support force bind in populators in case the storage class
-	// is wffc but the honorWaitForFirstConsumer feature gate is disabled we can't
-	// do immediate bind anyways, instead do regular flow
-	if wffc && !honorWaitForFirstConsumerEnabled {
-		log.Info("Not using CDI populators, currently we don't WFFC storage with disabled honorWaitForFirstConsumer feature gate")
 		return false, nil
 	}
 

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1150,7 +1150,7 @@ func (r *ReconcilerBase) shouldBeMarkedPendingPopulation(pvc *corev1.PersistentV
 		return false, err
 	}
 	nodeName := pvc.Annotations[cc.AnnSelectedNode]
-	_, immediateBindingRequested := pvc.Annotations[cc.AnnImmediateBinding]
+	immediateBindingRequested := cc.ImmediateBindingRequested(pvc)
 
 	return wffc && nodeName == "" && !immediateBindingRequested, nil
 }

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -131,6 +131,9 @@ func (r *ImportReconciler) updatePVCForPopulation(dataVolume *cdiv1.DataVolume, 
 		dataVolume.Spec.Source.Blank == nil {
 		return errors.Errorf("no source set for import datavolume")
 	}
+	if err := cc.AddImmediateBindingAnnotationIfWFFCDisabled(pvc, r.featureGates); err != nil {
+		return err
+	}
 	apiGroup := cc.AnnAPIGroup
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -119,6 +119,9 @@ func (r *UploadReconciler) updatePVCForPopulation(dataVolume *cdiv1.DataVolume, 
 	if dataVolume.Spec.Source.Upload == nil {
 		return errors.Errorf("no source set for upload datavolume")
 	}
+	if err := cc.AddImmediateBindingAnnotationIfWFFCDisabled(pvc, r.featureGates); err != nil {
+		return err
+	}
 	apiGroup := cc.AnnAPIGroup
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -1180,7 +1180,7 @@ func setImporterPodCommons(pod *corev1.Pod, podEnvVar *importPodEnvVar, pvc *cor
 
 	pod.Spec.Containers[0].Env = makeImportEnv(podEnvVar, ownerUID)
 
-	setPodPvcAnnotations(pod, pvc)
+	cc.SetPvcAllowedAnnotations(pod, pvc)
 }
 
 func makeImporterContainerSpec(image, verbose, pullPolicy string) *corev1.Container {

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -199,6 +199,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 			Kind:    "PersistentVolumeClaim",
 		}),
 	}
+	cc.SetPvcAllowedAnnotations(pvcPrime, pvc)
 	util.SetRecommendedLabels(pvcPrime, r.installerLabels, "cdi-controller")
 
 	// We use the populator-specific pvcModifierFunc to add required annotations

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -120,7 +120,8 @@ func claimReadyForPopulation(ctx context.Context, c client.Client, pvc *corev1.P
 
 	if storageClass.VolumeBindingMode != nil && *storageClass.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
 		nodeName = pvc.Annotations[cc.AnnSelectedNode]
-		if nodeName == "" {
+		_, isImmediateBindingRequested := pvc.Annotations[cc.AnnImmediateBinding]
+		if nodeName == "" && !isImmediateBindingRequested {
 			// Wait for the PVC to get a node name before continuing
 			return false, nodeName, nil
 		}

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -120,7 +120,7 @@ func claimReadyForPopulation(ctx context.Context, c client.Client, pvc *corev1.P
 
 	if storageClass.VolumeBindingMode != nil && *storageClass.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
 		nodeName = pvc.Annotations[cc.AnnSelectedNode]
-		_, isImmediateBindingRequested := pvc.Annotations[cc.AnnImmediateBinding]
+		isImmediateBindingRequested := cc.ImmediateBindingRequested(pvc)
 		if nodeName == "" && !isImmediateBindingRequested {
 			// Wait for the PVC to get a node name before continuing
 			return false, nodeName, nil

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -893,7 +893,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			MountPath: common.ScratchDataDir,
 		})
 	}
-	setPodPvcAnnotations(pod, args.PVC)
+	cc.SetPvcAllowedAnnotations(pod, args.PVC)
 	cc.SetNodeNameIfPopulator(args.PVC, &pod.Spec)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	return pod

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -374,27 +374,6 @@ func getScratchNameFromPod(pod *v1.Pod) (string, bool) {
 	return "", false
 }
 
-// setPodPvcAnnotations applies PVC annotations on the pod
-func setPodPvcAnnotations(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) {
-	allowedAnnotations := map[string]string{
-		cc.AnnPodNetwork:              "",
-		cc.AnnPodSidecarInjection:     cc.AnnPodSidecarInjectionDefault,
-		cc.AnnPodMultusDefaultNetwork: ""}
-	for ann, def := range allowedAnnotations {
-		val, ok := pvc.Annotations[ann]
-		if !ok && def != "" {
-			val = def
-		}
-		if val != "" {
-			klog.V(1).Info("Applying PVC annotation on the pod", ann, val)
-			if pod.Annotations == nil {
-				pod.Annotations = map[string]string{}
-			}
-			pod.Annotations[ann] = val
-		}
-	}
-}
-
 func podUsingPVC(pvc *corev1.PersistentVolumeClaim, readOnly bool) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -226,11 +226,15 @@ var _ = Describe("DataSource", func() {
 			dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Verify DV conditions")
-			utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
-				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source snapshot snap1 doesn't exist", Reason: dvc.CloneWithoutSource},
-				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
-				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
+			pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+			if pvc.Spec.DataSourceRef == nil || pvc.Spec.DataSourceRef.Kind != cdiv1.VolumeCloneSourceRef {
+				By("Verify DV conditions")
+				utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
+					&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source snapshot snap1 doesn't exist", Reason: dvc.CloneWithoutSource},
+					&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
+					&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
+			}
 			f.ExpectEvent(dv.Namespace).Should(ContainSubstring(dvc.CloneWithoutSource))
 
 			By("Create snapshot so the DataSource will be ready")

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2650,10 +2650,15 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 
 			// verify PVC was created
-			By("verifying pvc was created and is Bound")
+			By("verifying pvc was created")
 			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
-			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimBound, pvc.Name)
+			expectedPVCPhase := v1.ClaimBound
+			if phase != cdiv1.Succeeded && pvc.Spec.DataSourceRef != nil {
+				expectedPVCPhase = v1.ClaimPending
+			}
+			By(fmt.Sprintf("waiting for pvc to match phase %s", string(expectedPVCPhase)))
+			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, expectedPVCPhase, pvc.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))
@@ -2748,10 +2753,15 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 
 			// verify PVC was created
-			By("verifying pvc was created and is Bound")
+			By("verifying pvc was created")
 			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 			Expect(err).ToNot(HaveOccurred())
-			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimBound, pvc.Name)
+			expectedPVCPhase := v1.ClaimBound
+			if phase != cdiv1.Succeeded && pvc.Spec.DataSourceRef != nil {
+				expectedPVCPhase = v1.ClaimPending
+			}
+			By(fmt.Sprintf("waiting for pvc to match phase %s", string(expectedPVCPhase)))
+			err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, expectedPVCPhase, pvc.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))


### PR DESCRIPTION
In case of using PVC with populators if the PVC has this annotation we prevent from waiting for it to be schedueled and we proceed with the process.
When using datavolumes with populators in case the dv has the annotation it will be passed to the PVC. we prevent from being in pendingPopulation in case the created pvc has the annotaion.
Plus when having honorWaitForFirstConsumer feature gate disabled we will put on the target PVC the immediateBinding annotation. Now we allow to use populators when having the annotation the the feature gate disabled.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Integration of clone datavolumes with populators is in a PR: https://github.com/kubevirt/containerized-data-importer/pull/2750
once merged will need to add to the datavolume clone controller the ImmediateBinding annotation in case of honorWaitForFirstConsumer feature gate disabled

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow ImmediateBinding annotation when using populators
```

