### PR TITLE
Feature Gate and annotation for PVCs to be "adopted" by DataVolumes

### DIFF
--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/util/cert/watcher:go_default_library",
         "//pkg/util/tls-crypto-watch:go_default_library",
         "//pkg/version/verflag:go_default_library",
+        "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/kelseyhightower/envconfig:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
@@ -19,6 +20,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/cluster:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals:go_default_library",
     ],
 )

--- a/pkg/apiserver/BUILD.bazel
+++ b/pkg/apiserver/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/validation/spec:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )
 

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Auth config tests", func() {
 			common.AppKubernetesPartOfLabel:  "testing",
 			common.AppKubernetesVersionLabel: "v0.0.0-tests",
 		}
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, authConfigWatcher, cdiConfigTLSWatcher, nil, installerLabels)
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, authConfigWatcher, cdiConfigTLSWatcher, nil, installerLabels)
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)
@@ -168,7 +168,7 @@ var _ = Describe("Auth config tests", func() {
 		acw, err := NewAuthConfigWatcher(ctx, client)
 		Expect(err).ToNot(HaveOccurred())
 
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, nil, nil, map[string]string{})
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, nil, nil, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)
@@ -217,7 +217,7 @@ var _ = Describe("Auth config tests", func() {
 		ctw, err := cryptowatch.NewCdiConfigTLSWatcher(ctx, cdiClient)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, ctw, nil, map[string]string{})
+		_, err = NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, ctw, nil, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// 'Old' has TLS 1.0 as min version
@@ -256,7 +256,7 @@ var _ = Describe("Auth config tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		certWatcher := NewFakeCertWatcher()
 
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, ctw, certWatcher, map[string]string{})
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, ctw, certWatcher, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)

--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )
 
@@ -75,5 +76,6 @@ go_test(
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
     ],
 )

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
-		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
+		It("should reject DataVolume with unbound PVC and adoption featurgate set", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
-		It("should reject DataVolume with unbound PVC and adoption annotation", func() {
+		It("should accept DataVolume with unbound PVC and adoption annotation", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -248,7 +248,7 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreate(dataVolume, pvc)
-			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should accept DataVolume with PVC and adoption featurgate set", func() {
@@ -265,7 +265,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
-		It("should reject DataVolume with unbound PVC and adoption featurgate set", func() {
+		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +275,7 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
-			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should reject DataVolume with PVC adoption annotation false and featuregate set", func() {

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -247,6 +248,49 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should accept DataVolume with PVC and adoption featurgate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should reject DataVolume with PVC adoption annotation false and featuregate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "false",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -563,7 +607,7 @@ var _ = Describe("Validating Webhook", func() {
 				Name:      dataSource.Name,
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", nil, sourceRef, storage)
-			resp := validateDataVolumeCreateEx(dv, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dv, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -592,7 +636,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", snapSource, nil, storage)
-			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot})
+			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot}, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -612,7 +656,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", snapSource, nil, storage)
-			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot})
+			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot}, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -783,7 +827,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 				Spec: *newPVCSpec(pvcSizeDefault),
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		},
 			Entry("accept DataVolume with PVC and sourceRef on create", &testNamespace),
@@ -811,7 +855,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -831,7 +875,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -851,7 +895,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -1159,14 +1203,25 @@ func newPVCSpec(sizeValue int64) *corev1.PersistentVolumeClaimSpec {
 }
 
 func validateDataVolumeCreate(dv *cdiv1.DataVolume, objects ...runtime.Object) *admissionv1.AdmissionResponse {
-	return validateDataVolumeCreateEx(dv, objects, nil, nil)
+	return validateDataVolumeCreateEx(dv, objects, nil, nil, nil)
 }
 
-func validateDataVolumeCreateEx(dv *cdiv1.DataVolume, k8sObjects, cdiObjects, snapObjects []runtime.Object) *admissionv1.AdmissionResponse {
+func validateDataVolumeCreateEx(dv *cdiv1.DataVolume, k8sObjects, cdiObjects, snapObjects []runtime.Object, featureGates []string) *admissionv1.AdmissionResponse {
 	client := fakeclient.NewSimpleClientset(k8sObjects...)
 	cdiClient := cdiclientfake.NewSimpleClientset(cdiObjects...)
 	snapClient := snapclientfake.NewSimpleClientset(snapObjects...)
-	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient)
+	s := runtime.NewScheme()
+	_ = cdiv1.AddToScheme(s)
+	config := &cdiv1.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+		Spec: cdiv1.CDIConfigSpec{
+			FeatureGates: featureGates,
+		},
+	}
+	crClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(config).Build()
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient, crClient)
 
 	dvBytes, _ := json.Marshal(dv)
 	ar := &admissionv1.AdmissionReview{
@@ -1190,7 +1245,7 @@ func validateAdmissionReview(ar *admissionv1.AdmissionReview, objects ...runtime
 	client := fakeclient.NewSimpleClientset(objects...)
 	cdiClient := cdiclientfake.NewSimpleClientset()
 	snapClient := snapclientfake.NewSimpleClientset()
-	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient)
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient, nil)
 	return serve(ar, wh)
 }
 

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -195,8 +195,59 @@ var _ = Describe("Validating Webhook", func() {
 				},
 				Spec: *dataVolume.Spec.PVC,
 			}
+			pvc.Spec.VolumeName = "pv"
 			resp := validateDataVolumeCreate(dataVolume, pvc)
 			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should accept DataVolume with PVC adoption annotation", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "true",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject DataVolume with PVC adoption annotation false", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "false",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should reject DataVolume with unbound PVC and adoption annotation", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "true",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
 		})
 
 		It("should accept DataVolume with PVC source on create if PVC does not exist", func() {

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -29,11 +29,11 @@ import (
 	"time"
 
 	"github.com/appscode/jsonpatch"
-
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -52,8 +52,14 @@ type admissionHandler struct {
 }
 
 // NewDataVolumeValidatingWebhook creates a new DataVolumeValidation webhook
-func NewDataVolumeValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface, snapClient snapclient.Interface) http.Handler {
-	return newAdmissionHandler(&dataVolumeValidatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient, snapClient: snapClient})
+func NewDataVolumeValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface,
+	snapClient snapclient.Interface, controllerRuntimeClient client.Client) http.Handler {
+	return newAdmissionHandler(&dataVolumeValidatingWebhook{
+		k8sClient:               k8sClient,
+		cdiClient:               cdiClient,
+		snapClient:              snapClient,
+		controllerRuntimeClient: controllerRuntimeClient,
+	})
 }
 
 // NewDataVolumeMutatingWebhook creates a new DataVolumeMutation webhook

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2108,11 +2108,14 @@ func SetPvcAllowedAnnotations(obj metav1.Object, pvc *corev1.PersistentVolumeCla
 }
 
 // ClaimMayExistBeforeDataVolume returns true if the PVC may exist before the DataVolume
-func ClaimMayExistBeforeDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
+func ClaimMayExistBeforeDataVolume(c client.Client, pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
 	if IsUnbound(pvc) {
-		return false
+		return false, nil
 	}
-	return ClaimIsPopulatedForDataVolume(pvc, dv) || ClaimAllowsAdoption(pvc)
+	if ClaimIsPopulatedForDataVolume(pvc, dv) {
+		return true, nil
+	}
+	return ClaimAllowsAdoption(c, pvc)
 }
 
 // ClaimIsPopulatedForDataVolume returns true if the PVC is populated for the given DataVolume
@@ -2121,7 +2124,12 @@ func ClaimIsPopulatedForDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.
 }
 
 // ClaimAllowsAdoption returns true if the PVC may be adopted
-func ClaimAllowsAdoption(pvc *corev1.PersistentVolumeClaim) bool {
-	result, _ := strconv.ParseBool(pvc.Annotations[AnnAllowClaimAdoption])
-	return result
+func ClaimAllowsAdoption(c client.Client, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	anno, ok := pvc.Annotations[AnnAllowClaimAdoption]
+	// if annotation exists, go with that regardless of featuregate
+	if ok {
+		val, _ := strconv.ParseBool(anno)
+		return val, nil
+	}
+	return featuregates.NewFeatureGates(c).ClaimAdoptionEnabled()
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1209,6 +1209,9 @@ func CreatePvcInStorageClass(name, ns string, storageClassName *string, annotati
 		},
 	}
 	pvc.Status.Capacity = pvc.Spec.Resources.Requests.DeepCopy()
+	if pvc.Status.Phase == corev1.ClaimBound {
+		pvc.Spec.VolumeName = "pv-" + string(pvc.UID)
+	}
 	return pvc
 }
 

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -320,6 +320,9 @@ const (
 	AnnEventSourceKind = "cdi.kubevirt.io/events.source.kind"
 	// AnnEventSource is the source that should be related to events (namespace/name)
 	AnnEventSource = "cdi.kubevirt.io/events.source"
+
+	// AnnAllowClaimAdoption is the annotation that allows a claim to be adopted by a DataVolume
+	AnnAllowClaimAdoption = "cdi.kubevirt.io/allowClaimAdoption"
 )
 
 // Size-detection pod error codes
@@ -2099,4 +2102,23 @@ func SetPvcAllowedAnnotations(obj metav1.Object, pvc *corev1.PersistentVolumeCla
 			AddAnnotation(obj, ann, val)
 		}
 	}
+}
+
+// ClaimMayExistBeforeDataVolume returns true if the PVC may exist before the DataVolume
+func ClaimMayExistBeforeDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
+	if IsUnbound(pvc) {
+		return false
+	}
+	return ClaimIsPopulatedForDataVolume(pvc, dv) || ClaimAllowsAdoption(pvc)
+}
+
+// ClaimIsPopulatedForDataVolume returns true if the PVC is populated for the given DataVolume
+func ClaimIsPopulatedForDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
+	return pvc.Annotations[AnnPopulatedFor] == dv.Name
+}
+
+// ClaimAllowsAdoption returns true if the PVC may be adopted
+func ClaimAllowsAdoption(pvc *corev1.PersistentVolumeClaim) bool {
+	result, _ := strconv.ParseBool(pvc.Annotations[AnnAllowClaimAdoption])
+	return result
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2109,9 +2109,6 @@ func SetPvcAllowedAnnotations(obj metav1.Object, pvc *corev1.PersistentVolumeCla
 
 // ClaimMayExistBeforeDataVolume returns true if the PVC may exist before the DataVolume
 func ClaimMayExistBeforeDataVolume(c client.Client, pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
-	if IsUnbound(pvc) {
-		return false, nil
-	}
 	if ClaimIsPopulatedForDataVolume(pvc, dv) {
 		return true, nil
 	}

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,7 +459,11 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcRequiresNoWork(pvc, dataVolumeCopy) {
+		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		if err != nil {
+			return err
+		}
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || requiresNoWork {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,7 +459,7 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcIsPopulated(pvc, dataVolumeCopy) {
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcRequiresNoWork(pvc, dataVolumeCopy) {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,11 +459,11 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		requiresWork, err := r.pvcRequiresWork(pvc, dataVolumeCopy)
 		if err != nil {
 			return err
 		}
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || requiresNoWork {
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || !requiresWork {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -701,9 +701,6 @@ func (r *ReconcilerBase) validatePVC(dv *cdiv1.DataVolume, pvc *corev1.Persisten
 			return err
 		}
 		if !requiresWork {
-			if cc.IsUnbound(pvc) {
-				return fmt.Errorf("unbound populated/adoptable PVC %s/%s", pvc.Namespace, pvc.Name)
-			}
 			if err := r.addOwnerRef(pvc, dv); err != nil {
 				return err
 			}
@@ -905,8 +902,12 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 		} else {
 			switch pvc.Status.Phase {
 			case corev1.ClaimPending:
-				if err := r.updateStatusPVCPending(pvc, dvc, dataVolumeCopy, &event); err != nil {
-					return reconcile.Result{}, err
+				if requiresWork {
+					if err := r.updateStatusPVCPending(pvc, dvc, dataVolumeCopy, &event); err != nil {
+						return reconcile.Result{}, err
+					}
+				} else {
+					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
 				}
 			case corev1.ClaimBound:
 				switch dataVolumeCopy.Status.Phase {
@@ -918,12 +919,12 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					dataVolumeCopy.Status.Phase = cdiv1.PVCBound
 				}
 
-				if !requiresWork {
-					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
-				} else {
+				if requiresWork {
 					if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
 						return reconcile.Result{}, err
 					}
+				} else {
+					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
 				}
 
 			case corev1.ClaimLost:

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -696,11 +696,11 @@ func (r *ReconcilerBase) validatePVC(dv *cdiv1.DataVolume, pvc *corev1.Persisten
 	// If the PVC is not controlled by this DataVolume resource, we should log
 	// a warning to the event recorder and return
 	if !metav1.IsControlledBy(pvc, dv) {
-		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dv)
+		requiresWork, err := r.pvcRequiresWork(pvc, dv)
 		if err != nil {
 			return err
 		}
-		if requiresNoWork {
+		if !requiresWork {
 			if cc.IsUnbound(pvc) {
 				return fmt.Errorf("unbound populated/adoptable PVC %s/%s", pvc.Namespace, pvc.Name)
 			}
@@ -894,11 +894,11 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 		dataVolumeCopy.Status.ClaimName = pvc.Name
 
 		phase := pvc.Annotations[cc.AnnPodPhase]
-		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		requiresWork, err := r.pvcRequiresWork(pvc, dataVolumeCopy)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		if phase == string(cdiv1.Succeeded) && !requiresNoWork {
+		if phase == string(cdiv1.Succeeded) && requiresWork {
 			if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -918,7 +918,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					dataVolumeCopy.Status.Phase = cdiv1.PVCBound
 				}
 
-				if requiresNoWork {
+				if !requiresWork {
 					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
 				} else {
 					if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
@@ -1273,12 +1273,19 @@ func (r *ReconcilerBase) shouldUseCDIPopulator(syncState *dvSyncState) (bool, er
 	return usePopulator, nil
 }
 
-func (r *ReconcilerBase) pvcRequiresNoWork(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
+func (r *ReconcilerBase) pvcRequiresWork(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
 	if pvc == nil || dv == nil {
-		return false, nil
-	}
-	if pvcIsPopulatedForDataVolume(pvc, dv) {
 		return true, nil
 	}
-	return cc.ClaimAllowsAdoption(r.client, pvc)
+	if pvcIsPopulatedForDataVolume(pvc, dv) {
+		return false, nil
+	}
+	canAdopt, err := cc.ClaimAllowsAdoption(r.client, pvc)
+	if err != nil {
+		return true, err
+	}
+	if canAdopt {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -50,7 +50,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
-	"kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
 	"kubevirt.io/containerized-data-importer/pkg/token"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -79,6 +79,11 @@ const (
 
 var (
 	httpClient *http.Client
+
+	delayedAnnotations = []string{
+		cc.AnnPopulatedFor,
+		cc.AnnAllowClaimAdoption,
+	}
 )
 
 // Event represents DV controller event
@@ -504,6 +509,10 @@ func (r *ReconcilerBase) syncDvPvcState(log logr.Logger, req reconcile.Request, 
 		return syncState, err
 	}
 
+	if err := r.handleDelayedAnnotations(&syncState, log); err != nil || syncState.result != nil {
+		return syncState, err
+	}
+
 	if err = updateDataVolumeDefaultInstancetypeLabels(r.client, &syncState); err != nil {
 		return syncState, err
 	}
@@ -619,6 +628,37 @@ func (r *ReconcilerBase) handleStaticVolume(syncState *dvSyncState, log logr.Log
 	syncState.pvc = pvcCpy
 
 	return fmt.Errorf("DataVolume bound to unexpected PV %s", syncState.pvc.Spec.VolumeName)
+}
+
+func (r *ReconcilerBase) handleDelayedAnnotations(syncState *dvSyncState, log logr.Logger) error {
+	dataVolume := syncState.dv
+	if dataVolume.Status.Phase != cdiv1.Succeeded {
+		return nil
+	}
+
+	if syncState.pvc == nil {
+		return nil
+	}
+
+	pvcCpy := syncState.pvc.DeepCopy()
+	for _, anno := range delayedAnnotations {
+		if val, ok := dataVolume.Annotations[anno]; ok {
+			// only add if not already present
+			if _, ok := pvcCpy.Annotations[anno]; !ok {
+				cc.AddAnnotation(pvcCpy, anno, val)
+			}
+		}
+	}
+
+	if !reflect.DeepEqual(syncState.pvc, pvcCpy) {
+		if err := r.updatePVC(pvcCpy); err != nil {
+			return err
+		}
+		syncState.pvc = pvcCpy
+		syncState.result = &reconcile.Result{}
+	}
+
+	return nil
 }
 
 func (r *ReconcilerBase) getAvailableVolumesForDV(syncState *dvSyncState, log logr.Logger) ([]string, error) {
@@ -1106,6 +1146,10 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 			return nil, err
 		}
 		pvc.Annotations[cc.AnnOwnerUID] = string(dataVolume.UID)
+	}
+
+	for _, anno := range delayedAnnotations {
+		delete(pvc.Annotations, anno)
 	}
 
 	return pvc, nil

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -255,7 +255,11 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
+	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -255,7 +255,7 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcIsPopulated(pvcCopy, dv), nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -255,11 +255,11 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
 	if err != nil {
 		return false, err
 	}
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -184,6 +184,32 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.Labels[common.KubePersistentVolumeFillingUpSuppressLabelKey]).To(Equal(common.KubePersistentVolumeFillingUpSuppressLabelValue))
 		})
 
+		It("Should create a PVC on a valid import DV without delayed annotation then add on success", func() {
+			dv := NewImportDataVolume("test-dv")
+			AddAnnotation(dv, "foo", "bar")
+			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
+			reconciler = createImportReconciler(dv)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Annotations["foo"]).To(Equal("bar"))
+			Expect(pvc.Annotations).ToNot(HaveKey(AnnAllowClaimAdoption))
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			dv.Status.Phase = cdiv1.Succeeded
+			err = reconciler.client.Update(context.Background(), dv)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Annotations["foo"]).To(Equal("bar"))
+			Expect(pvc.Annotations[AnnAllowClaimAdoption]).To(Equal("true"))
+		})
+
 		It("Should fail if dv source not import when use populators", func() {
 			scName := "testSC"
 			sc := CreateStorageClassWithProvisioner(scName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, "csi-plugin")

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -254,12 +254,12 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	datavolume := syncRes.dvMutated
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
-	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	requiresWork, err := r.pvcRequiresWork(pvc, datavolume)
 	if err != nil {
 		return syncRes, err
 	}
 
-	if requiresNoWork || prePopulated || staticProvisionPending {
+	if !requiresWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -252,9 +252,12 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	pvc := syncRes.pvc
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
-	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
+	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	if err != nil {
+		return syncRes, err
+	}
 
 	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -252,11 +252,11 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	pvc := syncRes.pvc
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
-	pvcPopulated := pvcIsPopulated(pvc, datavolume)
+	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
 
-	if pvcPopulated || prePopulated || staticProvisionPending {
+	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -185,9 +185,12 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
 
-	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
+	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	if err != nil {
+		return syncRes, err
+	}
 
 	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -187,12 +187,12 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	requiresWork, err := r.pvcRequiresWork(pvc, datavolume)
 	if err != nil {
 		return syncRes, err
 	}
 
-	if requiresNoWork || prePopulated || staticProvisionPending {
+	if !requiresWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -185,11 +185,11 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
 
-	pvcPopulated := pvcIsPopulated(pvc, datavolume)
+	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
 
-	if pvcPopulated || prePopulated || staticProvisionPending {
+	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -211,11 +211,11 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
 	if err != nil {
 		return false, err
 	}
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -211,7 +211,11 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
+	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -211,7 +211,7 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcIsPopulated(pvcCopy, dv), nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1141,10 +1141,15 @@ func createImportTestEnv(podEnvVar *importPodEnvVar, uid string) []corev1.EnvVar
 
 type FakeFeatureGates struct {
 	honorWaitForFirstConsumerEnabled bool
+	claimAdoptionEnabled             bool
 }
 
 func (f *FakeFeatureGates) HonorWaitForFirstConsumerEnabled() (bool, error) {
 	return f.honorWaitForFirstConsumerEnabled, nil
+}
+
+func (f *FakeFeatureGates) ClaimAdoptionEnabled() (bool, error) {
+	return f.claimAdoptionEnabled, nil
 }
 
 func createPendingPvc(name, ns string, annotations, labels map[string]string) *v1.PersistentVolumeClaim {

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Import populator tests", func() {
 		})
 
 		DescribeTable("Should create PVC Prime with proper import annotations", func(key, value, expectedValue string) {
-			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, map[string]string{}, nil, corev1.ClaimBound)
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, map[string]string{}, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = dataSourceRef
 			targetPvc.Annotations[key] = value
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
@@ -396,7 +396,7 @@ var _ = Describe("Import populator tests", func() {
 		)
 
 		It("Should set multistage migration annotations on PVC prime", func() {
-			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = dataSourceRef
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
 			volumeImportSource.Spec.Source = &cdiv1.ImportSourceType{

--- a/pkg/feature-gates/feature-gates.go
+++ b/pkg/feature-gates/feature-gates.go
@@ -14,12 +14,19 @@ import (
 const (
 	// HonorWaitForFirstConsumer - if enabled will not schedule worker pods on a storage with WaitForFirstConsumer binding mode
 	HonorWaitForFirstConsumer = "HonorWaitForFirstConsumer"
+
+	// DataVolumeClaimAdoption - if enabled will allow PVC to be adopted by a DataVolume
+	// it is not an error if PVC of sam name exists before DataVolume is created
+	DataVolumeClaimAdoption = "DataVolumeClaimAdoption"
 )
 
 // FeatureGates is a util for determining whether an optional feature is enabled or not.
 type FeatureGates interface {
 	// HonorWaitForFirstConsumerEnabled - see the HonorWaitForFirstConsumer const
 	HonorWaitForFirstConsumerEnabled() (bool, error)
+
+	// ClaimAdoptionEnabled - see the DataVolumeClaimAdoption const
+	ClaimAdoptionEnabled() (bool, error)
 }
 
 // CDIConfigFeatureGates is a util for determining whether an optional feature is enabled or not.
@@ -58,4 +65,9 @@ func (f *CDIConfigFeatureGates) getConfig() ([]string, error) {
 // HonorWaitForFirstConsumerEnabled - see the HonorWaitForFirstConsumer const
 func (f *CDIConfigFeatureGates) HonorWaitForFirstConsumerEnabled() (bool, error) {
 	return f.isFeatureGateEnabled(HonorWaitForFirstConsumer)
+}
+
+// ClaimAdoptionEnabled - see the DataVolumeClaimAdoption const
+func (f *CDIConfigFeatureGates) ClaimAdoptionEnabled() (bool, error) {
+	return f.isFeatureGateEnabled(DataVolumeClaimAdoption)
 }

--- a/pkg/feature-gates/feature-gates_test.go
+++ b/pkg/feature-gates/feature-gates_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Feature Gates", func() {
 		Expect(featureGates.HonorWaitForFirstConsumerEnabled()).To(BeFalse())
 	})
 
-	It("Should reflect config changes", func() {
+	It("Should reflect HonorWaitForFirstConsumer config changes", func() {
 		featureGates, client := createFeatureGatesAndClient()
 		cdiConfig := &cdiv1.CDIConfig{}
 		err := client.Get(context.TODO(), types.NamespacedName{Name: common.ConfigName}, cdiConfig)
@@ -55,6 +55,24 @@ var _ = Describe("Feature Gates", func() {
 		err = client.Update(context.TODO(), cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(featureGates.HonorWaitForFirstConsumerEnabled()).To(BeFalse())
+	})
+
+	It("Should reflect DataVolumeClaimAdoption config changes", func() {
+		featureGates, client := createFeatureGatesAndClient()
+		cdiConfig := &cdiv1.CDIConfig{}
+		err := client.Get(context.TODO(), types.NamespacedName{Name: common.ConfigName}, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		// update the config on the status not the spec
+		cdiConfig.Spec.FeatureGates = []string{DataVolumeClaimAdoption}
+		err = client.Update(context.TODO(), cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(featureGates.ClaimAdoptionEnabled()).To(BeTrue())
+
+		cdiConfig.Spec.FeatureGates = nil
+		err = client.Update(context.TODO(), cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(featureGates.ClaimAdoptionEnabled()).To(BeFalse())
 	})
 })
 

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -155,6 +155,19 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
 				"cdis/finalizers",
 			},
 			Verbs: []string{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "adopt-volume_test.go",
         "api_validation_test.go",
         "apiserver_test.go",
         "badserver_test.go",

--- a/tests/adopt-volume_test.go
+++ b/tests/adopt-volume_test.go
@@ -1,0 +1,218 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var _ = Describe("PVC adoption tests", func() {
+	f := framework.NewFramework("adoption-test")
+
+	Context("with available PVC", func() {
+		const (
+			dvName = "testdv"
+			dvSize = "1Gi"
+		)
+
+		var (
+			storageClass *string
+			volumeMode   *corev1.PersistentVolumeMode
+		)
+
+		importDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithHTTPImport(dvName, dvSize, fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+		}
+
+		uploadDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForUpload(dvName, dvSize)
+		}
+
+		cloneDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForImageCloning(dvName, dvSize, "default", "foo", storageClass, volumeMode)
+		}
+
+		snapshotCloneDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForSnapshotCloning(dvName, dvSize, "default", "foo", storageClass, volumeMode)
+		}
+
+		populatorDef := func() *cdiv1.DataVolume {
+			dataSourceRef := &corev1.TypedObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: "doesnotmatter",
+			}
+			return utils.NewDataVolumeWithExternalPopulation(dvName, dvSize, *storageClass, *volumeMode, nil, dataSourceRef)
+		}
+
+		BeforeEach(func() {
+			By("Creating source DV")
+			// source here shouldn't matter
+			dvDef := importDef()
+			controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for source DV to succeed")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
+			err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			storageClass = pvc.Spec.StorageClassName
+			volumeMode = pvc.Spec.VolumeMode
+
+			By("Retaining PVC")
+			Eventually(func() error {
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if len(pvc.OwnerReferences) > 0 {
+					pvc.OwnerReferences = nil
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			}, timeout, pollingInterval).Should(BeNil())
+
+			By("Deleting source DV")
+			err = utils.DeleteDataVolume(f.CdiClient, dv.Namespace, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("with annotation on PVC", Serial, func() {
+			var disabledFeatureGate bool
+
+			BeforeEach(func() {
+				By("Disabling featuregate")
+				alreadyEnabled, err := utils.DisableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+				disabledFeatureGate = *alreadyEnabled
+			})
+
+			AfterEach(func() {
+				if !disabledFeatureGate {
+					return
+				}
+				By("Enabling featuregate")
+				_, err := utils.EnableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("it should get adopted", func(defFunc func() *cdiv1.DataVolume) {
+				var pvcUID string
+				By("Adding annotation to PVC")
+				Eventually(func() error {
+					pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					controller.AddAnnotation(pvc, controller.AnnAllowClaimAdoption, "true")
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+					pvcUID = string(pvc.UID)
+					return nil
+				}, timeout, pollingInterval).Should(BeNil())
+
+				By("Creating target DV")
+				dvDef := defFunc()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for target DV to succeed")
+				err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(pvc.UID)).To(Equal(pvcUID))
+			},
+				Entry("with import source", importDef),
+				Entry("with upload source", uploadDef),
+				Entry("with clone source", cloneDef),
+				Entry("with snapshot clone source", snapshotCloneDef),
+				Entry("with populator source", populatorDef),
+			)
+		})
+
+		Context("with featuregate enabled", Serial, func() {
+			var setFeatureGate bool
+
+			BeforeEach(func() {
+				By("Enabling featuregate")
+				alreadyEnabled, err := utils.EnableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+				setFeatureGate = !*alreadyEnabled
+			})
+
+			AfterEach(func() {
+				if !setFeatureGate {
+					return
+				}
+				By("Disabling featuregate")
+				_, err := utils.DisableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("it should get adopted", func(defFunc func() *cdiv1.DataVolume) {
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				pvcUID := string(pvc.UID)
+
+				By("Creating target DV")
+				dvDef := defFunc()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for target DV to succeed")
+				err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
+				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(pvc.UID)).To(Equal(pvcUID))
+			},
+				Entry("with import source", importDef),
+				Entry("with upload source", uploadDef),
+				Entry("with clone source", cloneDef),
+				Entry("with snapshot clone source", snapshotCloneDef),
+				Entry("with populator source", populatorDef),
+			)
+
+			It("should not be adopted if annotation says not to", func() {
+				By("Adding annotation to PVC")
+				Eventually(func() error {
+					pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					controller.AddAnnotation(pvc, controller.AnnAllowClaimAdoption, "false")
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+					return nil
+				}, timeout, pollingInterval).Should(BeNil())
+
+				By("Creating target DV")
+				dvDef := importDef()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				_, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("already exists"))
+			})
+		})
+	})
+})

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -39,6 +39,10 @@ func (f *Framework) CreateBoundPVCFromDefinition(def *k8sv1.PersistentVolumeClai
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	f.ForceBindIfWaitForFirstConsumer(pvc)
+	err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, k8sv1.ClaimBound, pvc.Name)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	pvc, err = utils.FindPVC(f.K8sClient, pvc.Namespace, pvc.Name)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return pvc
 }
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -958,6 +958,10 @@ var _ = Describe("Block PV upload Test", Serial, func() {
 	f := framework.NewFramework(namespacePrefix)
 
 	BeforeEach(func() {
+		if !f.IsBlockVolumeStorageClassAvailable() {
+			Skip("Storage Class for block volume is not available")
+		}
+
 		if pvc != nil {
 			Eventually(func() bool {
 				// Make sure the pvc doesn't still exist. The after each should have called delete.
@@ -995,10 +999,6 @@ var _ = Describe("Block PV upload Test", Serial, func() {
 	})
 
 	DescribeTable("should", func(validToken bool, expectedStatus int) {
-		if !f.IsBlockVolumeStorageClassAvailable() {
-			Skip("Storage Class for block volume is not available")
-		}
-
 		By("Verify PVC annotation says ready")
 		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In many DR/backup scenarios, a PVC may exist before a DataVolume.  Usually that results in an error when the DataVolume is created.  This PR provides two new mechanisms to avoid that error and allow the DataVolume controller to "adopt" an existing PVC.  Adoption of a PVC means that the DataVolume will immediately go to Succeeded state and not attempt to write any data to the PVC.

**DataVolumeClaimAdoption** feature gate:  This is a global setting to configure claim adoption for all PVCs in the system

**cdi.kubevirt.io/allowClaimAdoption** PVC annotation: This overrides any feature gate setting and and allows for one-off claim adoption.  It is also possible to add this annotation to PVCs indirectly when creating a DataVolume (PVCs inherit DataVolume annotations).  But there are some subtleties there.  To avoid a chicken/egg problem must be applied after the new DataVolume has succeeded.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DataVolume supports PVC adoption via DataVolumeClaimAdoption feature gate and cdi.kubevirt.io/allowClaimAdoption annotation on PVC
```

