### PR TITLE
Follow up for GC=on in some tests

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2393,9 +2393,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			updatePV(func(pv *v1.PersistentVolume) {
 				pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
 			})
-
-			err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			utils.CleanupDvPvc(f.K8sClient, f.CdiClient, pvc.Namespace, pvc.Name)
 
 			updatePV(func(pv *v1.PersistentVolume) {
 				pv.Spec.StorageClassName = scName


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This may be the reason for the flakes we're seeing: https://search.ci.kubevirt.io/?search=9924&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=containerized-data-importer&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

With GC on we want to delete the DV (PVC won't cut it)
We may have more cases like this one scattered around, so let's keep an eye

Not sure how populators DVs handle that situation but we see that the test PV is simply gone from artifacts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

