### PR TITLE
[release-v1.57] Check PVC Prime before updating DV status to improve status reporting

### DIFF
--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -245,13 +245,30 @@ func isPVCImportPopulation(pvc *corev1.PersistentVolumeClaim) bool {
 	return populators.IsPVCDataSourceRefKind(pvc, cdiv1.VolumeImportSourceRef)
 }
 
+func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
+	pvcCopy := pvc.DeepCopy()
+	if isPVCImportPopulation(pvcCopy) {
+		// Better to play it safe and check the PVC Prime too
+		// before updating DV phase.
+		nn := types.NamespacedName{Namespace: pvcCopy.Namespace, Name: populators.PVCPrimeName(pvcCopy)}
+		err := r.client.Get(context.TODO(), nn, pvcCopy)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcIsPopulated(pvcCopy, dv), nil
+}
+
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
-	importPopulation := isPVCImportPopulation(pvc)
-	if phase != string(corev1.PodSucceeded) && !importPopulation {
-		_, ok := pvc.Annotations[cc.AnnImportPod]
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcIsPopulated(pvc, dataVolumeCopy) {
-			return nil
+	if phase != string(corev1.PodSucceeded) {
+		update, err := r.shouldUpdateStatusPhase(pvc, dataVolumeCopy)
+		if !update || err != nil {
+			return err
 		}
 	}
 	dataVolumeCopy.Status.Phase = cdiv1.ImportScheduled

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -37,6 +37,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -206,11 +207,31 @@ var _ = Describe("All DataVolume Tests", func() {
 
 	var _ = Describe("Reconcile Datavolume status", func() {
 		DescribeTable("DV phase", func(testDv runtime.Object, current, expected cdiv1.DataVolumePhase, pvcPhase corev1.PersistentVolumeClaimPhase, podPhase corev1.PodPhase, ann, expectedEvent string, extraAnnotations ...string) {
+			// We first test the non-populator flow
 			scName := "testpvc"
 			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
 			storageProfile := createStorageProfile(scName, nil, BlockMode)
-
 			r := createUploadReconciler(testDv, sc, storageProfile)
+			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
+
+			// Test the populator flow, it should match
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			// Creating a valid PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = "prime-"
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[ann] = "something"
+			pvcPrime.GetAnnotations()[AnnPodPhase] = string(podPhase)
+			for i := 0; i < len(extraAnnotations); i += 2 {
+				pvcPrime.GetAnnotations()[extraAnnotations[i]] = extraAnnotations[i+1]
+			}
+			r = createUploadReconciler(testDv, sc, storageProfile, pvcPrime, csiDriver)
 			dvPhaseTest(r.ReconcilerBase, r, testDv, current, expected, pvcPhase, podPhase, ann, expectedEvent, extraAnnotations...)
 		},
 			Entry("should switch to scheduled for upload", newUploadDataVolume("test-dv"), cdiv1.Pending, cdiv1.UploadScheduled, corev1.ClaimBound, corev1.PodPending, AnnUploadRequest, "Upload into test-dv scheduled", AnnPriorityClassName, "p0-upload"),
@@ -245,6 +266,17 @@ var _ = Describe("All DataVolume Tests", func() {
 			AddAnnotation(pvc, AnnSelectedNode, "node01")
 			err = reconciler.client.Update(context.TODO(), pvc)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Create PVC Prime
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Namespace = metav1.NamespaceDefault
+			pvcPrime.Status.Phase = corev1.ClaimBound
+			pvcPrime.SetAnnotations(make(map[string]string))
+			pvcPrime.GetAnnotations()[AnnUploadRequest] = "something"
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
 			_, err = reconciler.updateStatus(getReconcileRequest(uploadDataVolume), nil, reconciler)
 			Expect(err).ToNot(HaveOccurred())
 			dv := &cdiv1.DataVolume{}
@@ -265,6 +297,44 @@ var _ = Describe("All DataVolume Tests", func() {
 				}
 			}
 			Expect(found).To(BeTrue())
+		})
+
+		It("Should not update DV phase when PVC Prime is unbound", func() {
+			scName := "testSC"
+			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")
+			csiDriver := &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "csi-plugin",
+				},
+			}
+			uploadDataVolume := newUploadDataVolume("test-dv")
+			uploadDataVolume.Spec.PVC.StorageClassName = &scName
+
+			reconciler = createUploadReconciler(sc, csiDriver, uploadDataVolume)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			dv := &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			// Get original DV phase
+			dvPhase := dv.Status.Phase
+
+			// Create PVC Prime
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			pvcPrime := &corev1.PersistentVolumeClaim{}
+			pvcPrime.Name = populators.PVCPrimeName(pvc)
+			pvcPrime.Status.Phase = corev1.ClaimPending
+			err = reconciler.client.Create(context.TODO(), pvcPrime)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = reconciler.updateStatus(getReconcileRequest(uploadDataVolume), nil, reconciler)
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(dvPhase))
 		})
 	})
 })

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -216,21 +216,36 @@ func (r *ImportPopulatorReconciler) updateImportProgress(podPhase string, pvc, p
 		cc.AddAnnotation(pvc, cc.AnnPopulatorProgress, "100.0%")
 		return nil
 	}
-	importPod, err := r.getImportPod(pvcPrime)
+
+	importPodName, ok := pvcPrime.Annotations[cc.AnnImportPod]
+	if !ok {
+		return nil
+	}
+
+	importPod, err := r.getImportPod(pvcPrime, importPodName)
 	if err != nil {
 		return err
 	}
+
+	if importPod == nil {
+		_, ok := pvc.Annotations[cc.AnnPopulatorProgress]
+		// Initialize the progress once PVC Prime is bound
+		if !ok && pvcPrime.Status.Phase == corev1.ClaimBound {
+			cc.AddAnnotation(pvc, cc.AnnPopulatorProgress, "N/A")
+		}
+		return nil
+	}
+
 	// This will only work when the import pod is running
-	if importPod != nil && importPod.Status.Phase != corev1.PodRunning {
+	if importPod.Status.Phase != corev1.PodRunning {
 		return nil
 	}
+
 	url, err := cc.GetMetricsURL(importPod)
-	if err != nil {
+	if url == "" || err != nil {
 		return err
 	}
-	if url == "" {
-		return nil
-	}
+
 	// We fetch the import progress from the import pod metrics
 	importRegExp := regexp.MustCompile("progress\\{ownerUID\\=\"" + string(pvc.UID) + "\"\\} (\\d{1,3}\\.?\\d*)")
 	httpClient = cc.BuildHTTPClient(httpClient)
@@ -247,12 +262,7 @@ func (r *ImportPopulatorReconciler) updateImportProgress(podPhase string, pvc, p
 	return nil
 }
 
-func (r *ImportPopulatorReconciler) getImportPod(pvc *corev1.PersistentVolumeClaim) (*corev1.Pod, error) {
-	importPodName, ok := pvc.Annotations[cc.AnnImportPod]
-	if !ok {
-		return nil, nil
-	}
-
+func (r *ImportPopulatorReconciler) getImportPod(pvc *corev1.PersistentVolumeClaim, importPodName string) (*corev1.Pod, error) {
 	pod := &corev1.Pod{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: importPodName, Namespace: pvc.GetNamespace()}, pod); err != nil {
 		if !k8serrors.IsNotFound(err) {

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -378,6 +378,19 @@ var _ = Describe("Import populator tests", func() {
 			Expect(targetPvc.Annotations[AnnPopulatorProgress]).To(Equal("100.0%"))
 		})
 
+		It("should set N/A once PVC Prime is bound", func() {
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
+			pvcPrime := getPVCPrime(targetPvc, nil)
+			importPodName := fmt.Sprintf("%s-%s", common.ImporterPodName, pvcPrime.Name)
+			pvcPrime.Annotations = map[string]string{AnnImportPod: importPodName}
+			pvcPrime.Status.Phase = corev1.ClaimBound
+
+			reconciler = createImportPopulatorReconciler(targetPvc, pvcPrime, sc)
+			err := reconciler.updateImportProgress("", targetPvc, pvcPrime)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(targetPvc.Annotations[AnnPopulatorProgress]).To(Equal("N/A"))
+		})
+
 		It("should return error if no metrics in pod", func() {
 			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
 			pvcPrime := getPVCPrime(targetPvc, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/2928

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Same code as the original, just removed a single line in the multi-stage import code.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Improve DataVolume status reporting with populators
```

