### PR TITLE
[release-v1.56] Add IBM and AWS EFS CSI to known provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -61,7 +61,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	//AWSElasticBlockStore
 	"kubernetes.io/aws-ebs": {{rwo, block}},
 	"ebs.csi.aws.com":       {{rwo, block}},
-	// AWSFIle is done by a pod
+	//AWSElasticFileSystem
+	"efs.csi.aws.com": {{rwx, file}, {rwo, file}},
 	//Azure disk
 	"kubernetes.io/azure-disk": {{rwo, block}},
 	"disk.csi.azure.com":       {{rwo, block}},
@@ -75,6 +76,10 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"hspc.csi.hitachi.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// HPE
 	"csi.hpe.com": createRWOBlockAndFilesystemCapabilities(),
+	// IBM HCI/GPFS2 (Spectrum Scale / Spectrum Fusion)
+	"spectrumscale.csi.ibm.com": {{rwx, file}, {rwo, file}},
+	// IBM block arrays (FlashSystem)
+	"block.csi.ibm.com": {{rwo, block}, {rwo, file}},
 	// Portworx in-tree CSI
 	"kubernetes.io/portworx-volume/shared": {{rwx, file}},
 	"kubernetes.io/portworx-volume":        {{rwo, file}},


### PR DESCRIPTION
Manual backport of #2762 #2771

**What this PR does / why we need it**:
Add StorageProfile default ClaimPropertySets (StorageCapabilities) for the provisioners.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes bz 2220844

**Special notes for your reviewer**:

**Release note**:
```release-note
Add IBM and AWS EFS CSI to known provisioners
```

