### PR TITLE
[release-v1.57] dataVolume: Add default instance type labels from source (#2787)

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -319,6 +319,14 @@ var (
 	// FilesystemMode is filesystem device mode
 	FilesystemMode = corev1.PersistentVolumeFilesystem
 
+	// DefaultInstanceTypeLabels is a list of currently supported default instance type labels
+	DefaultInstanceTypeLabels = []string{
+		LabelDefaultInstancetype,
+		LabelDefaultInstancetypeKind,
+		LabelDefaultPreference,
+		LabelDefaultPreferenceKind,
+	}
+
 	apiServerKeyOnce sync.Once
 	apiServerKey     *rsa.PrivateKey
 )

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -568,10 +568,9 @@ func (r *DataImportCronReconciler) updateDataSource(ctx context.Context, dataImp
 	dataSourceCopy := dataSource.DeepCopy()
 	r.setDataImportCronResourceLabels(dataImportCron, dataSource)
 
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultInstancetype)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultInstancetypeKind)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreference)
-	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDefaultPreferenceKind)
+	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+		passCronLabelToDataSource(dataImportCron, dataSource, defaultInstanceTypeLabel)
+	}
 
 	passCronLabelToDataSource(dataImportCron, dataSource, cc.LabelDynamicCredentialSupport)
 
@@ -1260,10 +1259,9 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	cc.AddAnnotation(dv, cc.AnnImmediateBinding, "true")
 	passCronAnnotationToDv(cron, dv, cc.AnnPodRetainAfterCompletion)
 
-	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetype)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultInstancetypeKind)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultPreference)
-	passCronLabelToDv(cron, dv, cc.LabelDefaultPreferenceKind)
+	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+		passCronLabelToDv(cron, dv, defaultInstanceTypeLabel)
+	}
 
 	passCronLabelToDv(cron, dv, cc.LabelDynamicCredentialSupport)
 

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -712,10 +712,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			cron.Annotations[AnnSourceDesiredDigest] = testDigest
 
 			cron.Labels = map[string]string{}
-			cron.Labels[cc.LabelDefaultInstancetype] = cc.LabelDefaultInstancetype
-			cron.Labels[cc.LabelDefaultInstancetypeKind] = cc.LabelDefaultInstancetypeKind
-			cron.Labels[cc.LabelDefaultPreference] = cc.LabelDefaultPreference
-			cron.Labels[cc.LabelDefaultPreferenceKind] = cc.LabelDefaultPreferenceKind
+			for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+				cron.Labels[defaultInstanceTypeLabel] = defaultInstanceTypeLabel
+			}
 			cron.Labels[cc.LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createDataImportCronReconciler(cron)
@@ -732,10 +731,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(dvName).ToNot(BeEmpty())
 
 			expectLabels := func(labels map[string]string) {
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetype, cc.LabelDefaultInstancetype))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultInstancetypeKind, cc.LabelDefaultInstancetypeKind))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreference, cc.LabelDefaultPreference))
-				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDefaultPreferenceKind, cc.LabelDefaultPreferenceKind))
+				for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+					ExpectWithOffset(1, labels).To(HaveKeyWithValue(defaultInstanceTypeLabel, defaultInstanceTypeLabel))
+				}
 				ExpectWithOffset(1, labels).To(HaveKeyWithValue(cc.LabelDynamicCredentialSupport, "true"))
 			}
 

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -472,6 +472,10 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 		return syncState, err
 	}
 
+	if err = updateDataVolumeDefaultInstancetypeLabels(r.client, &syncState); err != nil {
+		return syncState, err
+	}
+
 	if syncState.pvc != nil {
 		if err := r.garbageCollect(&syncState, log); err != nil {
 			return syncState, err

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -269,10 +269,9 @@ var _ = Describe("All DataVolume Tests", func() {
 		It("Should pass labels from DV to PVC", func() {
 			dv := NewImportDataVolume("test-dv")
 			dv.Labels = map[string]string{}
-			dv.Labels[LabelDefaultInstancetype] = LabelDefaultInstancetype
-			dv.Labels[LabelDefaultInstancetypeKind] = LabelDefaultInstancetypeKind
-			dv.Labels[LabelDefaultPreference] = LabelDefaultPreference
-			dv.Labels[LabelDefaultPreferenceKind] = LabelDefaultPreferenceKind
+			for _, defaultInstanceTypeLabel := range DefaultInstanceTypeLabels {
+				dv.Labels[defaultInstanceTypeLabel] = defaultInstanceTypeLabel
+			}
 			dv.Labels[LabelDynamicCredentialSupport] = "true"
 
 			reconciler = createImportReconciler(dv)
@@ -284,10 +283,9 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(pvc.Name).To(Equal("test-dv"))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetype, LabelDefaultInstancetype))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultInstancetypeKind, LabelDefaultInstancetypeKind))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreference, LabelDefaultPreference))
-			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDefaultPreferenceKind, LabelDefaultPreferenceKind))
+			for _, defaultInstanceTypeLabel := range DefaultInstanceTypeLabels {
+				Expect(pvc.Labels).To(HaveKeyWithValue(defaultInstanceTypeLabel, defaultInstanceTypeLabel))
+			}
 			Expect(pvc.Labels).To(HaveKeyWithValue(LabelDynamicCredentialSupport, "true"))
 		})
 

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -359,6 +359,55 @@ func updateDataVolumeUseCDIPopulator(syncState *dvSyncState) {
 	cc.AddAnnotation(syncState.dvMutated, cc.AnnUsePopulator, strconv.FormatBool(syncState.usePopulator))
 }
 
+func updateDataVolumeDefaultInstancetypeLabels(client client.Client, syncState *dvSyncState) error {
+	// Skip looking anything up if any default instance type labels are already present
+	dv := syncState.dvMutated
+	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {
+		if _, ok := dv.Labels[defaultInstanceTypeLabel]; ok {
+			return nil
+		}
+	}
+	if dv.Spec.Source != nil && dv.Spec.Source.PVC != nil {
+		pvc := &v1.PersistentVolumeClaim{}
+		key := types.NamespacedName{
+			Name:      dv.Spec.Source.PVC.Name,
+			Namespace: dv.Spec.Source.PVC.Namespace,
+		}
+		if err := client.Get(context.TODO(), key, pvc); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		copyDefaultInstancetypeLabels(dv, pvc.Labels)
+		return nil
+	}
+	if dv.Spec.SourceRef != nil && dv.Spec.SourceRef.Namespace != nil && dv.Spec.SourceRef.Kind == cdiv1.DataVolumeDataSource {
+		ds := &cdiv1.DataSource{}
+		key := types.NamespacedName{
+			Name:      dv.Spec.SourceRef.Name,
+			Namespace: *dv.Spec.SourceRef.Namespace,
+		}
+		if err := client.Get(context.TODO(), key, ds); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		copyDefaultInstancetypeLabels(dv, ds.Labels)
+		return nil
+	}
+	return nil
+}
+
+func copyDefaultInstancetypeLabels(dataVolume *cdiv1.DataVolume, labels map[string]string) {
+	for _, defaultInstancetypeLabel := range cc.DefaultInstanceTypeLabels {
+		if v, ok := labels[defaultInstancetypeLabel]; ok {
+			cc.AddLabel(dataVolume, defaultInstancetypeLabel, v)
+		}
+	}
+}
+
 func checkDVUsingPopulators(dv *cdiv1.DataVolume) (bool, error) {
 	usePopulator, ok := dv.Annotations[cc.AnnUsePopulator]
 	if !ok {

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -5,16 +5,19 @@ import (
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
@@ -97,6 +100,165 @@ var _ = Describe("resolveVolumeSize", func() {
 	})
 })
 
+var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
+
+	const (
+		namespace            = "namespace"
+		sourcePVCName        = "sourcePVC"
+		sourceDataSourceName = "sourceDataSource"
+	)
+
+	var (
+		fakeClient                     client.Client
+		dataVolumeWithSourcePVC        cdiv1.DataVolume
+		dataVolumeWithSourceDataSource cdiv1.DataVolume
+	)
+
+	defaultInstancetypeLabelMap := map[string]string{
+		LabelDefaultInstancetype:     LabelDefaultInstancetype,
+		LabelDefaultInstancetypeKind: LabelDefaultInstancetypeKind,
+		LabelDefaultPreference:       LabelDefaultPreference,
+		LabelDefaultPreferenceKind:   LabelDefaultPreferenceKind,
+	}
+
+	BeforeEach(func() {
+		dataVolumeWithSourcePVC = cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					PVC: &cdiv1.DataVolumeSourcePVC{
+						Name:      sourcePVCName,
+						Namespace: namespace,
+					},
+				},
+			},
+		}
+
+		dataVolumeWithSourceDataSource = cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datasource-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				SourceRef: &cdiv1.DataVolumeSourceRef{
+					Kind:      cdiv1.DataVolumeDataSource,
+					Name:      sourceDataSourceName,
+					Namespace: pointer.String(namespace),
+				},
+			},
+		}
+		fakeClient = createClient(
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourcePVCName,
+					Namespace: namespace,
+					Labels:    defaultInstancetypeLabelMap,
+				},
+			},
+			&cdiv1.DataSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceDataSourceName,
+					Namespace: namespace,
+					Labels:    defaultInstancetypeLabelMap,
+				},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Name: sourcePVCName,
+						},
+					},
+				},
+			},
+		)
+	})
+
+	table.DescribeTable("should update DataVolume with labels from source using", func(dataVolume *cdiv1.DataVolume) {
+		syncState := &dvSyncState{
+			dvMutated: dataVolume,
+		}
+		Expect(syncState.dvMutated.Labels).To(BeEmpty())
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+		Expect(syncState.dvMutated.Labels).ToNot(BeEmpty())
+		for k, v := range defaultInstancetypeLabelMap {
+			Expect(syncState.dvMutated.Labels).To(HaveKeyWithValue(k, v))
+		}
+	},
+		table.Entry("PVC", &dataVolumeWithSourcePVC),
+		table.Entry("dataSource", &dataVolumeWithSourceDataSource),
+	)
+
+	table.DescribeTable("should not update DataVolume with labels from source if already present using", func(dataVolume *cdiv1.DataVolume) {
+		const customDefaultInstancetype = "customDefaultInstancetype"
+		dv := dataVolume
+		dv.Labels = map[string]string{
+			LabelDefaultInstancetype: customDefaultInstancetype,
+		}
+		syncState := &dvSyncState{
+			dvMutated: dv,
+		}
+
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+		Expect(syncState.dvMutated.Labels).To(HaveLen(1))
+		Expect(syncState.dvMutated.Labels).To(HaveKeyWithValue(LabelDefaultInstancetype, customDefaultInstancetype))
+	},
+		table.Entry("PVC", &dataVolumeWithSourcePVC),
+		table.Entry("DataSource", &dataVolumeWithSourceDataSource),
+	)
+
+	table.DescribeTable("should ignore IsNotFound errors", func(dataVolume *cdiv1.DataVolume) {
+		syncState := &dvSyncState{
+			dvMutated: dataVolume,
+		}
+		Expect(updateDataVolumeDefaultInstancetypeLabels(fakeClient, syncState)).To(Succeed())
+	},
+		table.Entry("PVC", &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					PVC: &cdiv1.DataVolumeSourcePVC{
+						Name:      "unknown",
+						Namespace: namespace,
+					},
+				},
+			},
+		}),
+		table.Entry("DataSource", &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datasource-datavolume",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				SourceRef: &cdiv1.DataVolumeSourceRef{
+					Kind:      cdiv1.DataVolumeDataSource,
+					Name:      "unknown",
+					Namespace: pointer.String(namespace),
+				},
+			},
+		}),
+	)
+
+	table.DescribeTable("should return all non IsNotFound errors", func(dataVolume *cdiv1.DataVolume) {
+		err := updateDataVolumeDefaultInstancetypeLabels(
+			fakeClientWithGetServiceUnavailableErr{
+				fakeClient,
+			},
+			&dvSyncState{
+				dvMutated: dataVolume,
+			},
+		)
+		Expect(errors.IsServiceUnavailable(err)).To(BeTrue())
+	},
+		table.Entry("PVC", &dataVolumeWithSourcePVC),
+		table.Entry("DataSource", &dataVolumeWithSourceDataSource),
+	)
+})
+
 func createDataVolumeWithStorageAPI(name, ns string, source *cdiv1.DataVolumeSource, storageSpec *cdiv1.StorageSpec) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -118,4 +280,12 @@ func createClient(objs ...runtime.Object) client.Client {
 	_ = ocpconfigv1.Install(s)
 	// Create a fake client to mock API calls.
 	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+}
+
+type fakeClientWithGetServiceUnavailableErr struct {
+	client.Client
+}
+
+func (c fakeClientWithGetServiceUnavailableErr) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return errors.NewServiceUnavailable("error")
 }

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3105,6 +3105,69 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}
 		})
 	})
+
+	Describe("Default instance type labels", func() {
+
+		var (
+			sourceDataVolume *cdiv1.DataVolume
+			err              error
+		)
+
+		BeforeEach(func() {
+			By("creating a labelled DataVolume and PVC")
+			sourceDataVolume = utils.NewDataVolumeForBlankRawImage("", "1Gi")
+			sourceDataVolume.GenerateName = "source-datavolume"
+			sourceDataVolume.Labels = make(map[string]string)
+			for _, defaultInstancetypeLabel := range controller.DefaultInstanceTypeLabels {
+				sourceDataVolume.Labels[defaultInstancetypeLabel] = "defined"
+			}
+			sourceDataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDataVolume)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying PVC was created")
+			_, err = utils.WaitForPVC(f.K8sClient, sourceDataVolume.Namespace, sourceDataVolume.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		table.DescribeTable("should be passed to DataVolume from source", func(createDataVolume func() *cdiv1.DataVolume) {
+			dv := createDataVolume()
+			By("asserting that all default instance type labels have been passed to the DataVolume")
+			Eventually(func() bool {
+				dv, err = f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, defaultInstancetypeLabel := range controller.DefaultInstanceTypeLabels {
+					if _, ok := dv.Labels[defaultInstancetypeLabel]; !ok {
+						return false
+					}
+				}
+				return true
+			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+		},
+			table.Entry("PVC", func() *cdiv1.DataVolume {
+				By("createing a DataVolume pointing to a labelled PVC")
+				dv := utils.NewDataVolumeForImageCloning("datavolume-from-pvc", "1Gi", sourceDataVolume.Namespace, sourceDataVolume.Name, nil, nil)
+				dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+				Expect(err).ToNot(HaveOccurred())
+				return dv
+			}),
+			table.Entry("DataSource", func() *cdiv1.DataVolume {
+				By("createing a labelled DataSource")
+				ds := utils.NewPvcDataSource("datasource-from-pvc", f.Namespace.Name, sourceDataVolume.Name, sourceDataVolume.Namespace)
+				ds.Labels = make(map[string]string)
+				for _, defaultInstancetypeLabel := range controller.DefaultInstanceTypeLabels {
+					ds.Labels[defaultInstancetypeLabel] = "defined"
+				}
+				ds, err := f.CdiClient.CdiV1beta1().DataSources(f.Namespace.Name).Create(context.TODO(), ds, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("createing a DataVolume pointing to a labelled DataSource")
+				dv := utils.NewDataVolumeWithSourceRef("datavolume-from-datasource", "1Gi", f.Namespace.Name, ds.Name)
+				dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+				Expect(err).ToNot(HaveOccurred())
+				return dv
+			}),
+		)
+	})
 })
 
 func SetFilesystemOverhead(f *framework.Framework, globalOverhead, scOverhead string) {


### PR DESCRIPTION

**What this PR does / why we need it**:

f229aeb started to pass default instance type labels from DataImportCrons to DataVolumes and DataVolumes to any associated destination DataSources or PVCs. As documented in issue #2782 this does not however pass these labels from the initial source of a DataVolume to either the DataVolume or the destination DataSources or PVCs

This change corrects this by updating DataVolumes when reconciled, adding any labels found on PVC or DataSource sources. These labels will then be passed on to the destination PVC or DataSources by the existing functionality highlighted above.

Note that if any default instance type labels already exist on the DataVolume then the process is skipped as it is assumed these are provided either directly by the user or via a DataImportCron.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>

* refactor: Use DefaultInstanceTypeLabels more often

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>

---------

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>
(cherry picked from commit 33358569bbb3dc009e9bb9dc895276d7dbe1f514)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2782 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

