### PR TITLE
Fix StorageProfile ClaimPropertySets validation

### DIFF
--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -27171,6 +27171,7 @@ func schema_pkg_apis_core_v1beta1_ClaimPropertySet(ref common.ReferenceCallback)
 						},
 					},
 				},
+				Required: []string{"accessModes", "volumeMode"},
 			},
 		},
 	}

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -101,8 +102,8 @@ func (r *StorageProfileReconciler) reconcileStorageProfile(sc *storagev1.Storage
 
 	if len(storageProfile.Spec.ClaimPropertySets) > 0 {
 		for _, cps := range storageProfile.Spec.ClaimPropertySets {
-			if len(cps.AccessModes) == 0 && cps.VolumeMode != nil {
-				err = fmt.Errorf("must provide access mode for volume mode: %s", *cps.VolumeMode)
+			if cps.VolumeMode == nil || len(cps.AccessModes) == 0 {
+				err = errors.New("each ClaimPropertySet must provide both volume mode and access modes")
 				log.Error(err, "Unable to update StorageProfile")
 				return reconcile.Result{}, err
 			}

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -43,7 +43,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	"kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
 	"kubevirt.io/containerized-data-importer/pkg/storagecapabilities"
 )
 
@@ -275,7 +275,7 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(updatedSp.Labels[common.AppKubernetesPartOfLabel]).To(Equal("newtesting"))
 	})
 
-	It("Should error when updating storage profile with missing access modes", func() {
+	DescribeTable("Should error when updating storage profile with missing", func(hasVolumeMode, hasAccessModes bool) {
 		reconciler = createStorageProfileReconciler(CreateStorageClass(storageClassName, map[string]string{AnnDefaultStorageClass: "true"}))
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
 		Expect(err).ToNot(HaveOccurred())
@@ -287,16 +287,24 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(*sp.Status.StorageClass).To(Equal(storageClassName))
 		Expect(sp.Status.ClaimPropertySets).To(BeEmpty())
 
+		partialClaimPropertySet := cdiv1.ClaimPropertySet{}
+		if hasVolumeMode {
+			partialClaimPropertySet.VolumeMode = &FilesystemMode
+		}
+		if hasAccessModes {
+			partialClaimPropertySet.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}
+		}
+
 		claimPropertySets := []cdiv1.ClaimPropertySet{
 			{AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}, VolumeMode: &BlockMode},
-			{VolumeMode: &FilesystemMode},
+			partialClaimPropertySet,
 		}
 		sp.Spec.ClaimPropertySets = claimPropertySets
 		err = reconciler.client.Update(context.TODO(), sp.DeepCopy())
 		Expect(err).ToNot(HaveOccurred())
 		_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("must provide access mode for volume mode: %s", FilesystemMode)))
+		Expect(err.Error()).To(ContainSubstring("each ClaimPropertySet must provide both volume mode and access modes"))
 		err = reconciler.client.List(context.TODO(), storageProfileList, &client.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(storageProfileList.Items).To(HaveLen(1))
@@ -304,7 +312,11 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(*updatedSp.Status.StorageClass).To(Equal(storageClassName))
 		Expect(updatedSp.Status.ClaimPropertySets).To(BeEmpty())
 		Expect(updatedSp.Spec.ClaimPropertySets).To(Equal(claimPropertySets))
-	})
+	},
+		Entry("volume mode", false, true),
+		Entry("access modes", true, false),
+		Entry("both volume mode and access modes", false, false),
+	)
 
 	DescribeTable("should create clone strategy", func(cloneStrategy cdiv1.CDICloneStrategy) {
 		storageClass := CreateStorageClass(storageClassName, map[string]string{AnnDefaultStorageClass: "true"})

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -7023,7 +7023,12 @@ spec:
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         type: string
+                      maxItems: 4
                       type: array
+                      x-kubernetes-validations:
+                      - message: Illegal AccessMode
+                        rule: self.all(am, am in ['ReadWriteOnce', 'ReadOnlyMany',
+                          'ReadWriteMany', 'ReadWriteOncePod'])
                     volumeMode:
                       description: VolumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
@@ -7036,6 +7041,7 @@ spec:
                   - accessModes
                   - volumeMode
                   type: object
+                maxItems: 8
                 type: array
               cloneStrategy:
                 description: CloneStrategy defines the preferred method for performing
@@ -7067,7 +7073,12 @@ spec:
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         type: string
+                      maxItems: 4
                       type: array
+                      x-kubernetes-validations:
+                      - message: Illegal AccessMode
+                        rule: self.all(am, am in ['ReadWriteOnce', 'ReadOnlyMany',
+                          'ReadWriteMany', 'ReadWriteOncePod'])
                     volumeMode:
                       description: VolumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
@@ -7080,6 +7091,7 @@ spec:
                   - accessModes
                   - volumeMode
                   type: object
+                maxItems: 8
                 type: array
               cloneStrategy:
                 description: CloneStrategy defines the preferred method for performing

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -7028,7 +7028,13 @@ spec:
                       description: VolumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
                         in claim spec.
+                      enum:
+                      - Block
+                      - Filesystem
                       type: string
+                  required:
+                  - accessModes
+                  - volumeMode
                   type: object
                 type: array
               cloneStrategy:
@@ -7066,7 +7072,13 @@ spec:
                       description: VolumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
                         in claim spec.
+                      enum:
+                      - Block
+                      - Filesystem
                       type: string
+                  required:
+                  - accessModes
+                  - volumeMode
                   type: object
                 type: array
               cloneStrategy:

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -418,6 +418,7 @@ type StorageProfileSpec struct {
 	// CloneStrategy defines the preferred method for performing a CDI clone
 	CloneStrategy *CDICloneStrategy `json:"cloneStrategy,omitempty"`
 	// ClaimPropertySets is a provided set of properties applicable to PVC
+	// +kubebuilder:validation:MaxItems=8
 	ClaimPropertySets []ClaimPropertySet `json:"claimPropertySets,omitempty"`
 	// DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources
 	DataImportCronSourceFormat *DataImportCronSourceFormat `json:"dataImportCronSourceFormat,omitempty"`
@@ -434,6 +435,7 @@ type StorageProfileStatus struct {
 	// CloneStrategy defines the preferred method for performing a CDI clone
 	CloneStrategy *CDICloneStrategy `json:"cloneStrategy,omitempty"`
 	// ClaimPropertySets computed from the spec and detected in the system
+	// +kubebuilder:validation:MaxItems=8
 	ClaimPropertySets []ClaimPropertySet `json:"claimPropertySets,omitempty"`
 	// DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources
 	DataImportCronSourceFormat *DataImportCronSourceFormat `json:"dataImportCronSourceFormat,omitempty"`
@@ -445,6 +447,8 @@ type StorageProfileStatus struct {
 type ClaimPropertySet struct {
 	// AccessModes contains the desired access modes the volume should have.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:XValidation:rule="self.all(am, am in ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany', 'ReadWriteOncePod'])", message="Illegal AccessMode"
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes"`
 	// VolumeMode defines what type of volume is required by the claim.
 	// Value of Filesystem is implied when not included in claim spec.

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -445,12 +445,11 @@ type StorageProfileStatus struct {
 type ClaimPropertySet struct {
 	// AccessModes contains the desired access modes the volume should have.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
-	// +optional
-	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
+	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes"`
 	// VolumeMode defines what type of volume is required by the claim.
 	// Value of Filesystem is implied when not included in claim spec.
-	// +optional
-	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode,omitempty" protobuf:"bytes,6,opt,name=volumeMode,casttype=PersistentVolumeMode"`
+	// +kubebuilder:validation:Enum="Block";"Filesystem"
+	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode"`
 }
 
 // StorageProfileList provides the needed parameters to request a list of StorageProfile from the system

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -203,8 +203,8 @@ func (StorageProfileStatus) SwaggerDoc() map[string]string {
 func (ClaimPropertySet) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":            "ClaimPropertySet is a set of properties applicable to PVC",
-		"accessModes": "AccessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1\n+optional",
-		"volumeMode":  "VolumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.\n+optional",
+		"accessModes": "AccessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+		"volumeMode":  "VolumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.\n+kubebuilder:validation:Enum=\"Block\";\"Filesystem\"",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -182,7 +182,7 @@ func (StorageProfileSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                           "StorageProfileSpec defines specification for StorageProfile",
 		"cloneStrategy":              "CloneStrategy defines the preferred method for performing a CDI clone",
-		"claimPropertySets":          "ClaimPropertySets is a provided set of properties applicable to PVC",
+		"claimPropertySets":          "ClaimPropertySets is a provided set of properties applicable to PVC\n+kubebuilder:validation:MaxItems=8",
 		"dataImportCronSourceFormat": "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
 		"snapshotClass":              "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
 	}
@@ -194,7 +194,7 @@ func (StorageProfileStatus) SwaggerDoc() map[string]string {
 		"storageClass":               "The StorageClass name for which capabilities are defined",
 		"provisioner":                "The Storage class provisioner plugin name",
 		"cloneStrategy":              "CloneStrategy defines the preferred method for performing a CDI clone",
-		"claimPropertySets":          "ClaimPropertySets computed from the spec and detected in the system",
+		"claimPropertySets":          "ClaimPropertySets computed from the spec and detected in the system\n+kubebuilder:validation:MaxItems=8",
 		"dataImportCronSourceFormat": "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
 		"snapshotClass":              "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
 	}
@@ -203,7 +203,7 @@ func (StorageProfileStatus) SwaggerDoc() map[string]string {
 func (ClaimPropertySet) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":            "ClaimPropertySet is a set of properties applicable to PVC",
-		"accessModes": "AccessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+		"accessModes": "AccessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1\n+kubebuilder:validation:MaxItems=4\n+kubebuilder:validation:XValidation:rule=\"self.all(am, am in ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany', 'ReadWriteOncePod'])\", message=\"Illegal AccessMode\"",
 		"volumeMode":  "VolumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.\n+kubebuilder:validation:Enum=\"Block\";\"Filesystem\"",
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We have no reason to allow setting `StorageProfile` `ClaimPropertySet` missing either `VolumeMode` or `AccessModes`.

**Which issue(s) this PR fixes**:
Jira-ticket: https://issues.redhat.com/browse/CNV-37991

**Release note**:
```release-note
BugFix: StorageProfile ClaimPropertySets validation
```

