### PR TITLE
fix(docs): registry datasource expect CA certs with .crt

### DIFF
--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -101,7 +101,7 @@ Create a `ConfigMap`  in the same namespace as the DataVolume containing all cer
 kubectl create configmap my-registry-certs --from-file=my-registry.crt
 ```
 
-The `ConfigMap` may contain multiple entries if necessary.  Key name is irrelevant.
+The `ConfigMap` may contain multiple entries if necessary.  Key name is irrelevant but should have suffix `.crt`.
 
 Add `certConfigMap` to `DataVolume` spec.
 


### PR DESCRIPTION
Registry source requires .crt suffix for CA certificates. It is a feature of the library "github.com/containers/image": See https://github.com/kubevirt/containerized-data-importer/blob/536af6b1ad3d4ee44e3e746ce850fd7d36b08e75/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go#L36

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

