### PR TITLE
Add HPE RWX/Block capability

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -79,7 +79,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// Hitachi
 	"hspc.csi.hitachi.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// HPE
-	"csi.hpe.com": createRWOBlockAndFilesystemCapabilities(),
+	"csi.hpe.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// IBM HCI/GPFS2 (Spectrum Scale / Spectrum Fusion)
 	"spectrumscale.csi.ibm.com": {{rwx, file}, {rwo, file}},
 	// IBM block arrays (FlashSystem)


### PR DESCRIPTION
**What this PR does / why we need it**:
Since version 2.4.1 the HPE CSI provisioner supports the RWX access mode for block volumes. We should update our storage profile to capture this.

**Which issue(s) this PR fixes**:
Fixes # https://issues.redhat.com/browse/CNV-39704

**Special notes for your reviewer**:

**Release note**:
```release-note
Add HPE RWX/Block capability
```

