### PR TITLE
Grant ns admin missing create RBAC for various CDI resources

### DIFF
--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -42,6 +42,11 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 			},
 			Resources: []string{
 				"datavolumes",
+				"dataimportcrons",
+				"datasources",
+				"volumeimportsources",
+				"volumeuploadsources",
+				"volumeclonesources",
 			},
 			Verbs: []string{
 				"*",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -217,6 +215,11 @@ var _ = Describe("Aggregated role definition tests", Serial, func() {
 			},
 			Resources: []string{
 				"datavolumes",
+				"dataimportcrons",
+				"datasources",
+				"volumeimportsources",
+				"volumeuploadsources",
+				"volumeclonesources",
 			},
 			Verbs: []string{
 				"*",
@@ -289,16 +292,7 @@ var _ = Describe("Aggregated role definition tests", Serial, func() {
 		clusterRole, err := f.K8sClient.RbacV1().ClusterRoles().Get(context.TODO(), role, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, expectedRule := range rules {
-			found := false
-			for _, r := range clusterRole.Rules {
-				if reflect.DeepEqual(expectedRule, r) {
-					found = true
-					break
-				}
-			}
-			Expect(found).To(BeTrue(), fmt.Sprintf("Rule for resources %v should exist", expectedRule.Resources))
-		}
+		Expect(clusterRole.Rules).To(ContainElements(rules))
 	},
 		Entry("[test_id:3945]for admin", "admin", adminRules),
 		Entry("[test_id:3946]for edit", "edit", editRules),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently a (non-cluster-admin) namespace admin cannot create various CDI user-facing resources,
this PR grants the missing permissions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-36309

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: ns admin cannot create multiple user-facing CDI resources
```

