### PR TITLE
Audit RBAC, avoid global (*) permissions

### DIFF
--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/go.uber.org/zap/zapcore:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap/zapcore"
+	batchv1 "k8s.io/api/batch/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -385,6 +386,12 @@ func getNewManagerCache(cdiNamespace string) cache.NewCacheFunc {
 					Field: namespaceSelector,
 				},
 				&routev1.Route{}: {
+					Field: namespaceSelector,
+				},
+				&batchv1.CronJob{}: {
+					Field: namespaceSelector,
+				},
+				&batchv1.Job{}: {
 					Field: namespaceSelector,
 				},
 			},

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -36,11 +36,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"kubevirt.io/containerized-data-importer/pkg/monitoring"
-
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/monitoring"
+	cdinamespaced "kubevirt.io/containerized-data-importer/pkg/operator/resources/namespaced"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+
 	sdk "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk"
 )
 
@@ -256,21 +257,7 @@ func newPrometheusRole(namespace string) *rbacv1.Role {
 				common.PrometheusLabelKey: common.PrometheusLabelValue,
 			},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"services",
-					"endpoints",
-					"pods",
-				},
-				Verbs: []string{
-					"get", "list", "watch",
-				},
-			},
-		},
+		Rules: cdinamespaced.GetPrometheusNamespacedRules(),
 	}
 }
 

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -136,7 +136,6 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"datasources",
 			},
 			Verbs: []string{
-				"list",
 				"get",
 			},
 		},
@@ -159,7 +158,7 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"cdis/finalizers",
 			},
 			Verbs: []string{
-				"*",
+				"update",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -58,7 +58,6 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"",
 			},
 			Resources: []string{
-				"persistentvolumes",
 				"persistentvolumeclaims",
 			},
 			Verbs: []string{
@@ -70,6 +69,20 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"delete",
 				"deletecollection",
 				"patch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"persistentvolumes",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"update",
 			},
 		},
 		{

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -155,10 +155,28 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"snapshot.storage.k8s.io",
 			},
 			Resources: []string{
-				"*",
+				"volumesnapshots",
+				"volumesnapshotclasses",
+				"volumesnapshotcontents",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"delete",
+			},
+		},
+		{
+			APIGroups: []string{
+				"snapshot.storage.k8s.io",
+			},
+			Resources: []string{
+				"volumesnapshots",
+			},
+			Verbs: []string{
+				"update",
+				"deletecollection",
 			},
 		},
 		{
@@ -209,30 +227,6 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"create",
-			},
-		},
-		{
-			APIGroups: []string{
-				"batch",
-			},
-			Resources: []string{
-				"cronjobs",
-			},
-			Verbs: []string{
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"batch",
-			},
-			Resources: []string{
-				"jobs",
-			},
-			Verbs: []string{
-				"list",
-				"watch",
 			},
 		},
 		{

--- a/pkg/operator/resources/namespaced/BUILD.bazel
+++ b/pkg/operator/resources/namespaced/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "controller.go",
         "cronjob.go",
         "factory.go",
+        "prometheus.go",
         "uploadproxy.go",
     ],
     importpath = "kubevirt.io/containerized-data-importer/pkg/operator/resources/namespaced",

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -59,8 +59,8 @@ func createAPIServerRoleBinding() *rbacv1.RoleBinding {
 	return utils.ResourceBuilder.CreateRoleBinding(apiServerRessouceName, apiServerRessouceName, apiServerRessouceName, "")
 }
 
-func createAPIServerRole() *rbacv1.Role {
-	rules := []rbacv1.PolicyRule{
+func getAPIServerNamespacedRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
 				"",
@@ -77,7 +77,10 @@ func createAPIServerRole() *rbacv1.Role {
 			},
 		},
 	}
-	return utils.ResourceBuilder.CreateRole(apiServerRessouceName, rules)
+}
+
+func createAPIServerRole() *rbacv1.Role {
+	return utils.ResourceBuilder.CreateRole(apiServerRessouceName, getAPIServerNamespacedRules())
 }
 
 func createAPIServerService() *corev1.Service {

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -70,7 +70,10 @@ func createAPIServerRole() *rbacv1.Role {
 				"configmaps",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
 			},
 		},
 	}

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -60,8 +60,8 @@ func createControllerRoleBinding() *rbacv1.RoleBinding {
 	return utils.ResourceBuilder.CreateRoleBinding(controllerResourceName, controllerResourceName, common.ControllerServiceAccountName, "")
 }
 
-func createControllerRole() *rbacv1.Role {
-	rules := []rbacv1.PolicyRule{
+func getControllerNamespacedRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
 				"",
@@ -162,7 +162,10 @@ func createControllerRole() *rbacv1.Role {
 			},
 		},
 	}
-	return utils.ResourceBuilder.CreateRole(controllerResourceName, rules)
+}
+
+func createControllerRole() *rbacv1.Role {
+	return utils.ResourceBuilder.CreateRole(controllerResourceName, getControllerNamespacedRules())
 }
 
 func createControllerServiceAccount() *corev1.ServiceAccount {

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -70,7 +70,12 @@ func createControllerRole() *rbacv1.Role {
 				"configmaps",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 		{
@@ -113,6 +118,8 @@ func createControllerRole() *rbacv1.Role {
 			Verbs: []string{
 				"create",
 				"delete",
+				"list",
+				"watch",
 			},
 		},
 		{
@@ -123,7 +130,9 @@ func createControllerRole() *rbacv1.Role {
 				"leases",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"create",
+				"update",
 			},
 		},
 		{

--- a/pkg/operator/resources/namespaced/factory.go
+++ b/pkg/operator/resources/namespaced/factory.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -96,4 +97,13 @@ func assignNamspaceIfMissing(resource client.Object, namespace string) {
 	if obj.GetNamespace() == "" {
 		obj.SetNamespace(namespace)
 	}
+}
+
+// GetRolePolicyRules returns all namespaced PolicyRules
+func GetRolePolicyRules() []rbacv1.PolicyRule {
+	result := getAPIServerNamespacedRules()
+	result = append(result, getControllerNamespacedRules()...)
+	result = append(result, getUploadProxyNamespacedRules()...)
+	result = append(result, GetPrometheusNamespacedRules()...)
+	return result
 }

--- a/pkg/operator/resources/namespaced/prometheus.go
+++ b/pkg/operator/resources/namespaced/prometheus.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaced
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// GetPrometheusNamespacedRules returns the policy rules needed for CDI alerting setup
+func GetPrometheusNamespacedRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"services",
+				"endpoints",
+				"pods",
+			},
+			Verbs: []string{
+				"get", "list", "watch",
+			},
+		},
+	}
+}

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -67,8 +67,8 @@ func createUploadProxyRoleBinding() *rbacv1.RoleBinding {
 	return utils.ResourceBuilder.CreateRoleBinding(uploadProxyResourceName, uploadProxyResourceName, uploadProxyResourceName, "")
 }
 
-func createUploadProxyRole() *rbacv1.Role {
-	rules := []rbacv1.PolicyRule{
+func getUploadProxyNamespacedRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
 				"",
@@ -81,7 +81,10 @@ func createUploadProxyRole() *rbacv1.Role {
 			},
 		},
 	}
-	return utils.ResourceBuilder.CreateRole(uploadProxyResourceName, rules)
+}
+
+func createUploadProxyRole() *rbacv1.Role {
+	return utils.ResourceBuilder.CreateRole(uploadProxyResourceName, getUploadProxyNamespacedRules())
 }
 
 func createUploadProxyDeployment(image, verbosity, pullPolicy string, imagePullSecrets []corev1.LocalObjectReference, priorityClassName string, infraNodePlacement *sdkapi.NodePlacement) *appsv1.Deployment {

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -33,7 +33,8 @@ import (
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"kubevirt.io/containerized-data-importer/pkg/operator/resources"
-	cluster "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
+	cdicluster "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
+	cdinamespaced "kubevirt.io/containerized-data-importer/pkg/operator/resources/namespaced"
 	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 )
 
@@ -54,7 +55,12 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"clusterroles",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 		{
@@ -168,7 +174,7 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 		},
 	}
-	rules = append(rules, cluster.GetClusterRolePolicyRules()...)
+	rules = append(rules, cdicluster.GetClusterRolePolicyRules()...)
 	return rules
 }
 
@@ -198,7 +204,12 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"roles",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 		{
@@ -300,6 +311,7 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 			},
 		},
 	}
+	rules = append(rules, cdinamespaced.GetRolePolicyRules()...)
 	return rules
 }
 

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -110,7 +110,45 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"mutatingwebhookconfigurations",
 			},
 			Verbs: []string{
-				"*",
+				"create",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"admissionregistration.k8s.io",
+			},
+			Resources: []string{
+				"validatingwebhookconfigurations",
+			},
+			ResourceNames: []string{
+				"cdi-api-dataimportcron-validate",
+				"cdi-api-populator-validate",
+				"cdi-api-datavolume-validate",
+				"cdi-api-validate",
+				"objecttransfer-api-validate",
+			},
+			Verbs: []string{
+				"get",
+				"update",
+				"delete",
+			},
+		},
+		{
+			APIGroups: []string{
+				"admissionregistration.k8s.io",
+			},
+			Resources: []string{
+				"mutatingwebhookconfigurations",
+			},
+			ResourceNames: []string{
+				"cdi-api-datavolume-mutate",
+			},
+			Verbs: []string{
+				"get",
+				"update",
+				"delete",
 			},
 		},
 		{

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -74,21 +74,6 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"pods",
-				"services",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"delete",
-			},
-		},
-		{
-			APIGroups: []string{
 				"apiextensions.k8s.io",
 			},
 			Resources: []string{
@@ -96,7 +81,12 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"customresourcedefinitions/status",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 		{
@@ -131,7 +121,12 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"apiservices",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 	}
@@ -180,7 +175,13 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"services",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"patch",
+				"delete",
 			},
 		},
 		{
@@ -192,7 +193,12 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"deployments/finalizers",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
 			},
 		},
 		{
@@ -204,7 +210,11 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"routes/custom-host",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
 			},
 		},
 		{
@@ -246,7 +256,9 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"leases",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"create",
+				"update",
 			},
 		},
 	}


### PR DESCRIPTION
There are some permissions that are logically not needed, and some others where we can just reduce the verb set.
Trying to follow https://kubernetes.io/docs/concepts/security/rbac-good-practices/

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2183659

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Global permissions [*] seen across CDI components
```

