### PR TITLE
feat(import): Set PVC labels derived from env vars on containerdisks

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -358,3 +358,8 @@ func (it *TerminationMessage) String() (string, error) {
 
 	return string(msg), nil
 }
+
+// ServerInfo contains data to be serialized and used as the body of responses to the info endpoint of the containerimage-server.
+type ServerInfo struct {
+	Env []string `json:"env,omitempty"`
+}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -410,11 +410,14 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		delete(anno, cc.AnnBoundConditionReason)
 	}
 
+	if pvc.GetLabels() == nil {
+		pvc.SetLabels(make(map[string]string, 0))
+	}
 	if !checkIfLabelExists(pvc, common.CDILabelKey, common.CDILabelValue) {
-		if pvc.GetLabels() == nil {
-			pvc.SetLabels(make(map[string]string, 0))
-		}
 		pvc.GetLabels()[common.CDILabelKey] = common.CDILabelValue
+	}
+	if cc.IsPVCComplete(pvc) {
+		setLabelsFromTerminationMessage(pvc.GetLabels(), termMsg)
 	}
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -156,9 +156,11 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 			break
 		}
 
-		// Once the import is succeeded, we rebind the PV from PVC' to target PVC
-		if err := cc.Rebind(context.TODO(), r.client, pvcPrime, pvc); err != nil {
-			return reconcile.Result{}, err
+		if cc.IsPVCComplete(pvcPrime) && cc.IsUnbound(pvc) {
+			// Once the import is succeeded, we rebind the PV from PVC to target PVC
+			if err := cc.Rebind(context.TODO(), r.client, pvcPrime, pvc); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -19,6 +19,7 @@ package populators
 import (
 	"context"
 	"reflect"
+	"regexp"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -58,6 +59,10 @@ const (
 	dataSourceRefField = "spec.dataSourceRef"
 
 	uidField = "metadata.uid"
+)
+
+var (
+	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/\w+$`)
 )
 
 // Interface to store populator-specific methods
@@ -223,7 +228,7 @@ var desiredAnnotations = []string{cc.AnnPodPhase, cc.AnnPodReady, cc.AnnPodResta
 	cc.AnnPreallocationRequested, cc.AnnPreallocationApplied, cc.AnnCurrentCheckpoint, cc.AnnMultiStageImportDone,
 	cc.AnnRunningCondition, cc.AnnRunningConditionMessage, cc.AnnRunningConditionReason}
 
-func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) error {
+func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) (*corev1.PersistentVolumeClaim, error) {
 	pvcCopy := pvc.DeepCopy()
 	for _, ann := range desiredAnnotations {
 		if value, ok := pvcPrime.GetAnnotations()[ann]; ok {
@@ -241,10 +246,25 @@ func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.
 	if !reflect.DeepEqual(pvc.ObjectMeta, pvcCopy.ObjectMeta) {
 		err := r.client.Update(context.TODO(), pvcCopy)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
+	return pvcCopy, nil
+}
+
+func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolumeClaim, pvcPrimeLabels map[string]string) error {
+	pvcCopy := pvc.DeepCopy()
+	for label, value := range pvcPrimeLabels {
+		if _, found := pvcCopy.GetLabels()[label]; !found && validLabelsMatch.MatchString(label) {
+			cc.AddLabel(pvcCopy, label, value)
+		}
+	}
+	if !reflect.DeepEqual(pvc.ObjectMeta, pvcCopy.ObjectMeta) {
+		if err := r.client.Update(context.TODO(), pvcCopy); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -159,9 +159,11 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		// We'll get called later once it succeeds
 		r.recorder.Eventf(pvc, corev1.EventTypeWarning, errUploadFailed, fmt.Sprintf(messageUploadFailed, pvc.Name))
 	case string(corev1.PodSucceeded):
-		// Once the upload is succeeded, we rebind the PV from PVC' to target PVC
-		if err := cc.Rebind(context.TODO(), r.client, pvcPrime, pvcCopy); err != nil {
-			return reconcile.Result{}, err
+		if cc.IsPVCComplete(pvcPrime) && cc.IsUnbound(pvc) {
+			// Once the upload is succeeded, we rebind the PV from PVC' to target PVC
+			if err := cc.Rebind(context.TODO(), r.client, pvcPrime, pvcCopy); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -165,7 +165,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 	}
 
-	err := r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
+	_, err := r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		cc.AddAnnotation(pvcPrime, AnnPVCPrimeName, pvcPrime.Name)
 
 		r := createUploadPopulatorReconciler(pvc, pvcPrime)
-		err := r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateUploadAnnotations)
+		pvc, err := r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateUploadAnnotations)
 		Expect(err).ToNot(HaveOccurred())
 
 		//should always remove the pvc prime annotation

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -332,6 +332,17 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, termMs
 	}
 }
 
+func setLabelsFromTerminationMessage(labels map[string]string, termMsg *common.TerminationMessage) {
+	if labels == nil || termMsg == nil {
+		return
+	}
+	for k, v := range termMsg.Labels {
+		if _, found := labels[k]; !found {
+			labels[k] = v
+		}
+	}
+}
+
 func simplifyKnownMessage(msg string) string {
 	if strings.Contains(msg, "is larger than the reported available") ||
 		strings.Contains(msg, "no space left on device") ||

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -232,6 +232,52 @@ var _ = Describe("setAnnotationsFromPod", func() {
 	})
 })
 
+var _ = Describe("setLabelsFromTerminationMessage", func() {
+	It("should set labels from termMsg", func() {
+		labels := make(map[string]string, 0)
+		termMsg := &common.TerminationMessage{
+			Labels: map[string]string{
+				"test": "test",
+			},
+		}
+
+		setLabelsFromTerminationMessage(labels, termMsg)
+		for k, v := range termMsg.Labels {
+			Expect(labels).To(HaveKeyWithValue(k, v))
+		}
+	})
+
+	It("should not overwrite existing labels from termMsg", func() {
+		const testKeyExisting = "test"
+		const testValueExisting = "existing"
+
+		labels := map[string]string{
+			testKeyExisting: testValueExisting,
+		}
+		termMsg := &common.TerminationMessage{
+			Labels: map[string]string{
+				testKeyExisting: "somethingelse",
+			},
+		}
+
+		setLabelsFromTerminationMessage(labels, termMsg)
+		Expect(labels).To(HaveKeyWithValue(testKeyExisting, testValueExisting))
+	})
+
+	It("should handle nil termMsg", func() {
+		labels := map[string]string{
+			"test": "test",
+		}
+		labelsOriginal := make(map[string]string, len(labels))
+		for k, v := range labels {
+			labelsOriginal[k] = v
+		}
+
+		setLabelsFromTerminationMessage(labels, nil)
+		Expect(labels).To(Equal(labelsOriginal))
+	})
+})
+
 var _ = Describe("GetPreallocation", func() {
 	It("Should return preallocation for DataVolume if specified", func() {
 		client := CreateClient()

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
         "//tests/utils:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",
+        "//vendor/github.com/containers/image/v5/types:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/ovirt/go-ovirt:go_default_library",

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -196,7 +197,19 @@ func (hs *HTTPDataSource) GetURL() *url.URL {
 
 // GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
 func (hs *HTTPDataSource) GetTerminationMessage() *common.TerminationMessage {
-	return nil
+	if pullMethod, _ := util.ParseEnvVar(common.ImporterPullMethod, false); pullMethod != string(cdiv1.RegistryPullNode) {
+		return nil
+	}
+
+	info, err := getServerInfo(hs.ctx, fmt.Sprintf("%s://%s/info", hs.endpoint.Scheme, hs.endpoint.Host))
+	if err != nil {
+		klog.Errorf("%+v", err)
+		return nil
+	}
+
+	return &common.TerminationMessage{
+		Labels: envsToLabels(info.Env),
+	}
 }
 
 // Close all readers.
@@ -501,4 +514,34 @@ func getExtraHeadersFromSecrets() ([]string, error) {
 	})
 
 	return secretExtraHeaders, err
+}
+
+func getServerInfo(ctx context.Context, infoURL string) (*common.ServerInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", infoURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct request for containerimage-server info")
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed request containerimage-server info")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed request containerimage-server info: expected status code 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read body of containerimage-server info request")
+	}
+
+	info := &common.ServerInfo{}
+	if err := json.Unmarshal(body, info); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal body of containerimage-server info request")
+	}
+
+	return info, nil
 }

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Imageio reader", func() {
 		newOvirtClientFunc = createMockOvirtClient
 		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
-		ts = createTestServer(imageDir)
+		ts = createTestServer(imageDir, nil)
 		disk.SetTotalSize(1024)
 		disk.SetId(diskID)
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
@@ -91,7 +91,7 @@ var _ = Describe("Imageio data source", func() {
 		newOvirtClientFunc = createMockOvirtClient
 		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
-		ts = createTestServer(imageDir)
+		ts = createTestServer(imageDir, nil)
 		disk.SetTotalSize(1024)
 		disk.SetId(diskID)
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
@@ -244,7 +244,7 @@ var _ = Describe("Imageio cancel", func() {
 		newOvirtClientFunc = createMockOvirtClient
 		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
-		ts = createTestServer(imageDir)
+		ts = createTestServer(imageDir, nil)
 		disk.SetTotalSize(1024)
 		disk.SetId(diskID)
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)
@@ -384,7 +384,7 @@ var _ = Describe("imageio snapshots", func() {
 		newOvirtClientFunc = createMockOvirtClient
 		newTerminationChannel = createMockTerminationChannel
 		tempDir = createCert()
-		ts = createTestServer(imageDir)
+		ts = createTestServer(imageDir, nil)
 		disk.SetTotalSize(diskSize)
 		disk.SetId(diskID)
 		it.SetPhase(ovirtsdk4.IMAGETRANSFERPHASE_TRANSFERRING)

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/image/v5/types"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 
@@ -48,6 +49,8 @@ type RegistryDataSource struct {
 	imageDir    string
 	//The discovered image file in scratch space.
 	url *url.URL
+	//The discovered image info from the registry.
+	info *types.ImageInspectInfo
 }
 
 // NewRegistryDataSource creates a new instance of the Registry Data Source.
@@ -94,7 +97,7 @@ func (rd *RegistryDataSource) Transfer(path string) (ProcessingPhase, error) {
 	}
 
 	klog.V(1).Infof("Copying registry image to scratch space.")
-	err = CopyRegistryImage(rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.certDir, rd.insecureTLS)
+	rd.info, err = CopyRegistryImage(rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.certDir, rd.insecureTLS)
 	if err != nil {
 		return ProcessingPhaseError, errors.Wrapf(err, "Failed to read registry image")
 	}
@@ -122,7 +125,12 @@ func (rd *RegistryDataSource) GetURL() *url.URL {
 
 // GetTerminationMessage returns data to be serialized and used as the termination message of the importer.
 func (rd *RegistryDataSource) GetTerminationMessage() *common.TerminationMessage {
-	return nil
+	if rd.info == nil {
+		return nil
+	}
+	return &common.TerminationMessage{
+		Labels: envsToLabels(rd.info.Env),
+	}
 }
 
 // Close closes any readers or other open resources.

--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -172,7 +172,7 @@ func processLayer(ctx context.Context,
 	return found, nil
 }
 
-func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry, stopAtFirst bool) error {
+func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry, stopAtFirst bool) (*types.ImageInspectInfo, error) {
 	klog.Infof("Downloading image from '%v', copying file from '%v' to '%v'", url, pathPrefix, destDir)
 
 	ctx, cancel := commandTimeoutContext()
@@ -181,14 +181,14 @@ func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir stri
 
 	src, err := readImageSource(ctx, srcCtx, url)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer closeImage(src)
 
 	imgCloser, err := image.FromSource(ctx, srcCtx, src)
 	if err != nil {
 		klog.Errorf("Error retrieving image: %v", err)
-		return errors.Wrap(err, "Error retrieving image")
+		return nil, errors.Wrap(err, "Error retrieving image")
 	}
 	defer imgCloser.Close()
 
@@ -212,10 +212,15 @@ func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir stri
 
 	if !found {
 		klog.Errorf("Failed to find VM disk image file in the container image")
-		return errors.New("Failed to find VM disk image file in the container image")
+		return nil, errors.New("Failed to find VM disk image file in the container image")
 	}
 
-	return nil
+	info, err := imgCloser.Inspect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 // GetImageDigest returns the digest of the container image at url.
@@ -258,7 +263,7 @@ func GetImageDigest(url, accessKey, secKey, certDir string, insecureRegistry boo
 // secKey: secretKey for the registry described in url.
 // certDir: directory public CA keys are stored for registry identity verification
 // insecureRegistry: boolean if true will allow insecure registries.
-func CopyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry bool) error {
+func CopyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry bool) (*types.ImageInspectInfo, error) {
 	return copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir, insecureRegistry, true)
 }
 
@@ -270,6 +275,6 @@ func CopyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir stri
 // secKey: secretKey for the registry described in url.
 // certDir: directory public CA keys are stored for registry identity verification
 // insecureRegistry: boolean if true will allow insecure registries.
-func CopyRegistryImageAll(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry bool) error {
+func CopyRegistryImageAll(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry bool) (*types.ImageInspectInfo, error) {
 	return copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, certDir, insecureRegistry, false)
 }

--- a/pkg/importer/transport_test.go
+++ b/pkg/importer/transport_test.go
@@ -39,15 +39,17 @@ var _ = Describe("Registry Importer", func() {
 	})
 
 	It("Should extract a single file", func() {
-		err := CopyRegistryImage(source, tmpDir, "disk/cirros-0.3.4-x86_64-disk.img", "", "", "", false)
+		info, err := CopyRegistryImage(source, tmpDir, "disk/cirros-0.3.4-x86_64-disk.img", "", "", "", false)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(info).ToNot(BeNil())
 
 		file := filepath.Join(tmpDir, "disk/cirros-0.3.4-x86_64-disk.img")
 		Expect(file).To(BeARegularFile())
 	})
 	It("Should extract files prefixed by path", func() {
-		err := CopyRegistryImageAll(source, tmpDir, "etc/", "", "", "", false)
+		info, err := CopyRegistryImageAll(source, tmpDir, "etc/", "", "", "", false)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(info).ToNot(BeNil())
 
 		file := filepath.Join(tmpDir, "etc/hosts")
 		Expect(file).To(BeARegularFile())
@@ -56,15 +58,17 @@ var _ = Describe("Registry Importer", func() {
 		Expect(file).To(BeARegularFile())
 	})
 	It("Should return an error if a single file is not found", func() {
-		err := CopyRegistryImage(source, tmpDir, "disk/invalid.img", "", "", "", false)
+		info, err := CopyRegistryImage(source, tmpDir, "disk/invalid.img", "", "", "", false)
 		Expect(err).To(HaveOccurred())
+		Expect(info).To(BeNil())
 
 		file := filepath.Join(tmpDir, "disk/cirros-0.3.4-x86_64-disk.img")
 		_, err = os.Stat(file)
 		Expect(err).To(HaveOccurred())
 	})
 	It("Should return an error if no files matches a prefix", func() {
-		err := CopyRegistryImageAll(source, tmpDir, "invalid/", "", "", "", false)
+		info, err := CopyRegistryImageAll(source, tmpDir, "invalid/", "", "", "", false)
 		Expect(err).To(HaveOccurred())
+		Expect(info).To(BeNil())
 	})
 })

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -4,12 +4,18 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+)
+
+const (
+	kubevirtEnvPrefix   = "KUBEVIRT_IO_"
+	kubevirtLabelPrefix = "kubevirt.io/"
 )
 
 // ParseEndpoint parses the required endpoint and return the url struct.
@@ -51,3 +57,28 @@ func GetTerminationChannel() <-chan os.Signal {
 
 // newTerminationChannel should be overriden for unit tests
 var newTerminationChannel = GetTerminationChannel
+
+func envsToLabels(envs []string) map[string]string {
+	labels := map[string]string{}
+	for _, env := range envs {
+		k, v, found := strings.Cut(env, "=")
+		if !found || !strings.Contains(k, kubevirtEnvPrefix) {
+			continue
+		}
+		labels[envToLabel(k)] = v
+	}
+
+	return labels
+}
+
+func envToLabel(env string) string {
+	label := ""
+	before, after, _ := strings.Cut(env, kubevirtEnvPrefix)
+	if elems := strings.Split(strings.TrimSuffix(before, "_"), "_"); len(elems) > 0 && elems[0] != "" {
+		label += strings.Join(elems, ".") + "."
+	}
+	label += kubevirtLabelPrefix
+	label += strings.Join(strings.Split(after, "_"), "-")
+
+	return strings.ToLower(label)
+}

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -136,6 +136,37 @@ var _ = Describe("Clean dir", func() {
 	})
 })
 
+var _ = Describe("Env vars to labels", func() {
+	It("Should convert KUBEVIRT_IO_ env vars to labels with values", func() {
+		envs := []string{
+			"INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE=u1.small",
+			"INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE=fedora",
+		}
+		labels := envsToLabels(envs)
+		Expect(labels).To(HaveLen(2))
+		Expect(labels).To(HaveKeyWithValue("instancetype.kubevirt.io/default-instancetype", "u1.small"))
+		Expect(labels).To(HaveKeyWithValue("instancetype.kubevirt.io/default-preference", "fedora"))
+	})
+
+	It("Should ignore invalid env vars and env vars without KUBEVIRT_IO_", func() {
+		envs := []string{
+			"SOMETHING_ELSE_IO=testval",
+			"NOTAVALIDENVVAR",
+		}
+		Expect(envsToLabels(envs)).To(BeEmpty())
+	})
+
+	DescribeTable("Should correctly convert an env var to a label key", func(env, label string) {
+		Expect(envToLabel(env)).To(Equal(label))
+	},
+		Entry("Simple suffix", "KUBEVIRT_IO_TEST", "kubevirt.io/test"),
+		Entry("Double suffix", "KUBEVIRT_IO_TEST_TEST", "kubevirt.io/test-test"),
+		Entry("Simple prefix", "TEST_KUBEVIRT_IO_TEST", "test.kubevirt.io/test"),
+		Entry("Double prefix", "TEST_TEST_KUBEVIRT_IO_TEST", "test.test.kubevirt.io/test"),
+		Entry("Double prefix and suffix", "TEST_TEST_KUBEVIRT_IO_TEST_TEST", "test.test.kubevirt.io/test-test"),
+	)
+})
+
 // For use in transfer cancellation unit tests, currently VDDK/ImageIO
 var mockTerminationChannel chan os.Signal
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -142,6 +142,10 @@ pkg_tar(
 
 container_image(
     name = "cdi-func-test-tinycore",
+    env = {
+        "TEST_KUBEVIRT_IO_TEST": "testvalue",
+        "TEST_KUBEVIRT_IO_EXISTING": "somethingelse",
+    },
     tars = [":tinycore-tar"],
     visibility = ["//visibility:public"],
 )

--- a/tools/cdi-containerimage-server/BUILD.bazel
+++ b/tools/cdi-containerimage-server/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["main.go"],
     importpath = "kubevirt.io/containerized-data-importer/tools/cdi-containerimage-server",
     visibility = ["//visibility:private"],
-    deps = ["//vendor/github.com/pkg/errors:go_default_library"],
+    deps = [
+        "//pkg/common:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
 )
 
 go_binary(

--- a/tools/cdi-func-test-registry-init/populate-registry.sh
+++ b/tools/cdi-func-test-registry-init/populate-registry.sh
@@ -74,6 +74,8 @@ function prepareImages {
         /bin/cat  >$FILE <<-EOF
                 FROM $CONTAINER_DISK_IMAGE
                 COPY $FILENAME $IMAGE_LOCATION
+                ENV TEST_KUBEVIRT_IO_TEST=testvalue
+                ENV TEST_KUBEVIRT_IO_EXISTING=somethingelse
 EOF
 
         rm $FILENAME


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This allows to set labels on PVCs derived from env vars containing `KUBEVIRT_IO_` on containerdisks. Env vars on containerdisks were chosen because they can be accessed in both pullMethods pod and node. While the pod pullMethod is talking to the registry and can query for the `Labels` field in the image config, the pullMethod node cannot access the image config. However, the server running in the context of the containerdisk can still see all associated env vars of the containerdisk.

```
skopeo inspect docker://quay.io/containerdisks/fedora
{
    "Name": "quay.io/containerdisks/fedora",
    "Digest": "sha256:bbc58d0576a236bafe4917c0fbe40701c5164344a499af257ab61b29dacde57c",
    "RepoTags": [
        "35-2111250200",
        "35-2112061510",
        "35-1.2",
        "35",
        "36-2205130206",
        "36-1.5",
        "36",
        "37-2211160206",
        "37-1.7",
        "37",
        "38-2304200207",
        "39-2311080206",
        "39-2401311200",
        "39-1.5",
        "39",
        "latest",
        "38-2401311200",
        "38-1.6",
        "38"
    ],
    "Created": "0001-01-01T00:00:00Z",
    "DockerVersion": "",
    "Labels": {
        "instancetype.kubevirt.io/default-instancetype": "u1.small",
        "instancetype.kubevirt.io/default-preference": "fedora",
        "shasum": "ab5be5058c5c839528a7d6373934e0ce5ad6c8f80bd71ed3390032027da52f37"
    },
    "Architecture": "amd64",
    "Os": "",
    "Layers": [
        "sha256:f06e97b1240fefbb716a8ef4158fe20c0cf92057e625fb79c539334ba1bbd5ee"
    ],
    "LayersData": [
        {
            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "Digest": "sha256:f06e97b1240fefbb716a8ef4158fe20c0cf92057e625fb79c539334ba1bbd5ee",
            "Size": 542252872,
            "Annotations": null
        }
    ],
    "Env": [
        "SHASUM=ab5be5058c5c839528a7d6373934e0ce5ad6c8f80bd71ed3390032027da52f37",
        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE=u1.small",
        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE=fedora"
    ]
}
```

Create a DataVolume from that:

```
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  name: "example-import-dv"
  annotations:
    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
spec:
  source:
      registry:
         url: "docker://quay.io/containerdisks/fedora:latest"
  storage:
    accessModes:
      - ReadWriteOnce
    resources:
      requests:
        storage: "10Gi"
```

The resulting PVC will look like this, pay attention to its labels:

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
    cdi.kubevirt.io/storage.condition.running: "false"
    cdi.kubevirt.io/storage.condition.running.message: Import Complete
    cdi.kubevirt.io/storage.condition.running.reason: Completed
    cdi.kubevirt.io/storage.contentType: kubevirt
    cdi.kubevirt.io/storage.import.endpoint: docker://quay.io/containerdisks/fedora:latest
    cdi.kubevirt.io/storage.import.importPodName: importer-example-import-dv
    cdi.kubevirt.io/storage.import.requiresScratch: "false"
    cdi.kubevirt.io/storage.import.source: registry
    cdi.kubevirt.io/storage.pod.phase: Succeeded
    cdi.kubevirt.io/storage.pod.restarts: "0"
    cdi.kubevirt.io/storage.preallocation.requested: "false"
    cdi.kubevirt.io/storage.usePopulator: "false"
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
  labels:
    alerts.k8s.io/KubePersistentVolumeFillingUp: disabled
    app: containerized-data-importer
    app.kubernetes.io/component: storage
    app.kubernetes.io/managed-by: cdi-controller
    instancetype.kubevirt.io/default-instancetype: u1.small
    instancetype.kubevirt.io/default-preference: fedora
  name: example-import-dv
[...]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is based on #3101, merge that first

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The containerdisk importer can now set PVC labels derived from env vars on containerdisks
```

