### PR TITLE
[release-v1.55] Backport 'Skip tls config upload test when openshift route is used'

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -856,6 +856,9 @@ var _ = Describe("CDIConfig manipulation upload tests", func() {
 	})
 
 	It("[test_id:9063]Should fail upload when TLS profile requires minimal TLS version higher than our client's", func() {
+		if utils.IsOpenshift(f.K8sClient) {
+			Skip("OpenShift reencrypt routes are used, client tls config will be dropped")
+		}
 		err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
 			config.TLSSecurityProfile = &ocpconfigv1.TLSSecurityProfile{
 				// Modern profile requires TLS 1.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Partial backport of https://github.com/kubevirt/containerized-data-importer/pull/2677;
Skip TLS config test since our `reencrypt` route will terminate the client connection at the router (and lose tls context)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

