### PR TITLE
Default storage class for virtualization purposes

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -369,6 +369,7 @@ func getTokenPrivateKey() *rsa.PrivateKey {
 func registerMetrics() {
 	metrics.Registry.MustRegister(controller.IncompleteProfileGauge)
 	controller.IncompleteProfileGauge.Set(-1)
+	metrics.Registry.MustRegister(controller.DefaultVirtStorageClassesGauge)
 	metrics.Registry.MustRegister(controller.DataImportCronOutdatedGauge)
 }
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -11,6 +11,8 @@ CDI install ready. Type: Gauge.
 DataImportCron has an outdated import. Type: Gauge.
 ### kubevirt_cdi_dataimportcron_outdated_aggregated
 Total count of outdated DataImportCron imports. Type: Gauge.
+### kubevirt_cdi_default_virt_storageclasses
+Number of default virt storage classes currently configured. Type: Gauge.
 ### kubevirt_cdi_import_pods_high_restart
 The number of CDI import pods with high restart count. Type: Gauge.
 ### kubevirt_cdi_incomplete_storageprofiles

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -753,7 +753,7 @@ func ValidateCanCloneSourceAndTargetContentType(sourcePvc, targetPvc *corev1.Per
 	if sourceContentType != targetContentType {
 		return "", fmt.Errorf("source contentType (%s) and target contentType (%s) do not match", sourceContentType, targetContentType)
 	}
-	return cdiv1.DataVolumeContentType(sourceContentType), nil
+	return sourceContentType, nil
 }
 
 // ValidateCanCloneSourceAndTargetSpec validates the specs passed in are compatible for cloning.

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -483,7 +483,7 @@ func getFallbackStorageClass(ctx context.Context, client client.Client, contentT
 		return nil, errors.New("unable to retrieve storage classes")
 	}
 
-	if GetContentType(string(contentType)) == string(cdiv1.DataVolumeKubeVirt) {
+	if GetContentType(contentType) == cdiv1.DataVolumeKubeVirt {
 		virtSc := GetPlatformDefaultStorageClass(ctx, storageClasses, AnnDefaultVirtStorageClass)
 		if virtSc != nil {
 			return virtSc, nil
@@ -1285,7 +1285,7 @@ func CreateImporterTestPod(pvc *corev1.PersistentVolumeClaim, dvname string, scr
 		},
 		{
 			Name:  common.ImporterContentType,
-			Value: contentType,
+			Value: string(contentType),
 		},
 		{
 			Name:  common.ImporterImageSize,
@@ -1346,27 +1346,27 @@ func ErrQuotaExceeded(err error) bool {
 }
 
 // GetContentType returns the content type. If invalid or not set, default to kubevirt
-func GetContentType(contentType string) string {
+func GetContentType(contentType cdiv1.DataVolumeContentType) cdiv1.DataVolumeContentType {
 	switch contentType {
 	case
-		string(cdiv1.DataVolumeKubeVirt),
-		string(cdiv1.DataVolumeArchive):
+		cdiv1.DataVolumeKubeVirt,
+		cdiv1.DataVolumeArchive:
 	default:
 		// TODO - shouldn't archive be the default?
-		contentType = string(cdiv1.DataVolumeKubeVirt)
+		contentType = cdiv1.DataVolumeKubeVirt
 	}
 	return contentType
 }
 
 // GetPVCContentType returns the content type of the source image. If invalid or not set, default to kubevirt
-func GetPVCContentType(pvc *corev1.PersistentVolumeClaim) string {
+func GetPVCContentType(pvc *corev1.PersistentVolumeClaim) cdiv1.DataVolumeContentType {
 	contentType, found := pvc.Annotations[AnnContentType]
 	if !found {
 		// TODO - shouldn't archive be the default?
-		return string(cdiv1.DataVolumeKubeVirt)
+		return cdiv1.DataVolumeKubeVirt
 	}
 
-	return GetContentType(contentType)
+	return GetContentType(cdiv1.DataVolumeContentType(contentType))
 }
 
 // GetNamespace returns the given namespace if not empty, otherwise the default namespace

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -319,7 +319,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 
 	dataVolume := dataImportCron.Spec.Template
 	explicitScName := getStorageClassFromTemplate(&dataVolume)
-	desiredStorageClass, err := cc.GetStorageClassByName(ctx, r.client, explicitScName)
+	desiredStorageClass, err := cc.GetStorageClassByNameWithVirtFallback(ctx, r.client, explicitScName, dataVolume.Spec.ContentType)
 	if err != nil {
 		return res, err
 	}
@@ -1007,7 +1007,7 @@ func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Contro
 		for _, cron := range crons.Items {
 			dataVolume := cron.Spec.Template
 			explicitScName := getStorageClassFromTemplate(&dataVolume)
-			templateSc, err := cc.GetStorageClassByName(context.TODO(), mgr.GetClient(), explicitScName)
+			templateSc, err := cc.GetStorageClassByNameWithVirtFallback(context.TODO(), mgr.GetClient(), explicitScName, dataVolume.Spec.ContentType)
 			if err != nil || templateSc == nil {
 				c.GetLogger().Error(err, "Unable to get storage class", "templateSc", templateSc)
 				return

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -683,7 +683,7 @@ func (r *ReconcilerBase) createPvcForDatavolume(datavolume *cdiv1.DataVolume, pv
 
 func (r *ReconcilerBase) getStorageClassBindingMode(storageClassName *string) (*storagev1.VolumeBindingMode, error) {
 	// Handle unspecified storage class name, fallback to default storage class
-	storageClass, err := cc.GetStorageClassByName(context.TODO(), r.client, storageClassName)
+	storageClass, err := cc.GetStorageClassByNameWithK8sFallback(context.TODO(), r.client, storageClassName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1034,7 +1034,7 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 		annotations[k] = v
 	}
 	annotations[cc.AnnPodRestarts] = "0"
-	annotations[cc.AnnContentType] = cc.GetContentType(string(dataVolume.Spec.ContentType))
+	annotations[cc.AnnContentType] = string(cc.GetContentType(dataVolume.Spec.ContentType))
 	if dataVolume.Spec.PriorityClassName != "" {
 		annotations[cc.AnnPriorityClassName] = dataVolume.Spec.PriorityClassName
 	}

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -94,7 +94,7 @@ func renderPvcSpecVolumeModeAndAccessModes(client client.Client, recorder record
 		pvcSpec.VolumeMode = &volumeMode
 	}
 
-	storageClass, err := cc.GetStorageClassByName(context.TODO(), client, dv.Spec.Storage.StorageClassName)
+	storageClass, err := cc.GetStorageClassByNameWithVirtFallback(context.TODO(), client, dv.Spec.Storage.StorageClassName, dv.Spec.ContentType)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func resolveVolumeSize(c client.Client, dvSpec cdiv1.DataVolumeSpec, pvcSpec *v1
 func storageClassCSIDriverExists(client client.Client, log logr.Logger, storageClassName *string) (bool, error) {
 	log = log.WithName("storageClassCSIDriverExists").V(3)
 
-	storageClass, err := cc.GetStorageClassByName(context.TODO(), client, storageClassName)
+	storageClass, err := cc.GetStorageClassByNameWithK8sFallback(context.TODO(), client, storageClassName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -541,7 +541,7 @@ func createScratchNameFromPvc(pvc *v1.PersistentVolumeClaim) string {
 func (r *ImportReconciler) createImportEnvVar(pvc *corev1.PersistentVolumeClaim) (*importPodEnvVar, error) {
 	podEnvVar := &importPodEnvVar{}
 	podEnvVar.source = cc.GetSource(pvc)
-	podEnvVar.contentType = cc.GetPVCContentType(pvc)
+	podEnvVar.contentType = string(cc.GetPVCContentType(pvc))
 
 	var err error
 	if podEnvVar.source != cc.SourceNone {
@@ -691,7 +691,7 @@ func (r *ImportReconciler) requiresScratchSpace(pvc *corev1.PersistentVolumeClai
 	scratchRequired := false
 	contentType := cc.GetPVCContentType(pvc)
 	// All archive requires scratch space.
-	if contentType == "archive" {
+	if contentType == cdiv1.DataVolumeArchive {
 		scratchRequired = true
 	} else {
 		switch cc.GetSource(pvc) {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -935,7 +935,7 @@ var _ = Describe("GetContentType", func() {
 
 	DescribeTable("should", func(pvc *corev1.PersistentVolumeClaim, expectedResult cdiv1.DataVolumeContentType) {
 		result := cc.GetPVCContentType(pvc)
-		Expect(result).To(BeEquivalentTo(expectedResult))
+		Expect(result).To(Equal(expectedResult))
 	},
 		Entry("return kubevirt contenttype if no annotation provided", pvcNoAnno, cdiv1.DataVolumeKubeVirt),
 		Entry("return archive contenttype if archive annotation present", pvcArchiveAnno, cdiv1.DataVolumeArchive),

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -178,7 +178,7 @@ func (r *ImportPopulatorReconciler) updatePVCForPopulation(pvc *corev1.Persisten
 	volumeImportSource := source.(*cdiv1.VolumeImportSource)
 	annotations := pvc.Annotations
 	annotations[cc.AnnPopulatorKind] = cdiv1.VolumeImportSourceRef
-	annotations[cc.AnnContentType] = cc.GetContentType(string(volumeImportSource.Spec.ContentType))
+	annotations[cc.AnnContentType] = string(cc.GetContentType(volumeImportSource.Spec.ContentType))
 	annotations[cc.AnnPreallocationRequested] = strconv.FormatBool(cc.GetPreallocation(context.TODO(), r.client, volumeImportSource.Spec.Preallocation))
 
 	if checkpoint := cc.GetNextCheckpoint(pvc, r.getCheckpointArgs(source)); checkpoint != nil {

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -113,7 +113,7 @@ func (r *UploadPopulatorReconciler) getPopulationSource(pvc *corev1.PersistentVo
 func (r *UploadPopulatorReconciler) updatePVCForPopulation(pvc *corev1.PersistentVolumeClaim, source client.Object) {
 	pvc.Annotations[cc.AnnUploadRequest] = ""
 	uploadSource := source.(*cdiv1.VolumeUploadSource)
-	pvc.Annotations[cc.AnnContentType] = cc.GetContentType(string(uploadSource.Spec.ContentType))
+	pvc.Annotations[cc.AnnContentType] = string(cc.GetContentType(uploadSource.Spec.ContentType))
 	pvc.Annotations[cc.AnnPopulatorKind] = cdiv1.VolumeUploadSourceRef
 	pvc.Annotations[cc.AnnPreallocationRequested] = strconv.FormatBool(cc.GetPreallocation(context.TODO(), r.client, uploadSource.Spec.Preallocation))
 }

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -110,7 +110,7 @@ func claimReadyForPopulation(ctx context.Context, c client.Client, pvc *corev1.P
 	}
 
 	nodeName := ""
-	storageClass, err := cc.GetStorageClassByName(ctx, c, pvc.Spec.StorageClassName)
+	storageClass, err := cc.GetStorageClassByNameWithK8sFallback(ctx, c, pvc.Spec.StorageClassName)
 	if err != nil {
 		return false, nodeName, err
 	}

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -25,10 +25,11 @@ type MetricsKey string
 
 // All metrics names for reference
 const (
-	ReadyGauge             MetricsKey = "readyGauge"
-	IncompleteProfile      MetricsKey = "incompleteProfile"
-	DataImportCronOutdated MetricsKey = "dataImportCronOutdated"
 	CloneProgress          MetricsKey = "cloneProgress"
+	DataImportCronOutdated MetricsKey = "dataImportCronOutdated"
+	IncompleteProfile      MetricsKey = "incompleteProfile"
+	ReadyGauge             MetricsKey = "readyGauge"
+	DefaultVirtClasses     MetricsKey = "defaultVirtClasses"
 )
 
 // MetricOptsList list all CDI metrics
@@ -46,6 +47,11 @@ var MetricOptsList = map[MetricsKey]MetricOpts{
 	ReadyGauge: {
 		Name: "kubevirt_cdi_cr_ready",
 		Help: "CDI install ready",
+		Type: "Gauge",
+	},
+	DefaultVirtClasses: {
+		Name: "kubevirt_cdi_default_virt_storageclasses",
+		Help: "Number of default virt storage classes currently configured",
 		Type: "Gauge",
 	},
 }

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -221,6 +221,21 @@ func getAlertRules(runbookURLTemplate string) []promv1.Rule {
 				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
+		generateAlertRule(
+			"CDIMultipleDefaultVirtStorageClasses",
+			"kubevirt_cdi_default_virt_storageclasses > 1",
+			promv1.Duration("5m"),
+			map[string]string{
+				"summary":     "More than one default virtualization StorageClass detected",
+				"runbook_url": fmt.Sprintf(runbookURLTemplate, "CDIMultipleDefaultVirtStorageClasses"),
+			},
+			map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "warning",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
+			},
+		),
 	}
 }
 

--- a/tests/clone-populator_test.go
+++ b/tests/clone-populator_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Clone Populator tests", func() {
 				}
 				sc, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), utils.DefaultStorageClass.GetName(), metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				noExpansionStorageClass, err = f.CreateVariationOfStorageClass(sc, disableVolumeExpansion)
+				noExpansionStorageClass, err = f.CreateNonDefaultVariationOfStorageClass(sc, disableVolumeExpansion)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2716,7 +2716,7 @@ var _ = Describe("all clone tests", func() {
 				}
 				sc, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), utils.DefaultStorageClass.GetName(), metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				noExpansionStorageClass, err = f.CreateVariationOfStorageClass(sc, disableVolumeExpansion)
+				noExpansionStorageClass, err = f.CreateNonDefaultVariationOfStorageClass(sc, disableVolumeExpansion)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -969,8 +969,33 @@ func NewDataVolumeWithArchiveContent(dataVolumeName string, size string, httpURL
 					URL: httpURL,
 				},
 			},
-			ContentType: "archive",
+			ContentType: cdiv1.DataVolumeArchive,
 			PVC: &k8sv1.PersistentVolumeClaimSpec{
+				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+				Resources: k8sv1.ResourceRequirements{
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewDataVolumeWithArchiveContentStorage initializes a DataVolume struct with 'archive' ContentType
+func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dataVolumeName,
+		},
+		Spec: cdiv1.DataVolumeSpec{
+			Source: &cdiv1.DataVolumeSource{
+				HTTP: &cdiv1.DataVolumeSourceHTTP{
+					URL: httpURL,
+				},
+			},
+			ContentType: cdiv1.DataVolumeArchive,
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Storage providers in the field may supply many ways of utilizing a back end storage solution;  
They do so by providing different Kubernetes StorageClass parameters.

With the growth of kubevirt adoptions, we may sometimes see a certain combination of storage class parameters is preferrable for VM workloads.
This PR presents a possible way of steering kubevirt users
towards using such identified storage class.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Was considering not doing functional tests but this feels too important.
There is little to no penalty because the entire block of tests I'm adding takes less than 30 seconds.
(No wait for dv success)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default virtualization storage class that takes precedence over k8s default storage class
```

