### PR TITLE
[release-v1.56] Fix DataImportCron PVC update error check

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -309,7 +309,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	if dv != nil {
 		switch dv.Status.Phase {
 		case cdiv1.Succeeded:
-			if r.updatePvc(ctx, dataImportCron, pvc); err != nil {
+			if err = r.updatePvc(ctx, dataImportCron, pvc); err != nil {
 				return res, err
 			}
 			importSucceeded = true
@@ -322,7 +322,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, fmt.Sprintf("Import DataVolume phase %s", dvPhase), dvPhase)
 		}
 	} else if pvc != nil {
-		if r.updatePvc(ctx, dataImportCron, pvc); err != nil {
+		if err = r.updatePvc(ctx, dataImportCron, pvc); err != nil {
 			return res, err
 		}
 		importSucceeded = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed in #2696 in main/release-v1.57 as part of the linter error fixes.

PVC lastUseTime annotation was sometimes not updated so DataImportCron PVC garbage collection was misbehaving and deleting the latest imported PVC, which was then re-imported again until the update succeeded.

The issue was introduced by #2539 and found due to flaky [test_id:7406].

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes bz #2221913

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix DataImportCron PVC garbage collection by correctly updating PVC lastUseTime annotation
```

