### PR TITLE
[release-v1.57] Manual cherrypick of #2821

### DIFF
--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -174,11 +174,9 @@ var _ = Describe("Import populator tests", func() {
 			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = namespacedDataSourceRef
 			volumeImportSource := getVolumeImportSource(true, nsName)
-			pvcPrime := getPVCPrime(targetPvc, nil)
-			pvcPrime.Annotations = map[string]string{AnnPodPhase: string(corev1.PodSucceeded)}
 
 			By("Reconcile")
-			reconciler = createImportPopulatorReconciler(targetPvc, pvcPrime, volumeImportSource, sc)
+			reconciler = createImportPopulatorReconciler(targetPvc, volumeImportSource, sc)
 			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: targetPvcName, Namespace: metav1.NamespaceDefault}})
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(result).To(Not(BeNil()))

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -279,6 +279,16 @@ func (r *ReconcilerBase) reconcileCommon(pvc *corev1.PersistentVolumeClaim, popu
 		return nil, nil
 	}
 
+	// Get the PVC'. If it does exist, return it and skip the rest of the checks
+	// If it doesn't, we'll attempt to create it.
+	pvcPrime, err := r.getPVCPrime(pvc)
+	if err != nil {
+		return nil, err
+	}
+	if pvcPrime != nil {
+		return pvcPrime, nil
+	}
+
 	// We should ignore PVCs that aren't for this populator to handle
 	dataSourceRef := pvc.Spec.DataSourceRef
 	if !IsPVCDataSourceRefKind(pvc, r.sourceKind) {
@@ -303,16 +313,10 @@ func (r *ReconcilerBase) reconcileCommon(pvc *corev1.PersistentVolumeClaim, popu
 		return nil, err
 	}
 
-	// Get the PVC'
-	pvcPrime, err := r.getPVCPrime(pvc)
-	if err != nil {
-		return nil, err
-	}
-
 	// If PVC' doesn't exist and target PVC is not bound, we should create the PVC' to start the population.
-	// We still return the nil PVC' as we'll get called again once PVC' exists.
+	// We still return nil as we'll get called again once PVC' exists.
 	// If target PVC is bound, we don't really need to populate anything.
-	if pvcPrime == nil && cc.IsUnbound(pvc) {
+	if cc.IsUnbound(pvc) {
 		_, err := r.createPVCPrime(pvc, populationSource, nodeName != "", populator.updatePVCForPopulation)
 		if err != nil {
 			r.recorder.Eventf(pvc, corev1.EventTypeWarning, errCreatingPVCPrime, err.Error())
@@ -320,7 +324,7 @@ func (r *ReconcilerBase) reconcileCommon(pvc *corev1.PersistentVolumeClaim, popu
 		}
 	}
 
-	return pvcPrime, nil
+	return nil, nil
 }
 
 func (r *ReconcilerBase) reconcileCleanup(pvcPrime *corev1.PersistentVolumeClaim) (reconcile.Result, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of https://github.com/kubevirt/containerized-data-importer/pull/2821 since we can't backport the multi-stage import code. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Clean up PVC' when population succeeds even if the population source doesn't exist
```

