### PR TITLE
Fix flakiness in waitForStorageProfileMetricInit

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -97,7 +97,7 @@ fi
     export TESTS_WORKDIR=${CDI_DIR}/tests
     ginkgo_args="--trace --timeout=8h"
     if [[ -n "$CDI_E2E_FOCUS" || -n "$CDI_E2E_SKIP" ]]; then
-        ginkgo_args="${ginkgo_args} --nodes=3"
+        ginkgo_args="${ginkgo_args} --nodes=3 --v"
     else
         ginkgo_args="${ginkgo_args} --v"
     fi

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -88,7 +88,7 @@ func GetRecordRulesDesc(namespace string) []RecordRulesDesc {
 				"The number of CDI import pods with high restart count",
 				"Gauge",
 			},
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s)", common.ImporterPodName, common.ImporterPodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.ImporterPodName, common.ImporterPodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
 		},
 		{
 			MetricOpts{
@@ -96,7 +96,7 @@ func GetRecordRulesDesc(namespace string) []RecordRulesDesc {
 				"The number of CDI upload server pods with high restart count",
 				"Gauge",
 			},
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s)", common.UploadPodName, common.UploadServerPodname, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.UploadPodName, common.UploadServerPodname, strconv.Itoa(common.UnusualRestartCountThreshold)),
 		},
 		{
 			MetricOpts{
@@ -104,7 +104,7 @@ func GetRecordRulesDesc(namespace string) []RecordRulesDesc {
 				"The number of CDI clone pods with high restart count",
 				"Gauge",
 			},
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'.*%s', container='%s'} > %s)", common.ClonerSourcePodNameSuffix, common.ClonerSourcePodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'.*%s', container='%s'} > %s) or on() vector(0)", common.ClonerSourcePodNameSuffix, common.ClonerSourcePodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
 		},
 	}
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -49,7 +49,8 @@ const (
 	nsDeleteTime = 5 * time.Minute
 	//NsPrefixLabel provides a cdi prefix label to identify the test namespace
 	NsPrefixLabel = "cdi-e2e"
-	cdiPodPrefix  = "cdi-deployment"
+	//CdiPodPrefix provides the cdi-deployment pod prefix
+	CdiPodPrefix = "cdi-deployment"
 )
 
 // run-time flags
@@ -161,7 +162,7 @@ func (f *Framework) BeforeEach() {
 	}
 
 	if f.ControllerPod == nil {
-		pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiPodPrefix, common.CDILabelSelector)
+		pod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, CdiPodPrefix, common.CDILabelSelector)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Located cdi-controller-pod: %q\n", pod.Name)
 		f.ControllerPod = pod

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -953,6 +953,10 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 	})
 
 	It("[test_id:3996] Import datavolume with bad url will increase dv retry count", func() {
+		if f.IsPrometheusAvailable() {
+			dataVolumeNoUnusualRestartTest(f)
+		}
+
 		dvName := "import-dv-bad-url"
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))
 		dv := utils.NewDataVolumeWithHTTPImport(dvName, "100Mi", invalidQcowImagesURL())

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -522,6 +522,15 @@ func dataVolumeUnusualRestartTest(f *framework.Framework) {
 	waitForPrometheusAlert(f, "CDIDataVolumeUnusualRestartCount")
 }
 
+func dataVolumeNoUnusualRestartTest(f *framework.Framework) {
+	By("Test metric for no unusual restart count")
+	Eventually(func() bool {
+		return getMetricValue(f, "kubevirt_cdi_import_pods_high_restart") == 0
+	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+
+	waitForNoPrometheusAlert(f, "CDIDataVolumeUnusualRestartCount")
+}
+
 // Helper functions
 
 // getMetricValue returns the metric value, or the sum in case of multiple values (GaugeVec)


### PR DESCRIPTION
**What this PR does / why we need it**:
If CDI CR was deleted and re-created, the metric may have old instances of the old cdi-deployment pod IP.
Also added alerts Polarion test_ids and restore ginkgo output verbosity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

