### PR TITLE
Tolerate GetActiveCDI returning nil, nil

### DIFF
--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -279,7 +279,7 @@ func (r *ReconcileCDI) watchCDICRD() error {
 				return nil
 			}
 			cr, err := cc.GetActiveCDI(context.TODO(), r.client)
-			if err != nil {
+			if err != nil || cr == nil {
 				return nil
 			}
 			return []reconcile.Request{


### PR DESCRIPTION
Seen in practice when deleting CDI CR in issue #2852

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2852

**Special notes for your reviewer**:
Surprisingly, when testing the code locally, cdi-operator was running and happy, with one restart.
I think the code in cruft.go is run infrequently, so perhaps I shouldn't burden our tests with trying hard to trigger it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid crash of cdi-operator when CDI CR is deleted
```

