### PR TITLE
Improve handling of unpopulated capacity field in clone populator

### DIFF
--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -70,6 +70,11 @@ func (p *PrepClaimPhase) Reconcile(ctx context.Context) (*reconcile.Result, erro
 
 	if !hasActual {
 		if cc.IsBound(actualClaim) {
+			// PVC is bound but its status hasn't been updated yet.
+			// We'll reconcile again once the status is updated.
+			if actualClaim.Status.Phase == corev1.ClaimPending {
+				return &reconcile.Result{}, nil
+			}
 			return nil, fmt.Errorf("actual PVC size missing")
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is part of a larger work to improve log reporting in CDI.

There is a short window of time where a bound PVC can have an unpopulated `capacity` field in its status. The clone-populator handles this case by returning an error.

This approach is overkill as the issue is usually fixed instantly and should hardly be considered an error as we will reconcile again once the status is updated. This pull request aims to improve the handling of this case and adds unit test coverage.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-35803

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve handling of unpopulated capacity field in clone populator
```

