### PR TITLE
Update bazel-build-builder.sh

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -41,12 +41,14 @@ if ! git diff-index --quiet HEAD~1 hack/build/docker; then
     if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
         (cd ${BUILDER_SPEC} && buildah build ${BUILDAH_PLATFORM_FLAG} --manifest ${BUILDER_MANIFEST} .)
         buildah manifest push --all ${BUILDER_MANIFEST} docker://${BUILDER_MANIFEST}
+        DIGEST=$(podman inspect $(podman images | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $3 }') |  jq '.[]["Digest"]')
     else
         (cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_MANIFEST} .)
         docker push ${BUILDER_MANIFEST}
+        DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
     fi
 
-    DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
+    
     echo "Image: ${BUILDER_MANIFEST}"
     echo "Digest: ${DIGEST}"
 fi


### PR DESCRIPTION
fixes bug/issue 2999

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fixes #2999
requires that `jq` be installed with `podman` on host for building KubeVirt CDI builder container if digest information required

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2999 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:

-->
```release-note
1. requires that `jq` be installed with `podman` on host for building KubeVirt CDI builder container if digest information required and `podman` is being used to enact the build of the builder
```

