### PR TITLE
Suppress alerts to reduce noise of dependent ones

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "//vendor/github.com/openshift/api/image/v1:go_default_library",
         "//vendor/github.com/openshift/api/route/v1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -467,6 +467,11 @@ func GetVolumeMode(pvc *corev1.PersistentVolumeClaim) corev1.PersistentVolumeMod
 	return util.ResolveVolumeMode(pvc.Spec.VolumeMode)
 }
 
+// IsDataVolumeUsingDefaultStorageClass checks if the DataVolume is using the default StorageClass
+func IsDataVolumeUsingDefaultStorageClass(dv *cdiv1.DataVolume) bool {
+	return GetStorageClassFromDVSpec(dv) == nil
+}
+
 // GetStorageClassFromDVSpec returns the StorageClassName from DataVolume PVC or Storage spec
 func GetStorageClassFromDVSpec(dv *cdiv1.DataVolume) *string {
 	if dv.Spec.PVC != nil {

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -58,7 +58,7 @@ func updateDataImportCronOutdatedMetric(cron *cdiv1.DataImportCron, status corev
 	// Check if the DataImportCron import DV is pending for default k8s/virt storage class
 	if !isUpToDate {
 		_, scExists := cron.Annotations[AnnStorageClass]
-		isPending = !scExists && common.GetStorageClassFromDVSpec(&cron.Spec.Template) == nil
+		isPending = !scExists && common.IsDataVolumeUsingDefaultStorageClass(&cron.Spec.Template)
 	}
 
 	labels := getPrometheusCronLabels(cron.Namespace, cron.Name)

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -17,13 +17,15 @@ See the License for the specific language governing permissions and
 package controller
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/controller/common"
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
 )
 
@@ -38,8 +40,20 @@ const (
 
 func updateDataImportCronCondition(cron *cdiv1.DataImportCron, conditionType cdiv1.DataImportCronConditionType, status corev1.ConditionStatus, message, reason string) {
 	if conditionType == cdiv1.DataImportCronUpToDate {
-		metrics.SetDataImportCronOutdated(getPrometheusCronLabels(types.NamespacedName{Namespace: cron.Namespace, Name: cron.Name}), status != corev1.ConditionTrue)
+		isUpToDate := status == corev1.ConditionTrue
+		isPending := false
+		if !isUpToDate {
+			_, scExists := cron.Annotations[AnnStorageClass]
+			isPending = !scExists && common.GetStorageClassFromDVSpec(&cron.Spec.Template) == nil
+		}
+
+		labels := getPrometheusCronLabels(cron.Namespace, cron.Name)
+		metrics.DeleteDataImportCronOutdated(labels)
+
+		labels[metrics.PrometheusCronPendingLabel] = strconv.FormatBool(isPending)
+		metrics.SetDataImportCronOutdated(labels, !isUpToDate)
 	}
+
 	if condition := FindDataImportCronConditionByType(cron, conditionType); condition != nil {
 		updateConditionState(&condition.ConditionState, status, message, reason)
 	} else {
@@ -74,9 +88,9 @@ func updateConditionState(condition *cdiv1.ConditionState, status corev1.Conditi
 	}
 }
 
-func getPrometheusCronLabels(cron types.NamespacedName) prometheus.Labels {
+func getPrometheusCronLabels(cronNamespace, cronName string) prometheus.Labels {
 	return prometheus.Labels{
-		prometheusNsLabel:       cron.Namespace,
-		prometheusCronNameLabel: cron.Name,
+		metrics.PrometheusCronNsLabel:   cronNamespace,
+		metrics.PrometheusCronNameLabel: cronName,
 	}
 }

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -68,9 +68,6 @@ const (
 	ErrDataSourceAlreadyManaged = "ErrDataSourceAlreadyManaged"
 	// MessageDataSourceAlreadyManaged provides a const to form DataSource already managed error message
 	MessageDataSourceAlreadyManaged = "DataSource %s is already managed by DataImportCron %s"
-
-	prometheusNsLabel       = "ns"
-	prometheusCronNameLabel = "cron_name"
 )
 
 // DataImportCronReconciler members
@@ -887,7 +884,8 @@ func (r *DataImportCronReconciler) garbageCollectSnapshots(ctx context.Context, 
 
 func (r *DataImportCronReconciler) cleanup(ctx context.Context, cron types.NamespacedName) error {
 	// Don't keep alerting over a cron thats being deleted, will get set back to 1 again by reconcile loop if needed.
-	metrics.DeleteDataImportCronOutdated(getPrometheusCronLabels(cron))
+	metrics.DeleteDataImportCronOutdated(getPrometheusCronLabels(cron.Namespace, cron.Name))
+
 	if err := r.deleteJobs(ctx, cron); err != nil {
 		return err
 	}

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -473,6 +473,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
 			verifyConditions("Import scheduled", false, false, false, scheduled, inProgress, noSource, &corev1.PersistentVolumeClaim{})
+			// Verify DIC outdated metric is 1 only with pending=true
 			verifyDataImportCronOutdatedMetric(cron, true, 1)
 			verifyDataImportCronOutdatedMetric(cron, false, 0)
 
@@ -490,6 +491,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &corev1.PersistentVolumeClaim{})
+			// Verify DIC outdated metric is 0 with either pending=true/false
 			verifyDataImportCronOutdatedMetric(cron, true, 0)
 			verifyDataImportCronOutdatedMetric(cron, false, 0)
 
@@ -586,6 +588,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			_, err = reconciler.Reconcile(context.TODO(), cronReq)
 			Expect(err).ToNot(HaveOccurred())
 
+			// Verify DIC outdated metric is 1 only with correct pending label
 			verifyDataImportCronOutdatedMetric(cron, isPending, 1)
 			verifyDataImportCronOutdatedMetric(cron, !isPending, 0)
 		},

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -412,10 +412,24 @@ func updatePendingDataVolumesGauge(ctx context.Context, log logr.Logger, dv *cdi
 		return
 	}
 
-	dvList := &cdiv1.DataVolumeList{}
-	if err := c.List(ctx, dvList, client.MatchingFields{dvPhaseField: string(cdiv1.Pending)}); err != nil {
+	countPending, err := getDefaultStorageClassDataVolumeCount(ctx, c, string(cdiv1.Pending))
+	if err != nil {
 		log.V(3).Error(err, "Failed listing the pending DataVolumes")
 		return
+	}
+	countUnset, err := getDefaultStorageClassDataVolumeCount(ctx, c, string(cdiv1.PhaseUnset))
+	if err != nil {
+		log.V(3).Error(err, "Failed listing the unset DataVolumes")
+		return
+	}
+
+	metrics.SetDataVolumePending(countPending + countUnset)
+}
+
+func getDefaultStorageClassDataVolumeCount(ctx context.Context, c client.Client, dvPhase string) (int, error) {
+	dvList := &cdiv1.DataVolumeList{}
+	if err := c.List(ctx, dvList, client.MatchingFields{dvPhaseField: dvPhase}); err != nil {
+		return 0, err
 	}
 
 	dvCount := 0
@@ -424,7 +438,8 @@ func updatePendingDataVolumesGauge(ctx context.Context, log logr.Logger, dv *cdi
 			dvCount++
 		}
 	}
-	metrics.SetDataVolumePending(dvCount)
+
+	return dvCount, nil
 }
 
 type dvController interface {

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -408,7 +408,7 @@ func getSourceRefOp(ctx context.Context, log logr.Logger, dv *cdiv1.DataVolume, 
 }
 
 func updatePendingDataVolumesGauge(ctx context.Context, log logr.Logger, dv *cdiv1.DataVolume, c client.Client) {
-	if cc.GetStorageClassFromDVSpec(dv) != nil {
+	if !cc.IsDataVolumeUsingDefaultStorageClass(dv) {
 		return
 	}
 
@@ -434,7 +434,7 @@ func getDefaultStorageClassDataVolumeCount(ctx context.Context, c client.Client,
 
 	dvCount := 0
 	for _, dv := range dvList.Items {
-		if cc.GetStorageClassFromDVSpec(&dv) == nil {
+		if cc.IsDataVolumeUsingDefaultStorageClass(&dv) {
 			dvCount++
 		}
 	}

--- a/pkg/monitoring/metrics/cdi-controller/dataimportcron.go
+++ b/pkg/monitoring/metrics/cdi-controller/dataimportcron.go
@@ -2,13 +2,18 @@ package cdicontroller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	ioprometheusclient "github.com/prometheus/client_model/go"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 )
 
 const (
-	prometheusNsLabel       = "ns"
-	prometheusCronNameLabel = "cron_name"
+	// PrometheusCronNsLabel labels the DataImportCron namespace
+	PrometheusCronNsLabel = "ns"
+	// PrometheusCronNameLabel labels the DataImportCron name
+	PrometheusCronNameLabel = "cron_name"
+	// PrometheusCronPendingLabel labels whether the DataImportCron import DataVolume is pending for default storage class
+	PrometheusCronPendingLabel = "pending"
 )
 
 var (
@@ -21,7 +26,7 @@ var (
 			Name: "kubevirt_cdi_dataimportcron_outdated",
 			Help: "DataImportCron has an outdated import",
 		},
-		[]string{prometheusNsLabel, prometheusCronNameLabel},
+		[]string{PrometheusCronNsLabel, PrometheusCronNameLabel, PrometheusCronPendingLabel},
 	)
 )
 
@@ -34,6 +39,13 @@ func SetDataImportCronOutdated(labels prometheus.Labels, isOutdated bool) {
 		outdatedValue = 0.0 // false
 	}
 	dataImportCronOutdated.With(labels).Set(outdatedValue)
+}
+
+// GetDataImportCronOutdated returns the dataImportCronOutdated value
+func GetDataImportCronOutdated(labels prometheus.Labels) float64 {
+	dto := &ioprometheusclient.Metric{}
+	_ = dataImportCronOutdated.With(labels).Write(dto)
+	return dto.Gauge.GetValue()
 }
 
 // DeleteDataImportCronOutdated deletes metrics by their labels, and return the number of deleted metrics

--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -57,8 +57,9 @@ var operatorAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "CDIDataImportCronOutdated",
-		Expr:  intstr.FromString("sum by(ns,cron_name) (kubevirt_cdi_dataimportcron_outdated) > 0"),
-		For:   (*promv1.Duration)(ptr.To("15m")),
+		Expr: intstr.FromString(`sum by(ns,cron_name) (kubevirt_cdi_dataimportcron_outdated) +
+								 on () (0*(sum(kubevirt_cdi_storageprofile_info{default="true"}) or sum(kubevirt_cdi_storageprofile_info{virtdefault="true"}))) > 0`),
+		For: (*promv1.Duration)(ptr.To("15m")),
 		Annotations: map[string]string{
 			"summary": "DataImportCron (recurring polling of VM templates disk image sources, also known as golden images) PVCs are not being updated on the defined schedule",
 		},
@@ -96,7 +97,8 @@ var operatorAlerts = []promv1.Rule{
 	{
 		Alert: "CDIDefaultStorageClassDegraded",
 		Expr: intstr.FromString(`sum(kubevirt_cdi_storageprofile_info{default="true",rwx="true",smartclone="true"} or on() vector(0)) +
-								 sum(kubevirt_cdi_storageprofile_info{virtdefault="true",rwx="true",smartclone="true"} or on() vector(0)) == 0`),
+								 sum(kubevirt_cdi_storageprofile_info{virtdefault="true",rwx="true",smartclone="true"} or on() vector(0)) +
+								 on () (0*(sum(kubevirt_cdi_storageprofile_info{default="true"}) or sum(kubevirt_cdi_storageprofile_info{virtdefault="true"}))) == 0`),
 		For: (*promv1.Duration)(ptr.To("5m")),
 		Annotations: map[string]string{
 			"summary": "Default storage class has no smart clone or ReadWriteMany",

--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -57,9 +57,8 @@ var operatorAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "CDIDataImportCronOutdated",
-		Expr: intstr.FromString(`sum by(ns,cron_name) (kubevirt_cdi_dataimportcron_outdated) +
-								 on () (0*(sum(kubevirt_cdi_storageprofile_info{default="true"}) or sum(kubevirt_cdi_storageprofile_info{virtdefault="true"}))) > 0`),
-		For: (*promv1.Duration)(ptr.To("15m")),
+		Expr:  intstr.FromString(`sum by(ns,cron_name) (kubevirt_cdi_dataimportcron_outdated{pending="false"}) > 0`),
+		For:   (*promv1.Duration)(ptr.To("15m")),
 		Annotations: map[string]string{
 			"summary": "DataImportCron (recurring polling of VM templates disk image sources, also known as golden images) PVCs are not being updated on the defined schedule",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to #2998 introducing the following changes to alert rules:

- CDIDefaultStorageClassDegraded - do not fire when no default SC (either k8s or virt).
- CDIDataImportCronOutdated - do not fire when no default SC (either k8s or virt), as DIC import DVs use default SC.
- CDINoDefaultStorageClass - fire not only when there is a pending DV (and PVC) but also when DV has an empty status (waiting for default SC etc.)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Suppress alerts to reduce noise of dependent ones
```

