### PR TITLE
Adapt test suite for Filesystem only advanced storage

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2674,6 +2674,9 @@ var _ = Describe("all clone tests", func() {
 			if !f.IsSnapshotStorageClassAvailable() {
 				Skip("Clone from volumesnapshot does not work without snapshot capable storage")
 			}
+			if volumeMode == v1.PersistentVolumeBlock && !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
 
 			targetNs := f.Namespace
 			if crossNamespace {
@@ -2746,6 +2749,9 @@ var _ = Describe("all clone tests", func() {
 				var i int
 				var err error
 
+				if volumeMode == v1.PersistentVolumeBlock && !f.IsBlockVolumeStorageClassAvailable() {
+					Skip("Storage Class for block volume is not available")
+				}
 				targetNs := f.Namespace
 				if crossNamespace {
 					targetNamespace, err = f.CreateNamespace("cdi-cross-ns-snapshot-clone-test", nil)

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -67,6 +67,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		if !f.IsCSIVolumeCloneStorageClassAvailable() {
 			Skip("CSI Volume Clone is not applicable")
 		}
+		if !f.IsBlockVolumeStorageClassAvailable() {
+			Skip("Storage Class for block volume is not available")
+		}
 
 		By(fmt.Sprintf("configure storage profile %s", f.CsiCloneSCName))
 		Expect(

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2413,6 +2413,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6101]Clone pod should not have size corrected on block", func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied
@@ -2440,6 +2443,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		})
 
 		It("[test_id:6487]Clone pod should not have size corrected on block, when no volumeMode on DV", func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
 			// volumeMode Block, so no overhead applied

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1409,7 +1409,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			By("Create PVC")
 			annotations := map[string]string{"cdi.kubevirt.io/storage.populatedFor": dataVolumeName}
-			pvc := utils.NewPVCDefinition(dataVolumeName, "100m", annotations, nil)
+			pvc := utils.NewPVCDefinition(dataVolumeName, "100Mi", annotations, nil)
 			pvc = f.CreateBoundPVCFromDefinition(pvc)
 
 			By("Verifying Succeed with PVC Bound")

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -129,6 +129,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 		if !f.IsSnapshotStorageClassAvailable() {
 			Skip("Smart Clone is not applicable")
 		}
+		if !f.IsBlockVolumeStorageClassAvailable() {
+			Skip("Storage Class for block volume is not available")
+		}
 		dataVolume, expectedMd5 := createDataVolume("dv-smart-clone-test-1", utils.DefaultPvcMountPath, v1.PersistentVolumeBlock, f.SnapshotSCName, f)
 		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.SnapshotForSmartCloneInProgress))
 		if !f.IsBindingModeWaitForFirstConsumer(&cloneStorageClassName) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Lessons learned during testing of FSx for ONTAP-nas (Filesystem only advanced storage)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

