### PR TITLE
Do not fail DV reconcile if storage class is not found

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -454,6 +454,10 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 			Event{corev1.EventTypeWarning, cc.ErrClaimNotValid, err.Error()}); syncErr != nil {
 			log.Error(syncErr, "failed to sync DataVolume status with event")
 		}
+		if errors.Is(err, ErrStorageClassNotFound) {
+			syncState.result = &reconcile.Result{}
+			return syncState, nil
+		}
 		return syncState, err
 	}
 

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -43,6 +43,14 @@ import (
 const (
 	// AnnOwnedByDataVolume annotation has the owner DataVolume name
 	AnnOwnedByDataVolume = "cdi.kubevirt.io/ownedByDataVolume"
+
+	// MessageErrStorageClassNotFound provides a const to indicate the DV storage spec is missing accessMode and no storageClass to choose profile
+	MessageErrStorageClassNotFound = "DataVolume.storage spec is missing accessMode and no storageClass to choose profile"
+)
+
+var (
+	// ErrStorageClassNotFound indicates the DV storage spec is missing accessMode and no storageClass to choose profile
+	ErrStorageClassNotFound = errors.New(MessageErrStorageClassNotFound)
 )
 
 // renderPvcSpec creates a new PVC Spec based on either the dv.spec.pvc or dv.spec.storage section
@@ -97,8 +105,8 @@ func renderPvcSpecVolumeModeAndAccessModes(client client.Client, recorder record
 		// Not even default storageClass on the cluster, cannot apply the defaults, verify spec is ok
 		if len(pvcSpec.AccessModes) == 0 {
 			log.V(1).Info("Cannot set accessMode for new pvc", "namespace", dv.Namespace, "name", dv.Name)
-			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid, "DataVolume.storage spec is missing accessMode and no storageClass to choose profile")
-			return errors.Errorf("DataVolume spec is missing accessMode")
+			recorder.Eventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid, MessageErrStorageClassNotFound)
+			return ErrStorageClassNotFound
 		}
 		return nil
 	}

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2036,7 +2036,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				events, err := f.RunKubectlCommand("get", "events", "-n", dataVolume.Namespace, "--field-selector=involvedObject.kind=DataVolume")
 				if err == nil {
 					fmt.Fprintf(GinkgoWriter, "%s", events)
-					return strings.Contains(events, controller.ErrClaimNotValid) && strings.Contains(events, "DataVolume.storage spec is missing accessMode and no storageClass to choose profile")
+					return strings.Contains(events, controller.ErrClaimNotValid) && strings.Contains(events, dvc.MessageErrStorageClassNotFound)
 				}
 				fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
 				return false
@@ -2451,19 +2451,19 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("verifying event occurred")
-			f.ExpectEvent(dataVolume.Namespace).Should(And(ContainSubstring(controller.ErrClaimNotValid), ContainSubstring("DataVolume spec is missing accessMode")))
+			f.ExpectEvent(dataVolume.Namespace).Should(And(ContainSubstring(controller.ErrClaimNotValid), ContainSubstring(dvc.MessageErrStorageClassNotFound)))
 
 			By("verifying conditions")
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
 				Status:  v1.ConditionUnknown,
-				Message: "DataVolume spec is missing accessMode",
+				Message: dvc.MessageErrStorageClassNotFound,
 				Reason:  controller.ErrClaimNotValid,
 			}
 			readyCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeReady,
 				Status:  v1.ConditionFalse,
-				Message: "DataVolume spec is missing accessMode",
+				Message: dvc.MessageErrStorageClassNotFound,
 				Reason:  controller.ErrClaimNotValid,
 			}
 			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, readyCondition)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there is a repeating reconcile error due to exponential backoff: `DataVolume.storage spec is missing accessMode and no storageClass to choose profile`, however the error is not needed as we already have `StorageClass` watch for this case, e.g. when the `DataVolume` is using the default `StorageClass` but no default `StorageClass` is configured yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Remove DataVolume reconcile error when storage class is not found yet
```

