### PR TITLE
fix: calculate clone progress from disk usage, not apparent-size

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -36,7 +36,15 @@ if [ "$VOLUME_MODE" == "block" ]; then
     /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type blockdevice-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 else
     pushd $MOUNT_POINT
-    UPLOAD_BYTES=$(du -sb . | cut -f1)
+    if [ "$PREALLOCATION" == "true" ]; then
+        echo "Preallocating filesystem, uploading all bytes"
+        UPLOAD_BYTES=$(du -sb . | cut -f1)
+    else
+        # If we don't preallocate, we need to make sure we don't upload more than
+        # the filesystem actually contains.
+        echo "Not preallocating filesystem, uploading only used bytes"
+        UPLOAD_BYTES=$(du -s --block-size=1 . | cut -f1)
+    fi
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
     /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type filesystem-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When cloning an image from an existing DV/PVC, i found that the clone progress is not accurate. 
Because the cdi-cloner calculate the clone progress by **(transmitted Bytes)/(apparent size of disk.img) * 100**.
Actually the transmitted bytes is equal to the disk usage of the raw image file, not equal to the apparent size. 

For example：
```
/ # ls -lh /data/disk.img 
-rw-rw----    1 107      107        94.5G Nov 15 13:02 /data/disk.img

/ # qemu-img info /data/disk.img 
image: /data/disk.img
file format: raw
virtual size: 94.5 GiB (101468602368 bytes)
disk size: 30.8 GiB
Child node '/file':
    filename: /data/disk.img
    protocol type: file
    file length: 94.5 GiB (101468602368 bytes)
    disk size: 30.8 GiB

/ # du -sb /data/disk.img 
101468602368    /data/disk.img

/ # du -s --block-size=1 /data/disk.img 
33127833600     /data/disk.img 
```
**The apparent size of disk.img is 101468602368 bytes, and the disk usage of disk.img is 33127833600 bytes**. The clone progress is like this:

```
$ kubectl logs -f fa5e1a81-f0a7-4b0e-afea-b9d07e1062a2-source-pod
VOLUME_MODE=filesystem
MOUNT_POINT=/var/run/cdi/clone/source
/var/run/cdi/clone/source /
UPLOAD_BYTES=101468606464
I1115 01:59:36.693661      10 clone-source.go:220] content-type is "filesystem-clone"
I1115 01:59:36.693711      10 clone-source.go:221] mount is "/var/run/cdi/clone/source"
I1115 01:59:36.693718      10 clone-source.go:222] upload-bytes is 101468606464
I1115 01:59:36.693732      10 clone-source.go:239] Starting cloner target
I1115 01:59:36.693776      10 clone-source.go:177] Executing [/usr/bin/tar cv -S disk.img]
I1115 01:59:37.351909      10 clone-source.go:251] Set header to filesystem-clone
I1115 01:59:37.694446      10 prometheus.go:72] 0.02
I1115 01:59:39.694685      10 prometheus.go:72] 0.20
I1115 01:59:41.695241      10 prometheus.go:72] 0.37
I1115 01:59:42.695374      10 prometheus.go:72] 0.44
I1115 01:59:44.695697      10 prometheus.go:72] 0.61
I1115 01:59:51.698849      10 prometheus.go:72] 1.15
I1115 01:59:53.699458      10 prometheus.go:72] 1.30
I1115 01:59:56.699784      10 prometheus.go:72] 1.54
I1115 02:00:00.701536      10 prometheus.go:72] 1.86
I1115 02:00:03.702146      10 prometheus.go:72] 2.11
I1115 02:00:04.702813      10 prometheus.go:72] 2.19
I1115 02:00:08.704326      10 prometheus.go:72] 2.51
....
I1115 02:06:15.822381      10 prometheus.go:72] 31.60
I1115 02:06:16.823235      10 prometheus.go:72] 31.68
I1115 02:06:18.823478      10 prometheus.go:72] 31.84
I1115 02:06:20.824564      10 prometheus.go:72] 32.00
I1115 02:06:22.824785      10 prometheus.go:72] 32.16
I1115 02:06:23.825913      10 prometheus.go:72] 32.24
I1115 02:06:25.826422      10 prometheus.go:72] 32.40
I1115 02:06:27.826646      10 prometheus.go:72] 32.57
I1115 02:06:28.826721      10 prometheus.go:72] 32.65
I1115 02:06:29.186391      10 clone-source.go:127] Wrote 33155338240 bytes
I1115 02:06:29.263899      10 clone-source.go:269] Response body:
I1115 02:06:29.263934      10 clone-source.go:271] clone complete
```
We can see that when the cloning is completed, **the clone progress is far from 100%.**

**This PR is meant to solve that problem**. With this PR the clone progress will be like this:
```
$ kubectl logs -f f0d96991-95a6-4958-b2a1-91570c750f35-source-pod
VOLUME_MODE=filesystem
MOUNT_POINT=/var/run/cdi/clone/source
/var/run/cdi/clone/source /
UPLOAD_BYTES=33127833600
I1115 12:16:28.848966      10 clone-source.go:220] content-type is "filesystem-clone"
I1115 12:16:28.849064      10 clone-source.go:221] mount is "/var/run/cdi/clone/source"
I1115 12:16:28.849080      10 clone-source.go:222] upload-bytes is 33127833600
I1115 12:16:28.849103      10 clone-source.go:239] Starting cloner target
I1115 12:16:28.849183      10 clone-source.go:177] Executing [/usr/bin/tar cv -S disk.img]
I1115 12:16:29.433181      10 clone-source.go:251] Set header to filesystem-clone
I1115 12:16:29.850046      10 prometheus.go:72] 0.08
I1115 12:16:31.850982      10 prometheus.go:72] 0.63
I1115 12:16:33.851200      10 prometheus.go:72] 1.16
I1115 12:16:35.851377      10 prometheus.go:72] 1.59
I1115 12:16:38.851938      10 prometheus.go:72] 2.07
I1115 12:16:41.871247      10 prometheus.go:72] 2.80
I1115 12:16:42.871370      10 prometheus.go:72] 3.07
I1115 12:16:43.871754      10 prometheus.go:72] 3.31
I1115 12:16:46.872271      10 prometheus.go:72] 4.04
I1115 12:16:47.872544      10 prometheus.go:72] 4.27
I1115 12:16:49.873785      10 prometheus.go:72] 4.53
I1115 12:16:51.874264      10 prometheus.go:72] 5.03
I1115 12:16:52.874595      10 prometheus.go:72] 5.26
......
I1115 12:23:32.953824      10 prometheus.go:72] 95.27
I1115 12:23:33.953987      10 prometheus.go:72] 95.52
I1115 12:23:34.954130      10 prometheus.go:72] 95.77
I1115 12:23:35.954238      10 prometheus.go:72] 96.02
I1115 12:23:41.955573      10 prometheus.go:72] 97.50
I1115 12:23:42.955653      10 prometheus.go:72] 97.75
I1115 12:23:46.956175      10 prometheus.go:72] 98.75
I1115 12:23:48.956398      10 prometheus.go:72] 99.25
I1115 12:23:49.956485      10 prometheus.go:72] 99.51
I1115 12:23:50.956560      10 prometheus.go:72] 99.77
I1115 12:23:51.887828      10 clone-source.go:127] Wrote 33127874560 bytes
I1115 12:23:51.957631      10 prometheus.go:72] 100.00
I1115 12:23:52.036262      10 clone-source.go:269] Response body:
I1115 12:23:52.036304      10 clone-source.go:271] clone complete
```
**Now the clone progress is normal.**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: calculate clone progress from size on disk, not content size
```