### PR TITLE
Allow StorageProfile to use a specific VolumeSnapshotClass

### DIFF
--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -27276,6 +27276,13 @@ func schema_pkg_apis_core_v1beta1_StorageProfileSpec(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"snapshotClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -27329,6 +27336,13 @@ func schema_pkg_apis_core_v1beta1_StorageProfileStatus(ref common.ReferenceCallb
 					"dataImportCronSourceFormat": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"snapshotClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/controller/clone/common.go
+++ b/pkg/controller/clone/common.go
@@ -247,7 +247,7 @@ func getCommonSnapshotClass(ctx context.Context, c client.Client, pvcs ...*corev
 }
 
 // GetCompatibleVolumeSnapshotClass returns a VolumeSnapshotClass name that works for all PVCs
-func GetCompatibleVolumeSnapshotClass(ctx context.Context, c client.Client, pvcs ...*corev1.PersistentVolumeClaim) (*string, error) {
+func GetCompatibleVolumeSnapshotClass(ctx context.Context, c client.Client, log logr.Logger, pvcs ...*corev1.PersistentVolumeClaim) (*string, error) {
 	driver, err := GetCommonDriver(ctx, c, pvcs...)
 	if err != nil {
 		return nil, err
@@ -261,7 +261,7 @@ func GetCompatibleVolumeSnapshotClass(ctx context.Context, c client.Client, pvcs
 		return nil, err
 	}
 
-	return cc.GetVolumeSnapshotClass(context.TODO(), c, *driver, snapshotClassName)
+	return cc.GetVolumeSnapshotClass(context.TODO(), c, *driver, snapshotClassName, log)
 }
 
 // SameVolumeMode returns true if all pvcs have the same volume mode

--- a/pkg/controller/clone/common.go
+++ b/pkg/controller/clone/common.go
@@ -3,14 +3,11 @@ package clone
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/go-logr/logr"
-	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -222,27 +219,8 @@ func GetCompatibleVolumeSnapshotClass(ctx context.Context, c client.Client, pvcs
 		return nil, nil
 	}
 
-	volumeSnapshotClasses := &snapshotv1.VolumeSnapshotClassList{}
-	if err := c.List(ctx, volumeSnapshotClasses); err != nil {
-		if meta.IsNoMatchError(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var candidates []string
-	for _, vcs := range volumeSnapshotClasses.Items {
-		if *driver == vcs.Driver {
-			candidates = append(candidates, vcs.Name)
-		}
-	}
-
-	if len(candidates) > 0 {
-		sort.Strings(candidates)
-		return &candidates[0], nil
-	}
-
-	return nil, nil
+	//FIXME: may pass snapshotClassName if common to all pvcs?
+	return cc.GetVolumeSnapshotClass(context.TODO(), c, *driver, nil)
 }
 
 // SameVolumeMode returns true if all pvcs have the same volume mode

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -340,7 +340,7 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 	}
 
 	if strategy == cdiv1.CloneStrategySnapshot {
-		n, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, sourceClaim, args.TargetClaim)
+		n, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, p.Recorder, sourceClaim, args.TargetClaim)
 		if err != nil {
 			return nil, err
 		}
@@ -660,7 +660,7 @@ func (p *Planner) planSnapshotFromPVC(ctx context.Context, args *PlanArgs) ([]Ph
 		return nil, fmt.Errorf("source claim does not exist")
 	}
 
-	vsc, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, args.TargetClaim)
+	vsc, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, p.Recorder, args.TargetClaim)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -340,7 +340,7 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 	}
 
 	if strategy == cdiv1.CloneStrategySnapshot {
-		n, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, sourceClaim, args.TargetClaim)
+		n, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, sourceClaim, args.TargetClaim)
 		if err != nil {
 			return nil, err
 		}
@@ -660,7 +660,7 @@ func (p *Planner) planSnapshotFromPVC(ctx context.Context, args *PlanArgs) ([]Ph
 		return nil, fmt.Errorf("source claim does not exist")
 	}
 
-	vsc, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, sourceClaim, args.TargetClaim)
+	vsc, err := GetCompatibleVolumeSnapshotClass(ctx, p.Client, args.Log, args.TargetClaim)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/clone/planner_test.go
+++ b/pkg/controller/clone/planner_test.go
@@ -55,6 +55,8 @@ var _ = Describe("Planner test", func() {
 	)
 
 	var (
+		planner *Planner
+
 		storageClassName = "sc"
 
 		small  = resource.MustParse("5Gi")
@@ -242,6 +244,13 @@ var _ = Describe("Planner test", func() {
 		Expect(found).To(BeTrue())
 	}
 
+	AfterEach(func() {
+		if planner != nil && planner.Recorder != nil {
+			close(planner.Recorder.(*record.FakeRecorder).Events)
+			planner = nil
+		}
+	})
+
 	Context("ChooseStrategy tests", func() {
 
 		It("should error if unsupported kind", func() {
@@ -251,7 +260,7 @@ var _ = Describe("Planner test", func() {
 				DataSource: source,
 				Log:        log,
 			}
-			planner := createPlanner()
+			planner = createPlanner()
 			_, err := planner.ChooseStrategy(context.Background(), args)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unsupported datasource"))
@@ -266,7 +275,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner()
+				planner = createPlanner()
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).To(BeNil())
@@ -280,7 +289,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner()
+				planner = createPlanner()
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("claim has emptystring storageclass, will not work"))
@@ -293,7 +302,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner()
+				planner = createPlanner()
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("target storage class not found"))
@@ -306,7 +315,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass())
+				planner = createPlanner(createStorageClass())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).To(BeNil())
@@ -322,7 +331,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), source)
+				planner = createPlanner(createStorageClass(), source)
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(HavePrefix("target resources requests storage size is smaller than the source"))
@@ -336,7 +345,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createSourceClaim())
+				planner = createPlanner(createStorageClass(), createSourceClaim())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -352,7 +361,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass(), createSourceVolume())
+				planner = createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass(), createSourceVolume())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -365,7 +374,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass())
+				planner = createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -382,7 +391,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createVolumeSnapshotClass(), sourceClaim, sourceVolume)
+				planner = createPlanner(createStorageClass(), createVolumeSnapshotClass(), sourceClaim, sourceVolume)
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -397,7 +406,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass())
+				planner = createPlanner(createStorageClass(), createSourceClaim(), createVolumeSnapshotClass())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -414,7 +423,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(storageClass, createSourceClaim(), createVolumeSnapshotClass())
+				planner = createPlanner(storageClass, createSourceClaim(), createVolumeSnapshotClass())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -433,7 +442,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createVolumeSnapshotClass(), source)
+				planner = createPlanner(createStorageClass(), createVolumeSnapshotClass(), source)
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -450,7 +459,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createPVCDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), createSourceClaim())
+				planner = createPlanner(createStorageClass(), createSourceClaim())
 				cdi := &cdiv1.CDI{}
 				err := planner.Client.Get(context.Background(), client.ObjectKeyFromObject(cc.MakeEmptyCDICR()), cdi)
 				Expect(err).ToNot(HaveOccurred())
@@ -478,7 +487,7 @@ var _ = Describe("Planner test", func() {
 						CloneStrategy: &cs,
 					},
 				}
-				planner := createPlanner(sp, createStorageClass(), createSourceClaim())
+				planner = createPlanner(sp, createStorageClass(), createSourceClaim())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -505,7 +514,7 @@ var _ = Describe("Planner test", func() {
 				sourceVolume := createSourceVolume()
 				sourceVolume.Spec.StorageClassName = "foo"
 				sourceVolume.Spec.PersistentVolumeSource.CSI.Driver = "baz"
-				planner := createPlanner(sp, createStorageClass(), sourceClaim, sourceVolume)
+				planner = createPlanner(sp, createStorageClass(), sourceClaim, sourceVolume)
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -533,7 +542,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass())
+				planner = createPlanner(createStorageClass())
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).To(BeNil())
@@ -546,7 +555,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner()
+				planner = createPlanner()
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("target storage class not found"))
@@ -562,7 +571,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), source)
+				planner = createPlanner(createStorageClass(), source)
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("volumeSnapshotContent name not found"))
@@ -577,7 +586,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("test"))
+				planner = createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("test"))
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -596,7 +605,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("driver"))
+				planner = createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("driver"))
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("snapshot has no RestoreSize"))
@@ -613,7 +622,7 @@ var _ = Describe("Planner test", func() {
 				}
 				sc := createStorageClass()
 				sc.AllowVolumeExpansion = nil
-				planner := createPlanner(sc, source, createDefaultVolumeSnapshotContent("driver"))
+				planner = createPlanner(sc, source, createDefaultVolumeSnapshotContent("driver"))
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -631,7 +640,7 @@ var _ = Describe("Planner test", func() {
 					DataSource:  createSnapshotDataSource(),
 					Log:         log,
 				}
-				planner := createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("driver"))
+				planner = createPlanner(createStorageClass(), source, createDefaultVolumeSnapshotContent("driver"))
 				csr, err := planner.ChooseStrategy(context.Background(), args)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csr).ToNot(BeNil())
@@ -750,7 +759,7 @@ var _ = Describe("Planner test", func() {
 				DataSource:  createPVCDataSource(),
 				Log:         log,
 			}
-			planner := createPlanner(cdiConfig, createStorageClass(), source)
+			planner = createPlanner(cdiConfig, createStorageClass(), source)
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(plan).ToNot(BeNil())
@@ -768,7 +777,7 @@ var _ = Describe("Planner test", func() {
 				DataSource:  createPVCDataSource(),
 				Log:         log,
 			}
-			planner := createPlanner(cdiConfig, createStorageClass(), createVolumeSnapshotClass(), source)
+			planner = createPlanner(cdiConfig, createStorageClass(), createVolumeSnapshotClass(), source)
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(plan).ToNot(BeNil())
@@ -788,7 +797,7 @@ var _ = Describe("Planner test", func() {
 				DataSource:  createPVCDataSource(),
 				Log:         log,
 			}
-			planner := createPlanner(cdiConfig, createStorageClass(), source)
+			planner = createPlanner(cdiConfig, createStorageClass(), source)
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(plan).ToNot(BeNil())
@@ -807,7 +816,7 @@ var _ = Describe("Planner test", func() {
 				DataSource:  createSnapshotDataSource(),
 				Log:         log,
 			}
-			planner := createPlanner(cdiConfig, createStorageClass(), source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
+			planner = createPlanner(cdiConfig, createStorageClass(), source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(plan).ToNot(BeNil())
@@ -826,7 +835,7 @@ var _ = Describe("Planner test", func() {
 				DataSource:  createSnapshotDataSource(),
 				Log:         log,
 			}
-			planner := createPlanner(cdiConfig, createStorageClass(), source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
+			planner = createPlanner(cdiConfig, createStorageClass(), source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(plan).ToNot(BeNil())
@@ -848,7 +857,7 @@ var _ = Describe("Planner test", func() {
 			}
 			sc := createStorageClass()
 			sc.Provisioner = "test-error"
-			planner := createPlanner(cdiConfig, sc, source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
+			planner = createPlanner(cdiConfig, sc, source, createVolumeSnapshotClass(), createDefaultVolumeSnapshotContent())
 			plan, err := planner.Plan(context.Background(), args)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unable to find a valid storage class for the temporal source claim"))
@@ -893,7 +902,7 @@ var _ = Describe("Planner test", func() {
 		It("should cleanup tmp resources", func() {
 			tempObjs := tempResources()
 			target := createTargetClaim()
-			planner := createPlanner(tempObjs...)
+			planner = createPlanner(tempObjs...)
 			err := planner.Cleanup(context.Background(), log, target)
 			Expect(err).ToNot(HaveOccurred())
 			for _, r := range tempResources() {

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1915,6 +1915,7 @@ func GetSnapshotClassForSmartClone(pvc *corev1.PersistentVolumeClaim, targetPvcS
 }
 
 // GetVolumeSnapshotClass looks up the snapshot class based on the driver and an optional specific name
+// In case of multiple candidates, it returns the default-annotated one, or the sorted list first one if no such default
 func GetVolumeSnapshotClass(ctx context.Context, c client.Client, pvc *corev1.PersistentVolumeClaim, driver string, snapshotClassName *string, log logr.Logger, recorder record.EventRecorder) (*string, error) {
 	logger := log.WithName("GetVolumeSnapshotClass").V(3)
 
@@ -1933,7 +1934,7 @@ func GetVolumeSnapshotClass(ctx context.Context, c client.Client, pvc *corev1.Pe
 		}
 		if vsc.Driver == driver {
 			logEvent(MessageStorageProfileVolumeSnapshotClassSelected, vsc.Name)
-			return &vsc.Name, nil
+			return snapshotClassName, nil
 		}
 		return nil, nil
 	}
@@ -1951,7 +1952,8 @@ func GetVolumeSnapshotClass(ctx context.Context, c client.Client, pvc *corev1.Pe
 		if vsc.Driver == driver {
 			if vsc.Annotations[AnnDefaultSnapshotClass] == "true" {
 				logEvent(MessageDefaultVolumeSnapshotClassSelected, vsc.Name)
-				return &vsc.Name, nil
+				vscName := vsc.Name
+				return &vscName, nil
 			}
 			candidates = append(candidates, vsc.Name)
 		}

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -326,7 +326,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	if desiredStorageClass != nil {
 		cc.AddAnnotation(dataImportCron, AnnStorageClass, desiredStorageClass.Name)
 	}
-	format, err := r.getSourceFormat(ctx, dataImportCron, desiredStorageClass)
+	format, err := r.getSourceFormat(ctx, desiredStorageClass)
 	if err != nil {
 		return res, err
 	}
@@ -688,8 +688,11 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 		r.log.Info("Attempt to change storage class, will not try making a snapshot of the old PVC")
 		return nil
 	}
-
-	className, err := cc.GetSnapshotClassForSmartClone(pvc.Name, &desiredStorageClass.Name, r.log, r.client)
+	storageProfile := &cdiv1.StorageProfile{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: desiredStorageClass.Name}, storageProfile); err != nil {
+		return err
+	}
+	className, err := cc.GetSnapshotClassForSmartClone(pvc.Name, &desiredStorageClass.Name, storageProfile.Status.SnapshotClass, r.log, r.client)
 	if err != nil {
 		return err
 	}
@@ -713,7 +716,7 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 	r.setDataImportCronResourceLabels(dataImportCron, desiredSnapshot)
 
 	currentSnapshot := &snapshotv1.VolumeSnapshot{}
-	if err := r.client.Get(context.TODO(), client.ObjectKeyFromObject(desiredSnapshot), currentSnapshot); err != nil {
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(desiredSnapshot), currentSnapshot); err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
@@ -757,14 +760,14 @@ func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(ctx cont
 	return nil
 }
 
-func (r *DataImportCronReconciler) getSourceFormat(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass *storagev1.StorageClass) (cdiv1.DataImportCronSourceFormat, error) {
+func (r *DataImportCronReconciler) getSourceFormat(ctx context.Context, desiredStorageClass *storagev1.StorageClass) (cdiv1.DataImportCronSourceFormat, error) {
 	format := cdiv1.DataImportCronSourceFormatPvc
 	if desiredStorageClass == nil {
 		return format, nil
 	}
 
 	storageProfile := &cdiv1.StorageProfile{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: desiredStorageClass.Name}, storageProfile); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Name: desiredStorageClass.Name}, storageProfile); err != nil {
 		return format, err
 	}
 	if storageProfile.Status.DataImportCronSourceFormat != nil {

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -692,7 +692,7 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 	if err := r.client.Get(ctx, types.NamespacedName{Name: desiredStorageClass.Name}, storageProfile); err != nil {
 		return err
 	}
-	className, err := cc.GetSnapshotClassForSmartClone(pvc.Name, &desiredStorageClass.Name, storageProfile.Status.SnapshotClass, r.log, r.client)
+	className, err := cc.GetSnapshotClassForSmartClone(pvc, &desiredStorageClass.Name, storageProfile.Status.SnapshotClass, r.log, r.client, r.recorder)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -1109,7 +1109,7 @@ func createDataImportCronReconcilerWithoutConfig(objects ...runtime.Object) *Dat
 	_ = snapshotv1.AddToScheme(s)
 
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-	rec := record.NewFakeRecorder(1)
+	rec := record.NewFakeRecorder(10)
 	r := &DataImportCronReconciler{
 		client:         cl,
 		uncachedClient: cl,

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -364,7 +364,7 @@ func NewStorageProfileController(mgr manager.Manager, log logr.Logger, installer
 	}
 
 	storageProfileController, err := controller.New(
-		dataImportControllerName,
+		storageProfileControllerName,
 		mgr,
 		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: 3})
 	if err != nil {

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -92,9 +92,12 @@ func (r *StorageProfileReconciler) reconcileStorageProfile(sc *storagev1.Storage
 
 	storageProfile.Status.StorageClass = &sc.Name
 	storageProfile.Status.Provisioner = &sc.Provisioner
-	snapClass, err := cc.GetSnapshotClassForSmartClone("", &sc.Name, r.log, r.client)
+	snapClass, err := cc.GetSnapshotClassForSmartClone("", &sc.Name, storageProfile.Spec.SnapshotClass, r.log, r.client)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+	if snapClass != "" {
+		storageProfile.Status.SnapshotClass = &snapClass
 	}
 	storageProfile.Status.CloneStrategy = r.reconcileCloneStrategy(sc, storageProfile.Spec.CloneStrategy, snapClass)
 	storageProfile.Status.DataImportCronSourceFormat = r.reconcileDataImportCronSourceFormat(sc, storageProfile.Spec.DataImportCronSourceFormat, snapClass)

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -33,6 +34,8 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/storagecapabilities"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
+
+const storageProfileControllerName = "storageprofile-controller"
 
 var (
 	// IncompleteProfileGauge is the metric we use to alert about incomplete storage profiles
@@ -54,6 +57,7 @@ type StorageProfileReconciler struct {
 	client client.Client
 	// use this for getting any resources not in the install namespace or cluster scope
 	uncachedClient  client.Client
+	recorder        record.EventRecorder
 	scheme          *runtime.Scheme
 	log             logr.Logger
 	installerLabels map[string]string
@@ -92,7 +96,7 @@ func (r *StorageProfileReconciler) reconcileStorageProfile(sc *storagev1.Storage
 
 	storageProfile.Status.StorageClass = &sc.Name
 	storageProfile.Status.Provisioner = &sc.Provisioner
-	snapClass, err := cc.GetSnapshotClassForSmartClone("", &sc.Name, storageProfile.Spec.SnapshotClass, r.log, r.client)
+	snapClass, err := cc.GetSnapshotClassForSmartClone(nil, &sc.Name, storageProfile.Spec.SnapshotClass, r.log, r.client, r.recorder)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -349,16 +353,18 @@ func NewStorageProfileController(mgr manager.Manager, log logr.Logger, installer
 	if err != nil {
 		return nil, err
 	}
+
 	reconciler := &StorageProfileReconciler{
 		client:          mgr.GetClient(),
 		uncachedClient:  uncachedClient,
+		recorder:        mgr.GetEventRecorderFor(storageProfileControllerName),
 		scheme:          mgr.GetScheme(),
-		log:             log.WithName("storageprofile-controller"),
+		log:             log.WithName(storageProfileControllerName),
 		installerLabels: installerLabels,
 	}
 
 	storageProfileController, err := controller.New(
-		"storageprofile-controller",
+		dataImportControllerName,
 		mgr,
 		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: 3})
 	if err != nil {

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6907,6 +6907,11 @@ spec:
                 description: DataImportCronSourceFormat defines the format of the
                   DataImportCron-created disk image sources
                 type: string
+              snapshotClass:
+                description: SnapshotClass is optional specific VolumeSnapshotClass
+                  for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is
+                  chosen according to the provisioner.
+                type: string
             type: object
           status:
             description: StorageProfileStatus provides the most recently observed
@@ -6942,6 +6947,11 @@ spec:
                 type: string
               provisioner:
                 description: The Storage class provisioner plugin name
+                type: string
+              snapshotClass:
+                description: SnapshotClass is optional specific VolumeSnapshotClass
+                  for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is
+                  chosen according to the provisioner.
                 type: string
               storageClass:
                 description: The StorageClass name for which capabilities are defined

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -421,6 +421,8 @@ type StorageProfileSpec struct {
 	ClaimPropertySets []ClaimPropertySet `json:"claimPropertySets,omitempty"`
 	// DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources
 	DataImportCronSourceFormat *DataImportCronSourceFormat `json:"dataImportCronSourceFormat,omitempty"`
+	// SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.
+	SnapshotClass *string `json:"snapshotClass,omitempty"`
 }
 
 // StorageProfileStatus provides the most recently observed status of the StorageProfile
@@ -435,6 +437,8 @@ type StorageProfileStatus struct {
 	ClaimPropertySets []ClaimPropertySet `json:"claimPropertySets,omitempty"`
 	// DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources
 	DataImportCronSourceFormat *DataImportCronSourceFormat `json:"dataImportCronSourceFormat,omitempty"`
+	// SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.
+	SnapshotClass *string `json:"snapshotClass,omitempty"`
 }
 
 // ClaimPropertySet is a set of properties applicable to PVC

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -184,6 +184,7 @@ func (StorageProfileSpec) SwaggerDoc() map[string]string {
 		"cloneStrategy":              "CloneStrategy defines the preferred method for performing a CDI clone",
 		"claimPropertySets":          "ClaimPropertySets is a provided set of properties applicable to PVC",
 		"dataImportCronSourceFormat": "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
+		"snapshotClass":              "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
 	}
 }
 
@@ -195,6 +196,7 @@ func (StorageProfileStatus) SwaggerDoc() map[string]string {
 		"cloneStrategy":              "CloneStrategy defines the preferred method for performing a CDI clone",
 		"claimPropertySets":          "ClaimPropertySets computed from the spec and detected in the system",
 		"dataImportCronSourceFormat": "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
+		"snapshotClass":              "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1509,6 +1509,11 @@ func (in *StorageProfileSpec) DeepCopyInto(out *StorageProfileSpec) {
 		*out = new(DataImportCronSourceFormat)
 		**out = **in
 	}
+	if in.SnapshotClass != nil {
+		in, out := &in.SnapshotClass, &out.SnapshotClass
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -1550,6 +1555,11 @@ func (in *StorageProfileStatus) DeepCopyInto(out *StorageProfileStatus) {
 	if in.DataImportCronSourceFormat != nil {
 		in, out := &in.DataImportCronSourceFormat, &out.DataImportCronSourceFormat
 		*out = new(DataImportCronSourceFormat)
+		**out = **in
+	}
+	if in.SnapshotClass != nil {
+		in, out := &in.SnapshotClass, &out.SnapshotClass
+		*out = new(string)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
**What this PR does / why we need it**:
When there are several `VolumeSnapshotClasses` of the same provisioner but with different parameters, we would like to allow `StorageProfile` choose `VolumeSnapshotClass` for its `StorageClass`, so we won't choose the wrong one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes bz #2219774

**Special notes for your reviewer**:

**Release note**:
```release-note
Allow StorageProfile to use a specific VolumeSnapshotClass
```

