### PR TITLE
[WIP] Set importer restart policy to never to avoid race condition during termination

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -187,7 +187,7 @@ func handleImport(
 			if err := util.WriteTerminationMessage(common.ScratchSpaceRequired); err != nil {
 				klog.Errorf("%+v", err)
 			}
-			return common.ScratchSpaceNeededExitCode
+			return 0
 		}
 		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error()))
 		if err != nil {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -371,16 +371,18 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 	setAnnotationsFromPodWithPrefix(anno, pod, cc.AnnRunningCondition)
 
 	scratchExitCode := false
+	failedPod := false
 	if pod.Status.ContainerStatuses != nil &&
-		pod.Status.ContainerStatuses[0].LastTerminationState.Terminated != nil &&
-		pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode > 0 {
-		log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode)
-		if pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode == common.ScratchSpaceNeededExitCode {
+		pod.Status.ContainerStatuses[0].State.Terminated != nil &&
+		pod.Status.ContainerStatuses[0].State.Terminated.ExitCode > 0 {
+		log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
+		failedPod = true
+		if pod.Status.ContainerStatuses[0].State.Terminated.ExitCode == common.ScratchSpaceNeededExitCode {
 			log.V(1).Info("Pod requires scratch space, terminating pod, and restarting with scratch space", "pod.Name", pod.Name)
 			scratchExitCode = true
 			anno[cc.AnnRequiresScratch] = "true"
 		} else {
-			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.Message)
+			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].State.Terminated.Message)
 		}
 	}
 
@@ -423,12 +425,12 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		log.V(1).Info("Updated PVC", "pvc.anno.Phase", anno[cc.AnnPodPhase], "pvc.anno.Restarts", anno[cc.AnnPodRestarts])
 	}
 
-	if cc.IsPVCComplete(pvc) || scratchExitCode {
-		if !scratchExitCode {
+	if cc.IsPVCComplete(pvc) || failedPod {
+		if cc.IsPVCComplete(pvc) {
 			r.recorder.Event(pvc, corev1.EventTypeNormal, ImportSucceededPVC, "Import Successful")
 			log.V(1).Info("Import completed successfully")
 		}
-		if cc.ShouldDeletePod(pvc) {
+		if cc.ShouldDeletePod(pvc) || failedPod {
 			log.V(1).Info("Deleting pod", "pod.Name", pod.Name)
 			if err := r.cleanup(pvc, pod, log); err != nil {
 				return err
@@ -930,7 +932,7 @@ func makeNodeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 					},
 				},
 			},
-			RestartPolicy:     corev1.RestartPolicyOnFailure,
+			RestartPolicy:     corev1.RestartPolicyNever,
 			Volumes:           volumes,
 			NodeSelector:      args.workloadNodePlacement.NodeSelector,
 			Tolerations:       args.workloadNodePlacement.Tolerations,
@@ -1049,7 +1051,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			Containers: []corev1.Container{
 				*importerContainer,
 			},
-			RestartPolicy:     corev1.RestartPolicyOnFailure,
+			RestartPolicy:     corev1.RestartPolicyNever,
 			Volumes:           volumes,
 			NodeSelector:      args.workloadNodePlacement.NodeSelector,
 			Tolerations:       args.workloadNodePlacement.Tolerations,

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -540,17 +540,10 @@ var _ = Describe("Update PVC from POD", func() {
 			Phase: corev1.PodPending,
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					LastTerminationState: corev1.ContainerState{
+					State: v1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: common.ScratchSpaceNeededExitCode,
 							Message:  "scratch space needed",
-						},
-					},
-					State: v1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: 1,
-							Message:  "I went poof",
-							Reason:   "Explosion",
 						},
 					},
 				},
@@ -571,9 +564,6 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundCondition]).To(Equal("false"))
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionMessage]).To(Equal("Creating scratch space"))
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionReason]).To(Equal(creatingScratch))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningCondition]).To(Equal("false"))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningConditionMessage]).To(Equal("I went poof"))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningConditionReason]).To(Equal("Explosion"))
 	})
 
 	It("Should mark PVC as waiting for VDDK configmap, if not already present", func() {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -542,8 +542,8 @@ var _ = Describe("Update PVC from POD", func() {
 				{
 					State: v1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: common.ScratchSpaceNeededExitCode,
-							Message:  "scratch space needed",
+							ExitCode: 0,
+							Message:  common.ScratchSpaceRequired,
 						},
 					},
 				},
@@ -673,8 +673,8 @@ var _ = Describe("Update PVC from POD", func() {
 				{
 					LastTerminationState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: common.ScratchSpaceNeededExitCode,
-							Message:  "",
+							ExitCode: 0,
+							Message:  common.ScratchSpaceRequired,
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is an alternative to https://github.com/kubevirt/containerized-data-importer/pull/3044.

This pull request changes the importer restart policy from "on failure" to "never". The old behavior caused some issues during termination while the pod was already restarting after scratchSpaceNeeded.

Importer pod lifecycle for a regular DV before the fix:

```sh
# k get pod importer-cirros-dv-source -woyaml | grep exitCode
selecting docker as container runtime
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 2
        exitCode: 42
        exitCode: 2
        exitCode: 42
        exitCode: 2
        exitCode: 0
        exitCode: 0
```

After the fix:

```sh
# k get pod importer-cirros-dv-source -woyaml | grep exitCode
selecting docker as container runtime
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 0
        exitCode: 0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2240963 (follow-up)

**Special notes for your reviewer**:

Let's see how tests behave and decide which option is better.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid race condition during importer termination
```

