### PR TITLE
Escape user-controlled strings in upload proxy to avoid XSS attacks

### DIFF
--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -247,7 +248,8 @@ func (app *uploadProxyApp) resolveUploadPath(pvc *v1.PersistentVolumeClaim, pvcN
 			path = common.UploadArchivePath
 		}
 	default:
-		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", pvcName, contentType)
+		// Escaping user-controlled strings to avoid cross-site scripting (XSS) attacks
+		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", html.EscapeString(pvcName), html.EscapeString(contentType))
 	}
 
 	return app.urlResolver(pvc.Namespace, pvc.Name, path), nil

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -244,7 +244,39 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			By("Try upload again")
 			err = uploadImage(uploadProxyURL, token, http.StatusServiceUnavailable)
 			Expect(err).ToNot(HaveOccurred())
+		})
 
+		It("Verify cross-site scripting XSS attempt is escaped accordingly to avoid attack", func() {
+			By("Verify PVC annotation says ready")
+			const XSSAttempt = "<script>Bad stuff here...</script>"
+			found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			pvc.Annotations[controller.AnnContentType] = XSSAttempt
+			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var token string
+			By("Get an upload token")
+			token, err = utils.RequestUploadToken(f.CdiClient, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(token).ToNot(BeEmpty())
+
+			By("Do upload")
+			resp, err := getUploadToPathResponse(binaryRequestFunc, utils.UploadFile, uploadProxyURL, syncUploadPath, token)
+			Expect(err).ToNot(HaveOccurred())
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify XSS attempt")
+			// Verify XSS attack is not present in the error msg
+			Expect(string(body)).ToNot(ContainSubstring(XSSAttempt))
+			// Verify < and > characters are escaped accordingly
+			Expect(string(body)).To(ContainSubstring("&lt;script&gt;"))
+			// Verify PVC name is intact
+			Expect(string(body)).To(ContainSubstring(pvc.Name))
 		})
 
 		DescribeTable("Verify validation error message on async upload if virtual size > pvc size", Serial, func(filename string) {
@@ -895,6 +927,32 @@ func uploadFileNameToPath(requestFunc uploadFileNameRequestCreator, fileName, po
 	}
 
 	return nil
+}
+
+func getUploadToPathResponse(requestFunc uploadFileNameRequestCreator, fileName, portForwardURL, path, token string) (*http.Response, error) {
+	url := portForwardURL + path
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := requestFunc(url, fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer req.Body.Close()
+
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Origin", "foo.bar.com")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func uploadFileNameToPathWithClient(client *http.Client, requestFunc uploadFileNameRequestCreator, fileName, portForwardURL, path, token string, expectedStatus int) error {


### PR DESCRIPTION

**What this PR does / why we need it**:

When upload content-type is invalid we post a error message with user-controlled parameters in our upload proxy. This makes the proxy vulnerable to XSS attacks as an user might maliciously inject a script into the content type.

This PR aims to fix this behavior by escaping the two user-controlled strings before posting them. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36208

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid XSS CWE in Upload proxy
```

