### PR TITLE
Address error condition to avoid DataVolumeError status during VM provisioning

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -184,6 +184,9 @@ func handleImport(
 	if err != nil {
 		klog.Errorf("%+v", err)
 		if err == importer.ErrRequiresScratchSpace {
+			if err := util.WriteTerminationMessage(common.ScratchSpaceRequired); err != nil {
+				klog.Errorf("%+v", err)
+			}
 			return common.ScratchSpaceNeededExitCode
 		}
 		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error()))

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -264,6 +264,9 @@ const (
 	// PreallocationApplied is a string inserted into importer's/uploader's exit message
 	PreallocationApplied = "Preallocation applied"
 
+	// ScratchSpaceRequired is a string inserted into a pod exist message when scratch space is needed
+	ScratchSpaceRequired = "scratch space required and none found"
+
 	// SecretHeader is the key in a secret containing a sensitive extra header for HTTP data sources
 	SecretHeader = "secretHeader"
 

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -958,8 +958,11 @@ func (r *ReconcilerBase) emitFailureConditionEvent(dataVolume *cdiv1.DataVolume,
 	}
 	if curReady.Status == corev1.ConditionFalse && curRunning.Status == corev1.ConditionFalse &&
 		dvBoundOrPopulationInProgress(dataVolume, curBound) {
-		//Bound or in progress, not ready, and not running
-		if curRunning.Message != "" && (orgRunning == nil || orgRunning.Message != curRunning.Message) {
+		// Bound or in progress, not ready, and not running.
+		// Avoiding triggering an event for scratch space required since it will be addressed
+		// by CDI and sounds more drastic than it actually is.
+		if curRunning.Message != "" && curRunning.Message != common.ScratchSpaceRequired &&
+			(orgRunning == nil || orgRunning.Message != curRunning.Message) {
 			r.recorder.Event(dataVolume, corev1.EventTypeWarning, curRunning.Reason, curRunning.Message)
 		}
 	}

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -213,6 +213,27 @@ var _ = Describe("setAnnotationsFromPod", func() {
 		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
 		Expect(result[AnnPreallocationApplied]).To(Equal("true"))
 	})
+
+	It("Should handle generic error when msg is scratch space required", func() {
+		result := make(map[string]string)
+		testPod := CreateImporterTestPod(CreatePvc("test", metav1.NamespaceDefault, nil, nil), "test", nil)
+		testPod.Status = v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Message: common.ScratchSpaceRequired,
+							Reason:  common.GenericError,
+						},
+					},
+				},
+			},
+		}
+		setAnnotationsFromPodWithPrefix(result, testPod, AnnRunningCondition)
+		Expect(result[AnnRunningCondition]).To(Equal("false"))
+		Expect(result[AnnRunningConditionMessage]).To(Equal(common.ScratchSpaceRequired))
+		Expect(result[AnnRunningConditionReason]).To(Equal(ScratchSpaceRequiredReason))
+	})
 })
 
 var _ = Describe("GetPreallocation", func() {

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -70,7 +70,7 @@ type ValidationSizeError struct {
 func (e ValidationSizeError) Error() string { return e.err.Error() }
 
 // ErrRequiresScratchSpace indicates that we require scratch space.
-var ErrRequiresScratchSpace = fmt.Errorf("scratch space required and none found")
+var ErrRequiresScratchSpace = fmt.Errorf(common.ScratchSpaceRequired)
 
 // ErrInvalidPath indicates that the path is invalid.
 var ErrInvalidPath = fmt.Errorf("invalid transfer path")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When scratch space is needed during imports/uploads, the pod typically fails so it can be restarted with the required space. This is expected behavior that's automatically handled by CDI.

However, since we use an error exit code, the DataVolume condition that's triggered leads to unwanted VM statuses during provisioning in Kubevirt.

This PR aims to address this behavior by altering the condition, so kubevirt ignores it and the VM can be provisioned as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2240963

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid DataVolumeError status during VM provisioning when scratch space is required
```

