### PR TITLE
[release-v1.57] Manual backport of AnnPodRetainAfterCompletion with populators

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1197,7 +1197,6 @@ func (r *ReconcilerBase) handlePvcCreation(log logr.Logger, syncState *dvSyncSta
 // shouldUseCDIPopulator returns if the population of the PVC should be done using
 // CDI populators.
 // Currently it will use populators only if:
-// * no podRetainAfterCompletion or immediateBinding annotations
 // * source is not VDDK, Imageio, PVC, Snapshot
 // * storageClass bindingMode is not wffc while honorWaitForFirstConsumer feature gate is disabled
 // * storageClass used is CSI storageClass
@@ -1211,11 +1210,7 @@ func (r *ReconcilerBase) shouldUseCDIPopulator(syncState *dvSyncState) (bool, er
 		return boolUsePopulator, nil
 	}
 	log := r.log.WithValues("DataVolume", dv.Name, "Namespace", dv.Namespace)
-	// currently populators don't support retain pod annotation so don't use populators in that case
-	if retain := dv.Annotations[cc.AnnPodRetainAfterCompletion]; retain == "true" {
-		log.Info("Not using CDI populators, currently we don't support populators with retainAfterCompletion annotation")
-		return false, nil
-	}
+
 	// currently we don't support populator with import source of VDDK or Imageio
 	// or clone either from PVC nor snapshot
 	if dv.Spec.Source.Imageio != nil ||

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1574,9 +1574,12 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv := createDataVolumeWithStorageAPI("test-dv", metav1.NamespaceDefault, httpSource, storageSpec)
 			AddAnnotation(dv, annotation, value)
 
-			reconciler = createImportReconciler()
+			reconciler = createImportReconciler(sc, csiDriver)
 			syncState := dvSyncState{
 				dvMutated: dv,
+				pvcSpec: &corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &scName,
+				},
 			}
 			usePopulator, err := reconciler.shouldUseCDIPopulator(&syncState)
 			Expect(err).ToNot(HaveOccurred())
@@ -1584,7 +1587,7 @@ var _ = Describe("All DataVolume Tests", func() {
 		},
 			Entry("AnnUsePopulator=true return true", AnnUsePopulator, "true", true),
 			Entry("AnnUsePopulator=false return false", AnnUsePopulator, "false", false),
-			Entry("AnnPodRetainAfterCompletion return false", AnnPodRetainAfterCompletion, "true", false),
+			Entry("AnnPodRetainAfterCompletion return true", AnnPodRetainAfterCompletion, "true", true),
 		)
 
 		DescribeTable("Should return false if source is", func(source *cdiv1.DataVolumeSource) {

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -176,6 +176,9 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 	if waitForFirstConsumer {
 		annotations[cc.AnnSelectedNode] = pvc.Annotations[cc.AnnSelectedNode]
 	}
+	if _, ok := pvc.Annotations[cc.AnnPodRetainAfterCompletion]; ok {
+		annotations[cc.AnnPodRetainAfterCompletion] = pvc.Annotations[cc.AnnPodRetainAfterCompletion]
+	}
 
 	// Assemble PVC' spec
 	pvcPrime := &corev1.PersistentVolumeClaim{
@@ -329,8 +332,13 @@ func (r *ReconcilerBase) reconcileCommon(pvc *corev1.PersistentVolumeClaim, popu
 
 func (r *ReconcilerBase) reconcileCleanup(pvcPrime *corev1.PersistentVolumeClaim) (reconcile.Result, error) {
 	if pvcPrime != nil {
-		if err := r.client.Delete(context.TODO(), pvcPrime); err != nil {
-			return reconcile.Result{}, err
+		if pvcPrime.Annotations[cc.AnnPodRetainAfterCompletion] == "true" {
+			// Retaining PVC' in Lost state. We can then keep the pod for debugging purposes.
+			r.recorder.Eventf(pvcPrime, corev1.EventTypeWarning, retainedPVCPrime, messageRetainedPVCPrime)
+		} else {
+			if err := r.client.Delete(context.TODO(), pvcPrime); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -40,6 +40,11 @@ const (
 	// messageCreatedPVCPrimeSuccessfully provides a const to indicate we created PVC prime for population (message)
 	messageCreatedPVCPrimeSuccessfully = "PVC Prime created successfully"
 
+	// retainedPVCPrime provides a const to indicate that the PVC prime has been retained in lost state (reason)
+	retainedPVCPrime = "RetainedPVCPrime"
+	// messageRetainedPVCPrime provides a const to indicate that the PVC prime has been retained in lost state (message)
+	messageRetainedPVCPrime = "PVC Prime retained in Lost state for debugging purposes"
+
 	// AnnPVCPrimeName annotation is the name of the PVC' that is added to the target PVC
 	// used by the upload-proxy in order to get the service name
 	AnnPVCPrimeName = cc.AnnAPIGroup + "/storage.populator.pvcPrime"


### PR DESCRIPTION

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/containerized-data-importer/pull/2873.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow the usage of AnnPodRetainAfterCompletion with populators
```

