### PR TITLE
Improve readability of importer pod's creation code

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -837,16 +837,15 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 		return nil, err
 	}
 
-	var pod *corev1.Pod
-	if cc.GetSource(args.pvc) == cc.SourceRegistry && args.pvc.Annotations[cc.AnnRegistryImportMethod] == string(cdiv1.RegistryPullNode) {
+	if isRegistryNodeImport(args) {
 		args.importImage, err = getRegistryImportImage(args.pvc)
 		if err != nil {
 			return nil, err
 		}
-		pod = makeNodeImporterPodSpec(args)
-	} else {
-		pod = makeImporterPodSpec(args)
+		setRegistryNodeImportEnvVars(args)
 	}
+
+	pod := makeImporterPodSpec(args)
 
 	util.SetRecommendedLabels(pod, installerLabels, "cdi-controller")
 
@@ -858,165 +857,10 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 	return pod, nil
 }
 
-// makeNodeImporterPodSpec creates and returns the node docker cache based importer pod spec based on the passed-in importImage and pvc.
-func makeNodeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
-	// importer pod name contains the pvc name
-	podName := args.pvc.Annotations[cc.AnnImportPod]
-
-	volumes := []corev1.Volume{
-		{
-			Name: "shared-volume",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		{
-			Name: cc.DataVolName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: args.pvc.Name,
-					ReadOnly:  false,
-				},
-			},
-		},
-	}
-
-	importerContainer := makeImporterContainerSpec(args.image, args.verbose, args.pullPolicy)
-
-	pod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: args.pvc.Namespace,
-			Annotations: map[string]string{
-				cc.AnnCreatedBy: "yes",
-			},
-			Labels: map[string]string{
-				common.CDILabelKey:        common.CDILabelValue,
-				common.CDIComponentLabel:  common.ImporterPodName,
-				common.PrometheusLabelKey: common.PrometheusLabelValue,
-			},
-		},
-		Spec: corev1.PodSpec{
-			InitContainers: []corev1.Container{
-				{
-					Name:            "init",
-					Image:           args.image,
-					ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
-					Command:         []string{"sh", "-c", "cp /usr/bin/cdi-containerimage-server /shared/server"},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: "/shared",
-							Name:      "shared-volume",
-						},
-					},
-				},
-			},
-			Containers: []corev1.Container{
-				*importerContainer,
-				{
-					Name:            "server",
-					Image:           args.importImage,
-					ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
-					Command:         []string{"/shared/server", "-p", "8100", "-image-dir", "/disk", "-ready-file", "/shared/ready", "-done-file", "/shared/done"},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: "/shared",
-							Name:      "shared-volume",
-						},
-					},
-				},
-			},
-			RestartPolicy:     corev1.RestartPolicyOnFailure,
-			Volumes:           volumes,
-			NodeSelector:      args.workloadNodePlacement.NodeSelector,
-			Tolerations:       args.workloadNodePlacement.Tolerations,
-			Affinity:          args.workloadNodePlacement.Affinity,
-			PriorityClassName: args.priorityClassName,
-			ImagePullSecrets:  args.imagePullSecrets,
-		},
-	}
-
-	/**
-	FIXME: When registry source is ImageStream, if we set importer pod OwnerReference (to its pvc, like all other cases),
-	for some reason (OCP issue?) we get the following error:
-		Failed to pull image "imagestream-name": rpc error: code = Unknown
-		desc = Error reading manifest latest in docker.io/library/imagestream-name: errors:
-		denied: requested access to the resource is denied
-		unauthorized: authentication required
-	When we don't set pod OwnerReferences, all works well.
-	*/
-	if cc.IsImageStream(args.pvc) {
-		pod.Annotations[cc.AnnOpenShiftImageLookup] = "*"
-	} else {
-		blockOwnerDeletion := true
-		isController := true
-		ownerRef := metav1.OwnerReference{
-			APIVersion:         "v1",
-			Kind:               "PersistentVolumeClaim",
-			Name:               args.pvc.Name,
-			UID:                args.pvc.GetUID(),
-			BlockOwnerDeletion: &blockOwnerDeletion,
-			Controller:         &isController,
-		}
-		pod.OwnerReferences = append(pod.OwnerReferences, ownerRef)
-	}
-
-	args.podEnvVar.source = cc.SourceHTTP
-	args.podEnvVar.ep = "http://localhost:8100/disk.img"
-	args.podEnvVar.pullMethod = string(cdiv1.RegistryPullNode)
-	args.podEnvVar.readyFile = "/shared/ready"
-	args.podEnvVar.doneFile = "/shared/done"
-	setImporterPodCommons(pod, args.podEnvVar, args.pvc, args.podResourceRequirements, args.imagePullSecrets)
-	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		MountPath: "/shared",
-		Name:      "shared-volume",
-	})
-
-	cc.SetRestrictedSecurityContext(&pod.Spec)
-	// We explicitly define a NodeName for dynamically provisioned PVCs
-	// when the PVC is being handled by a populator (PVC')
-	cc.SetNodeNameIfPopulator(args.pvc, &pod.Spec)
-
-	return pod
-}
-
 // makeImporterPodSpec creates and return the importer pod spec based on the passed-in endpoint, secret and pvc.
 func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 	// importer pod name contains the pvc name
 	podName := args.pvc.Annotations[cc.AnnImportPod]
-
-	blockOwnerDeletion := true
-	isController := true
-
-	volumes := []corev1.Volume{
-		{
-			Name: cc.DataVolName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: args.pvc.Name,
-					ReadOnly:  false,
-				},
-			},
-		},
-	}
-
-	if args.scratchPvcName != nil {
-		volumes = append(volumes, corev1.Volume{
-			Name: cc.ScratchVolName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: *args.scratchPvcName,
-					ReadOnly:  false,
-				},
-			},
-		})
-	}
-
-	importerContainer := makeImporterContainerSpec(args.image, args.verbose, args.pullPolicy)
 
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -1040,17 +884,16 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 					Kind:               "PersistentVolumeClaim",
 					Name:               args.pvc.Name,
 					UID:                args.pvc.GetUID(),
-					BlockOwnerDeletion: &blockOwnerDeletion,
-					Controller:         &isController,
+					BlockOwnerDeletion: ptr.To[bool](true),
+					Controller:         ptr.To[bool](true),
 				},
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				*importerContainer,
-			},
+			Containers:        makeImporterContainerSpec(args),
+			InitContainers:    makeImporterInitContainersSpec(args),
+			Volumes:           makeImporterVolumeSpec(args),
 			RestartPolicy:     corev1.RestartPolicyOnFailure,
-			Volumes:           volumes,
 			NodeSelector:      args.workloadNodePlacement.NodeSelector,
 			Tolerations:       args.workloadNodePlacement.Tolerations,
 			Affinity:          args.workloadNodePlacement.Affinity,
@@ -1059,23 +902,192 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 		},
 	}
 
-	setImporterPodCommons(pod, args.podEnvVar, args.pvc, args.podResourceRequirements, args.imagePullSecrets)
+	/**
+	FIXME: When registry source is ImageStream, if we set importer pod OwnerReference (to its pvc, like all other cases),
+	for some reason (OCP issue?) we get the following error:
+		Failed to pull image "imagestream-name": rpc error: code = Unknown
+		desc = Error reading manifest latest in docker.io/library/imagestream-name: errors:
+		denied: requested access to the resource is denied
+		unauthorized: authentication required
+	When we don't set pod OwnerReferences, all works well.
+	*/
+	if isRegistryNodeImport(args) && cc.IsImageStream(args.pvc) {
+		pod.OwnerReferences = nil
+		pod.Annotations[cc.AnnOpenShiftImageLookup] = "*"
+	}
 
+	cc.SetPvcAllowedAnnotations(pod, args.pvc)
+	cc.SetRestrictedSecurityContext(&pod.Spec)
+	// We explicitly define a NodeName for dynamically provisioned PVCs
+	// when the PVC is being handled by a populator (PVC')
+	cc.SetNodeNameIfPopulator(args.pvc, &pod.Spec)
+
+	return pod
+}
+
+func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
+	containers := []corev1.Container{
+		{
+			Name:            common.ImporterPodName,
+			Image:           args.image,
+			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
+			Args:            []string{"-v=" + args.verbose},
+			Env:             makeImportEnv(args.podEnvVar, getOwnerUID(args)),
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "metrics",
+					ContainerPort: 8443,
+					Protocol:      corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	if cc.GetVolumeMode(args.pvc) == corev1.PersistentVolumeBlock {
+		containers[0].VolumeDevices = cc.AddVolumeDevices()
+	} else {
+		containers[0].VolumeMounts = cc.AddImportVolumeMounts()
+	}
+	if isRegistryNodeImport(args) {
+		containers = append(containers, corev1.Container{
+			Name:            "server",
+			Image:           args.importImage,
+			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
+			Command:         []string{"/shared/server", "-p", "8100", "-image-dir", "/disk", "-ready-file", "/shared/ready", "-done-file", "/shared/done"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/shared",
+					Name:      "shared-volume",
+				},
+			},
+		})
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			MountPath: "/shared",
+			Name:      "shared-volume",
+		})
+	}
 	if args.scratchPvcName != nil {
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      cc.ScratchVolName,
 			MountPath: common.ScratchDataDir,
 		})
 	}
-
 	if args.vddkImageName != nil {
-		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      "vddk-vol-mount",
+			MountPath: "/opt",
+		})
+	}
+	if args.podEnvVar.certConfigMap != "" {
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      CertVolName,
+			MountPath: common.ImporterCertDir,
+		})
+	}
+	if args.podEnvVar.certConfigMapProxy != "" {
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      ProxyCertVolName,
+			MountPath: common.ImporterProxyCertDir,
+		})
+	}
+	if args.podEnvVar.source == cc.SourceGCS && args.podEnvVar.secretName != "" {
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      SecretVolName,
+			MountPath: common.ImporterGoogleCredentialDir,
+		})
+	}
+	for index := range args.podEnvVar.secretExtraHeaders {
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      fmt.Sprintf(secretExtraHeadersVolumeName, index),
+			MountPath: path.Join(common.ImporterSecretExtraHeadersDir, fmt.Sprint(index)),
+		})
+	}
+	if args.podResourceRequirements != nil {
+		for i := range containers {
+			containers[i].Resources = *args.podResourceRequirements
+		}
+	}
+	return containers
+}
+
+func makeImporterVolumeSpec(args *importerPodArgs) []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: cc.DataVolName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: args.pvc.Name,
+					ReadOnly:  false,
+				},
+			},
+		},
+	}
+	if isRegistryNodeImport(args) {
+		volumes = append(volumes, corev1.Volume{
+			Name: "shared-volume",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+	if args.scratchPvcName != nil {
+		volumes = append(volumes, corev1.Volume{
+			Name: cc.ScratchVolName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: *args.scratchPvcName,
+					ReadOnly:  false,
+				},
+			},
+		})
+	}
+	if args.vddkImageName != nil {
+		volumes = append(volumes, corev1.Volume{
 			Name: "vddk-vol-mount",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
-		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+	}
+	if args.podEnvVar.certConfigMap != "" {
+		volumes = append(volumes, createConfigMapVolume(CertVolName, args.podEnvVar.certConfigMap))
+	}
+	if args.podEnvVar.certConfigMapProxy != "" {
+		volumes = append(volumes, createConfigMapVolume(ProxyCertVolName, GetImportProxyConfigMapName(args.pvc.Name)))
+	}
+	if args.podEnvVar.source == cc.SourceGCS && args.podEnvVar.secretName != "" {
+		volumes = append(volumes, createSecretVolume(SecretVolName, args.podEnvVar.secretName))
+	}
+	for index, header := range args.podEnvVar.secretExtraHeaders {
+		volumes = append(volumes, corev1.Volume{
+			Name: fmt.Sprintf(secretExtraHeadersVolumeName, index),
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: header,
+				},
+			},
+		})
+	}
+	return volumes
+}
+
+func makeImporterInitContainersSpec(args *importerPodArgs) []corev1.Container {
+	var initContainers []corev1.Container
+	if isRegistryNodeImport(args) {
+		initContainers = append(initContainers, corev1.Container{
+			Name:            "init",
+			Image:           args.image,
+			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
+			Command:         []string{"sh", "-c", "cp /usr/bin/cdi-containerimage-server /shared/server"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/shared",
+					Name:      "shared-volume",
+				},
+			},
+		})
+	}
+	if args.vddkImageName != nil {
+		initContainers = append(initContainers, corev1.Container{
 			Name:  "vddk-side-car",
 			Image: *args.vddkImageName,
 			VolumeMounts: []corev1.VolumeMount{
@@ -1085,104 +1097,28 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 				},
 			},
 		})
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      "vddk-vol-mount",
-			MountPath: "/opt",
-		})
 	}
-
-	if args.podEnvVar.certConfigMap != "" {
-		vm := corev1.VolumeMount{
-			Name:      CertVolName,
-			MountPath: common.ImporterCertDir,
-		}
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, createConfigMapVolume(CertVolName, args.podEnvVar.certConfigMap))
-	}
-
-	if args.podEnvVar.certConfigMapProxy != "" {
-		vm := corev1.VolumeMount{
-			Name:      ProxyCertVolName,
-			MountPath: common.ImporterProxyCertDir,
-		}
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, createConfigMapVolume(ProxyCertVolName, GetImportProxyConfigMapName(args.pvc.Name)))
-	}
-
-	if args.podEnvVar.source == cc.SourceGCS && args.podEnvVar.secretName != "" {
-		vm := corev1.VolumeMount{
-			Name:      SecretVolName,
-			MountPath: common.ImporterGoogleCredentialDir,
-		}
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, createSecretVolume(SecretVolName, args.podEnvVar.secretName))
-	}
-
-	for index, header := range args.podEnvVar.secretExtraHeaders {
-		vm := corev1.VolumeMount{
-			Name:      fmt.Sprintf(secretExtraHeadersVolumeName, index),
-			MountPath: path.Join(common.ImporterSecretExtraHeadersDir, fmt.Sprint(index)),
-		}
-
-		vol := corev1.Volume{
-			Name: fmt.Sprintf(secretExtraHeadersVolumeName, index),
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: header,
-				},
-			},
-		}
-
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, vm)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
-	}
-
-	cc.SetRestrictedSecurityContext(&pod.Spec)
-	// We explicitly define a NodeName for dynamically provisioned PVCs
-	// when the PVC is being handled by a populator (PVC')
-	cc.SetNodeNameIfPopulator(args.pvc, &pod.Spec)
-
-	return pod
+	return initContainers
 }
 
-func setImporterPodCommons(pod *corev1.Pod, podEnvVar *importPodEnvVar, pvc *corev1.PersistentVolumeClaim, podResourceRequirements *corev1.ResourceRequirements, imagePullSecrets []corev1.LocalObjectReference) {
-	if podResourceRequirements != nil {
-		for i := range pod.Spec.Containers {
-			pod.Spec.Containers[i].Resources = *podResourceRequirements
-		}
-	}
-	pod.Spec.ImagePullSecrets = imagePullSecrets
-
-	ownerUID := pvc.UID
-	if len(pvc.OwnerReferences) == 1 {
-		ownerUID = pvc.OwnerReferences[0].UID
-	}
-
-	if cc.GetVolumeMode(pvc) == corev1.PersistentVolumeBlock {
-		pod.Spec.Containers[0].VolumeDevices = cc.AddVolumeDevices()
-	} else {
-		pod.Spec.Containers[0].VolumeMounts = cc.AddImportVolumeMounts()
-	}
-
-	pod.Spec.Containers[0].Env = makeImportEnv(podEnvVar, ownerUID)
-
-	cc.SetPvcAllowedAnnotations(pod, pvc)
+func isRegistryNodeImport(args *importerPodArgs) bool {
+	return cc.GetSource(args.pvc) == cc.SourceRegistry &&
+		args.pvc.Annotations[cc.AnnRegistryImportMethod] == string(cdiv1.RegistryPullNode)
 }
 
-func makeImporterContainerSpec(image, verbose, pullPolicy string) *corev1.Container {
-	return &corev1.Container{
-		Name:            common.ImporterPodName,
-		Image:           image,
-		ImagePullPolicy: corev1.PullPolicy(pullPolicy),
-		Args:            []string{"-v=" + verbose},
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "metrics",
-				ContainerPort: 8443,
-				Protocol:      corev1.ProtocolTCP,
-			},
-		},
+func getOwnerUID(args *importerPodArgs) types.UID {
+	if len(args.pvc.OwnerReferences) == 1 {
+		return args.pvc.OwnerReferences[0].UID
 	}
+	return args.pvc.UID
+}
+
+func setRegistryNodeImportEnvVars(args *importerPodArgs) {
+	args.podEnvVar.source = cc.SourceHTTP
+	args.podEnvVar.ep = "http://localhost:8100/disk.img"
+	args.podEnvVar.pullMethod = string(cdiv1.RegistryPullNode)
+	args.podEnvVar.readyFile = "/shared/ready"
+	args.podEnvVar.doneFile = "/shared/done"
 }
 
 func createConfigMapVolume(certVolName, objRef string) corev1.Volume {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Importer pod's creation code always seemed a bit redundant, with two functions (`makeNodeImporterPodSpec` and `makeImporterPodSpec`) sharing common code and logic.

This Pull Request aims to clean that code a bit, in an attempt to improve readability.

Summary of changes:

- `makeNodeImporterPodSpec` and `makeImporterPodSpec` have been merged into a single function.
- Most of the import-type specific logic has been moved to container, volume, and initContainer-specific functions.
- No need of `setImporterPodCommons` since now most of the code is shared between node and regular import.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

