### PR TITLE
[release-v1.55] Escape user-controlled strings in uploadproxy to avoid XSS attacks

### DIFF
--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -248,7 +249,8 @@ func (app *uploadProxyApp) resolveUploadPath(pvcName, pvcNamespace, defaultPath 
 
 		return common.UploadArchivePath, nil
 	default:
-		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", pvcName, contentType)
+		// Escaping user-controlled strings to avoid cross-site scripting (XSS) attacks
+		return "", fmt.Errorf("rejecting upload request for PVC %s - upload content-type %s is invalid", html.EscapeString(pvcName), html.EscapeString(contentType))
 	}
 }
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -274,6 +274,39 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Entry("succeed upload of tar.xz", uploadArchive, true, image.ExtXz),
 	)
 
+	It("Verify cross-site scripting XSS attempt is escaped accordingly to avoid attack", func() {
+		By("Verify PVC annotation says ready")
+		const XSSAttempt = "<script>Bad stuff here...</script>"
+		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		pvc.Annotations[controller.AnnContentType] = XSSAttempt
+		pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		var token string
+		By("Get an upload token")
+		token, err = utils.RequestUploadToken(f.CdiClient, pvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token).ToNot(BeEmpty())
+
+		By("Do upload")
+		resp, err := getUploadToPathResponse(binaryRequestFunc, utils.UploadFile, uploadProxyURL, syncUploadPath, token)
+		Expect(err).ToNot(HaveOccurred())
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify XSS attempt")
+		// Verify XSS attack is not present in the error msg
+		Expect(string(body)).ToNot(ContainSubstring(XSSAttempt))
+		// Verify < and > characters are escaped accordingly
+		Expect(string(body)).To(ContainSubstring("&lt;script&gt;"))
+		// Verify PVC name is intact
+		Expect(string(body)).To(ContainSubstring(pvc.Name))
+	})
+
 	It("[test_id:4988]Verify upload to the same pvc fails", func() {
 		By("Verify PVC annotation says ready")
 		found, err := utils.WaitPVCPodStatusReady(f.K8sClient, pvc)
@@ -553,6 +586,32 @@ func uploadFileNameToPath(requestFunc uploadFileNameRequestCreator, fileName, po
 	}
 
 	return nil
+}
+
+func getUploadToPathResponse(requestFunc uploadFileNameRequestCreator, fileName, portForwardURL, path, token string) (*http.Response, error) {
+	url := portForwardURL + path
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := requestFunc(url, fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer req.Body.Close()
+
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Origin", "foo.bar.com")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func uploadFileNameToPathWithClient(client *http.Client, requestFunc uploadFileNameRequestCreator, fileName, portForwardURL, path, token string, expectedStatus int) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3131.

When upload content-type is invalid we post a error message with user-controlled parameters in our upload proxy. This makes the proxy vulnerable to XSS attacks as an user might maliciously inject a script into the content type.

This PR aims to fix this behavior by escaping the two user-controlled strings before posting them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36209

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid XSS vulnerability in Upload proxy
```

