### PR TITLE
[release-v1.56] Fix flakes when using gigabytes intead of gibibytes

### DIFF
--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -213,11 +213,11 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 			})
 
 			DescribeTable("should deny/allow user when creating PVC clone datavolume", func(role *rbacv1.Role, saName, groupName string) {
-				srcPVCDef := utils.NewPVCDefinition("source-pvc", "1G", nil, nil)
+				srcPVCDef := utils.NewPVCDefinition("source-pvc", "1Gi", nil, nil)
 				srcPVCDef.Namespace = f.Namespace.Name
 				f.CreateAndPopulateSourcePVC(srcPVCDef, "fill-source", fmt.Sprintf("echo \"hello world\" > %s/data.txt", utils.DefaultPvcMountPath))
 
-				targetDV := utils.NewCloningDataVolume("target-dv", "1G", srcPVCDef)
+				targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", srcPVCDef)
 
 				client, err := f.GetCdiClientForServiceAccount(targetNamespace.Name, serviceAccountName)
 				Expect(err).ToNot(HaveOccurred())
@@ -281,7 +281,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 					Skip("Clone from volumesnapshot does not work without snapshot capable storage")
 				}
 
-				srcPVCDef := utils.NewPVCDefinition("source-pvc", "1G", nil, nil)
+				srcPVCDef := utils.NewPVCDefinition("source-pvc", "1Gi", nil, nil)
 				srcPVCDef.Namespace = f.Namespace.Name
 				pvc := f.CreateAndPopulateSourcePVC(srcPVCDef, "fill-source", fmt.Sprintf("echo \"hello world\" > %s/data.txt", utils.DefaultPvcMountPath))
 
@@ -301,7 +301,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 				err = f.CrClient.Create(context.TODO(), snapshot)
 				Expect(err).ToNot(HaveOccurred())
 				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
-				targetDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("target-dv", "1G", snapshot.Namespace, snapshot.Name, nil, &volumeMode)
+				targetDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("target-dv", "1Gi", snapshot.Namespace, snapshot.Name, nil, &volumeMode)
 
 				client, err := f.GetCdiClientForServiceAccount(targetNamespace.Name, serviceAccountName)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a partial backport of https://github.com/kubevirt/containerized-data-importer/pull/2636
This tends to flake often, especially in OpenShift testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

