### PR TITLE
Add AWS EFS CSI to known provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -63,7 +63,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	//AWSElasticBlockStore
 	"kubernetes.io/aws-ebs": {{rwo, block}},
 	"ebs.csi.aws.com":       {{rwo, block}},
-	// AWSFIle is done by a pod
+	//AWSElasticFileSystem
+	"efs.csi.aws.com": {{rwx, file}, {rwo, file}},
 	//Azure disk
 	"kubernetes.io/azure-disk": {{rwo, block}},
 	"disk.csi.azure.com":       {{rwo, block}},


### PR DESCRIPTION
**What this PR does / why we need it**:
Add StorageProfile default ClaimPropertySets (StorageCapabilities) for the provisioner.

**Release note**:
```release-note
Add AWS EFS CSI to known provisioners
```