### PR TITLE
Fix DataImportCron import DataVolume creation when last import is not found

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -363,7 +363,8 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 		importSucceeded = true
 	} else {
 		if len(imports) > 0 {
-			dataImportCron.Status.CurrentImports = imports[1:]
+			imports = imports[1:]
+			dataImportCron.Status.CurrentImports = imports
 		}
 		updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, "No current import", noImport)
 	}

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -464,6 +464,38 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Entry("empty schedule", emptySchedule, "should succeed with an empty schedule"),
 		)
 
+		It("Should recreate DataVolume if the last import was deleted", func() {
+			cron = newDataImportCron(cronName)
+			cron.Annotations[AnnSourceDesiredDigest] = testDigest
+			reconciler = createDataImportCronReconciler(cron)
+
+			_, err := reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), cronKey, cron)
+			Expect(err).ToNot(HaveOccurred())
+
+			imports := cron.Status.CurrentImports
+			Expect(imports).ToNot(BeEmpty())
+			dvName := imports[0].DataVolumeName
+			Expect(dvName).ToNot(BeEmpty())
+
+			dv := &cdiv1.DataVolume{}
+			err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Delete(context.TODO(), dv)
+			Expect(err).ToNot(HaveOccurred())
+			err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			_, err = reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Should not create DV if PVC exists on DesiredDigest update; Should update DIC and DAS, and GC LRU PVCs", func() {
 			const nPVCs = 3
 			var (


### PR DESCRIPTION
**What this PR does / why we need it**:
The `imports` local variable was not updated correctly, and later referenced, so another reconcile was required for the DV to be created.

**Which issue(s) this PR fixes**:
Fixes CNV-33973

**Release note**:
```release-note
Fix DataImportCron import DataVolume creation when last import is not found
```

