### PR TITLE
Skip code-block formatting from api-reference

### DIFF
--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -66,6 +66,8 @@ ${LINK_OPERATIONS}
 __END__
 
 if [ "$OUTPUT_FORMAT" = "html" ]; then
+    # Skipping code-block formatting so it doesn't break the api-reference
+    sed -i 's|```||g' "$WORKDIR/definitions.adoc"
     # $$ has special meaning in asciidoc, we need to escape it
     sed -i 's|\$\$|+++$$+++|g' "$WORKDIR/definitions.adoc"
     sed -i '1 i\:last-update-label!:' "$WORKDIR/"*.adoc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Our api-reference broke due to `quantity`'s description containing code-block formatting that's not rendered properly: https://kubevirt.io/cdi-api-reference/main/definitions.html.

Kubevirt [skips code-block formatting ](https://github.com/kubevirt/kubevirt/blob/main/hack/gen-swagger-doc/gen-swagger-docs.sh#L72)to avoid this behavior, so we should do the same.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/containerized-data-importer/issues/2827

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

