### PR TITLE
Allow Deployed CDI to get out of Error Phase

### DIFF
--- a/pkg/controller/common/BUILD.bazel
+++ b/pkg/controller/common/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log/zap:go_default_library",
     ],

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -745,6 +745,14 @@ func GetActiveCDI(ctx context.Context, c client.Client) (*cdiv1.CDI, error) {
 		return nil, err
 	}
 
+	if len(crList.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(crList.Items) == 1 {
+		return &crList.Items[0], nil
+	}
+
 	var activeResources []cdiv1.CDI
 	for _, cr := range crList.Items {
 		if cr.Status.Phase != sdkapi.PhaseError {
@@ -752,12 +760,8 @@ func GetActiveCDI(ctx context.Context, c client.Client) (*cdiv1.CDI, error) {
 		}
 	}
 
-	if len(activeResources) == 0 {
-		return nil, nil
-	}
-
-	if len(activeResources) > 1 {
-		return nil, fmt.Errorf("number of active CDI CRs > 1")
+	if len(activeResources) != 1 {
+		return nil, fmt.Errorf("invalid number of active CDI resources: %d", len(activeResources))
 	}
 
 	return &activeResources[0], nil

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
 var _ = Describe("GetRequestedImageSize", func() {
@@ -233,6 +234,69 @@ var _ = Describe("Rebind", func() {
 		Expect(updatedPV.Spec.ClaimRef.Name).To(Equal(targetPVC.Name))
 		//make sure annotations of pv from before rebind dont get deleted
 		Expect(pv.Annotations["someAnno"]).To(Equal("somevalue"))
+	})
+
+	Context("GetActiveCDI tests", func() {
+		createCDI := func(name string, phase sdkapi.Phase) *cdiv1.CDI {
+			return &cdiv1.CDI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Status: cdiv1.CDIStatus{
+					Status: sdkapi.Status{
+						Phase: phase,
+					},
+				},
+			}
+		}
+
+		It("Should return nil if no CDI", func() {
+			client := CreateClient()
+			cdi, err := GetActiveCDI(context.Background(), client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cdi).To(BeNil())
+		})
+
+		It("Should return single active", func() {
+			client := CreateClient(
+				createCDI("cdi1", sdkapi.PhaseDeployed),
+			)
+			cdi, err := GetActiveCDI(context.Background(), client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cdi).ToNot(BeNil())
+		})
+
+		It("Should return success with single active one error", func() {
+			client := CreateClient(
+				createCDI("cdi1", sdkapi.PhaseDeployed),
+				createCDI("cdi2", sdkapi.PhaseError),
+			)
+			cdi, err := GetActiveCDI(context.Background(), client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cdi).ToNot(BeNil())
+			Expect(cdi.Name).To(Equal("cdi1"))
+		})
+
+		It("Should return error if multiple CDIs are active", func() {
+			client := CreateClient(
+				createCDI("cdi1", sdkapi.PhaseDeployed),
+				createCDI("cdi2", sdkapi.PhaseDeployed),
+			)
+			cdi, err := GetActiveCDI(context.Background(), client)
+			Expect(err).To(HaveOccurred())
+			Expect(cdi).To(BeNil())
+		})
+
+		It("Should return error if multiple CDIs are error", func() {
+			client := CreateClient(
+				createCDI("cdi1", sdkapi.PhaseError),
+				createCDI("cdi2", sdkapi.PhaseError),
+			)
+			cdi, err := GetActiveCDI(context.Background(), client)
+			Expect(err).To(HaveOccurred())
+			Expect(cdi).To(BeNil())
+		})
+
 	})
 })
 

--- a/pkg/operator/controller/cr-manager.go
+++ b/pkg/operator/controller/cr-manager.go
@@ -72,7 +72,7 @@ func (r *ReconcileCDI) GetDependantResourcesListObjects() []client.ObjectList {
 func (r *ReconcileCDI) IsCreating(_ client.Object) (bool, error) {
 	configMap, err := r.getConfigMap()
 	if err != nil {
-		return true, nil
+		return false, err
 	}
 	return configMap == nil, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Was impossible for CDI to get out of `Error` phase once in it because `GetActiveCDI()` filtered out resources in `Error` state.  This change allows the function to return success if there is a single CDI in error state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-36904

**Special notes for your reviewer**:

If you look at attached issues, what appears to have happened is that CDI somehow got in an error state (not sure how but not that important).  Once in error state, cdi-operator reconcile loop would always error out.  Eventually certs would expire and you can't do anything CDI related.  Not good!  This makes things resilient.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix:  Allow Deployed CDI to get out of Error Phase
```

