### PR TITLE
Improve DataVolume status reporting with populators

### DIFF
--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -47,6 +47,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 )
 
@@ -1209,6 +1210,17 @@ var _ = Describe("All DataVolume Tests", func() {
 			AddAnnotation(pvc, AnnSelectedNode, "node01")
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Creating a valid PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[AnnImportPod] = "something"
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
 			_, err = reconciler.updateStatus(getReconcileRequest(importDataVolume), nil, reconciler)
 			Expect(err).ToNot(HaveOccurred())
 			dv := &cdiv1.DataVolume{}
@@ -1229,6 +1241,44 @@ var _ = Describe("All DataVolume Tests", func() {
 				}
 			}
 			Expect(found).To(BeTrue())
+		})
+
+		It("Should not update DV phase when PVC Prime is unbound", func() {
+			scName := "testSC"
+			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			importDataVolume := NewImportDataVolume("test-dv")
+			importDataVolume.Spec.PVC.StorageClassName = &scName
+
+			reconciler = createImportReconciler(sc, csiDriver, importDataVolume)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			dv := &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			// Get original DV phase
+			dvPhase := dv.Status.Phase
+
+			// Create PVC Prime
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Status.Phase = corev1.ClaimPending
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = reconciler.updateStatus(getReconcileRequest(importDataVolume), nil, reconciler)
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(dvPhase))
 		})
 
 		It("Should switch to succeeded if PVC phase is pending, but pod phase is succeeded", func() {
@@ -1325,11 +1375,31 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		DescribeTable("DV phase", func(testDv runtime.Object, current, expected cdiv1.DataVolumePhase, pvcPhase corev1.PersistentVolumeClaimPhase, podPhase corev1.PodPhase, ann, expectedEvent string, extraAnnotations ...string) {
+			// First we test the non-populator flow
 			scName := "testpvc"
 			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
 			storageProfile := createStorageProfile(scName, nil, BlockMode)
-
 			r := createImportReconciler(testDv, sc, storageProfile)
+			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
+
+			// Test the populator flow, it should match
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			// Creating a valid PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = "prime-"
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[ann] = "something"
+			pvcPrime.GetAnnotations()[AnnPodPhase] = string(podPhase)
+			for i := 0; i < len(extraAnnotations); i += 2 {
+				pvcPrime.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
+			}
+			r = createImportReconciler(testDv, sc, storageProfile, pvcPrime, csiDriver)
 			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
 		},
 			Entry("should switch to bound for import", NewImportDataVolume("test-dv"), cdiv1.Pending, cdiv1.PVCBound, corev1.ClaimBound, corev1.PodPending, "invalid", "PVC test-dv Bound", AnnPriorityClassName, "p0"),

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -36,6 +36,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -205,11 +206,31 @@ var _ = Describe("All DataVolume Tests", func() {
 
 	var _ = Describe("Reconcile Datavolume status", func() {
 		DescribeTable("DV phase", func(testDv runtime.Object, current, expected cdiv1.DataVolumePhase, pvcPhase corev1.PersistentVolumeClaimPhase, podPhase corev1.PodPhase, ann, expectedEvent string, extraAnnotations ...string) {
+			// We first test the non-populator flow
 			scName := "testpvc"
 			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
 			storageProfile := createStorageProfile(scName, nil, BlockMode)
-
 			r := createUploadReconciler(testDv, sc, storageProfile)
+			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
+
+			// Test the populator flow, it should match
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			// Creating a valid PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = "prime-"
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[ann] = "something"
+			pvcPrime.GetAnnotations()[AnnPodPhase] = string(podPhase)
+			for i := 0; i < len(extraAnnotations); i += 2 {
+				pvcPrime.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
+			}
+			r = createUploadReconciler(testDv, sc, storageProfile, pvcPrime, csiDriver)
 			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
 		},
 			Entry("should switch to scheduled for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadScheduled, corev1.ClaimBound, corev1.PodPending, AnnUploadRequest, "Upload into test-dv scheduled", AnnPriorityClassName, "p0-upload"),
@@ -244,6 +265,17 @@ var _ = Describe("All DataVolume Tests", func() {
 			AddAnnotation(pvc, AnnSelectedNode, "node01")
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Create PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[AnnUploadRequest] = "something"
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
 			_, err = reconciler.updateStatus(getReconcileRequest(uploadDataVolume), nil, reconciler)
 			Expect(err).ToNot(HaveOccurred())
 			dv := &cdiv1.DataVolume{}
@@ -264,6 +296,44 @@ var _ = Describe("All DataVolume Tests", func() {
 				}
 			}
 			Expect(found).To(BeTrue())
+		})
+
+		It("Should not update DV phase when PVC Prime is unbound", func() {
+			scName := "testSC"
+			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			uploadDataVolume := newUploadDataVolume("test-dv")
+			uploadDataVolume.Spec.PVC.StorageClassName = &scName
+
+			reconciler = createUploadReconciler(sc, csiDriver, uploadDataVolume)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			dv := &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			// Get original DV phase
+			dvPhase := dv.Status.Phase
+
+			// Create PVC Prime
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Status.Phase = corev1.ClaimPending
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = reconciler.updateStatus(getReconcileRequest(uploadDataVolume), nil, reconciler)
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(dvPhase))
 		})
 	})
 })

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -454,6 +454,19 @@ var _ = Describe("Import populator tests", func() {
 			Expect(targetPvc.Annotations[AnnPopulatorProgress]).To(Equal("100.0%"))
 		})
 
+		It("should set N/A once PVC Prime is bound", func() {
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
+			pvcPrime := getPVCPrime(targetPvc, nil)
+			importPodName := fmt.Sprintf("%s-%s", common.ImporterPodName, pvcPrime.Name)
+			pvcPrime.Annotations = map[string]string{AnnImportPod: importPodName}
+			pvcPrime.Status.Phase = corev1.ClaimBound
+
+			reconciler = createImportPopulatorReconciler(targetPvc, pvcPrime, sc)
+			err := reconciler.updateImportProgress("", targetPvc, pvcPrime)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(targetPvc.Annotations[AnnPopulatorProgress]).To(Equal("N/A"))
+		})
+
 		It("should return error if no metrics in pod", func() {
 			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
 			pvcPrime := getPVCPrime(targetPvc, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With the addition of populators into CDI, we introduced a minor divergence in the DataVolume status reporting between the new and the old flow to avoid checking PVC Prime from the legacy controllers.

Though it would be ideal to ignore the PVC Prime in the DV layer completely, there are certain cases where the reported status does not match the current behavior (check https://bugzilla.redhat.com/show_bug.cgi?id=2241637 for an example).

This PR aims to update the status reporting mechanism in import and upload controllers so both the old flow and the populator flow match.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2241637

**Special notes for your reviewer**:

It would be ideal to completely ignore the PVC Prime from the DV layer, but I think this solution will help us with all the specific cases where we are reporting a status that doesn't match CDI behavior. Let me know what you think.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Improve DataVolume status reporting with populators
```

