### PR TITLE
HTTP import with DIC

### DIFF
--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/util/naming:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/klauspost/compress/zstd:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/tests/utils/dataimportcron.go
+++ b/tests/utils/dataimportcron.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
@@ -60,6 +62,43 @@ func NewDataImportCronWithStorageSpec(name, size, schedule, dataSource string, i
 			},
 			Schedule:          schedule,
 			ManagedDataSource: dataSource,
+			ImportsToKeep:     &importsToKeep,
+		},
+	}
+}
+
+// NewDataImportCronForHTTP initializes a DataImportCron struct with HTTP source URL
+func NewDataImportCronForHTTP(name, size, dataSource, schedule, url string, importsToKeep int32) *cdiv1.DataImportCron {
+	garbageCollect := cdiv1.DataImportCronGarbageCollectOutdated
+
+	return &cdiv1.DataImportCron{
+		TypeMeta: metav1.TypeMeta{APIVersion: cdiv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			UID:         types.UID(uuid.NewString()),
+			Annotations: map[string]string{},
+		},
+		Spec: cdiv1.DataImportCronSpec{
+			Template: cdiv1.DataVolume{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						HTTP: &cdiv1.DataVolumeSourceHTTP{
+							URL: url,
+						},
+					},
+					PVC: &corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse(size),
+							},
+						},
+					},
+				},
+			},
+			Schedule:          schedule,
+			ManagedDataSource: dataSource,
+			GarbageCollect:    &garbageCollect,
 			ImportsToKeep:     &importsToKeep,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Ido Aharon <iaharon@redhat.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow using the CDI DataImportCron framework (auto import to golden image namespace, DataSource update, garbage collection of old PVCs etc.) when the user wants to use HTTP import instead of registry import. It requires the user to either implement a customized poller (or manually) updating the DataImportCron desired digest annotation, and triggering new import.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow using the CDI DataImportCron framework with HTTP imports.
```

