### PR TITLE
Add storage capabilities for minikube's hostpath provider

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -34,6 +34,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// hostpath-provisioner
 	"kubevirt.io.hostpath-provisioner": {{rwo, file}},
 	"kubevirt.io/hostpath-provisioner": {{rwo, file}},
+	"k8s.io/minikube-hostpath":         {{rwo, file}},
 	// nfs-csi
 	"nfs.csi.k8s.io": {{rwx, file}},
 	"k8s-sigs.io/nfs-subdir-external-provisioner": {{rwx, file}},


### PR DESCRIPTION
minikube (https://github.com/kubernetes/minikube) ships with its own default storage provider.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CDI does not detect the minikube default storage provider out of the box, requiring manual configuration by the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added the k8s.io/minikube-hostpath storage provider to the list of known storage providers to make the out of the box experience better with minikube.
```

