### PR TITLE
[release-v1.58] Feature Gate and annotation for PVCs to be "adopted" by DataVolumes

### DIFF
--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/util/cert/watcher:go_default_library",
         "//pkg/util/tls-crypto-watch:go_default_library",
         "//pkg/version/verflag:go_default_library",
+        "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/kelseyhightower/envconfig:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
@@ -19,6 +20,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/cluster:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals:go_default_library",
     ],
 )

--- a/pkg/apiserver/BUILD.bazel
+++ b/pkg/apiserver/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/validation/spec:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )
 

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Auth config tests", func() {
 			common.AppKubernetesPartOfLabel:  "testing",
 			common.AppKubernetesVersionLabel: "v0.0.0-tests",
 		}
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, authConfigWatcher, cdiConfigTLSWatcher, nil, installerLabels)
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, authConfigWatcher, cdiConfigTLSWatcher, nil, installerLabels)
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)
@@ -168,7 +168,7 @@ var _ = Describe("Auth config tests", func() {
 		acw, err := NewAuthConfigWatcher(ctx, client)
 		Expect(err).ToNot(HaveOccurred())
 
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, nil, nil, map[string]string{})
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, nil, nil, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)
@@ -217,7 +217,7 @@ var _ = Describe("Auth config tests", func() {
 		ctw, err := cryptowatch.NewCdiConfigTLSWatcher(ctx, cdiClient)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, ctw, nil, map[string]string{})
+		_, err = NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, ctw, nil, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// 'Old' has TLS 1.0 as min version
@@ -256,7 +256,7 @@ var _ = Describe("Auth config tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		certWatcher := NewFakeCertWatcher()
 
-		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, authorizer, acw, ctw, certWatcher, map[string]string{})
+		server, err := NewCdiAPIServer("0.0.0.0", 0, client, aggregatorClient, cdiClient, nil, nil, authorizer, acw, ctw, certWatcher, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
 
 		app := server.(*cdiAPIApp)

--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )
 
@@ -75,5 +76,6 @@ go_test(
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
     ],
 )

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
-		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
+		It("should reject DataVolume with unbound PVC and adoption featurgate set", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
-		It("should reject DataVolume with unbound PVC and adoption annotation", func() {
+		It("should accept DataVolume with unbound PVC and adoption annotation", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -248,7 +248,7 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreate(dataVolume, pvc)
-			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should accept DataVolume with PVC and adoption featurgate set", func() {
@@ -265,7 +265,7 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
-		It("should reject DataVolume with unbound PVC and adoption featurgate set", func() {
+		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +275,7 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
-			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should reject DataVolume with PVC adoption annotation false and featuregate set", func() {

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -247,6 +248,49 @@ var _ = Describe("Validating Webhook", func() {
 				Spec: *dataVolume.Spec.PVC,
 			}
 			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should accept DataVolume with PVC and adoption featurgate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should accept DataVolume with unbound PVC and adoption featurgate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should reject DataVolume with PVC adoption annotation false and featuregate set", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "false",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, nil, nil, []string{"DataVolumeClaimAdoption"})
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -563,7 +607,7 @@ var _ = Describe("Validating Webhook", func() {
 				Name:      dataSource.Name,
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", nil, sourceRef, storage)
-			resp := validateDataVolumeCreateEx(dv, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dv, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -592,7 +636,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", snapSource, nil, storage)
-			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot})
+			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot}, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -612,7 +656,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			}
 			dv := newDataVolumeWithStorageSpec("testDV", snapSource, nil, storage)
-			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot})
+			resp := validateDataVolumeCreateEx(dv, nil, nil, []runtime.Object{snapshot}, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -783,7 +827,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 				Spec: *newPVCSpec(pvcSizeDefault),
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, []runtime.Object{pvc}, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		},
 			Entry("accept DataVolume with PVC and sourceRef on create", &testNamespace),
@@ -811,7 +855,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
@@ -831,7 +875,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -851,7 +895,7 @@ var _ = Describe("Validating Webhook", func() {
 					},
 				},
 			}
-			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil)
+			resp := validateDataVolumeCreateEx(dataVolume, nil, []runtime.Object{dataSource}, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -1159,14 +1203,25 @@ func newPVCSpec(sizeValue int64) *corev1.PersistentVolumeClaimSpec {
 }
 
 func validateDataVolumeCreate(dv *cdiv1.DataVolume, objects ...runtime.Object) *admissionv1.AdmissionResponse {
-	return validateDataVolumeCreateEx(dv, objects, nil, nil)
+	return validateDataVolumeCreateEx(dv, objects, nil, nil, nil)
 }
 
-func validateDataVolumeCreateEx(dv *cdiv1.DataVolume, k8sObjects, cdiObjects, snapObjects []runtime.Object) *admissionv1.AdmissionResponse {
+func validateDataVolumeCreateEx(dv *cdiv1.DataVolume, k8sObjects, cdiObjects, snapObjects []runtime.Object, featureGates []string) *admissionv1.AdmissionResponse {
 	client := fakeclient.NewSimpleClientset(k8sObjects...)
 	cdiClient := cdiclientfake.NewSimpleClientset(cdiObjects...)
 	snapClient := snapclientfake.NewSimpleClientset(snapObjects...)
-	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient)
+	s := runtime.NewScheme()
+	_ = cdiv1.AddToScheme(s)
+	config := &cdiv1.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+		Spec: cdiv1.CDIConfigSpec{
+			FeatureGates: featureGates,
+		},
+	}
+	crClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(config).Build()
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient, crClient)
 
 	dvBytes, _ := json.Marshal(dv)
 	ar := &admissionv1.AdmissionReview{
@@ -1190,7 +1245,7 @@ func validateAdmissionReview(ar *admissionv1.AdmissionReview, objects ...runtime
 	client := fakeclient.NewSimpleClientset(objects...)
 	cdiClient := cdiclientfake.NewSimpleClientset()
 	snapClient := snapclientfake.NewSimpleClientset()
-	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient)
+	wh := NewDataVolumeValidatingWebhook(client, cdiClient, snapClient, nil)
 	return serve(ar, wh)
 }
 

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -195,8 +195,59 @@ var _ = Describe("Validating Webhook", func() {
 				},
 				Spec: *dataVolume.Spec.PVC,
 			}
+			pvc.Spec.VolumeName = "pv"
 			resp := validateDataVolumeCreate(dataVolume, pvc)
 			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should accept DataVolume with PVC adoption annotation", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "true",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject DataVolume with PVC adoption annotation false", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "false",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			pvc.Spec.VolumeName = "pv"
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should reject DataVolume with unbound PVC and adoption annotation", func() {
+			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dataVolume.Name,
+					Namespace: dataVolume.Namespace,
+					Annotations: map[string]string{
+						"cdi.kubevirt.io/allowClaimAdoption": "true",
+					},
+				},
+				Spec: *dataVolume.Spec.PVC,
+			}
+			resp := validateDataVolumeCreate(dataVolume, pvc)
+			Expect(resp.Allowed).To(BeFalse())
 		})
 
 		It("should accept DataVolume with PVC source on create if PVC does not exist", func() {

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -203,13 +203,13 @@ var _ = Describe("Validating Webhook", func() {
 
 		It("should accept DataVolume with PVC adoption annotation", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			dataVolume.Annotations = map[string]string{
+				"cdi.kubevirt.io/allowClaimAdoption": "true",
+			}
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dataVolume.Name,
 					Namespace: dataVolume.Namespace,
-					Annotations: map[string]string{
-						"cdi.kubevirt.io/allowClaimAdoption": "true",
-					},
 				},
 				Spec: *dataVolume.Spec.PVC,
 			}
@@ -237,13 +237,13 @@ var _ = Describe("Validating Webhook", func() {
 
 		It("should accept DataVolume with unbound PVC and adoption annotation", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			dataVolume.Annotations = map[string]string{
+				"cdi.kubevirt.io/allowClaimAdoption": "true",
+			}
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dataVolume.Name,
 					Namespace: dataVolume.Namespace,
-					Annotations: map[string]string{
-						"cdi.kubevirt.io/allowClaimAdoption": "true",
-					},
 				},
 				Spec: *dataVolume.Spec.PVC,
 			}
@@ -280,13 +280,13 @@ var _ = Describe("Validating Webhook", func() {
 
 		It("should reject DataVolume with PVC adoption annotation false and featuregate set", func() {
 			dataVolume := newHTTPDataVolume("testDV", "http://www.example.com")
+			dataVolume.Annotations = map[string]string{
+				"cdi.kubevirt.io/allowClaimAdoption": "false",
+			}
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dataVolume.Name,
 					Namespace: dataVolume.Namespace,
-					Annotations: map[string]string{
-						"cdi.kubevirt.io/allowClaimAdoption": "false",
-					},
 				},
 				Spec: *dataVolume.Spec.PVC,
 			}

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -29,11 +29,11 @@ import (
 	"time"
 
 	"github.com/appscode/jsonpatch"
-
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -52,8 +52,14 @@ type admissionHandler struct {
 }
 
 // NewDataVolumeValidatingWebhook creates a new DataVolumeValidation webhook
-func NewDataVolumeValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface, snapClient snapclient.Interface) http.Handler {
-	return newAdmissionHandler(&dataVolumeValidatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient, snapClient: snapClient})
+func NewDataVolumeValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface,
+	snapClient snapclient.Interface, controllerRuntimeClient client.Client) http.Handler {
+	return newAdmissionHandler(&dataVolumeValidatingWebhook{
+		k8sClient:               k8sClient,
+		cdiClient:               cdiClient,
+		snapClient:              snapClient,
+		controllerRuntimeClient: controllerRuntimeClient,
+	})
 }
 
 // NewDataVolumeMutatingWebhook creates a new DataVolumeMutation webhook

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2107,17 +2107,20 @@ func ClaimMayExistBeforeDataVolume(c client.Client, pvc *corev1.PersistentVolume
 	if ClaimIsPopulatedForDataVolume(pvc, dv) {
 		return true, nil
 	}
-	return ClaimAllowsAdoption(c, pvc)
+	return AllowClaimAdoption(c, pvc, dv)
 }
 
 // ClaimIsPopulatedForDataVolume returns true if the PVC is populated for the given DataVolume
 func ClaimIsPopulatedForDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
-	return pvc.Annotations[AnnPopulatedFor] == dv.Name
+	return pvc != nil && dv != nil && pvc.Annotations[AnnPopulatedFor] == dv.Name
 }
 
-// ClaimAllowsAdoption returns true if the PVC may be adopted
-func ClaimAllowsAdoption(c client.Client, pvc *corev1.PersistentVolumeClaim) (bool, error) {
-	anno, ok := pvc.Annotations[AnnAllowClaimAdoption]
+// AllowClaimAdoption returns true if the PVC may be adopted
+func AllowClaimAdoption(c client.Client, pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
+	if pvc == nil || dv == nil {
+		return false, nil
+	}
+	anno, ok := dv.Annotations[AnnAllowClaimAdoption]
 	// if annotation exists, go with that regardless of featuregate
 	if ok {
 		val, _ := strconv.ParseBool(anno)

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2104,9 +2104,6 @@ func SetPvcAllowedAnnotations(obj metav1.Object, pvc *corev1.PersistentVolumeCla
 
 // ClaimMayExistBeforeDataVolume returns true if the PVC may exist before the DataVolume
 func ClaimMayExistBeforeDataVolume(c client.Client, pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
-	if IsUnbound(pvc) {
-		return false, nil
-	}
 	if ClaimIsPopulatedForDataVolume(pvc, dv) {
 		return true, nil
 	}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1205,6 +1205,9 @@ func CreatePvcInStorageClass(name, ns string, storageClassName *string, annotati
 		},
 	}
 	pvc.Status.Capacity = pvc.Spec.Resources.Requests.DeepCopy()
+	if pvc.Status.Phase == corev1.ClaimBound {
+		pvc.Spec.VolumeName = "pv-" + string(pvc.UID)
+	}
 	return pvc
 }
 

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,7 +459,11 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcRequiresNoWork(pvc, dataVolumeCopy) {
+		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		if err != nil {
+			return err
+		}
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || requiresNoWork {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,7 +459,7 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcIsPopulated(pvc, dataVolumeCopy) {
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || pvcRequiresNoWork(pvc, dataVolumeCopy) {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -459,11 +459,11 @@ func (r *CloneReconcilerBase) updateStatusPhase(pvc *corev1.PersistentVolumeClai
 	phase, ok := pvc.Annotations[cc.AnnPodPhase]
 	if phase != string(corev1.PodSucceeded) {
 		_, ok = pvc.Annotations[cc.AnnCloneRequest]
-		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		requiresWork, err := r.pvcRequiresWork(pvc, dataVolumeCopy)
 		if err != nil {
 			return err
 		}
-		if !ok || pvc.Status.Phase != corev1.ClaimBound || requiresNoWork {
+		if !ok || pvc.Status.Phase != corev1.ClaimBound || !requiresWork {
 			return nil
 		}
 		dataVolumeCopy.Status.Phase = cdiv1.CloneScheduled

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -128,7 +128,14 @@ type ReconcilerBase struct {
 	shouldUpdateProgress bool
 }
 
-func pvcIsPopulated(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
+func pvcRequiresNoWork(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
+	if pvc == nil || dv == nil {
+		return false
+	}
+	return pvcIsPopulatedForDataVolume(pvc, dv) || cc.ClaimAllowsAdoption(pvc)
+}
+
+func pvcIsPopulatedForDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
 	if pvc == nil || dv == nil {
 		return false
 	}
@@ -649,7 +656,7 @@ func (r *ReconcilerBase) getAvailableVolumesForDV(syncState *dvSyncState, log lo
 }
 
 func (r *ReconcilerBase) handlePrePopulation(dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) {
-	if pvc.Status.Phase == corev1.ClaimBound && pvcIsPopulated(pvc, dv) {
+	if pvc.Status.Phase == corev1.ClaimBound && pvcIsPopulatedForDataVolume(pvc, dv) {
 		cc.AddAnnotation(dv, cc.AnnPrePopulated, pvc.Name)
 	}
 }
@@ -665,7 +672,10 @@ func (r *ReconcilerBase) validatePVC(dv *cdiv1.DataVolume, pvc *corev1.Persisten
 	// If the PVC is not controlled by this DataVolume resource, we should log
 	// a warning to the event recorder and return
 	if !metav1.IsControlledBy(pvc, dv) {
-		if pvcIsPopulated(pvc, dv) {
+		if pvcRequiresNoWork(pvc, dv) {
+			if cc.IsUnbound(pvc) {
+				return fmt.Errorf("unbound populated/adoptable PVC %s/%s", pvc.Namespace, pvc.Name)
+			}
 			if err := r.addOwnerRef(pvc, dv); err != nil {
 				return err
 			}
@@ -856,7 +866,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 		dataVolumeCopy.Status.ClaimName = pvc.Name
 
 		phase := pvc.Annotations[cc.AnnPodPhase]
-		if phase == string(cdiv1.Succeeded) {
+		if phase == string(cdiv1.Succeeded) && !pvcRequiresNoWork(pvc, dataVolumeCopy) {
 			if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -876,7 +886,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					dataVolumeCopy.Status.Phase = cdiv1.PVCBound
 				}
 
-				if pvcIsPopulated(pvc, dataVolumeCopy) {
+				if pvcRequiresNoWork(pvc, dataVolumeCopy) {
 					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
 				} else {
 					if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -133,13 +133,6 @@ type ReconcilerBase struct {
 	shouldUpdateProgress bool
 }
 
-func pvcRequiresNoWork(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
-	if pvc == nil || dv == nil {
-		return false
-	}
-	return pvcIsPopulatedForDataVolume(pvc, dv) || cc.ClaimAllowsAdoption(pvc)
-}
-
 func pvcIsPopulatedForDataVolume(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) bool {
 	if pvc == nil || dv == nil {
 		return false
@@ -712,7 +705,11 @@ func (r *ReconcilerBase) validatePVC(dv *cdiv1.DataVolume, pvc *corev1.Persisten
 	// If the PVC is not controlled by this DataVolume resource, we should log
 	// a warning to the event recorder and return
 	if !metav1.IsControlledBy(pvc, dv) {
-		if pvcRequiresNoWork(pvc, dv) {
+		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dv)
+		if err != nil {
+			return err
+		}
+		if requiresNoWork {
 			if cc.IsUnbound(pvc) {
 				return fmt.Errorf("unbound populated/adoptable PVC %s/%s", pvc.Namespace, pvc.Name)
 			}
@@ -906,7 +903,11 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 		dataVolumeCopy.Status.ClaimName = pvc.Name
 
 		phase := pvc.Annotations[cc.AnnPodPhase]
-		if phase == string(cdiv1.Succeeded) && !pvcRequiresNoWork(pvc, dataVolumeCopy) {
+		requiresNoWork, err := r.pvcRequiresNoWork(pvc, dataVolumeCopy)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if phase == string(cdiv1.Succeeded) && !requiresNoWork {
 			if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -926,7 +927,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					dataVolumeCopy.Status.Phase = cdiv1.PVCBound
 				}
 
-				if pvcRequiresNoWork(pvc, dataVolumeCopy) {
+				if requiresNoWork {
 					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
 				} else {
 					if err := dvc.updateStatusPhase(pvc, dataVolumeCopy, &event); err != nil {
@@ -1287,4 +1288,14 @@ func (r *ReconcilerBase) shouldUseCDIPopulator(syncState *dvSyncState) (bool, er
 	}
 
 	return usePopulator, nil
+}
+
+func (r *ReconcilerBase) pvcRequiresNoWork(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
+	if pvc == nil || dv == nil {
+		return false, nil
+	}
+	if pvcIsPopulatedForDataVolume(pvc, dv) {
+		return true, nil
+	}
+	return cc.ClaimAllowsAdoption(r.client, pvc)
 }

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -91,7 +91,6 @@ var (
 
 	delayedAnnotations = []string{
 		cc.AnnPopulatedFor,
-		cc.AnnAllowClaimAdoption,
 	}
 )
 
@@ -1298,7 +1297,7 @@ func (r *ReconcilerBase) pvcRequiresWork(pvc *corev1.PersistentVolumeClaim, dv *
 	if pvcIsPopulatedForDataVolume(pvc, dv) {
 		return false, nil
 	}
-	canAdopt, err := cc.ClaimAllowsAdoption(r.client, pvc)
+	canAdopt, err := cc.AllowClaimAdoption(r.client, pvc, dv)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -254,7 +254,7 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcIsPopulated(pvcCopy, dv), nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -254,11 +254,11 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
 	if err != nil {
 		return false, err
 	}
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -254,7 +254,11 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
+	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
 }
 
 func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -195,7 +195,7 @@ var _ = Describe("All DataVolume Tests", func() {
 		It("Should create a PVC on a valid import DV without delayed annotation then add on success", func() {
 			dv := NewImportDataVolume("test-dv")
 			AddAnnotation(dv, "foo", "bar")
-			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
+			AddAnnotation(dv, AnnPopulatedFor, "true")
 			reconciler = createImportReconciler(dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
@@ -203,7 +203,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Annotations["foo"]).To(Equal("bar"))
-			Expect(pvc.Annotations).ToNot(HaveKey(AnnAllowClaimAdoption))
+			Expect(pvc.Annotations).ToNot(HaveKey(AnnPopulatedFor))
 
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
 			Expect(err).ToNot(HaveOccurred())
@@ -215,7 +215,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvc.Annotations["foo"]).To(Equal("bar"))
-			Expect(pvc.Annotations[AnnAllowClaimAdoption]).To(Equal("true"))
+			Expect(pvc.Annotations[AnnPopulatedFor]).To(Equal("true"))
 		})
 
 		It("Should fail if dv source not import when use populators", func() {
@@ -796,10 +796,10 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		It("Should adopt a PVC (with annotation)", func() {
-			annotations := map[string]string{AnnAllowClaimAdoption: "true"}
-			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
 			pvc.Status.Phase = corev1.ClaimBound
 			dv := NewImportDataVolume("test-dv")
+			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 			reconciler = createImportReconciler(pvc, dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
@@ -817,11 +817,11 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		It("Should adopt a unbound PVC (with annotation)", func() {
-			annotations := map[string]string{AnnAllowClaimAdoption: "true"}
-			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
 			pvc.Spec.VolumeName = ""
 			pvc.Status.Phase = corev1.ClaimPending
 			dv := NewImportDataVolume("test-dv")
+			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 			reconciler = createImportReconciler(pvc, dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -795,12 +795,33 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 		})
 
-		It("Should adopt a PVC", func() {
+		It("Should adopt a PVC (with annotation)", func() {
 			annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
 			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
 			pvc.Status.Phase = corev1.ClaimBound
 			dv := NewImportDataVolume("test-dv")
 			reconciler = createImportReconciler(pvc, dv)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			or := pvc.OwnerReferences[0]
+			Expect(or.UID).To(Equal(dv.UID))
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		})
+
+		It("Should adopt a PVC (with featuregate)", func() {
+			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
+			pvc.Status.Phase = corev1.ClaimBound
+			dv := NewImportDataVolume("test-dv")
+			featureGates := []string{featuregates.DataVolumeClaimAdoption, featuregates.HonorWaitForFirstConsumer}
+			reconciler = createImportReconcilerWithFeatureGates(featureGates, pvc, dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1906,25 +1927,19 @@ func readyStatusByPhase(phase cdiv1.DataVolumePhase) corev1.ConditionStatus {
 }
 
 func createImportReconcilerWFFCDisabled(objects ...runtime.Object) *ImportReconciler {
-	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
-	cdiConfig.Status = cdiv1.CDIConfigStatus{
-		ScratchSpaceStorageClass: testStorageClass,
-	}
-	cdiConfig.Spec.FeatureGates = []string{}
-
-	objs := []runtime.Object{}
-	objs = append(objs, objects...)
-	objs = append(objs, cdiConfig)
-
-	return createImportReconcilerWithoutConfig(objs...)
+	return createImportReconcilerWithFeatureGates(nil, objects...)
 }
 
 func createImportReconciler(objects ...runtime.Object) *ImportReconciler {
+	return createImportReconcilerWithFeatureGates([]string{featuregates.HonorWaitForFirstConsumer}, objects...)
+}
+
+func createImportReconcilerWithFeatureGates(featureGates []string, objects ...runtime.Object) *ImportReconciler {
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
 	cdiConfig.Status = cdiv1.CDIConfigStatus{
 		ScratchSpaceStorageClass: testStorageClass,
 	}
-	cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
+	cdiConfig.Spec.FeatureGates = featureGates
 
 	objs := []runtime.Object{}
 	objs = append(objs, objects...)

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -769,6 +769,27 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 		})
 
+		It("Should adopt a PVC", func() {
+			annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+			pvc.Status.Phase = corev1.ClaimBound
+			dv := NewImportDataVolume("test-dv")
+			reconciler = createImportReconciler(pvc, dv)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			or := pvc.OwnerReferences[0]
+			Expect(or.UID).To(Equal(dv.UID))
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		})
+
 		It("Should set multistage migration annotations on a newly created PVC", func() {
 			dv := NewImportDataVolume("test-dv")
 			dv.Spec.Checkpoints = []cdiv1.DataVolumeCheckpoint{
@@ -850,7 +871,6 @@ var _ = Describe("All DataVolume Tests", func() {
 
 		DescribeTable("After successful checkpoint copy", func(finalCheckpoint bool, modifyAnnotations func(annotations map[string]string), validate func(pv *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume)) {
 			annotations := map[string]string{
-				AnnPopulatedFor:       "test-dv",
 				AnnPreviousCheckpoint: "previous",
 				AnnCurrentCheckpoint:  "current",
 				AnnFinalCheckpoint:    strconv.FormatBool(finalCheckpoint),
@@ -887,6 +907,16 @@ var _ = Describe("All DataVolume Tests", func() {
 				},
 			}
 			dv.Spec.FinalCheckpoint = finalCheckpoint
+
+			pvc.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: "cdi.kubevirt.io/v1beta1",
+					Kind:       "DataVolume",
+					Name:       dv.Name,
+					UID:        dv.UID,
+					Controller: pointer.Bool(true),
+				},
+			}
 
 			reconciler = createImportReconciler(dv, pvc)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -796,9 +796,31 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		It("Should adopt a PVC (with annotation)", func() {
-			annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+			annotations := map[string]string{AnnAllowClaimAdoption: "true"}
 			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
 			pvc.Status.Phase = corev1.ClaimBound
+			dv := NewImportDataVolume("test-dv")
+			reconciler = createImportReconciler(pvc, dv)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			or := pvc.OwnerReferences[0]
+			Expect(or.UID).To(Equal(dv.UID))
+
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		})
+
+		It("Should adopt a unbound PVC (with annotation)", func() {
+			annotations := map[string]string{AnnAllowClaimAdoption: "true"}
+			pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+			pvc.Spec.VolumeName = ""
+			pvc.Status.Phase = corev1.ClaimPending
 			dv := NewImportDataVolume("test-dv")
 			reconciler = createImportReconciler(pvc, dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -254,12 +254,12 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	datavolume := syncRes.dvMutated
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
-	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	requiresWork, err := r.pvcRequiresWork(pvc, datavolume)
 	if err != nil {
 		return syncRes, err
 	}
 
-	if requiresNoWork || prePopulated || staticProvisionPending {
+	if !requiresWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -252,9 +252,12 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	pvc := syncRes.pvc
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
-	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
+	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	if err != nil {
+		return syncRes, err
+	}
 
 	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -252,11 +252,11 @@ func (r *PvcCloneReconciler) syncClone(log logr.Logger, req reconcile.Request) (
 	pvc := syncRes.pvc
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
-	pvcPopulated := pvcIsPopulated(pvc, datavolume)
+	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	prePopulated := dvIsPrePopulated(datavolume)
 
-	if pvcPopulated || prePopulated || staticProvisionPending {
+	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -486,10 +486,9 @@ var _ = Describe("All DataVolume Tests", func() {
 
 		It("Validate clone will adopt PVC (with annotation)", func() {
 			dv := newCloneDataVolume("test-dv")
+			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 			storageProfile := createStorageProfile(scName, nil, FilesystemMode)
 			pvc := CreatePvcInStorageClass("test-dv", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimBound)
-			pvc.SetAnnotations(make(map[string]string))
-			pvc.GetAnnotations()[AnnAllowClaimAdoption] = "true"
 			reconciler = createCloneReconciler(dv, pvc, storageProfile, sc)
 
 			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
@@ -513,11 +512,10 @@ var _ = Describe("All DataVolume Tests", func() {
 
 		It("Validate clone will adopt unbound PVC (with annotation)", func() {
 			dv := newCloneDataVolume("test-dv")
+			AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 			storageProfile := createStorageProfile(scName, nil, FilesystemMode)
 			pvc := CreatePvcInStorageClass("test-dv", metav1.NamespaceDefault, &scName, nil, nil, corev1.ClaimPending)
 			pvc.Spec.VolumeName = ""
-			pvc.SetAnnotations(make(map[string]string))
-			pvc.GetAnnotations()[AnnAllowClaimAdoption] = "true"
 			reconciler = createCloneReconciler(dv, pvc, storageProfile, sc)
 
 			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -185,9 +185,12 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
 
-	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
+	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	if err != nil {
+		return syncRes, err
+	}
 
 	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -187,12 +187,12 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvc, datavolume)
+	requiresWork, err := r.pvcRequiresWork(pvc, datavolume)
 	if err != nil {
 		return syncRes, err
 	}
 
-	if requiresNoWork || prePopulated || staticProvisionPending {
+	if !requiresWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -185,11 +185,11 @@ func (r *SnapshotCloneReconciler) syncSnapshotClone(log logr.Logger, req reconci
 	pvcSpec := syncRes.pvcSpec
 	datavolume := syncRes.dvMutated
 
-	pvcPopulated := pvcIsPopulated(pvc, datavolume)
+	requiresNoWork := pvcRequiresNoWork(pvc, datavolume)
 	staticProvisionPending := checkStaticProvisionPending(pvc, datavolume)
 	_, prePopulated := datavolume.Annotations[cc.AnnPrePopulated]
 
-	if pvcPopulated || prePopulated || staticProvisionPending {
+	if requiresNoWork || prePopulated || staticProvisionPending {
 		return syncRes, nil
 	}
 

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -210,7 +210,11 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
+	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -210,7 +210,7 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcIsPopulated(pvcCopy, dv), nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !pvcRequiresNoWork(pvcCopy, dv), nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -210,11 +210,11 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	requiresNoWork, err := r.pvcRequiresNoWork(pvcCopy, dv)
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
 	if err != nil {
 		return false, err
 	}
-	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && !requiresNoWork, nil
+	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 
 func (r *UploadReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -212,6 +212,39 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 	})
 
+	It("Should adopt a PVC", func() {
+		annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+		pvc.Status.Phase = corev1.ClaimBound
+		dv := newUploadDataVolume("test-dv")
+		reconciler = createUploadReconciler(pvc, dv)
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+		Expect(err).ToNot(HaveOccurred())
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pvc.OwnerReferences).To(HaveLen(1))
+		or := pvc.OwnerReferences[0]
+		Expect(or.UID).To(Equal(dv.UID))
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+	})
+
+	It("Should NOT adopt a unbound PVC", func() {
+		annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+		pvc.Spec.VolumeName = ""
+		pvc.Status.Phase = corev1.ClaimPending
+		dv := newUploadDataVolume("test-dv")
+		reconciler = createUploadReconciler(pvc, dv)
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unbound populated/adoptable PVC"))
+	})
+
 	var _ = Describe("Reconcile Datavolume status", func() {
 		DescribeTable("DV phase", func(testDv runtime.Object, current, expected cdiv1.DataVolumePhase, pvcPhase corev1.PersistentVolumeClaimPhase, podPhase corev1.PodPhase, ann, expectedEvent string, extraAnnotations ...string) {
 			// We first test the non-populator flow

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -214,10 +214,10 @@ var _ = Describe("All DataVolume Tests", func() {
 	})
 
 	It("Should adopt a PVC (with annotation)", func() {
-		annotations := map[string]string{AnnAllowClaimAdoption: "true"}
-		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
 		pvc.Status.Phase = corev1.ClaimBound
 		dv := newUploadDataVolume("test-dv")
+		AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 		reconciler = createUploadReconciler(pvc, dv)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
@@ -256,11 +256,11 @@ var _ = Describe("All DataVolume Tests", func() {
 	})
 
 	It("Should adopt a unbound PVC", func() {
-		annotations := map[string]string{AnnAllowClaimAdoption: "true"}
-		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
+		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
 		pvc.Spec.VolumeName = ""
 		pvc.Status.Phase = corev1.ClaimPending
 		dv := newUploadDataVolume("test-dv")
+		AddAnnotation(dv, AnnAllowClaimAdoption, "true")
 		reconciler = createUploadReconciler(pvc, dv)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -33,14 +33,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -213,7 +214,7 @@ var _ = Describe("All DataVolume Tests", func() {
 	})
 
 	It("Should adopt a PVC (with annotation)", func() {
-		annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+		annotations := map[string]string{AnnAllowClaimAdoption: "true"}
 		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
 		pvc.Status.Phase = corev1.ClaimBound
 		dv := newUploadDataVolume("test-dv")
@@ -254,16 +255,26 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 	})
 
-	It("Should NOT adopt a unbound PVC", func() {
-		annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
+	It("Should adopt a unbound PVC", func() {
+		annotations := map[string]string{AnnAllowClaimAdoption: "true"}
 		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
 		pvc.Spec.VolumeName = ""
 		pvc.Status.Phase = corev1.ClaimPending
 		dv := newUploadDataVolume("test-dv")
 		reconciler = createUploadReconciler(pvc, dv)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("unbound populated/adoptable PVC"))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pvc.OwnerReferences).To(HaveLen(1))
+		or := pvc.OwnerReferences[0]
+		Expect(or.UID).To(Equal(dv.UID))
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 	})
 
 	var _ = Describe("Reconcile Datavolume status", func() {

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -212,12 +212,33 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
 	})
 
-	It("Should adopt a PVC", func() {
+	It("Should adopt a PVC (with annotation)", func() {
 		annotations := map[string]string{"cdi.kubevirt.io/allowClaimAdoption": "true"}
 		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, annotations, nil)
 		pvc.Status.Phase = corev1.ClaimBound
 		dv := newUploadDataVolume("test-dv")
 		reconciler = createUploadReconciler(pvc, dv)
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+		Expect(err).ToNot(HaveOccurred())
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pvc.OwnerReferences).To(HaveLen(1))
+		or := pvc.OwnerReferences[0]
+		Expect(or.UID).To(Equal(dv.UID))
+
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, dv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
+		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+	})
+
+	It("Should adopt a PVC (with featuregate)", func() {
+		pvc := CreatePvc("test-dv", metav1.NamespaceDefault, nil, nil)
+		pvc.Status.Phase = corev1.ClaimBound
+		dv := newUploadDataVolume("test-dv")
+		featureGates := []string{featuregates.DataVolumeClaimAdoption, featuregates.HonorWaitForFirstConsumer}
+		reconciler = createUploadReconcilerWithFeatureGates(featureGates, pvc, dv)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -380,11 +401,15 @@ var _ = Describe("All DataVolume Tests", func() {
 })
 
 func createUploadReconciler(objects ...runtime.Object) *UploadReconciler {
+	return createUploadReconcilerWithFeatureGates([]string{featuregates.HonorWaitForFirstConsumer}, objects...)
+}
+
+func createUploadReconcilerWithFeatureGates(featureGates []string, objects ...runtime.Object) *UploadReconciler {
 	cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
 	cdiConfig.Status = cdiv1.CDIConfigStatus{
 		ScratchSpaceStorageClass: testStorageClass,
 	}
-	cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
+	cdiConfig.Spec.FeatureGates = featureGates
 
 	objs := []runtime.Object{}
 	objs = append(objs, objects...)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1140,10 +1140,15 @@ func createImportTestEnv(podEnvVar *importPodEnvVar, uid string) []corev1.EnvVar
 
 type FakeFeatureGates struct {
 	honorWaitForFirstConsumerEnabled bool
+	claimAdoptionEnabled             bool
 }
 
 func (f *FakeFeatureGates) HonorWaitForFirstConsumerEnabled() (bool, error) {
 	return f.honorWaitForFirstConsumerEnabled, nil
+}
+
+func (f *FakeFeatureGates) ClaimAdoptionEnabled() (bool, error) {
+	return f.claimAdoptionEnabled, nil
 }
 
 func createPendingPvc(name, ns string, annotations, labels map[string]string) *v1.PersistentVolumeClaim {

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Import populator tests", func() {
 		})
 
 		DescribeTable("Should create PVC Prime with proper import annotations", func(key, value, expectedValue string) {
-			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, map[string]string{}, nil, corev1.ClaimBound)
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, map[string]string{}, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = dataSourceRef
 			targetPvc.Annotations[key] = value
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
@@ -395,7 +395,7 @@ var _ = Describe("Import populator tests", func() {
 		)
 
 		It("Should set multistage migration annotations on PVC prime", func() {
-			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimBound)
+			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = dataSourceRef
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
 			volumeImportSource.Spec.Source = &cdiv1.ImportSourceType{

--- a/pkg/feature-gates/feature-gates.go
+++ b/pkg/feature-gates/feature-gates.go
@@ -14,12 +14,19 @@ import (
 const (
 	// HonorWaitForFirstConsumer - if enabled will not schedule worker pods on a storage with WaitForFirstConsumer binding mode
 	HonorWaitForFirstConsumer = "HonorWaitForFirstConsumer"
+
+	// DataVolumeClaimAdoption - if enabled will allow PVC to be adopted by a DataVolume
+	// it is not an error if PVC of sam name exists before DataVolume is created
+	DataVolumeClaimAdoption = "DataVolumeClaimAdoption"
 )
 
 // FeatureGates is a util for determining whether an optional feature is enabled or not.
 type FeatureGates interface {
 	// HonorWaitForFirstConsumerEnabled - see the HonorWaitForFirstConsumer const
 	HonorWaitForFirstConsumerEnabled() (bool, error)
+
+	// ClaimAdoptionEnabled - see the DataVolumeClaimAdoption const
+	ClaimAdoptionEnabled() (bool, error)
 }
 
 // CDIConfigFeatureGates is a util for determining whether an optional feature is enabled or not.
@@ -58,4 +65,9 @@ func (f *CDIConfigFeatureGates) getConfig() ([]string, error) {
 // HonorWaitForFirstConsumerEnabled - see the HonorWaitForFirstConsumer const
 func (f *CDIConfigFeatureGates) HonorWaitForFirstConsumerEnabled() (bool, error) {
 	return f.isFeatureGateEnabled(HonorWaitForFirstConsumer)
+}
+
+// ClaimAdoptionEnabled - see the DataVolumeClaimAdoption const
+func (f *CDIConfigFeatureGates) ClaimAdoptionEnabled() (bool, error) {
+	return f.isFeatureGateEnabled(DataVolumeClaimAdoption)
 }

--- a/pkg/feature-gates/feature-gates_test.go
+++ b/pkg/feature-gates/feature-gates_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Feature Gates", func() {
 		Expect(featureGates.HonorWaitForFirstConsumerEnabled()).To(BeFalse())
 	})
 
-	It("Should reflect config changes", func() {
+	It("Should reflect HonorWaitForFirstConsumer config changes", func() {
 		featureGates, client := createFeatureGatesAndClient()
 		cdiConfig := &cdiv1.CDIConfig{}
 		err := client.Get(context.TODO(), types.NamespacedName{Name: common.ConfigName}, cdiConfig)
@@ -55,6 +55,24 @@ var _ = Describe("Feature Gates", func() {
 		err = client.Update(context.TODO(), cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(featureGates.HonorWaitForFirstConsumerEnabled()).To(BeFalse())
+	})
+
+	It("Should reflect DataVolumeClaimAdoption config changes", func() {
+		featureGates, client := createFeatureGatesAndClient()
+		cdiConfig := &cdiv1.CDIConfig{}
+		err := client.Get(context.TODO(), types.NamespacedName{Name: common.ConfigName}, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		// update the config on the status not the spec
+		cdiConfig.Spec.FeatureGates = []string{DataVolumeClaimAdoption}
+		err = client.Update(context.TODO(), cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(featureGates.ClaimAdoptionEnabled()).To(BeTrue())
+
+		cdiConfig.Spec.FeatureGates = nil
+		err = client.Update(context.TODO(), cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(featureGates.ClaimAdoptionEnabled()).To(BeFalse())
 	})
 })
 

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -155,6 +155,19 @@ func getAPIServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
 				"cdis/finalizers",
 			},
 			Verbs: []string{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "adopt-volume_test.go",
         "api_validation_test.go",
         "apiserver_test.go",
         "badserver_test.go",

--- a/tests/adopt-volume_test.go
+++ b/tests/adopt-volume_test.go
@@ -1,0 +1,218 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	controller "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
+	"kubevirt.io/containerized-data-importer/tests/framework"
+	"kubevirt.io/containerized-data-importer/tests/utils"
+)
+
+var _ = Describe("PVC adoption tests", func() {
+	f := framework.NewFramework("adoption-test")
+
+	Context("with available PVC", func() {
+		const (
+			dvName = "testdv"
+			dvSize = "1Gi"
+		)
+
+		var (
+			storageClass *string
+			volumeMode   *corev1.PersistentVolumeMode
+		)
+
+		importDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeWithHTTPImport(dvName, dvSize, fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+		}
+
+		uploadDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForUpload(dvName, dvSize)
+		}
+
+		cloneDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForImageCloning(dvName, dvSize, "default", "foo", storageClass, volumeMode)
+		}
+
+		snapshotCloneDef := func() *cdiv1.DataVolume {
+			return utils.NewDataVolumeForSnapshotCloning(dvName, dvSize, "default", "foo", storageClass, volumeMode)
+		}
+
+		populatorDef := func() *cdiv1.DataVolume {
+			dataSourceRef := &corev1.TypedObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: "doesnotmatter",
+			}
+			return utils.NewDataVolumeWithExternalPopulation(dvName, dvSize, *storageClass, *volumeMode, nil, dataSourceRef)
+		}
+
+		BeforeEach(func() {
+			By("Creating source DV")
+			// source here shouldn't matter
+			dvDef := importDef()
+			controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for source DV to succeed")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dv)
+			err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			storageClass = pvc.Spec.StorageClassName
+			volumeMode = pvc.Spec.VolumeMode
+
+			By("Retaining PVC")
+			Eventually(func() error {
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if len(pvc.OwnerReferences) > 0 {
+					pvc.OwnerReferences = nil
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			}, timeout, pollingInterval).Should(BeNil())
+
+			By("Deleting source DV")
+			err = utils.DeleteDataVolume(f.CdiClient, dv.Namespace, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("with annotation on PVC", Serial, func() {
+			var disabledFeatureGate bool
+
+			BeforeEach(func() {
+				By("Disabling featuregate")
+				alreadyEnabled, err := utils.DisableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+				disabledFeatureGate = *alreadyEnabled
+			})
+
+			AfterEach(func() {
+				if !disabledFeatureGate {
+					return
+				}
+				By("Enabling featuregate")
+				_, err := utils.EnableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("it should get adopted", func(defFunc func() *cdiv1.DataVolume) {
+				var pvcUID string
+				By("Adding annotation to PVC")
+				Eventually(func() error {
+					pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					controller.AddAnnotation(pvc, controller.AnnAllowClaimAdoption, "true")
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+					pvcUID = string(pvc.UID)
+					return nil
+				}, timeout, pollingInterval).Should(BeNil())
+
+				By("Creating target DV")
+				dvDef := defFunc()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for target DV to succeed")
+				err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(pvc.UID)).To(Equal(pvcUID))
+			},
+				Entry("with import source", importDef),
+				Entry("with upload source", uploadDef),
+				Entry("with clone source", cloneDef),
+				Entry("with snapshot clone source", snapshotCloneDef),
+				Entry("with populator source", populatorDef),
+			)
+		})
+
+		Context("with featuregate enabled", Serial, func() {
+			var setFeatureGate bool
+
+			BeforeEach(func() {
+				By("Enabling featuregate")
+				alreadyEnabled, err := utils.EnableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+				setFeatureGate = !*alreadyEnabled
+			})
+
+			AfterEach(func() {
+				if !setFeatureGate {
+					return
+				}
+				By("Disabling featuregate")
+				_, err := utils.DisableFeatureGate(f.CrClient, featuregates.DataVolumeClaimAdoption)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("it should get adopted", func(defFunc func() *cdiv1.DataVolume) {
+				pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				pvcUID := string(pvc.UID)
+
+				By("Creating target DV")
+				dvDef := defFunc()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for target DV to succeed")
+				err = utils.WaitForDataVolumePhaseWithTimeout(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name, 300*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
+				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(pvc.UID)).To(Equal(pvcUID))
+			},
+				Entry("with import source", importDef),
+				Entry("with upload source", uploadDef),
+				Entry("with clone source", cloneDef),
+				Entry("with snapshot clone source", snapshotCloneDef),
+				Entry("with populator source", populatorDef),
+			)
+
+			It("should not be adopted if annotation says not to", func() {
+				By("Adding annotation to PVC")
+				Eventually(func() error {
+					pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), dvName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					controller.AddAnnotation(pvc, controller.AnnAllowClaimAdoption, "false")
+					_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+					return nil
+				}, timeout, pollingInterval).Should(BeNil())
+
+				By("Creating target DV")
+				dvDef := importDef()
+				controller.AddAnnotation(dvDef, controller.AnnDeleteAfterCompletion, "false")
+				_, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dvDef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("already exists"))
+			})
+		})
+	})
+})

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -39,6 +39,10 @@ func (f *Framework) CreateBoundPVCFromDefinition(def *k8sv1.PersistentVolumeClai
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	f.ForceBindIfWaitForFirstConsumer(pvc)
+	err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, k8sv1.ClaimBound, pvc.Name)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	pvc, err = utils.FindPVC(f.K8sClient, pvc.Namespace, pvc.Name)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return pvc
 }
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -958,6 +958,10 @@ var _ = Describe("Block PV upload Test", func() {
 	f := framework.NewFramework(namespacePrefix)
 
 	BeforeEach(func() {
+		if !f.IsBlockVolumeStorageClassAvailable() {
+			Skip("Storage Class for block volume is not available")
+		}
+
 		if pvc != nil {
 			Eventually(func() bool {
 				// Make sure the pvc doesn't still exist. The after each should have called delete.
@@ -995,10 +999,6 @@ var _ = Describe("Block PV upload Test", func() {
 	})
 
 	DescribeTable("should", func(validToken bool, expectedStatus int) {
-		if !f.IsBlockVolumeStorageClassAvailable() {
-			Skip("Storage Class for block volume is not available")
-		}
-
 		By("Verify PVC annotation says ready")
 		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of #3029 and #3105

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-35100

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DataVolume supports PVC adoption via DataVolumeClaimAdoption feature gate and cdi.kubevirt.io/allowClaimAdoption annotation on PVC
```

