### PR TITLE
Use direct io with qemu-img convert if pod is OOMKilled

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -224,7 +224,7 @@ func writeTerminationMessage(termMsg *common.TerminationMessage) error {
 
 func newDataProcessor(contentType string, volumeMode v1.PersistentVolumeMode, ds importer.DataSourceInterface, imageSize string, filesystemOverhead float64, preallocation bool) *importer.DataProcessor {
 	dest := getImporterDestPath(contentType, volumeMode)
-	processor := importer.NewDataProcessor(ds, dest, common.ImporterDataDir, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
+	processor := importer.NewDataProcessor(ds, dest, common.ImporterDataDir, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation, os.Getenv(common.CacheMode))
 	return processor
 }
 

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -121,6 +121,8 @@ fi
 if [ -n "$DOCKER_CA_CERT_FILE" ]; then
     volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
 fi
+# add tmpfs path for testing purposes
+volumes="$volumes --tmpfs /mnt/cditmpfs"
 
 # Ensure that a bazel server is running
 if [ -z "$(${CDI_CRI} ps --format '{{.Names}}' | grep ${BAZEL_BUILDER_SERVER})" ]; then

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -141,6 +141,10 @@ const (
 	ImporterPreviousCheckpoint = "IMPORTER_PREVIOUS_CHECKPOINT"
 	// ImporterFinalCheckpoint provides a constant to capture our env variable "IMPORTER_FINAL_CHECKPOINT"
 	ImporterFinalCheckpoint = "IMPORTER_FINAL_CHECKPOINT"
+	// CacheMode provides a constant to capture our env variable "CACHE_MODE"
+	CacheMode = "CACHE_MODE"
+	// CacheModeTryNone provides a constant to capture our env variable value for "CACHE_MODE" that tries O_DIRECT writing if target supports it
+	CacheModeTryNone = "TRYNONE"
 	// Preallocation provides a constant to capture out env variable "PREALLOCATION"
 	Preallocation = "PREALLOCATION"
 	// ImportProxyHTTP provides a constant to capture our env variable "http_proxy"

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -150,8 +150,13 @@ const (
 	// AnnVddkInitImageURL saves a per-DV VDDK image URL on the PVC
 	AnnVddkInitImageURL = AnnAPIGroup + "/storage.pod.vddk.initimageurl"
 
-	// AnnRequiresScratch provides a const for our PVC requires scratch annotation
+	// AnnRequiresScratch provides a const for our PVC requiring scratch annotation
 	AnnRequiresScratch = AnnAPIGroup + "/storage.import.requiresScratch"
+
+	// AnnRequiresDirectIO provides a const for our PVC requiring direct io annotation (due to OOMs we need to try qemu cache=none)
+	AnnRequiresDirectIO = AnnAPIGroup + "/storage.import.requiresDirectIo"
+	// OOMKilledReason provides a value that container runtimes must return in the reason field for an OOMKilled container
+	OOMKilledReason = "OOMKilled"
 
 	// AnnContentType provides a const for the PVC content-type
 	AnnContentType = AnnAPIGroup + "/storage.contentType"
@@ -837,7 +842,7 @@ func GetPriorityClass(pvc *corev1.PersistentVolumeClaim) string {
 
 // ShouldDeletePod returns whether the PVC workload pod should be deleted
 func ShouldDeletePod(pvc *corev1.PersistentVolumeClaim) bool {
-	return pvc.GetAnnotations()[AnnPodRetainAfterCompletion] != "true" || pvc.GetAnnotations()[AnnRequiresScratch] == "true" || pvc.DeletionTimestamp != nil
+	return pvc.GetAnnotations()[AnnPodRetainAfterCompletion] != "true" || pvc.GetAnnotations()[AnnRequiresScratch] == "true" || pvc.GetAnnotations()[AnnRequiresDirectIO] == "true" || pvc.DeletionTimestamp != nil
 }
 
 // AddFinalizer adds a finalizer to a resource

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -101,6 +101,7 @@ type importPodEnvVar struct {
 	certConfigMapProxy string
 	extraHeaders       []string
 	secretExtraHeaders []string
+	cacheMode          string
 }
 
 type importerPodArgs struct {
@@ -378,12 +379,18 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 	if scratchSpaceRequired {
 		log.V(1).Info("Pod requires scratch space, terminating pod, and restarting with scratch space", "pod.Name", pod.Name)
 	}
+	podModificationsNeeded := scratchSpaceRequired
 
-	if pod.Status.ContainerStatuses != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated.ExitCode > 0 {
-		log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
-		r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].State.Terminated.Message)
+	if statuses := pod.Status.ContainerStatuses; len(statuses) > 0 {
+		if isOOMKilled(statuses[0]) {
+			log.V(1).Info("Pod died of an OOM, deleting pod, and restarting with qemu cache mode=none if storage supports it", "pod.Name", pod.Name)
+			podModificationsNeeded = true
+			anno[cc.AnnRequiresDirectIO] = "true"
+		}
+		if terminated := statuses[0].State.Terminated; terminated != nil && terminated.ExitCode > 0 {
+			log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", terminated.ExitCode)
+			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, terminated.Message)
+		}
 	}
 
 	if anno[cc.AnnCurrentCheckpoint] != "" {
@@ -391,10 +398,16 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 	}
 
 	anno[cc.AnnImportPod] = pod.Name
-	if !scratchSpaceRequired {
+	if !podModificationsNeeded {
 		// No scratch space required, update the phase based on the pod. If we require scratch space we don't want to update the
 		// phase, because the pod might terminate cleanly and mistakenly mark the import complete.
 		anno[cc.AnnPodPhase] = string(pod.Status.Phase)
+	}
+
+	for _, ev := range pod.Spec.Containers[0].Env {
+		if ev.Name == common.CacheMode && ev.Value == common.CacheModeTryNone {
+			anno[cc.AnnRequiresDirectIO] = "false"
+		}
 	}
 
 	// Check if the POD is waiting for scratch space, if so create some.
@@ -428,8 +441,8 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		log.V(1).Info("Updated PVC", "pvc.anno.Phase", anno[cc.AnnPodPhase], "pvc.anno.Restarts", anno[cc.AnnPodRestarts])
 	}
 
-	if cc.IsPVCComplete(pvc) || scratchSpaceRequired {
-		if !scratchSpaceRequired {
+	if cc.IsPVCComplete(pvc) || podModificationsNeeded {
+		if !podModificationsNeeded {
 			r.recorder.Event(pvc, corev1.EventTypeNormal, ImportSucceededPVC, "Import Successful")
 			log.V(1).Info("Import completed successfully")
 		}
@@ -623,6 +636,11 @@ func (r *ImportReconciler) createImportEnvVar(pvc *corev1.PersistentVolumeClaim)
 	if err != nil {
 		return nil, err
 	}
+
+	if v, ok := pvc.Annotations[cc.AnnRequiresDirectIO]; ok && v == "true" {
+		podEnvVar.cacheMode = common.CacheModeTryNone
+	}
+
 	return podEnvVar, nil
 }
 
@@ -1242,6 +1260,10 @@ func makeImportEnv(podEnvVar *importPodEnvVar, uid types.UID) []corev1.EnvVar {
 			Name:  common.Preallocation,
 			Value: strconv.FormatBool(podEnvVar.preallocation),
 		},
+		{
+			Name:  common.CacheMode,
+			Value: podEnvVar.cacheMode,
+		},
 	}
 	if podEnvVar.secretName != "" && podEnvVar.source != cc.SourceGCS {
 		env = append(env, corev1.EnvVar{
@@ -1291,4 +1313,19 @@ func makeImportEnv(podEnvVar *importPodEnvVar, uid types.UID) []corev1.EnvVar {
 		})
 	}
 	return env
+}
+
+func isOOMKilled(status v1.ContainerStatus) bool {
+	if terminated := status.State.Terminated; terminated != nil {
+		if terminated.Reason == cc.OOMKilledReason {
+			return true
+		}
+	}
+	if terminated := status.LastTerminationState.Terminated; terminated != nil {
+		if terminated.Reason == cc.OOMKilledReason {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/image/BUILD.bazel
+++ b/pkg/image/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "directio.go",
         "filefmt.go",
         "nbdkit.go",
         "qemu.go",
@@ -32,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/common:go_default_library",
         "//pkg/system:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/image/directio.go
+++ b/pkg/image/directio.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/klog/v2"
+)
+
+// DirectIOChecker checks if a certain destination supports direct I/O (bypassing page cache)
+type DirectIOChecker interface {
+	CheckBlockDevice(path string) (bool, error)
+	CheckFile(path string) (bool, error)
+}
+
+type directIOChecker struct{}
+
+// NewDirectIOChecker returns a new direct I/O checker
+func NewDirectIOChecker() DirectIOChecker {
+	return &directIOChecker{}
+}
+
+func (c *directIOChecker) CheckBlockDevice(path string) (bool, error) {
+	return c.check(path, syscall.O_RDONLY)
+}
+
+func (c *directIOChecker) CheckFile(path string) (bool, error) {
+	flags := syscall.O_RDONLY
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		// try to create the file and perform the check
+		flags = flags | syscall.O_CREAT
+		defer os.Remove(path)
+	}
+	return c.check(path, flags)
+}
+
+// based on https://github.com/kubevirt/kubevirt/blob/c4fc4ab72a868399f5331438f35b8c33e7dd0720/pkg/virt-launcher/virtwrap/converter/converter.go#L346
+func (c *directIOChecker) check(path string, flags int) (bool, error) {
+	// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
+	f, err := os.OpenFile(path, flags|syscall.O_DIRECT, 0600)
+	if err != nil {
+		// EINVAL is returned if the filesystem does not support the O_DIRECT flag
+		if perr := (&os.PathError{}); errors.As(err, &perr) && errors.Is(perr, syscall.EINVAL) {
+			// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
+			f, err := os.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
+			if err == nil {
+				defer closeIOAndCheckErr(f)
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	defer closeIOAndCheckErr(f)
+	return true, nil
+}
+
+func closeIOAndCheckErr(c io.Closer) {
+	if ferr := c.Close(); ferr != nil {
+		klog.Errorf("Error when closing file: \n%s\n", ferr)
+	}
+}

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -32,6 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/system"
 )
 
@@ -130,7 +132,9 @@ var _ = Describe("Convert to Raw", func() {
 	var tmpDir, destPath string
 
 	BeforeEach(func() {
-		tmpDir, err := os.MkdirTemp(os.TempDir(), "qemutestdest")
+		var err error
+		// dest is usually not tmpfs, stay honest in unit tests as well
+		tmpDir, err = os.MkdirTemp("/var/tmp", "qemutestdest")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 		destPath = filepath.Join(tmpDir, "dest")
@@ -144,14 +148,14 @@ var _ = Describe("Convert to Raw", func() {
 
 	It("should return no error if exec function returns no error", func() {
 		replaceExecFunction(mockExecFunction("", "", nil, "convert", "-p", "-O", "raw", "source", destPath), func() {
-			err := convertToRaw("source", destPath, false)
+			err := convertToRaw("source", destPath, false, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	It("should return conversion error if exec function returns error", func() {
 		replaceExecFunction(mockExecFunction("", "exit 1", nil, "convert", "-p", "-O", "raw", "source", destPath), func() {
-			err := convertToRaw("source", destPath, false)
+			err := convertToRaw("source", destPath, false, "")
 			Expect(err).To(HaveOccurred())
 			Expect(strings.Contains(err.Error(), "could not convert image to raw")).To(BeTrue())
 		})
@@ -161,7 +165,7 @@ var _ = Describe("Convert to Raw", func() {
 		replaceExecFunction(mockExecFunction("", "", nil, "convert", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
-			err = ConvertToRawStream(ep, destPath, false)
+			err = ConvertToRawStream(ep, destPath, false, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -170,7 +174,7 @@ var _ = Describe("Convert to Raw", func() {
 		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-o", "preallocation=falloc", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
-			err = ConvertToRawStream(ep, destPath, true)
+			err = ConvertToRawStream(ep, destPath, true, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -179,8 +183,51 @@ var _ = Describe("Convert to Raw", func() {
 		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
-			err = ConvertToRawStream(ep, destPath, false)
+			err = ConvertToRawStream(ep, destPath, false, "")
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("cache mode adjusted according to O_DIRECT support", func() {
+		var tmpFsDir string
+
+		BeforeEach(func() {
+			var err error
+
+			tmpFsDir, err = os.MkdirTemp("/mnt/cditmpfs", "qemutestdestontmpfs")
+			Expect(err).NotTo(HaveOccurred())
+			By("tmpFsDir: " + tmpFsDir)
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpFsDir)
+		})
+
+		It("should use cache=none when destination supports O_DIRECT", func() {
+			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "none", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
+				ep, err := url.Parse("/somefile/somewhere")
+				Expect(err).NotTo(HaveOccurred())
+				err = ConvertToRawStream(ep, destPath, false, common.CacheModeTryNone)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		It("should use cache=writeback when destination does not support O_DIRECT", func() {
+			// ensure tmpfs destination
+			out, err := exec.Command("/usr/bin/findmnt", "-T", tmpFsDir, "-o", "FSTYPE").CombinedOutput()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("tmpfs"))
+
+			tmpFsDestPath := filepath.Join(tmpFsDir, "dest")
+			_, err = os.Create(tmpFsDestPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", tmpFsDestPath), func() {
+				ep, err := url.Parse("/somefile/somewhere")
+				Expect(err).NotTo(HaveOccurred())
+				err = ConvertToRawStream(ep, tmpFsDestPath, false, common.CacheModeTryNone)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 })
@@ -295,7 +342,8 @@ var _ = Describe("Create blank image", func() {
 	var tmpDir, destPath string
 
 	BeforeEach(func() {
-		tmpDir, err := os.MkdirTemp(os.TempDir(), "qemutestdest")
+		var err error
+		tmpDir, err = os.MkdirTemp(os.TempDir(), "qemutestdest")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
 		destPath = filepath.Join(tmpDir, "dest")
@@ -350,12 +398,45 @@ var _ = Describe("Create blank image", func() {
 })
 
 var _ = Describe("Create preallocated blank block", func() {
+	var tmpDir, tmpFsDir, destPath string
+
+	BeforeEach(func() {
+		var err error
+		// dest is usually not tmpfs, stay honest in unit tests as well
+		tmpDir, err = os.MkdirTemp("/var/tmp", "qemutestdest")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpDir: " + tmpDir)
+		destPath = filepath.Join(tmpDir, "dest")
+		_, err = os.Create(destPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		tmpFsDir, err = os.MkdirTemp("/mnt/cditmpfs", "qemutestdestontmpfs")
+		Expect(err).NotTo(HaveOccurred())
+		By("tmpFsDir: " + tmpFsDir)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+		os.RemoveAll(tmpFsDir)
+	})
+
 	It("Should complete successfully if preallocation succeeds", func() {
 		quantity, err := resource.ParseQuantity("10Gi")
 		Expect(err).NotTo(HaveOccurred())
-		dest := "cdi-block-volume"
-		replaceExecFunction(mockExecFunction("", "", nil, "if=/dev/zero", "of="+dest, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes"), func() {
-			err = PreallocateBlankBlock(dest, quantity)
+		replaceExecFunction(mockExecFunction("", "", nil, "if=/dev/zero", "of="+destPath, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes,direct"), func() {
+			err = PreallocateBlankBlock(destPath, quantity)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("Should complete successfully with tmpfs dest without O_DIRECT if preallocation succeeds", func() {
+		tmpFsDestPath := filepath.Join(tmpFsDir, "dest")
+		_, err := os.Create(tmpFsDestPath)
+		Expect(err).NotTo(HaveOccurred())
+		quantity, err := resource.ParseQuantity("10Gi")
+		Expect(err).NotTo(HaveOccurred())
+		replaceExecFunction(mockExecFunction("", "", nil, "if=/dev/zero", "of="+tmpFsDestPath, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes"), func() {
+			err = PreallocateBlankBlock(tmpFsDestPath, quantity)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -363,11 +444,10 @@ var _ = Describe("Create preallocated blank block", func() {
 	It("Should complete successfully with value not aligned to 1MiB", func() {
 		quantity, err := resource.ParseQuantity("5243392Ki")
 		Expect(err).NotTo(HaveOccurred())
-		dest := "cdi-block-volume"
-		firstCallArgs := []string{"if=/dev/zero", "of=" + dest, "bs=1048576", "count=5120", "seek=0", "oflag=seek_bytes"}
-		secondCallArgs := []string{"if=/dev/zero", "of=" + dest, "bs=524288", "count=1", "seek=5368709120", "oflag=seek_bytes"}
+		firstCallArgs := []string{"if=/dev/zero", "of=" + destPath, "bs=1048576", "count=5120", "seek=0", "oflag=seek_bytes,direct"}
+		secondCallArgs := []string{"if=/dev/zero", "of=" + destPath, "bs=524288", "count=1", "seek=5368709120", "oflag=seek_bytes,direct"}
 		replaceExecFunction(mockExecFunctionTwoCalls("", "", nil, firstCallArgs, secondCallArgs), func() {
-			err = PreallocateBlankBlock(dest, quantity)
+			err = PreallocateBlankBlock(destPath, quantity)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -375,9 +455,8 @@ var _ = Describe("Create preallocated blank block", func() {
 	It("Should fail if preallocation fails", func() {
 		quantity, err := resource.ParseQuantity("10Gi")
 		Expect(err).NotTo(HaveOccurred())
-		dest := "cdi-block-volume"
-		replaceExecFunction(mockExecFunction("", "exit 1", nil, "if=/dev/zero", "of="+dest, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes"), func() {
-			err = PreallocateBlankBlock(dest, quantity)
+		replaceExecFunction(mockExecFunction("", "exit 1", nil, "if=/dev/zero", "of="+destPath, "bs=1048576", "count=10240", "seek=0", "oflag=seek_bytes,direct"), func() {
+			err = PreallocateBlankBlock(destPath, quantity)
 			Expect(strings.Contains(err.Error(), "Could not preallocate blank block volume at")).To(BeTrue())
 		})
 	})

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -111,10 +111,13 @@ type DataProcessor struct {
 	preallocationApplied bool
 	// phaseExecutors is a mapping from the given processing phase to its execution function. The function returns the next processing phase or error.
 	phaseExecutors map[ProcessingPhase]func() (ProcessingPhase, error)
+	// cacheMode is the mode in which we choose the qemu-img cache mode:
+	// TRY_NONE = bypass page cache if the target supports it, otherwise, fall back to using page cache
+	cacheMode string
 }
 
 // NewDataProcessor create a new instance of a data processor using the passed in data provider.
-func NewDataProcessor(dataSource DataSourceInterface, dataFile, dataDir, scratchDataDir, requestImageSize string, filesystemOverhead float64, preallocation bool) *DataProcessor {
+func NewDataProcessor(dataSource DataSourceInterface, dataFile, dataDir, scratchDataDir, requestImageSize string, filesystemOverhead float64, preallocation bool, cacheMode string) *DataProcessor {
 	dp := &DataProcessor{
 		currentPhase:       ProcessingPhaseInfo,
 		source:             dataSource,
@@ -124,6 +127,7 @@ func NewDataProcessor(dataSource DataSourceInterface, dataFile, dataDir, scratch
 		requestImageSize:   requestImageSize,
 		filesystemOverhead: filesystemOverhead,
 		preallocation:      preallocation,
+		cacheMode:          cacheMode,
 	}
 	// Calculate available space before doing anything.
 	dp.availableSpace = dp.calculateTargetSize()
@@ -265,7 +269,7 @@ func (dp *DataProcessor) convert(url *url.URL) (ProcessingPhase, error) {
 		return ProcessingPhaseError, err
 	}
 	klog.V(3).Infoln("Converting to Raw")
-	err = qemuOperations.ConvertToRawStream(url, dp.dataFile, dp.preallocation)
+	err = qemuOperations.ConvertToRawStream(url, dp.dataFile, dp.preallocation, dp.cacheMode)
 	if err != nil {
 		return ProcessingPhaseError, errors.Wrap(err, "Conversion to Raw failed")
 	}

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferScratch,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -167,7 +167,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataDir,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -181,7 +181,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferScratch,
 			transferResponse: ProcessingPhaseError,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -195,7 +195,7 @@ var _ = Describe("Data Processor", func() {
 			transferResponse: ProcessingPhaseError,
 			needsScratch:     true,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(ErrRequiresScratchSpace).To(Equal(err))
@@ -209,7 +209,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataFile,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			err := dp.ProcessData()
@@ -225,7 +225,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataFile,
 			transferResponse: ProcessingPhaseError,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewQEMUAllErrors()
 		replaceQEMUOperations(qemuOperations, func() {
 			err := dp.ProcessData()
@@ -240,7 +240,7 @@ var _ = Describe("Data Processor", func() {
 		mdp := &MockDataProvider{
 			infoResponse: ProcessingPhase("invalidphase"),
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(1).To(Equal(len(mdp.calledPhases)))
@@ -259,7 +259,7 @@ var _ = Describe("Data Processor", func() {
 			transferResponse: ProcessingPhaseConvert,
 			url:              url,
 		}
-		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.055, false, "")
 		dp.availableSpace = int64(1536000)
 		usableSpace := dp.getUsableSpace()
 
@@ -282,7 +282,7 @@ var _ = Describe("Data Processor", func() {
 			},
 			fooResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		dp.RegisterPhaseExecutor(ProcessingPhaseFoo, func() (ProcessingPhase, error) {
 			return mcdp.Foo()
 		})
@@ -304,7 +304,7 @@ var _ = Describe("Data Processor", func() {
 			},
 			fooResponse: ProcessingPhaseInfo,
 		}
-		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		dp.RegisterPhaseExecutor(ProcessingPhaseFoo, func() (ProcessingPhase, error) {
 			return mcdp.Foo()
 		})
@@ -316,7 +316,7 @@ var _ = Describe("Data Processor", func() {
 		mdp := &MockDataProvider{
 			infoResponse: "unknown",
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 	})
@@ -329,7 +329,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -344,7 +344,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, errors.New("Validation failure"), nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -359,7 +359,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(errors.New("Conversion failure"), nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -378,7 +378,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "", 0.055, false)
+		dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -400,7 +400,7 @@ var _ = Describe("Resize", func() {
 			mdp := &MockDataProvider{
 				url: url,
 			}
-			dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "1G", 0.055, false)
+			dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "1G", 0.055, false, "")
 			qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 			replaceQEMUOperations(qemuOperations, func() {
 				nextPhase, err := dp.resize()
@@ -418,7 +418,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, tmpDir, tmpDir, "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, tmpDir, tmpDir, "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -435,7 +435,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G", 0.055, false, "")
 		qemuOperations := NewQEMUAllErrors()
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -449,7 +449,7 @@ var _ = Describe("Resize", func() {
 			return int64(100000), nil
 		}, func() {
 			mdp := &MockDataProvider{}
-			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false)
+			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
 			Expect(int64(100000)).To(Equal(dp.calculateTargetSize()))
 		})
 	})
@@ -459,7 +459,7 @@ var _ = Describe("Resize", func() {
 			return int64(-1), errors.New("error")
 		}, func() {
 			mdp := &MockDataProvider{}
-			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false)
+			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
 			// We just log the error if one happens.
 			Expect(int64(-1)).To(Equal(dp.calculateTargetSize()))
 
@@ -490,7 +490,7 @@ var _ = Describe("ResizeImage", func() {
 var _ = Describe("DataProcessorResume", func() {
 	It("Should fail with an error if the data provider cannot resume", func() {
 		mdp := &MockDataProvider{}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false)
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
 		err := dp.ProcessDataResume()
 		Expect(err).To(HaveOccurred())
 	})
@@ -499,7 +499,7 @@ var _ = Describe("DataProcessorResume", func() {
 		amdp := &MockAsyncDataProvider{
 			ResumePhase: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(amdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false)
+		dp := NewDataProcessor(amdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
 		err := dp.ProcessDataResume()
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -520,7 +520,7 @@ var _ = Describe("MergeDelta", func() {
 			url:              url,
 		}
 
-		dp := NewDataProcessor(mdp, expectedBackingFile, "dataDir", "scratchDataDir", "", 0.055, false)
+		dp := NewDataProcessor(mdp, expectedBackingFile, "dataDir", "scratchDataDir", "", 0.055, false, "")
 		err := errors.New("this operation should not be called")
 		info := &image.ImgInfo{
 			Format:      "",
@@ -565,7 +565,7 @@ func NewFakeQEMUOperations(e2, e3 error, ret4 fakeInfoOpRetVal, e5 error, e6 err
 	return &fakeQEMUOperations{e2, e3, ret4, e5, e6, targetResize}
 }
 
-func (o *fakeQEMUOperations) ConvertToRawStream(*url.URL, string, bool) error {
+func (o *fakeQEMUOperations) ConvertToRawStream(*url.URL, string, bool, string) error {
 	return o.e2
 }
 

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -440,7 +440,7 @@ func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string,
 	}
 
 	uds := importer.NewAsyncUploadDataSource(newContentReader(stream, sourceContentType))
-	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
+	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation, "")
 	return processor, processor.ProcessDataWithPause()
 }
 
@@ -451,7 +451,7 @@ func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, file
 
 	// Clone block device to block device or file system
 	uds := importer.NewUploadDataSource(newContentReader(stream, sourceContentType), dvContentType)
-	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation)
+	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation, "")
 	err := processor.ProcessData()
 	return processor.PreallocationApplied(), err
 }

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -158,11 +158,11 @@ func (amd *AsyncMockDataSource) GetResumePhase() importer.ProcessingPhase {
 }
 
 func saveAsyncProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
-	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false), nil
+	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false, ""), nil
 }
 
 func saveAsyncProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
-	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false), fmt.Errorf("Error using datastream")
+	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false, ""), fmt.Errorf("Error using datastream")
 }
 
 func withAsyncProcessorSuccess(f func()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For a while now we have been switching between cache=none (direct io) and cache=writeback (page cache) for qemu-img's writes.

We have settled on cache=writeback for quite some time since https://github.com/kubevirt/containerized-data-importer/pull/1919,
however, this has proven to be problematic;
Our pod's live in a constrained memory environment (default limit 600M).
cgroupsv1 compares utilization of page cache vs the host's dirty_ratio.
This means that on a standard system (30% dirty ratio) pages only get forced to disk at 0.3 * HOST_MEM (basically never),
easily triggering OOM on hosts with lots of free memory.

cgroupsv2 does come to the rescue here:
- It considers dirty_ratio against CGROUP_MEM (forced to disk much faster, 0.3 * 600M)
- Has a new memory.high knob that throttles instead of OOM killing
Sadly, k8s is yet to capitalize on memory.high since this feature is still alpha:
https://kubernetes.io/blog/2023/05/05/qos-memory-resources/
Leaving us with no way to avoid frequent OOMs.

This PR introduces a cache=trynone behavior, in which writes bypass page cache (cache=none) if the target supports it,
otherwise, fall back to cache=writeback (use page cache).
This env var will automatically be set in case the pod fails once with an OOMKilled.

Note, there have previously been [issues](https://bugzilla.redhat.com/show_bug.cgi?id=2017262) where target did not support O_DIRECT. A quick example is tmpfs (ram-based). This is why we must have a fallback in case cache=none is not an option.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use direct io (cache=none) with qemu-img convert if target supports it
```

