### PR TITLE
document enablement of podman socket in README.md

### DIFF
--- a/cluster-up/README.md
+++ b/cluster-up/README.md
@@ -4,6 +4,15 @@ This directory provides a wrapper around gocli. It can be vendored into other
 git repos and integrated to provide in the kubevirt well-known cluster commands
 like `make cluster-up` and `make cluster-down`.
 
+In order to use `make cluster-up` with `podman` you need to enable podman sockets by running 
+```
+systemctl start podman.socket
+```
+as root. If you need this configuration to persist beyond a system reboot, also:
+```
+systemctl enable podman.socket
+```
+
 In order to properly use it, one has to vendor this folder from a git tag,
 which can be found on the github release page.
 


### PR DESCRIPTION
This addresses issue #3052

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The enablement of podman socket on the test host should be documented. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3052 

**Special notes for your reviewer**:
we ran into this setting up an external CI/CD system for s390x but it applies to all platforms where `podman` is in use over `docker`.  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

