### PR TITLE
Avoid race condition during importer termination

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -187,7 +187,10 @@ func handleImport(
 			if err := util.WriteTerminationMessage(common.ScratchSpaceRequired); err != nil {
 				klog.Errorf("%+v", err)
 			}
-			return common.ScratchSpaceNeededExitCode
+			// Exiting instead of returning 0 as normally to avoid clashing
+			// with cleanup functions (fsyncDataFile) that assume the imported
+			// file will be there during regular exit.
+			os.Exit(0)
 		}
 		err = util.WriteTerminationMessage(fmt.Sprintf("Unable to process data: %v", err.Error()))
 		if err != nil {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -205,9 +205,6 @@ const (
 	// DefaultResyncPeriod sets a 10 minute resync period, used in the controller pkg and the controller cmd executable
 	DefaultResyncPeriod = 10 * time.Minute
 
-	// ScratchSpaceNeededExitCode is the exit code that indicates the importer pod requires scratch space to function properly.
-	ScratchSpaceNeededExitCode = 42
-
 	// ScratchNameSuffix (controller pkg only)
 	ScratchNameSuffix = "scratch"
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -372,15 +372,14 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 
 	scratchExitCode := false
 	if pod.Status.ContainerStatuses != nil &&
-		pod.Status.ContainerStatuses[0].LastTerminationState.Terminated != nil &&
-		pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode > 0 {
-		log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode)
-		if pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode == common.ScratchSpaceNeededExitCode {
+		pod.Status.ContainerStatuses[0].State.Terminated != nil {
+		if message := pod.Status.ContainerStatuses[0].State.Terminated.Message; strings.Contains(message, common.ScratchSpaceRequired) {
 			log.V(1).Info("Pod requires scratch space, terminating pod, and restarting with scratch space", "pod.Name", pod.Name)
 			scratchExitCode = true
 			anno[cc.AnnRequiresScratch] = "true"
-		} else {
-			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.Message)
+		} else if pod.Status.ContainerStatuses[0].State.Terminated.ExitCode > 0 {
+			log.Info("Pod termination code", "pod.Name", pod.Name, "ExitCode", pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
+			r.recorder.Event(pvc, corev1.EventTypeWarning, ErrImportFailedPVC, pod.Status.ContainerStatuses[0].State.Terminated.Message)
 		}
 	}
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(resPvc.GetAnnotations()[cc.AnnRunningConditionReason]).To(Equal("Explosion"))
 	})
 
-	It("Should NOT update phase on PVC, if pod exited with error state that is scratchspace exit", func() {
+	It("Should NOT update phase on PVC, if pod exited with scratchspace required msg", func() {
 		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodRunning)}, nil, corev1.ClaimBound)
 		scratchPvcName := &corev1.PersistentVolumeClaim{}
 		scratchPvcName.Name = "testPvc1-scratch"
@@ -540,17 +540,10 @@ var _ = Describe("Update PVC from POD", func() {
 			Phase: corev1.PodPending,
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					LastTerminationState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: common.ScratchSpaceNeededExitCode,
-							Message:  "scratch space needed",
-						},
-					},
 					State: v1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: 1,
-							Message:  "I went poof",
-							Reason:   "Explosion",
+							ExitCode: 0,
+							Message:  common.ScratchSpaceRequired,
 						},
 					},
 				},
@@ -571,9 +564,6 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundCondition]).To(Equal("false"))
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionMessage]).To(Equal("Creating scratch space"))
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionReason]).To(Equal(creatingScratch))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningCondition]).To(Equal("false"))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningConditionMessage]).To(Equal("I went poof"))
-		Expect(resPvc.GetAnnotations()[cc.AnnRunningConditionReason]).To(Equal("Explosion"))
 	})
 
 	It("Should mark PVC as waiting for VDDK configmap, if not already present", func() {
@@ -683,8 +673,8 @@ var _ = Describe("Update PVC from POD", func() {
 				{
 					LastTerminationState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: common.ScratchSpaceNeededExitCode,
-							Message:  "",
+							ExitCode: 0,
+							Message:  common.ScratchSpaceRequired,
 						},
 					},
 				},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request sets the exit code when scratch space is required to 0 so, when deleting the importer pod after exiting for scratchSpaceNeeded, we don't need to deal with unwanted automatic restarts (RestartPolicyOnFailure). This conflicting behavior caused some issues during termination while the pod was already restarting after scratchSpaceNeeded.

Importer pod lifecycle for a regular DV before the fix:
```sh
# k get pod importer-cirros-dv-source -woyaml | grep exitCode
selecting docker as container runtime
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 42
        exitCode: 2
        exitCode: 42
        exitCode: 2
        exitCode: 42
        exitCode: 2
        exitCode: 0
        exitCode: 0
```
After the fix:
```sh
# k get pod importer-cirros-dv-source -woyaml | grep exitCode
selecting docker as container runtime
        exitCode: 0
        exitCode: 0
        exitCode: 0
        exitCode: 0
        exitCode: 0
        exitCode: 0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2240963 (follow-up)

**Special notes for your reviewer**:

I think this is a better solution than https://github.com/kubevirt/containerized-data-importer/pull/3044 and https://github.com/kubevirt/containerized-data-importer/pull/3060. Let me know what you think.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid race condition during importer termination
```


