### PR TITLE
Remove deprecated insecure registries config map from user's install

### DIFF
--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -45,15 +45,12 @@ import (
 
 func addReconcileCallbacks(r *ReconcileCDI) {
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteControllerDeployment)
-	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileServiceAccountRead)
-	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileServiceAccounts)
 	r.reconciler.AddCallback(&corev1.ServiceAccount{}, reconcileSCC)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCreateRoute)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCreatePrometheusInfra)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileRemainingRelationshipLabels)
-	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteSecrets)
+	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileDeleteDeprecatedResources)
 	r.reconciler.AddCallback(&appsv1.Deployment{}, reconcileCDICRD)
-	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileInitializeCRD)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileSetConfigAuthority)
 	r.reconciler.AddCallback(&extv1.CustomResourceDefinition{}, reconcileHandleOldVersion)
 }

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -512,6 +512,21 @@ var _ = Describe("Controller", func() {
 				Expect(cm.Labels[common.AppKubernetesPartOfLabel]).To(Equal("newtesting"))
 			})
 
+			It("should get rid of deprecated insecure registries config map", func() {
+				args := createArgs()
+				doReconcile(args)
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+
+				cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: cdiNamespace, Name: "cdi-insecure-registries"}}
+				err := args.client.Create(context.TODO(), cm)
+				Expect(err).ToNot(HaveOccurred())
+
+				doReconcile(args)
+
+				_, err = getObject(args.client, cm)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+
 			It("should set config authority", func() {
 				args := createArgs()
 				doReconcile(args)

--- a/pkg/operator/controller/cruft.go
+++ b/pkg/operator/controller/cruft.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -47,13 +46,7 @@ import (
 	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/callbacks"
 )
 
-const (
-	// SCCAnnotation is the annotation listing SCCs for a SA
-	SCCAnnotation = "cdi-scc"
-)
-
-// delete when we no longer support <= 1.12.0
-func reconcileDeleteSecrets(args *callbacks.ReconcileCallbackArgs) error {
+func reconcileDeleteDeprecatedResources(args *callbacks.ReconcileCallbackArgs) error {
 	if args.State != callbacks.ReconcileStatePostRead {
 		return nil
 	}
@@ -63,142 +56,28 @@ func reconcileDeleteSecrets(args *callbacks.ReconcileCallbackArgs) error {
 		return nil
 	}
 
-	for _, s := range []string{"cdi-api-server-cert",
-		"cdi-upload-proxy-ca-key",
-		"cdi-upload-proxy-server-key",
-		"cdi-upload-server-ca-key",
-		"cdi-upload-server-client-ca-key",
-		"cdi-upload-server-client-key",
-	} {
-		secret := &corev1.Secret{}
-		key := client.ObjectKey{Namespace: args.Namespace, Name: s}
-		err := args.Client.Get(context.TODO(), key, secret)
-		if errors.IsNotFound(err) {
-			continue
-		}
+	namespace := deployment.GetNamespace()
+	deprecatedResources := []client.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cdi-insecure-registries",
+				Namespace: namespace,
+			},
+		},
+	}
 
-		if err != nil {
-			return err
-		}
-
-		err = args.Client.Delete(context.TODO(), secret)
+	for _, k := range deprecatedResources {
 		cr := args.Resource.(runtime.Object)
-		if err != nil {
-			args.Recorder.Event(cr, corev1.EventTypeWarning, deleteResourceFailed, fmt.Sprintf("Failed to delete secret %s, %v", s, err))
+		if err := args.Client.Delete(context.TODO(), k); err != nil {
+			if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				// Doesn't exist or CRD not installed, we're fine
+				continue
+			}
+			args.Recorder.Event(cr, corev1.EventTypeWarning, deleteResourceFailed, fmt.Sprintf("Failed to delete deprecated resource %s, %v", k.GetName(), err))
 			return err
 		}
-		args.Recorder.Event(cr, corev1.EventTypeNormal, deleteResourceSuccess, fmt.Sprintf("Deleted secret %s successfully", s))
+		args.Recorder.Event(cr, corev1.EventTypeNormal, deleteResourceSuccess, fmt.Sprintf("Deleted deprecated resource %s successfully", k.GetName()))
 	}
-
-	return nil
-}
-
-// delete when we no longer support <= 1.13.3
-func reconcileServiceAccountRead(args *callbacks.ReconcileCallbackArgs) error {
-	if args.State != callbacks.ReconcileStatePostRead {
-		return nil
-	}
-
-	do := args.DesiredObject.(*corev1.ServiceAccount)
-	co := args.CurrentObject.(*corev1.ServiceAccount)
-
-	delete(co.Annotations, SCCAnnotation)
-
-	val, exists := do.Annotations[SCCAnnotation]
-	if exists {
-		if co.Annotations == nil {
-			co.Annotations = make(map[string]string)
-		}
-		co.Annotations[SCCAnnotation] = val
-	}
-
-	return nil
-}
-
-// delete when we no longer support <= 1.13.3
-func reconcileServiceAccounts(args *callbacks.ReconcileCallbackArgs) error {
-	switch args.State {
-	case callbacks.ReconcileStatePreCreate, callbacks.ReconcileStatePreUpdate, callbacks.ReconcileStatePostDelete, callbacks.ReconcileStateOperatorDelete:
-	default:
-		return nil
-	}
-
-	var sa *corev1.ServiceAccount
-	if args.CurrentObject != nil {
-		sa = args.CurrentObject.(*corev1.ServiceAccount)
-	} else if args.DesiredObject != nil {
-		sa = args.DesiredObject.(*corev1.ServiceAccount)
-	} else {
-		args.Logger.Info("Received callback with no desired/current object")
-		return nil
-	}
-
-	desiredSCCs := []string{}
-	saName := fmt.Sprintf("system:serviceaccount:%s:%s", sa.Namespace, sa.Name)
-
-	switch args.State {
-	case callbacks.ReconcileStatePreCreate, callbacks.ReconcileStatePreUpdate:
-		val, exists := sa.Annotations[SCCAnnotation]
-		if exists {
-			if err := json.Unmarshal([]byte(val), &desiredSCCs); err != nil {
-				args.Logger.Error(err, "Error unmarshalling data")
-				return err
-			}
-		}
-	default:
-		// want desiredSCCs empty because deleting resource/CDI
-	}
-
-	listObj := &secv1.SecurityContextConstraintsList{}
-	if err := args.Client.List(context.TODO(), listObj, &client.ListOptions{}); err != nil {
-		if meta.IsNoMatchError(err) {
-			// not openshift
-			return nil
-		}
-		args.Logger.Error(err, "Error listing SCCs")
-		return err
-	}
-
-	for _, scc := range listObj.Items {
-		desiredUsers := []string{}
-		add := sdk.ContainsStringValue(desiredSCCs, scc.Name)
-		seenUser := false
-
-		for _, u := range scc.Users {
-			if u == saName {
-				seenUser = true
-				if !add {
-					continue
-				}
-			}
-			desiredUsers = append(desiredUsers, u)
-		}
-
-		if add && !seenUser {
-			desiredUsers = append(desiredUsers, saName)
-		}
-
-		if !reflect.DeepEqual(desiredUsers, scc.Users) {
-			args.Logger.Info("Doing SCC update", "name", scc.Name, "desired", desiredUsers, "current", scc.Users)
-			scc.Users = desiredUsers
-			if err := args.Client.Update(context.TODO(), &scc); err != nil {
-				args.Logger.Error(err, "Error updating SCC")
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// delete when we no longer support <= 1.21.0
-func reconcileInitializeCRD(args *callbacks.ReconcileCallbackArgs) error {
-	if args.State != callbacks.ReconcileStatePreUpdate {
-		return nil
-	}
-
-	crd := args.CurrentObject.(*extv1.CustomResourceDefinition)
-	crd.Spec.PreserveUnknownFields = false
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This has been deprecated for years, and recently we even stopped creating it:
https://github.com/kubevirt/containerized-data-importer/pull/2723
https://github.com/kubevirt/containerized-data-importer/pull/1754
This PR is about removing the stray configmap on a user environment that kept carrying it through the versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated insecure registries config map from a CDI install 
```

