### PR TITLE
[release-v1.55] Allow Deployed CDI to get out of Error Phase

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -733,6 +733,14 @@ func GetActiveCDI(c client.Client) (*cdiv1.CDI, error) {
 		return nil, err
 	}
 
+	if len(crList.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(crList.Items) == 1 {
+		return &crList.Items[0], nil
+	}
+
 	var activeResources []cdiv1.CDI
 	for _, cr := range crList.Items {
 		if cr.Status.Phase != sdkapi.PhaseError {
@@ -740,12 +748,8 @@ func GetActiveCDI(c client.Client) (*cdiv1.CDI, error) {
 		}
 	}
 
-	if len(activeResources) == 0 {
-		return nil, nil
-	}
-
-	if len(activeResources) > 1 {
-		return nil, fmt.Errorf("number of active CDI CRs > 1")
+	if len(activeResources) != 1 {
+		return nil, fmt.Errorf("invalid number of active CDI resources: %d", len(activeResources))
 	}
 
 	return &activeResources[0], nil

--- a/pkg/operator/controller/cr-manager.go
+++ b/pkg/operator/controller/cr-manager.go
@@ -71,7 +71,7 @@ func (r *ReconcileCDI) GetDependantResourcesListObjects() []client.ObjectList {
 func (r *ReconcileCDI) IsCreating(_ client.Object) (bool, error) {
 	configMap, err := r.getConfigMap()
 	if err != nil {
-		return true, nil
+		return false, err
 	}
 	return configMap == nil, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3080

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-38364

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix:  Allow Deployed CDI to get out of Error Phase
```

