### PR TITLE
Extract regular files as well during clone from filesystem

### DIFF
--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -485,7 +485,11 @@ func untarToBlockdev(stream io.Reader, dest string) error {
 		case header == nil:
 			continue
 		}
-		if header.Typeflag == tar.TypeGNUSparse && strings.Contains(header.Name, common.DiskImageName) {
+		if !strings.Contains(header.Name, common.DiskImageName) {
+			continue
+		}
+		switch header.Typeflag {
+		case tar.TypeReg, tar.TypeGNUSparse:
 			klog.Infof("Untaring %d bytes to %s", header.Size, dest)
 			f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, os.ModeDevice|os.ModePerm)
 			if err != nil {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -430,7 +430,7 @@ var _ = Describe("all clone tests", func() {
 				completeClone(f, f.Namespace, targetPvc, filepath.Join(testBaseDir, testFile), fillDataFSMD5sum, "")
 			})
 
-			It("[test_id:cnv-5569]Should clone data from filesystem to block", func() {
+			DescribeTable("Should clone data from filesystem to block", func(preallocate bool) {
 				if !f.IsBlockVolumeStorageClassAvailable() {
 					Skip("Storage Class for block volume is not available")
 				}
@@ -445,6 +445,9 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				targetDV := utils.NewDataVolumeCloneToBlockPV("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, f.BlockSCName)
+				if preallocate {
+					targetDV.Spec.Preallocation = ptr.To[bool](true)
+				}
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				targetPvc, err := utils.WaitForPVC(f.K8sClient, targetDataVolume.Namespace, targetDataVolume.Name)
@@ -474,9 +477,12 @@ var _ = Describe("all clone tests", func() {
 				By("Deleting verifier pod")
 				err = utils.DeleteVerifierPod(f.K8sClient, f.Namespace.Name)
 				Expect(err).ToNot(HaveOccurred())
-			})
+			},
+				Entry("[test_id:5569]regular target", false),
+				Entry("[test_id:XXXX]preallocated target", true),
+			)
 
-			It("[test_id:cnv-5570]Should clone data from block to filesystem", func() {
+			It("[test_id:5570]Should clone data from block to filesystem", func() {
 				if !f.IsBlockVolumeStorageClassAvailable() {
 					Skip("Storage Class for block volume is not available")
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes the tar entry will not be sparse:
- Preallocated target
- CephFS way of reporting sparse files - https://docs.ceph.com/en/latest/cephfs/posix/

In those cases we still want to grab the disk image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-36684

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Cephfs to Block cloning is creating empty block device
```

