### PR TITLE
dataVolume: Add default instance type labels from source

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -320,6 +320,14 @@ var (
 	// FilesystemMode is filesystem device mode
 	FilesystemMode = corev1.PersistentVolumeFilesystem
 
+	// DefaultInstanceTypeLabels is a list of currently supported default instance type labels
+	DefaultInstanceTypeLabels = []string{
+		LabelDefaultInstancetype,
+		LabelDefaultInstancetypeKind,
+		LabelDefaultPreference,
+		LabelDefaultPreferenceKind,
+	}
+
 	apiServerKeyOnce sync.Once
 	apiServerKey     *rsa.PrivateKey
 )

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -567,10 +567,9 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 	dataSourceCopy := dataSource.DeepCopy()
 	r.setDataImportCronResourceLabels(dataImportCron, dataSource)
 
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultInstancetype)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultInstancetypeKind)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreference)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreferenceKind)
+	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+		passCronLabelToDataSource(dataImportCron, dataSource, defaultInstanceTypeLabel)
+	}
 
 	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDynamicCredentialSupport)
 
@@ -1256,10 +1255,9 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	cc.AddAnnotation(dv, cc.AnnImmediateBinding, "true")
 	passCronAnnotationToDv(cron, dv, cc.AnnPodRetainAfterCompletion)
 
-	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetype)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetypeKind)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultPreference)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultPreferenceKind)
+	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+		passCronLabelToDv(cron, dv, defaultInstanceTypeLabel)
+	}
 
 	passCronLabelToDv(cron, dv, cc.LabelDynamicCredentialSupport)
 

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -709,10 +709,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			cron.Annotations[AnnSourceDesiredDigest] = testDigest
 
 			cron.Labels = map[string]string{}
-			cron.Labels[cc.LabelDefaultInstancetype] = cc.LabelDefaultInstancetype
-			cron.Labels[cc.LabelDefaultInstancetypeKind] = cc.LabelDefaultInstancetypeKind
-			cron.Labels[cc.LabelDefaultPreference] = cc.LabelDefaultPreference
-			cron.Labels[cc.LabelDefaultPreferenceKind] = cc.LabelDefaultPreferenceKind
+			for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+				cron.Labels[defaultInstanceTypeLabel] = defaultInstanceTypeLabel
+			}
 			cron.Labels[cc.LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createDataImportCronReconciler(cron)
@@ -729,10 +728,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(dvName).ToNot(BeEmpty())
 
 			expectLabels := func(labels map[string]string) {
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetype, cc.LabelDefaultInstancetype))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetypeKind, cc.LabelDefaultInstancetypeKind))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreference, cc.LabelDefaultPreference))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreferenceKind, cc.LabelDefaultPreferenceKind))
+				for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+					ExpectWithOffset(1, labels).To(HaveKeyWithValue(defaultInstanceTypeLabel, defaultInstanceTypeLabel))
+				}
 				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDynamicCredentialSupport, "true"))
 			}
 

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -467,6 +467,10 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 		return syncState, err
 	}
 
+	if err = updateDataVolumeDefaultInstancetypeLabels(r.client, &syncState); err != nil {
+		return syncState, err
+	}
+
 	if syncState.pvc != nil {
 		if err := r.garbageCollect(&syncState, log); err != nil {
 			return syncState, err

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -249,10 +249,9 @@ var _ = Describe("All DataVolume Tests", func() {
 		It("Should pass labels from DV to PVC", func() {
 			dv := NewImportDataVolume("test-dv")
 			dv.Labels = map[string]string{}
-			dv.Labels[LabelDefaultInstancetype] = LabelDefaultInstancetype
-			dv.Labels[LabelDefaultInstancetypeKind] = LabelDefaultInstancetypeKind
-			dv.Labels[LabelDefaultPreference] = LabelDefaultPreference
-			dv.Labels[LabelDefaultPreferenceKind] = LabelDefaultPreferenceKind
+			for _, defaultInstanceTypeLabel := range DefaultInstanceTypeLabels {
+				dv.Labels[defaultInstanceTypeLabel] = defaultInstanceTypeLabel
+			}
 			dv.Labels[LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createImportReconciler(dv)
@@ -264,10 +263,9 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(pvc.Name).To(Equal("test-dv"))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetype, LabelDefaultInstancetype))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetypeKind, LabelDefaultInstancetypeKind))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreference, LabelDefaultPreference))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreferenceKind, LabelDefaultPreferenceKind))
+			for _, defaultInstanceTypeLabel := range DefaultInstanceTypeLabels {
+				Expect(pvc.Labels).To(HaveKeyWithValue(defaultInstanceTypeLabel, defaultInstanceTypeLabel))
+			}
 			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDynamicCredentialSupport, "true"))
 		})
 

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -11,10 +11,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
@@ -97,6 +99,165 @@ var _ = Describe("resolveVolumeSize", func() {
 	})
 })
 
+var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
+
+	const (
+		namespace            = "namespace"
+		sourcePVCName        = "sourcePVC"
+		sourceDataSourceName = "sourceDataSource"
+	)
+
+	var (
+		fakeClient                     client.Client
+		dataVolumeWithSourcePVC        cdiv1.DataVolume
+		dataVolumeWithSourceDataSource cdiv1.DataVolume
+	)
+
+	defaultInstancetypeLabelMap := map[string]string{
+		LabelDefaultInstancetype:     LabelDefaultInstancetype,
+		LabelDefaultInstancetypeKind: LabelDefaultInstancetypeKind,
+		LabelDefaultPreference:       LabelDefaultPreference,
+		LabelDefaultPreferenceKind:   LabelDefaultPreferenceKind,
+	}
+
+	BeforeEach(func() {
+		dataVolumeWithSourcePVC = cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					PVC: &cdiv1.DataVolumeSourcePVC{
+						Name:      sourcePVCName,
+						Namespace: namespace,
+					},
+				},
+			},
+		}
+
+		dataVolumeWithSourceDataSource = cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datasource-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				SourceRef: &cdiv1.DataVolumeSourceRef{
+					Kind:      cdiv1.DataVolumeDataSource,
+					Name:      sourceDataSourceName,
+					Namespace: pointer.String(namespace),
+				},
+			},
+		}
+		fakeClient = createClient(
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourcePVCName,
+					Namespace: namespace,
+					Labels:    defaultInstancetypeLabelMap,
+				},
+			},
+			&cdiv1.DataSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceDataSourceName,
+					Namespace: namespace,
+					Labels:    defaultInstancetypeLabelMap,
+				},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Name: sourcePVCName,
+						},
+					},
+				},
+			},
+		)
+	})
+
+	DescribeTable("should update DataVolume with labels from source using", func(dataVolume *cdiv1.DataVolume) {
+		syncState := &dvSyncState{
+			dvMutated: dataVolume,
+		}
+		Expect(syncState.dvMutated.Labels).To(BeEmpty())
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+		Expect(syncState.dvMutated.Labels).ToNot(BeEmpty())
+		for k, v := range defaultInstancetypeLabelMap {
+			Expect(syncState.dvMutated.Labels).To(HaveKeyWithValue(k, v))
+		}
+	},
+		Entry("PVC", &dataVolumeWithSourcePVC),
+		Entry("dataSource", &dataVolumeWithSourceDataSource),
+	)
+
+	DescribeTable("should not update DataVolume with labels from source if already present using", func(dataVolume *cdiv1.DataVolume) {
+		const customDefaultInstancetype = "customDefaultInstancetype"
+		dv := dataVolume
+		dv.Labels = map[string]string{
+			LabelDefaultInstancetype: customDefaultInstancetype,
+		}
+		syncState := &dvSyncState{
+			dvMutated: dv,
+		}
+
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+		Expect(syncState.dvMutated.Labels).To(HaveLen(1))
+		Expect(syncState.dvMutated.Labels).To(HaveKeyWithValue(LabelDefaultInstancetype, customDefaultInstancetype))
+	},
+		Entry("PVC", &dataVolumeWithSourcePVC),
+		Entry("DataSource", &dataVolumeWithSourceDataSource),
+	)
+
+	DescribeTable("should ignore IsNotFound errors", func(dataVolume *cdiv1.DataVolume) {
+		syncState := &dvSyncState{
+			dvMutated: dataVolume,
+		}
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+	},
+		Entry("PVC", &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					PVC: &cdiv1.DataVolumeSourcePVC{
+						Name:      "unknown",
+						Namespace: namespace,
+					},
+				},
+			},
+		}),
+		Entry("DataSource", &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datasource-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				SourceRef: &cdiv1.DataVolumeSourceRef{
+					Kind:      cdiv1.DataVolumeDataSource,
+					Name:      "unknown",
+					Namespace: pointer.String(namespace),
+				},
+			},
+		}),
+	)
+
+	DescribeTable("should return all non IsNotFound errors", func(dataVolume *cdiv1.DataVolume) {
+		err := updateDataVolumeDefaultInstancetypeLabels(
+			fakeClientWithGetServiceUnavailableErr{
+				fakeClient,
+			},
+			&dvSyncState{
+				dvMutated: dataVolume,
+			},
+		)
+		Expect(errors.IsServiceUnavailable(err)).To(BeTrue())
+	},
+		Entry("PVC", &dataVolumeWithSourcePVC),
+		Entry("DataSource", &dataVolumeWithSourceDataSource),
+	)
+})
+
 func createDataVolumeWithStorageAPI(name, ns string, source *cdiv1.DataVolumeSource, storageSpec *cdiv1.StorageSpec) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -118,4 +279,12 @@ func createClient(objs ...runtime.Object) client.Client {
 	_ = ocpconfigv1.Install(s)
 	// Create a fake client to mock API calls.
 	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+}
+
+type fakeClientWithGetServiceUnavailableErr struct {
+	client.Client
+}
+
+func (c fakeClientWithGetServiceUnavailableErr) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return errors.NewServiceUnavailable("error")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubevirt/containerized-data-importer/commit/f229aeb5ff69b3d89b537b39f547eb6c2bc3d5de started to pass default instance type labels from
DataImportCrons to DataVolumes and DataVolumes to any associated
destination DataSources or PVCs. As documented in issue https://github.com/kubevirt/containerized-data-importer/issues/2782 this does
not however pass these labels from the initial source of a DataVolume to
either the DataVolume or the destination DataSources or PVCs

This change corrects this by updating DataVolumes when reconciled,
adding any labels found on PVC or DataSource sources. These labels will
then be passed on to the destination PVC or DataSources by the existing
functionality highlighted above.

Note that if any default instance type labels already exist on the
DataVolume then the process is skipped as it is assumed these are
provided either directly by the user or via a DataImportCron.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2782

**Special notes for your reviewer**:

Depends on https://github.com/kubevirt/containerized-data-importer/pull/2818

Functional tests still missing, will try to add them later this week but reviews welcome in the meantime!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

