### PR TITLE
Add version field to the OpenAPI definition

### DIFF
--- a/pkg/apiserver/BUILD.bazel
+++ b/pkg/apiserver/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/util/openapi:go_default_library",
         "//pkg/util/tls-crypto-watch:go_default_library",
+        "//pkg/version:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1:go_default_library",
         "//vendor/github.com/emicklei/go-restful/v3:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned:go_default_library",

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -53,6 +53,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/util"
 	"kubevirt.io/containerized-data-importer/pkg/util/openapi"
 	cryptowatch "kubevirt.io/containerized-data-importer/pkg/util/tls-crypto-watch"
+	cdiversion "kubevirt.io/containerized-data-importer/pkg/version"
 )
 
 const (
@@ -494,6 +495,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 				if err != nil {
 					panic(fmt.Errorf("failed to build swagger: %s", err))
 				}
+				openapispec.Info.Version = cdiversion.Get().String()
 			})
 			writeJSONResponse(response, openapispec)
 		}))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This missing field is reported by [ZAP](https://www.zaproxy.org/) when trying to discover the CDI API: `error: attribute info.version is missing`.

Adding this field makes ZAP happy and the scan can proceed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-34683

**Special notes for your reviewer**:

I copied KubeVirt implementation (https://github.com/kubevirt/kubevirt/blob/5d8c225/pkg/virt-api/api.go#L728)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

