### PR TITLE
 [release-v1.56] Escape user-controlled strings in uploadproxy to avoid XSS attacks

### DIFF
--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -248,7 +249,8 @@ func (app *uploadProxyApp) resolveUploadPath(pvcName, pvcNamespace, defaultPath 
 		}
 		return common.UploadArchivePath, nil
 	default:
-		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", pvcName, contentType)
+		// Escaping user-controlled strings to avoid cross-site scripting (XSS) attacks
+		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", html.EscapeString(pvcName), html.EscapeString(contentType))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3131.

When upload content-type is invalid we post a error message with user-controlled parameters in our upload proxy. This makes the proxy vulnerable to XSS attacks as an user might maliciously inject a script into the content type.

This PR aims to fix this behavior by escaping the two user-controlled strings before posting them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36211

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid XSS vulnerability in Upload proxy
```

