### PR TITLE
Avoid creating snapshot of old storage class DataImportCron PVCs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5311,6 +5311,10 @@
      "lastImportedPVC": {
       "description": "LastImportedPVC is the last imported PVC",
       "$ref": "#/definitions/v1beta1.DataVolumeSourcePVC"
+     },
+     "sourceFormat": {
+      "description": "SourceFormat defines the format of the DataImportCron-created disk image sources",
+      "type": "string"
      }
     }
    },

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -25652,6 +25652,13 @@ func schema_pkg_apis_core_v1beta1_DataImportCronStatus(ref common.ReferenceCallb
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"sourceFormat": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SourceFormat defines the format of the DataImportCron-created disk image sources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -736,6 +736,8 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 }
 
 func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(ctx context.Context, dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, snapshot *snapshotv1.VolumeSnapshot) error {
+	dataImportCron.Status.SourceFormat = &format
+
 	switch format {
 	case cdiv1.DataImportCronSourceFormatPvc:
 		updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronUpToDate, corev1.ConditionTrue, "Latest import is up to date", upToDate)

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -319,14 +319,14 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 
 	dataVolume := dataImportCron.Spec.Template
 	explicitScName := getStorageClassFromTemplate(&dataVolume)
-	dvStorageClass, err := cc.GetStorageClassByName(ctx, r.client, explicitScName)
+	desiredStorageClass, err := cc.GetStorageClassByName(ctx, r.client, explicitScName)
 	if err != nil {
 		return res, err
 	}
-	if dvStorageClass != nil {
-		cc.AddAnnotation(dataImportCron, AnnStorageClass, dvStorageClass.Name)
+	if desiredStorageClass != nil {
+		cc.AddAnnotation(dataImportCron, AnnStorageClass, desiredStorageClass.Name)
 	}
-	format, err := r.getSourceFormat(ctx, dataImportCron, dvStorageClass)
+	format, err := r.getSourceFormat(ctx, dataImportCron, desiredStorageClass)
 	if err != nil {
 		return res, err
 	}
@@ -342,7 +342,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			}
 		}
 		importSucceeded = true
-		if err := r.handleCronFormat(ctx, dataImportCron, format, dvStorageClass); err != nil {
+		if err := r.handleCronFormat(ctx, dataImportCron, pvc, format, desiredStorageClass); err != nil {
 			return err
 		}
 
@@ -673,29 +673,24 @@ func (r *DataImportCronReconciler) createImportDataVolume(ctx context.Context, d
 	return nil
 }
 
-func (r *DataImportCronReconciler) handleCronFormat(ctx context.Context, dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, dvStorageClass *storagev1.StorageClass) error {
+func (r *DataImportCronReconciler) handleCronFormat(ctx context.Context, dataImportCron *cdiv1.DataImportCron, pvc *corev1.PersistentVolumeClaim, format cdiv1.DataImportCronSourceFormat, desiredStorageClass *storagev1.StorageClass) error {
 	switch format {
 	case cdiv1.DataImportCronSourceFormatPvc:
 		return nil
 	case cdiv1.DataImportCronSourceFormatSnapshot:
-		return r.handleSnapshot(ctx, dataImportCron, &dataImportCron.Spec.Template, dvStorageClass)
+		return r.handleSnapshot(ctx, dataImportCron, pvc, desiredStorageClass)
 	default:
 		return fmt.Errorf("unknown source format for snapshot")
 	}
 }
 
-func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImportCron *cdiv1.DataImportCron, dataVolume *cdiv1.DataVolume, dvStorageClass *storagev1.StorageClass) error {
-	dataSourceName := dataImportCron.Spec.ManagedDataSource
-	digest := dataImportCron.Annotations[AnnSourceDesiredDigest]
-	if digest == "" {
+func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImportCron *cdiv1.DataImportCron, pvc *corev1.PersistentVolumeClaim, desiredStorageClass *storagev1.StorageClass) error {
+	if sc := pvc.Spec.StorageClassName; sc != nil && *sc != desiredStorageClass.Name {
+		r.log.Info("Attempt to change storage class, will not try making a snapshot of the old PVC")
 		return nil
 	}
-	dvName, err := createDvName(dataSourceName, digest)
-	if err != nil {
-		return err
-	}
 
-	className, err := cc.GetSnapshotClassForSmartClone(dataVolume.Name, &dvStorageClass.Name, r.log, r.client)
+	className, err := cc.GetSnapshotClassForSmartClone(pvc.Name, &desiredStorageClass.Name, r.log, r.client)
 	if err != nil {
 		return err
 	}
@@ -705,13 +700,13 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 	}
 	desiredSnapshot := &snapshotv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dvName,
+			Name:      pvc.Name,
 			Namespace: dataImportCron.Namespace,
 			Labels:    labels,
 		},
 		Spec: snapshotv1.VolumeSnapshotSpec{
 			Source: snapshotv1.VolumeSnapshotSource{
-				PersistentVolumeClaimName: &dvName,
+				PersistentVolumeClaimName: &pvc.Name,
 			},
 			VolumeSnapshotClassName: &className,
 		},
@@ -761,14 +756,14 @@ func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(ctx cont
 	return nil
 }
 
-func (r *DataImportCronReconciler) getSourceFormat(ctx context.Context, dataImportCron *cdiv1.DataImportCron, dvStorageClass *storagev1.StorageClass) (cdiv1.DataImportCronSourceFormat, error) {
+func (r *DataImportCronReconciler) getSourceFormat(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass *storagev1.StorageClass) (cdiv1.DataImportCronSourceFormat, error) {
 	format := cdiv1.DataImportCronSourceFormatPvc
-	if dvStorageClass == nil {
+	if desiredStorageClass == nil {
 		return format, nil
 	}
 
 	storageProfile := &cdiv1.StorageProfile{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: dvStorageClass.Name}, storageProfile); err != nil {
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: desiredStorageClass.Name}, storageProfile); err != nil {
 		return format, err
 	}
 	if storageProfile.Status.DataImportCronSourceFormat != nil {

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -4925,7 +4925,12 @@ spec:
     singular: dataimportcron
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: The format in which created sources are saved
+      jsonPath: .status.sourceFormat
+      name: Format
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: DataImportCron defines a cron job for recurring polling/importing
@@ -5772,12 +5777,17 @@ spec:
                 - name
                 - namespace
                 type: object
+              sourceFormat:
+                description: SourceFormat defines the format of the DataImportCron-created
+                  disk image sources
+                type: string
             type: object
         required:
         - spec
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -533,6 +533,7 @@ type DataSourceList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=dic;dics,categories=all
+// +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".status.sourceFormat",description="The format in which created sources are saved"
 type DataImportCron struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -591,8 +592,10 @@ type DataImportCronStatus struct {
 	// LastExecutionTimestamp is the time of the last polling
 	LastExecutionTimestamp *metav1.Time `json:"lastExecutionTimestamp,omitempty"`
 	// LastImportTimestamp is the time of the last import
-	LastImportTimestamp *metav1.Time              `json:"lastImportTimestamp,omitempty"`
-	Conditions          []DataImportCronCondition `json:"conditions,omitempty" optional:"true"`
+	LastImportTimestamp *metav1.Time `json:"lastImportTimestamp,omitempty"`
+	// SourceFormat defines the format of the DataImportCron-created disk image sources
+	SourceFormat *DataImportCronSourceFormat `json:"sourceFormat,omitempty"`
+	Conditions   []DataImportCronCondition   `json:"conditions,omitempty" optional:"true"`
 }
 
 // ImportStatus of a currently in progress import

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -262,7 +262,7 @@ func (DataSourceList) SwaggerDoc() map[string]string {
 
 func (DataImportCron) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "DataImportCron defines a cron job for recurring polling/importing disk images as PVCs into a golden image namespace\n+genclient\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+kubebuilder:object:root=true\n+kubebuilder:storageversion\n+kubebuilder:resource:shortName=dic;dics,categories=all",
+		"": "DataImportCron defines a cron job for recurring polling/importing disk images as PVCs into a golden image namespace\n+genclient\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+kubebuilder:object:root=true\n+kubebuilder:storageversion\n+kubebuilder:resource:shortName=dic;dics,categories=all\n+kubebuilder:printcolumn:name=\"Format\",type=\"string\",JSONPath=\".status.sourceFormat\",description=\"The format in which created sources are saved\"",
 	}
 }
 
@@ -285,6 +285,7 @@ func (DataImportCronStatus) SwaggerDoc() map[string]string {
 		"lastImportedPVC":        "LastImportedPVC is the last imported PVC",
 		"lastExecutionTimestamp": "LastExecutionTimestamp is the time of the last polling",
 		"lastImportTimestamp":    "LastImportTimestamp is the time of the last import",
+		"sourceFormat":           "SourceFormat defines the format of the DataImportCron-created disk image sources",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -549,6 +549,11 @@ func (in *DataImportCronStatus) DeepCopyInto(out *DataImportCronStatus) {
 		in, out := &in.LastImportTimestamp, &out.LastImportTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.SourceFormat != nil {
+		in, out := &in.SourceFormat, &out.SourceFormat
+		*out = new(DataImportCronSourceFormat)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]DataImportCronCondition, len(*in))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We support changing the storage class on DataImportCrons, so let's be more friendly
toward that and not attempt to make a snapshot of the old storage class PVC.
Also, make it more visible in which format the image gets stored (snap/pvc).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2227066

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Avoid creating snapshot of old storage class DataImportCron PVCs
```

