### PR TITLE
Update output-bazel-arch.sh to be inclusive of s390x

### DIFF
--- a/hack/build/docker/builder/output-bazel-arch.sh
+++ b/hack/build/docker/builder/output-bazel-arch.sh
@@ -3,11 +3,14 @@ case ${PLATFORM} in
 x86_64* | i?86_64* | amd64*)
     ARCH="x86_64"
     ;;
+s390x)
+    ARCH="s390x"
+    ;;
 aarch64* | arm64*)
     ARCH="arm64"
     ;;
 *)
-    echo "invalid Arch, only support x86_64, aarch64"
+    echo "invalid Arch, only support x86_64, aarch64, s390x"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Remove key obstacle to s390x support for KubeVirt CDI Builder container 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
 s390x architecture enablement in the CDI build-the-builder container. Removes one obstacle.

**Which issue(s) this PR fixes** 
Partially Fixes #3010

**Special notes for your reviewer**:
Will still need a way to download a trusted up-to-date bazel executable for s390x into the CDI builder container and integration of all the rc files and rpm updates in order to have a fully functioning KubeVirt CDI build system. Please see https://github.com/bazelbuild/bazel/issues/10408

**Release note**:
<!--  Write your release note:
"NONE".
-->
```release-note
NONE
```

