### PR TITLE
Set CDI version/commit info on release images

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ try-import ci.bazelrc
 try-import user.bazelrc
 
 # Set common values for all builds (run, test and coverage inherit from build)
-build --stamp --host_force_python=PY3
+build --stamp --workspace_status_command=./hack/build/print-workspace-status.sh --host_force_python=PY3
 
 # Bazel has a rule of precedence so we can specify / overwrite architecture specific commands if needed
 build:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo

--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -23,10 +23,13 @@ go_library(
     ],
 )
 
+load("//pkg/version:def.bzl", "version_x_defs")
+
 go_binary(
     name = "cdi-apiserver",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
 )
 
 load(

--- a/hack/build/print-workspace-status.sh
+++ b/hack/build/print-workspace-status.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This command is used by bazel as the workspace_status_command
+# to implement build stamping with git information.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CDI_DIR=$(dirname "${BASH_SOURCE}")/../..
+
+source "${CDI_DIR}/hack/build/version.sh"
+cdi::version::get_version_vars
+
+# Prefix with STABLE_ so that these values are saved to stable-status.txt
+# instead of volatile-status.txt.
+# Stamped rules will be retriggered by changes to stable-status.txt, but not by
+# changes to volatile-status.txt.
+# IMPORTANT: the camelCase vars should match the lists in hack/build/version.sh
+# and pkg/version/def.bzl.
+cat <<EOF
+STABLE_BUILD_GIT_COMMIT ${CDI_GIT_COMMIT-}
+STABLE_BUILD_SCM_STATUS ${CDI_GIT_TREE_STATE-}
+STABLE_BUILD_SCM_REVISION ${CDI_GIT_VERSION-}
+STABLE_DOCKER_TAG ${CDI_GIT_VERSION/+/_}
+gitCommit ${CDI_GIT_COMMIT-}
+gitTreeState ${CDI_GIT_TREE_STATE-}
+gitVersion ${CDI_GIT_VERSION-}
+buildDate $(date \
+    ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} \
+    -u +'%Y-%m-%dT%H:%M:%SZ')
+EOF

--- a/pkg/version/def.bzl
+++ b/pkg/version/def.bzl
@@ -1,0 +1,36 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Implements hack/build/version.sh's cdi::version::ldflags() for Bazel.
+def version_x_defs():
+    # This should match the list of packages in cdi::version::ldflag
+    stamp_pkgs = [
+        "kubevirt.io/containerized-data-importer/pkg/version",
+    ]
+
+    # This should match the list of vars in cdi::version::ldflags
+    # It should also match the list of vars set in hack/build/print-workspace-status.sh.
+    stamp_vars = [
+        "buildDate",
+        "gitCommit",
+        "gitTreeState",
+        "gitVersion",
+    ]
+
+    # Generate the cross-product.
+    x_defs = {}
+    for pkg in stamp_pkgs:
+        for var in stamp_vars:
+            x_defs["%s.%s" % (pkg, var)] = "{%s}" % var
+    return x_defs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This patch sets the version information on release images built by bazel.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2979

**Special notes for your reviewer**:
I copied KubeVirt implementation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

