### PR TITLE
Respect wffc override for blank block disks

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -152,6 +152,10 @@ func handleEmptyImage(contentType string, imageSize string, availableDestSpace i
 	var preallocationApplied bool
 
 	if contentType == string(cdiv1.DataVolumeKubeVirt) {
+		if volumeMode == v1.PersistentVolumeBlock && !preallocation {
+			klog.V(1).Infoln("Blank block without preallocation is exactly an empty PVC, done populating")
+			return nil
+		}
 		createBlankImage(imageSize, availableDestSpace, preallocation, volumeMode, filesystemOverhead)
 		preallocationApplied = preallocation
 	} else {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -215,20 +215,6 @@ func (r *ImportReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	// In case this is a request to create a blank disk on a block device, we do not create a pod.
-	// we just mark the DV as successful
-	volumeMode := cc.GetVolumeMode(pvc)
-	if volumeMode == corev1.PersistentVolumeBlock && pvc.GetAnnotations()[cc.AnnSource] == cc.SourceNone && pvc.GetAnnotations()[cc.AnnPreallocationRequested] != "true" {
-		log.V(1).Info("attempting to create blank disk for block mode, this is a no-op, marking pvc with pod-phase succeeded")
-		if pvc.GetAnnotations() == nil {
-			pvc.SetAnnotations(make(map[string]string, 0))
-		}
-		pvc.GetAnnotations()[cc.AnnPodPhase] = string(corev1.PodSucceeded)
-		if err := r.updatePVC(pvc, log); err != nil {
-			return reconcile.Result{}, errors.WithMessage(err, fmt.Sprintf("could not update pvc %q annotation and/or label", pvc.Name))
-		}
-		return reconcile.Result{}, nil
-	}
 	return r.reconcilePvc(pvc, log)
 }
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -184,7 +184,22 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 	})
 
 	It("Should succeed and be marked complete, if creating a block PVC with source none", func() {
-		reconciler = createImportReconciler(createBlockPvc("testPvc1", "block", map[string]string{cc.AnnSource: cc.SourceNone}, nil))
+		pvc := createBlockPvc("testPvc1", "block", map[string]string{cc.AnnSource: cc.SourceNone}, nil)
+		pod := cc.CreateImporterTestPod(pvc, "testPvc1", nil)
+		pod.Status = corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Message: "Import Completed",
+							Reason:  "Reason",
+						},
+					},
+				},
+			},
+		}
+		reconciler = createImportReconciler(pvc, pod)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "testPvc1", Namespace: "block"}})
 		Expect(err).ToNot(HaveOccurred())
 		resultPvc := &corev1.PersistentVolumeClaim{}

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -587,31 +587,34 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 
 	})
 
-	It("[test_id:4972]Should create blank raw image for block PV", func() {
+	DescribeTable("Should create blank raw image for block PV", func(consumer bool) {
 		if !f.IsBlockVolumeStorageClassAvailable() {
 			Skip("Storage Class for block volume is not available")
 		}
 		dv := utils.NewDataVolumeForBlankRawImageBlock("create-blank-image-to-block-pvc", "500Mi", f.BlockSCName)
+		if !consumer {
+			controller.AddAnnotation(dv, controller.AnnImmediateBinding, "true")
+		}
 		dv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("verifying pvc was created")
 		pvc, err := utils.WaitForPVC(f.K8sClient, dv.Namespace, dv.Name)
 		Expect(err).ToNot(HaveOccurred())
-		f.ForceBindIfWaitForFirstConsumer(pvc)
+		if consumer {
+			f.ForceBindIfWaitForFirstConsumer(pvc)
+		}
 
 		By("Waiting for import to be completed")
 		err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
 		Expect(err).ToNot(HaveOccurred(), "Datavolume not in phase succeeded in time")
 
-		By("Verifying a message was printed to indicate a request for a blank disk on a block device")
-		Eventually(func() bool {
-			log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-			Expect(err).NotTo(HaveOccurred())
-			return strings.Contains(log, "attempting to create blank disk for block mode")
-		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
+		err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimBound, pvc.Name)
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("[test_id:4972] with first consumer", true),
+		Entry("with bind immediate annotation", false),
+	)
 
 	It("Should perform fsync syscall after qemu-img convert to raw", func() {
 		if !f.IsBlockVolumeStorageClassAvailable() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We currently don't support the wffc override for blank block disks,
while there may be some use cases where that is desired.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2915 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: wffc override not respected for blank block disks
```

