### PR TITLE
Allow modifying log verbosity in CDI

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4935,6 +4935,11 @@
        "default": ""
       }
      },
+     "logVerbosity": {
+      "description": "LogVerbosity overrides the default verbosity level used to initialize loggers",
+      "type": "integer",
+      "format": "int32"
+     },
      "podResourceRequirements": {
       "description": "ResourceRequirements describes the compute resource requirements.",
       "$ref": "#/definitions/v1.ResourceRequirements"

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -28,3 +28,21 @@ spec:
       requests:
         storage: 1Gi
 ```
+
+## Log verbosity
+
+Different levels of verbosity are used in CDI to control the amount of information that is logged. The verbosity level of logs in CDI can be adjusted using a dedicated field in CDIConfig. This feature enables users to control the amount of detail displayed in logs, ranging from minimal to detailed debugging information.
+
+For example:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+# ...
+spec:
+  config:
+    # Overrides the default verbosity level with 4
+    logVerbosity: 4
+```
+
+Changing the verbosity level will automatically restart the CDI components to re-initialize the loggers with the new value.

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -25086,6 +25086,13 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"logVerbosity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LogVerbosity overrides the default verbosity level used to initialize loggers",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operator/controller/cr-manager.go
+++ b/pkg/operator/controller/cr-manager.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 
 	"kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
 
@@ -83,8 +84,14 @@ func (r *ReconcileCDI) getNamespacedArgs(cr *cdiv1.CDI) *cdinamespaced.FactoryAr
 		if cr.Spec.ImagePullPolicy != "" {
 			result.PullPolicy = string(cr.Spec.ImagePullPolicy)
 		}
-		if cr.Spec.Config != nil && len(cr.Spec.Config.ImagePullSecrets) > 0 {
-			result.ImagePullSecrets = cr.Spec.Config.ImagePullSecrets
+		if cr.Spec.Config != nil {
+			// Overrides default verbosity level
+			if logVerbosity := cr.Spec.Config.LogVerbosity; logVerbosity != nil {
+				result.Verbosity = strconv.Itoa(int(*logVerbosity))
+			}
+			if len(cr.Spec.Config.ImagePullSecrets) > 0 {
+				result.ImagePullSecrets = cr.Spec.Config.ImagePullSecrets
+			}
 		}
 		if cr.Spec.PriorityClass != nil && string(*cr.Spec.PriorityClass) != "" {
 			result.PriorityClassName = string(*cr.Spec.PriorityClass)

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -175,6 +175,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  logVerbosity:
+                    description: LogVerbosity overrides the default verbosity level
+                      used to initialize loggers
+                    format: int32
+                    type: integer
                   podResourceRequirements:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -2410,6 +2415,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  logVerbosity:
+                    description: LogVerbosity overrides the default verbosity level
+                      used to initialize loggers
+                    format: int32
+                    type: integer
                   podResourceRequirements:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -4616,6 +4626,11 @@ spec:
                 items:
                   type: string
                 type: array
+              logVerbosity:
+                description: LogVerbosity overrides the default verbosity level used
+                  to initialize loggers
+                format: int32
+                type: integer
               podResourceRequirements:
                 description: ResourceRequirements describes the compute resource requirements.
                 properties:

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -949,6 +949,9 @@ type CDIConfigSpec struct {
 	TLSSecurityProfile *ocpconfigv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
 	// The imagePullSecrets used to pull the container images
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// LogVerbosity overrides the default verbosity level used to initialize loggers
+	// +optional
+	LogVerbosity *int32 `json:"logVerbosity,omitempty"`
 }
 
 // CDIConfigStatus provides the most recently observed status of the CDI Config resource

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -476,6 +476,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.\n+optional",
 		"tlsSecurityProfile":       "TLSSecurityProfile is used by operators to apply cluster-wide TLS security settings to operands.",
 		"imagePullSecrets":         "The imagePullSecrets used to pull the container images",
+		"logVerbosity":             "LogVerbosity overrides the default verbosity level used to initialize loggers\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -201,6 +201,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.LogVerbosity != nil {
+		in, out := &in.LogVerbosity, &out.LogVerbosity
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR aims to make the debugging process of CDI easier, allowing changes in log verbosity from the CDI config.

It adds a new field in the `CDIConfig` API to allow specifying a different log verbosity level to re-initialize all loggers. Changes in this field will restart all CDI components to initialize all loggers with the new value.

**Special notes for your reviewer**:  

The new API looks like this:

```yaml
apiVersion: cdi.kubevirt.io/v1beta1
Kind: CDI
# ...
spec:
  config:
      logVerbosity: 4
```

I opted for a simpler API compared to [the one used in kubevirt](https://github.com/kubevirt/kubevirt/pull/4672/files#diff-5469726ef6ef072d9258db4593eb8811363099d9181a4e5dbd119af7b2b1414eR1614). I think the kubevirt API is overkill for CDI, but I can always change it if preferred.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow modifying log verbosity in CDI
```

