### PR TITLE
Fix DataImportCron PVC GC race and test flakiness

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -57,7 +57,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	cdv "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
-	"kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
 	"kubevirt.io/containerized-data-importer/pkg/operator"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 	"kubevirt.io/containerized-data-importer/pkg/util/naming"
@@ -1254,6 +1254,7 @@ func (r *DataImportCronReconciler) newSourceDataVolume(cron *cdiv1.DataImportCro
 	dv.Namespace = cron.Namespace
 	r.setDataImportCronResourceLabels(cron, dv)
 	cc.AddAnnotation(dv, cc.AnnImmediateBinding, "true")
+	cc.AddAnnotation(dv, AnnLastUseTime, time.Now().UTC().Format(time.RFC3339Nano))
 	passCronAnnotationToDv(cron, dv, cc.AnnPodRetainAfterCompletion)
 
 	for _, defaultInstanceTypeLabel := range cc.DefaultInstanceTypeLabels {

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -512,9 +512,11 @@ var _ = Describe("DataImportCron", Serial, func() {
 			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			pvcList, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pvcList.Items).To(HaveLen(garbageSources + 1))
+			Eventually(func() []corev1.PersistentVolumeClaim {
+				pvcList, err := f.K8sClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return pvcList.Items
+			}, dataImportCronTimeout, pollingInterval).Should(HaveLen(garbageSources + 1))
 		case cdiv1.DataImportCronSourceFormatSnapshot:
 			snapshots := &snapshotv1.VolumeSnapshotList{}
 			err := f.CrClient.List(context.TODO(), snapshots, &client.ListOptions{Namespace: ns})


### PR DESCRIPTION
**What this PR does / why we need it**:
PVC should be timestamped in creation and not only upon import completion, as it might be mistakenly GCed. LRU sort will choose PVC with empty timestamp as the first candidate for deletion. The PVC will be recreated by the controller and eventually timestamped, so this bug was hidden for a while.

**Which issue(s) this PR fixes**:
Fixes CNV-36896

**Release note**:
```release-note
Fix DataImportCron PVC timestamping for garbage collection
```