### PR TITLE
[release-v1.58] cdi.kubevirt.io/allowClaimAdoption annotation breaking "regular" operations

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -321,7 +321,10 @@ const (
 	AnnEventSource = "cdi.kubevirt.io/events.source"
 
 	// AnnAllowClaimAdoption is the annotation that allows a claim to be adopted by a DataVolume
-	AnnAllowClaimAdoption = "cdi.kubevirt.io/allowClaimAdoption"
+	AnnAllowClaimAdoption = AnnAPIGroup + "/allowClaimAdoption"
+
+	// AnnCreatedForDataVolume stores the UID of the datavolume that the PVC was created for
+	AnnCreatedForDataVolume = AnnAPIGroup + "/createdForDataVolume"
 )
 
 // Size-detection pod error codes
@@ -2127,7 +2130,11 @@ func AllowClaimAdoption(c client.Client, pvc *corev1.PersistentVolumeClaim, dv *
 	if pvc == nil || dv == nil {
 		return false, nil
 	}
-	anno, ok := dv.Annotations[AnnAllowClaimAdoption]
+	anno, ok := pvc.Annotations[AnnCreatedForDataVolume]
+	if ok && anno == string(dv.UID) {
+		return false, nil
+	}
+	anno, ok = dv.Annotations[AnnAllowClaimAdoption]
 	// if annotation exists, go with that regardless of featuregate
 	if ok {
 		val, _ := strconv.ParseBool(anno)

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1128,6 +1128,8 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 		annotations[cc.AnnPriorityClassName] = dataVolume.Spec.PriorityClassName
 	}
 	annotations[cc.AnnPreallocationRequested] = strconv.FormatBool(cc.GetPreallocation(context.TODO(), r.client, dataVolume.Spec.Preallocation))
+	annotations[cc.AnnCreatedForDataVolume] = string(dataVolume.UID)
+
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespace,

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -241,6 +241,10 @@ func isPVCImportPopulation(pvc *corev1.PersistentVolumeClaim) bool {
 
 func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
 	pvcCopy := pvc.DeepCopy()
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
 	if isPVCImportPopulation(pvcCopy) {
 		// Better to play it safe and check the PVC Prime too
 		// before updating DV phase.
@@ -254,10 +258,6 @@ func (r *ImportReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnImportPod]
-	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
-	if err != nil {
-		return false, err
-	}
 	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -181,7 +181,8 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 
 		It("Should create a PVC on a valid import DV", func() {
-			reconciler = createImportReconciler(NewImportDataVolume("test-dv"))
+			dv := NewImportDataVolume("test-dv")
+			reconciler = createImportReconciler(dv)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 			Expect(err).ToNot(HaveOccurred())
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -190,6 +191,9 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.Name).To(Equal("test-dv"))
 			Expect(pvc.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
 			Expect(pvc.Labels[common.KubePersistentVolumeFillingUpSuppressLabelKey]).To(Equal(common.KubePersistentVolumeFillingUpSuppressLabelValue))
+			val, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(string(dv.UID)))
 		})
 
 		It("Should create a PVC on a valid import DV without delayed annotation then add on success", func() {
@@ -814,6 +818,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		It("Should adopt a unbound PVC (with annotation)", func() {
@@ -836,6 +842,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		It("Should adopt a PVC (with featuregate)", func() {
@@ -857,6 +865,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 			Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		It("Should set multistage migration annotations on a newly created PVC", func() {
@@ -2087,6 +2097,7 @@ func newUploadDataVolume(name string) *cdiv1.DataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
+			UID:       types.UID("uid"),
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: &cdiv1.DataVolumeSource{

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -153,6 +153,9 @@ var _ = Describe("All DataVolume Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vcs.Spec.Source.Kind).To(Equal("PersistentVolumeClaim"))
 				Expect(vcs.Spec.Source.Name).To(Equal(srcPvc.Name))
+				val, ok := pvc.Annotations[AnnCreatedForDataVolume]
+				Expect(val).To(Equal(string(dv.UID)))
+				Expect(ok).To(BeTrue())
 			},
 				Entry("with same namespace", metav1.NamespaceDefault),
 				Entry("with different namespace", "source-ns"),
@@ -508,6 +511,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0].Name).To(Equal("test-dv"))
 			Expect(pvc.OwnerReferences[0].Kind).To(Equal("DataVolume"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		It("Validate clone will adopt unbound PVC (with annotation)", func() {
@@ -535,6 +540,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0].Name).To(Equal("test-dv"))
 			Expect(pvc.OwnerReferences[0].Kind).To(Equal("DataVolume"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		It("Validate clone will adopt PVC (with featuregate)", func() {
@@ -561,6 +568,8 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0].Name).To(Equal("test-dv"))
 			Expect(pvc.OwnerReferences[0].Kind).To(Equal("DataVolume"))
+			_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+			Expect(ok).To(BeFalse())
 		})
 
 		DescribeTable("Validation mechanism rejects or accepts the clone depending on the contentType combination",

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -197,6 +197,10 @@ func isPVCUploadPopulation(pvc *corev1.PersistentVolumeClaim) bool {
 
 func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeClaim, dv *cdiv1.DataVolume) (bool, error) {
 	pvcCopy := pvc.DeepCopy()
+	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
+	if err != nil {
+		return false, err
+	}
 	if isPVCUploadPopulation(pvcCopy) {
 		// Better to play it safe and check the PVC Prime too
 		// before updating DV phase.
@@ -210,10 +214,6 @@ func (r *UploadReconciler) shouldUpdateStatusPhase(pvc *corev1.PersistentVolumeC
 		}
 	}
 	_, ok := pvcCopy.Annotations[cc.AnnUploadRequest]
-	requiresWork, err := r.pvcRequiresWork(pvcCopy, dv)
-	if err != nil {
-		return false, err
-	}
 	return ok && pvcCopy.Status.Phase == corev1.ClaimBound && requiresWork, nil
 }
 

--- a/pkg/controller/datavolume/upload-controller_test.go
+++ b/pkg/controller/datavolume/upload-controller_test.go
@@ -174,6 +174,9 @@ var _ = Describe("All DataVolume Tests", func() {
 		uploadSourceName := volumeUploadSourceName(dv)
 		Expect(pvc.Spec.DataSourceRef.Name).To(Equal(uploadSourceName))
 		Expect(pvc.Spec.DataSourceRef.Kind).To(Equal(cdiv1.VolumeUploadSourceRef))
+		val, ok := pvc.Annotations[AnnCreatedForDataVolume]
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(string(dv.UID)))
 	})
 
 	It("Should always report NA progress for upload population", func() {
@@ -232,6 +235,8 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+		Expect(ok).To(BeFalse())
 	})
 
 	It("Should adopt a PVC (with featuregate)", func() {
@@ -253,6 +258,8 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+		Expect(ok).To(BeFalse())
 	})
 
 	It("Should adopt a unbound PVC", func() {
@@ -275,6 +282,8 @@ var _ = Describe("All DataVolume Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dv.Status.Phase).To(Equal(cdiv1.Succeeded))
 		Expect(string(dv.Status.Progress)).To(Equal("N/A"))
+		_, ok := pvc.Annotations[AnnCreatedForDataVolume]
+		Expect(ok).To(BeFalse())
 	})
 
 	var _ = Describe("Reconcile Datavolume status", func() {


### PR DESCRIPTION
Have to better track when a PVC was created for a particular DV (populate it) or createed for someone else (adopt it)

Fixes:  https://issues.redhat.com/browse/CNV-39618

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

manual backport of #3136

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix for CNV-39618 - cdi.kubevirt.io/allowClaimAdoption annotation broken
```

