### PR TITLE
feat: Make importer datasource communication explicit

### DIFF
--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -13,10 +13,10 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
-        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
     ],
 )
 

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -13,6 +13,7 @@ package main
 //    ImporterSecretKey     Optional. Secret key is the password to your account.
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -20,11 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
@@ -149,20 +149,17 @@ func main() {
 }
 
 func handleEmptyImage(contentType string, imageSize string, availableDestSpace int64, preallocation bool, volumeMode v1.PersistentVolumeMode, filesystemOverhead float64) error {
-	var preallocationApplied bool
-
 	if contentType == string(cdiv1.DataVolumeKubeVirt) {
 		if volumeMode == v1.PersistentVolumeBlock && !preallocation {
 			klog.V(1).Infoln("Blank block without preallocation is exactly an empty PVC, done populating")
 			return nil
 		}
 		createBlankImage(imageSize, availableDestSpace, preallocation, volumeMode, filesystemOverhead)
-		preallocationApplied = preallocation
 	} else {
 		errorEmptyDiskWithContentTypeArchive()
 	}
 
-	err := importCompleteTerminationMessage(preallocationApplied)
+	err := writeTerminationMessage(&common.TerminationMessage{PreallocationApplied: ptr.To(preallocation)})
 	return err
 }
 
@@ -181,49 +178,47 @@ func handleImport(
 	processor := newDataProcessor(contentType, volumeMode, ds, imageSize, filesystemOverhead, preallocation)
 	err := processor.ProcessData()
 
-	if err != nil {
+	scratchSpaceRequired := errors.Is(err, importer.ErrRequiresScratchSpace)
+	if err != nil && !scratchSpaceRequired {
 		klog.Errorf("%+v", err)
-		if err == importer.ErrRequiresScratchSpace {
-			if err := util.WriteTerminationMessage(common.ScratchSpaceRequired); err != nil {
-				klog.Errorf("%+v", err)
-			}
-			// Exiting instead of returning 0 as normally to avoid clashing
-			// with cleanup functions (fsyncDataFile) that assume the imported
-			// file will be there during regular exit.
-			os.Exit(0)
-		}
-		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error()))
-		if err != nil {
+		if err := util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error())); err != nil {
 			klog.Errorf("%+v", err)
 		}
-
 		return 1
 	}
+
+	termMsg := ds.GetTerminationMessage()
+	if termMsg == nil {
+		termMsg = &common.TerminationMessage{}
+	}
+	termMsg.ScratchSpaceRequired = &scratchSpaceRequired
+	termMsg.PreallocationApplied = ptr.To(processor.PreallocationApplied())
+
 	touchDoneFile()
-	// due to the way some data sources can add additional information to termination message
-	// after finished (ds.close() ) termination message has to be written first, before the
-	// the ds is closed
-	// TODO: think about making communication explicit, probably DS interface should be extended
-	err = importCompleteTerminationMessage(processor.PreallocationApplied())
-	if err != nil {
+	if err := writeTerminationMessage(termMsg); err != nil {
 		klog.Errorf("%+v", err)
 		return 1
+	}
+
+	if scratchSpaceRequired {
+		// Exiting instead of returning 0 as normally to avoid clashing
+		// with cleanup functions (fsyncDataFile) that assume the imported
+		// file will be there during regular exit.
+		os.Exit(0)
 	}
 
 	return 0
 }
 
-func importCompleteTerminationMessage(preallocationApplied bool) error {
-	message := "Import Complete"
-	if preallocationApplied {
-		message += ", " + common.PreallocationApplied
-	}
-	err := util.WriteTerminationMessage(message)
+func writeTerminationMessage(termMsg *common.TerminationMessage) error {
+	msg, err := termMsg.String()
 	if err != nil {
 		return err
 	}
-
-	klog.V(1).Infoln(message)
+	if err := util.WriteTerminationMessage(msg); err != nil {
+		return err
+	}
+	klog.V(1).Infoln(msg)
 	return nil
 }
 

--- a/pkg/common/BUILD.bazel
+++ b/pkg/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,18 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/common",
     visibility = ["//visibility:public"],
     deps = ["//vendor/k8s.io/api/core/v1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "common_suite_test.go",
+        "common_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
+    ],
 )

--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,13 @@
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("TerminationMessage", func() {
+	It("Should successfully serialize a TerminationMessage", func() {
+		termMsg := TerminationMessage{
+			VddkInfo: &VddkInfo{
+				Version: "testversion",
+				Host:    "testhost",
+			},
+			Labels: map[string]string{
+				"testlabel": "testvalue",
+			},
+			PreallocationApplied: ptr.To(true),
+		}
+
+		serialized, err := termMsg.String()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serialized).To(Equal(`{"preallocationApplied":true,"vddkInfo":{"Version":"testversion","Host":"testhost"},"labels":{"testlabel":"testvalue"}}`))
+	})
+
+	It("Should fail if serialized data is longer than 4096 bytes", func() {
+		const length = 5000
+		const serializationOffset = 19
+
+		termMsg := TerminationMessage{
+			Labels: map[string]string{},
+		}
+		for i := 0; i < length-serializationOffset; i++ {
+			termMsg.Labels["t"] += "c"
+		}
+
+		_, err := termMsg.String()
+		Expect(err).To(MatchError(fmt.Sprintf("Termination message length %d exceeds maximum length of 4096 bytes", length)))
+	})
+})

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -331,7 +331,7 @@ func (r *CloneReconciler) updatePvcFromPod(sourcePod *corev1.Pod, pvc *corev1.Pe
 		r.recorder.Event(pvc, corev1.EventTypeNormal, CloneSucceededPVC, cc.CloneComplete)
 	}
 
-	setAnnotationsFromPodWithPrefix(pvc.Annotations, sourcePod, cc.AnnSourceRunningCondition)
+	setAnnotationsFromPodWithPrefix(pvc.Annotations, sourcePod, nil, cc.AnnSourceRunningCondition)
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {
 		return r.updatePVC(pvc)

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -488,7 +488,7 @@ func updateUploadAnnotations(pvc *corev1.PersistentVolumeClaim, anno map[string]
 	anno[cc.AnnPodPhase] = string(podPhase)
 	anno[cc.AnnPodReady] = strconv.FormatBool(isPodReady(pod))
 
-	setAnnotationsFromPodWithPrefix(anno, pod, cc.AnnRunningCondition)
+	setAnnotationsFromPodWithPrefix(anno, pod, nil, cc.AnnRunningCondition)
 }
 
 func isPodReady(pod *v1.Pod) bool {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -61,6 +60,9 @@ const (
 	// ScratchSpaceRequiredReason is a const that defines the pod exited due to a lack of scratch space
 	ScratchSpaceRequiredReason = "Scratch space required"
 
+	// ImportCompleteMessage is a const that defines the pod completeded the import successfully
+	ImportCompleteMessage = "Import Complete"
+
 	// ProxyCertVolName is the name of the volumecontaining certs
 	ProxyCertVolName = "cdi-proxy-cert-vol"
 	// ClusterWideProxyAPIGroup is the APIGroup for OpenShift Cluster Wide Proxy
@@ -77,10 +79,6 @@ const (
 	ClusterWideProxyConfigMapNameSpace = "openshift-config"
 	// ClusterWideProxyConfigMapKey is the OpenShift Cluster Wide Proxy ConfigMap key name for CA certificates.
 	ClusterWideProxyConfigMapKey = "ca-bundle.crt"
-)
-
-var (
-	vddkInfoMatch = regexp.MustCompile(`((.*; )|^)VDDK: (?P<info>{.*})`)
 )
 
 func checkPVC(pvc *v1.PersistentVolumeClaim, annotation string, log logr.Logger) bool {
@@ -277,7 +275,7 @@ func podSucceededFromPVC(pvc *v1.PersistentVolumeClaim) bool {
 	return podPhaseFromPVC(pvc) == v1.PodSucceeded
 }
 
-func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, prefix string) {
+func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, termMsg *common.TerminationMessage, prefix string) {
 	if pod == nil || pod.Status.ContainerStatuses == nil {
 		return
 	}
@@ -286,38 +284,52 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, prefix
 	if podRestarts >= annPodRestarts {
 		anno[cc.AnnPodRestarts] = strconv.Itoa(podRestarts)
 	}
-	setVddkAnnotations(anno, pod)
+
 	containerState := pod.Status.ContainerStatuses[0].State
 	if containerState.Running != nil {
 		anno[prefix] = "true"
 		anno[prefix+".message"] = ""
 		anno[prefix+".reason"] = PodRunningReason
-	} else {
-		anno[cc.AnnRunningCondition] = "false"
-		if containerState.Waiting != nil && containerState.Waiting.Reason != "CrashLoopBackOff" {
-			anno[prefix+".message"] = simplifyKnownMessage(containerState.Waiting.Message)
-			anno[prefix+".reason"] = containerState.Waiting.Reason
-		} else if containerState.Terminated != nil {
-			anno[prefix+".message"] = simplifyKnownMessage(containerState.Terminated.Message)
-			reason := containerState.Terminated.Reason
-			if reason == common.GenericError {
-				reason = handleGenericErrorReason(containerState.Terminated.Message)
+		return
+	}
+
+	anno[cc.AnnRunningCondition] = "false"
+	if containerState.Waiting != nil && containerState.Waiting.Reason != "CrashLoopBackOff" {
+		anno[prefix+".message"] = simplifyKnownMessage(containerState.Waiting.Message)
+		anno[prefix+".reason"] = containerState.Waiting.Reason
+		return
+	}
+
+	if containerState.Terminated != nil {
+		if termMsg != nil {
+			if termMsg.ScratchSpaceRequired != nil && *termMsg.ScratchSpaceRequired {
+				anno[cc.AnnRequiresScratch] = "true"
+				anno[prefix+".message"] = common.ScratchSpaceRequired
+				anno[prefix+".reason"] = ScratchSpaceRequiredReason
+				return
 			}
-			anno[prefix+".reason"] = reason
+			// Handle extended termination message
+			anno[prefix+".message"] = ImportCompleteMessage
+			if termMsg.VddkInfo != nil {
+				if termMsg.VddkInfo.Host != "" {
+					anno[cc.AnnVddkHostConnection] = termMsg.VddkInfo.Host
+				}
+				if termMsg.VddkInfo.Version != "" {
+					anno[cc.AnnVddkVersion] = termMsg.VddkInfo.Version
+				}
+			}
+			if termMsg.PreallocationApplied != nil && *termMsg.PreallocationApplied {
+				anno[cc.AnnPreallocationApplied] = "true"
+			}
+		} else {
+			// Handle plain termination message (legacy)
+			anno[prefix+".message"] = simplifyKnownMessage(containerState.Terminated.Message)
 			if strings.Contains(containerState.Terminated.Message, common.PreallocationApplied) {
 				anno[cc.AnnPreallocationApplied] = "true"
 			}
 		}
+		anno[prefix+".reason"] = containerState.Terminated.Reason
 	}
-}
-
-func handleGenericErrorReason(message string) string {
-	if strings.Contains(message, common.ScratchSpaceRequired) {
-		// Sometimes the pod will need scratch space to complete some operations.
-		// Better to add a custom reason instead of a generic container state.
-		return ScratchSpaceRequiredReason
-	}
-	return common.GenericError
 }
 
 func simplifyKnownMessage(msg string) string {
@@ -330,33 +342,22 @@ func simplifyKnownMessage(msg string) string {
 	return msg
 }
 
-func setVddkAnnotations(anno map[string]string, pod *v1.Pod) {
-	if pod.Status.ContainerStatuses[0].State.Terminated == nil {
-		return
-	}
-	terminationMessage := pod.Status.ContainerStatuses[0].State.Terminated.Message
-	klog.V(1).Info("Saving VDDK annotations from pod status message: ", "message", terminationMessage)
-
-	var terminationInfo string
-	matches := vddkInfoMatch.FindAllStringSubmatch(terminationMessage, -1)
-	for index, matchName := range vddkInfoMatch.SubexpNames() {
-		if matchName == "info" && len(matches) > 0 {
-			terminationInfo = matches[0][index]
-			break
-		}
+func parseTerminationMessage(pod *v1.Pod) (*common.TerminationMessage, error) {
+	if pod == nil || pod.Status.ContainerStatuses == nil {
+		return nil, nil
 	}
 
-	var vddkInfo util.VddkInfo
-	err := json.Unmarshal([]byte(terminationInfo), &vddkInfo)
-	if err != nil {
-		return
+	state := pod.Status.ContainerStatuses[0].State
+	if state.Terminated == nil || state.Terminated.ExitCode != 0 {
+		return nil, nil
 	}
-	if vddkInfo.Host != "" {
-		anno[cc.AnnVddkHostConnection] = vddkInfo.Host
+
+	termMsg := &common.TerminationMessage{}
+	if err := json.Unmarshal([]byte(state.Terminated.Message), termMsg); err != nil {
+		return nil, err
 	}
-	if vddkInfo.Version != "" {
-		anno[cc.AnnVddkVersion] = vddkInfo.Version
-	}
+
+	return termMsg, nil
 }
 
 func setBoundConditionFromPVC(anno map[string]string, prefix string, pvc *v1.PersistentVolumeClaim) {

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -89,6 +89,8 @@ type DataSourceInterface interface {
 	TransferFile(fileName string) (ProcessingPhase, error)
 	// Geturl returns the url that the data processor can use when converting the data.
 	GetURL() *url.URL
+	// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+	GetTerminationMessage() *common.TerminationMessage
 	// Close closes any readers or other open resources.
 	Close() error
 }

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 )
 
@@ -87,6 +88,11 @@ func (m *MockDataProvider) TransferFile(fileName string) (ProcessingPhase, error
 // Geturl returns the url that the data processor can use when converting the data.
 func (m *MockDataProvider) GetURL() *url.URL {
 	return m.url
+}
+
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (m *MockDataProvider) GetTerminationMessage() *common.TerminationMessage {
+	return nil
 }
 
 // Close closes any readers or other open resources.

--- a/pkg/importer/gcs-datasource.go
+++ b/pkg/importer/gcs-datasource.go
@@ -16,6 +16,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
@@ -154,6 +155,11 @@ func (sd *GCSDataSource) TransferFile(fileName string) (ProcessingPhase, error) 
 // GetURL returns the url that the data processor can use when converting the data.
 func (sd *GCSDataSource) GetURL() *url.URL {
 	return sd.url
+}
+
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (sd *GCSDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
 }
 
 // Close closes any readers or other open resources.

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -194,6 +194,11 @@ func (hs *HTTPDataSource) GetURL() *url.URL {
 	return hs.url
 }
 
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (hs *HTTPDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
+}
+
 // Close all readers.
 func (hs *HTTPDataSource) Close() error {
 	var err error

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
@@ -191,6 +192,11 @@ func (is *ImageioDataSource) TransferFile(fileName string) (ProcessingPhase, err
 // GetURL returns the URI that the data processor can use when converting the data.
 func (is *ImageioDataSource) GetURL() *url.URL {
 	return is.url
+}
+
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (is *ImageioDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
 }
 
 // Close all readers.

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -120,6 +120,11 @@ func (rd *RegistryDataSource) GetURL() *url.URL {
 	return rd.url
 }
 
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (rd *RegistryDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
+}
+
 // Close closes any readers or other open resources.
 func (rd *RegistryDataSource) Close() error {
 	// No-op, no open readers

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -17,6 +17,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
@@ -124,6 +125,11 @@ func (sd *S3DataSource) TransferFile(fileName string) (ProcessingPhase, error) {
 // GetURL returns the url that the data processor can use when converting the data.
 func (sd *S3DataSource) GetURL() *url.URL {
 	return sd.url
+}
+
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (sd *S3DataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
 }
 
 // Close closes any readers or other open resources.

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog/v2"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
@@ -107,6 +108,11 @@ func (ud *UploadDataSource) GetURL() *url.URL {
 	return ud.url
 }
 
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (ud *UploadDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
+}
+
 // Close closes any readers or other open resources.
 func (ud *UploadDataSource) Close() error {
 	if ud.stream != nil {
@@ -185,6 +191,11 @@ func (aud *AsyncUploadDataSource) Close() error {
 // GetURL returns the url that the data processor can use when converting the data.
 func (aud *AsyncUploadDataSource) GetURL() *url.URL {
 	return aud.uploadDataSource.GetURL()
+}
+
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (aud *AsyncUploadDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
 }
 
 // GetResumePhase returns the next phase to process when resuming

--- a/pkg/importer/vddk-datasource_arm64.go
+++ b/pkg/importer/vddk-datasource_arm64.go
@@ -30,6 +30,10 @@ func (V VDDKDataSource) GetURL() *url.URL {
 	panic("not support")
 }
 
+func (V VDDKDataSource) GetTerminationMessage() *common.TerminationMessage {
+	panic("not support")
+}
+
 func (V VDDKDataSource) Close() error {
 	panic("not support")
 }

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	libnbd "libguestfs.org/libnbd"
 )
@@ -431,6 +432,18 @@ var _ = Describe("VDDK data source", func() {
 		_, err = NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(MaxPreadLength).To(Equal(uint32(MaxPreadLengthVC)))
+	})
+
+	It("GetTerminationMessage should contain VDDK connection information", func() {
+		const testVersion = "testVersion"
+		const testHost = "testHost"
+
+		source, err := NewVDDKDataSource("http://esx.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "testdisk.vmdk", "", "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+
+		vddkVersion = testVersion
+		vddkHost = testHost
+		Expect(*source.GetTerminationMessage()).To(Equal(common.TerminationMessage{VddkInfo: &common.VddkInfo{Version: testVersion, Host: testHost}}))
 	})
 })
 

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -147,6 +147,11 @@ func (amd *AsyncMockDataSource) GetURL() *url.URL {
 	return nil
 }
 
+// GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
+func (amd *AsyncMockDataSource) GetTerminationMessage() *common.TerminationMessage {
+	return nil
+}
+
 // GetResumePhase returns the next phase to process when resuming
 func (amd *AsyncMockDataSource) GetResumePhase() importer.ProcessingPhase {
 	return importer.ProcessingPhaseComplete

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -42,12 +42,6 @@ type CountingReader struct {
 	Done    bool
 }
 
-// VddkInfo holds VDDK version and connection information returned by an importer pod
-type VddkInfo struct {
-	Version string
-	Host    string
-}
-
 // RandAlphaNum provides an implementation to generate a random alpha numeric string of the specified length
 func RandAlphaNum(n int) string {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1013,7 +1013,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				runningCondition: &cdiv1.DataVolumeCondition{
 					Type:    cdiv1.DataVolumeRunning,
 					Status:  v1.ConditionFalse,
-					Message: "Import Complete; VDDK: {\"Version\":\"1.2.3\",\"Host\":\"esx.test\"}",
+					Message: "Import Complete",
 					Reason:  "Completed",
 				}}),
 			PEntry("[quarantine][test_id:5078]succeed creating warm import dv from VDDK source", dataVolumeTestArguments{
@@ -1037,7 +1037,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				runningCondition: &cdiv1.DataVolumeCondition{
 					Type:    cdiv1.DataVolumeRunning,
 					Status:  v1.ConditionFalse,
-					Message: "Import Complete; VDDK: {\"Version\":\"1.2.3\",\"Host\":\"esx.test\"}",
+					Message: "Import Complete",
 					Reason:  "Completed",
 				}}),
 			Entry("[rfe_id:XXXX][crit:high][test_id:XXXX]succeed creating import dv from GCS URL using RAW image", dataVolumeTestArguments{
@@ -1169,7 +1169,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				runningCondition: &cdiv1.DataVolumeCondition{
 					Type:    cdiv1.DataVolumeRunning,
 					Status:  v1.ConditionFalse,
-					Message: "Import Complete; VDDK: {\"Version\":\"1.2.3\",\"Host\":\"esx.test\"}",
+					Message: "Import Complete",
 					Reason:  "Completed",
 				}}),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Make the communication of datasources in the importer explicit by adding
a GetTerminationMessage method to the DataSourceInterface.
Then use this method to communicate additional information to the import
controller once the importer pod has terminated, instead of writing
additional data to the termination message in the Close method of
datasources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

