### PR TITLE
Revert some gomega error checks that produce confusing output

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2554,9 +2554,10 @@ var _ = Describe("all clone tests", func() {
 			cdiCr = crList.Items[0]
 
 			By("[BeforeEach] Forcing Host Assisted cloning")
-			var cloneStrategy cdiv1.CDICloneStrategy = cdiv1.CloneStrategyHostAssisted
+			cloneStrategy := cdiv1.CloneStrategyHostAssisted
 			cdiCr.Spec.CloneStrategyOverride = &cloneStrategy
-			Expect(f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &cdiCr, metav1.UpdateOptions{})).Error().ToNot(HaveOccurred())
+			_, err = f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &cdiCr, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(utils.WaitForCDICrCloneStrategy(f.CdiClient, cloneStrategy)).To(Succeed())
 		})
@@ -2578,7 +2579,8 @@ var _ = Describe("all clone tests", func() {
 
 			newCdiCr := crList.Items[0]
 			newCdiCr.Spec = *cdiCrSpec
-			Expect(f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &newCdiCr, metav1.UpdateOptions{})).Error().ToNot(HaveOccurred())
+			_, err = f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), &newCdiCr, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			if cdiCrSpec.CloneStrategyOverride == nil {
 				err = utils.WaitForCDICrCloneStrategyNil(f.CdiClient)
@@ -3303,7 +3305,8 @@ func VerifyDisabledGC(f *framework.Framework, dvName, dvNamespace string) {
 		Expect(err).NotTo(HaveOccurred())
 		return log
 	}, timeout, pollingInterval).Should(ContainSubstring(matchString))
-	Expect(f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})).Error().ToNot(HaveOccurred())
+	_, err := f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
 }
 
 // EnableGcAndAnnotateLegacyDv enables garbage collection, annotates the DV and verifies it is garbage collected
@@ -3324,7 +3327,8 @@ func EnableGcAndAnnotateLegacyDv(f *framework.Framework, dvName, dvNamespace str
 
 	By("Add true DeleteAfterCompletion annotation to DV")
 	controller.AddAnnotation(dv, controller.AnnDeleteAfterCompletion, "true")
-	Expect(f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Update(context.TODO(), dv, metav1.UpdateOptions{})).Error().ToNot(HaveOccurred())
+	_, err = f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Update(context.TODO(), dv, metav1.UpdateOptions{})
+	Expect(err).ToNot(HaveOccurred())
 	VerifyGC(f, dvName, dvNamespace, false, nil)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
One of these tests flakes, and the error is hard to debug because Gomega will yell about
`Unexpected non-nil/non-zero argument at index 0`
Instead of showing the error

Apparently, this is intended:
https://github.com/onsi/gomega/pull/480/files#diff-e696deff1a5be83ad03053b772926cb325cede3b33222fa76c2bb1fcf2efd809R186-R190

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

