### PR TITLE
Update ontap-san to be RWX

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -92,7 +92,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"pxd.portworx.com":           createOpenStorageSharedVolumeCapabilities(),
 	// Trident
 	"csi.trident.netapp.io/ontap-nas": {{rwx, file}},
-	"csi.trident.netapp.io/ontap-san": {{rwo, block}},
+	"csi.trident.netapp.io/ontap-san": {{rwx, block}},
 	// topolvm
 	"topolvm.cybozu.com": createTopoLVMCapabilities(),
 	"topolvm.io":         createTopoLVMCapabilities(),


### PR DESCRIPTION
For some reason it was marked RWO instead of RWX.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Trident ontap-san supports RWX not just RWO
```

