### PR TITLE
[release-v1.56] Tolerate GetActiveCDI returning nil, nil

### DIFF
--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -279,7 +279,7 @@ func (r *ReconcileCDI) watchCDICRD() error {
 				return nil
 			}
 			cr, err := cc.GetActiveCDI(r.client)
-			if err != nil {
+			if err != nil || cr == nil {
 				return nil
 			}
 			return []reconcile.Request{


### PR DESCRIPTION
Seen in practice when deleting CDI CR in issue #2852

**What this PR does / why we need it**:
Manual backport of #2856 for release-v1.56, resolving a conflict manually.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid crash of cdi-operator when CDI CR is deleted
```

