### PR TITLE
cleanup: Return modified labels added from termination message

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -417,7 +417,7 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		pvc.GetLabels()[common.CDILabelKey] = common.CDILabelValue
 	}
 	if cc.IsPVCComplete(pvc) {
-		setLabelsFromTerminationMessage(pvc.GetLabels(), termMsg)
+		pvc.SetLabels(addLabelsFromTerminationMessage(pvc.GetLabels(), termMsg))
 	}
 
 	if !reflect.DeepEqual(currentPvcCopy, pvc) {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -332,15 +332,19 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *v1.Pod, termMs
 	}
 }
 
-func setLabelsFromTerminationMessage(labels map[string]string, termMsg *common.TerminationMessage) {
-	if labels == nil || termMsg == nil {
-		return
+func addLabelsFromTerminationMessage(labels map[string]string, termMsg *common.TerminationMessage) map[string]string {
+	newLabels := make(map[string]string, 0)
+	for k, v := range labels {
+		newLabels[k] = v
 	}
-	for k, v := range termMsg.Labels {
-		if _, found := labels[k]; !found {
-			labels[k] = v
+	if termMsg != nil {
+		for k, v := range termMsg.Labels {
+			if _, found := newLabels[k]; !found {
+				newLabels[k] = v
+			}
 		}
 	}
+	return newLabels
 }
 
 func simplifyKnownMessage(msg string) string {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -232,8 +232,8 @@ var _ = Describe("setAnnotationsFromPod", func() {
 	})
 })
 
-var _ = Describe("setLabelsFromTerminationMessage", func() {
-	It("should set labels from termMsg", func() {
+var _ = Describe("addLabelsFromTerminationMessage", func() {
+	It("should add labels from termMsg", func() {
 		labels := make(map[string]string, 0)
 		termMsg := &common.TerminationMessage{
 			Labels: map[string]string{
@@ -241,9 +241,24 @@ var _ = Describe("setLabelsFromTerminationMessage", func() {
 			},
 		}
 
-		setLabelsFromTerminationMessage(labels, termMsg)
+		newLabels := addLabelsFromTerminationMessage(labels, termMsg)
+
+		Expect(labels).To(BeEmpty())
 		for k, v := range termMsg.Labels {
-			Expect(labels).To(HaveKeyWithValue(k, v))
+			Expect(newLabels).To(HaveKeyWithValue(k, v))
+		}
+	})
+
+	It("should handle nil labels", func() {
+		termMsg := &common.TerminationMessage{
+			Labels: map[string]string{
+				"test": "test",
+			},
+		}
+
+		newLabels := addLabelsFromTerminationMessage(nil, termMsg)
+		for k, v := range termMsg.Labels {
+			Expect(newLabels).To(HaveKeyWithValue(k, v))
 		}
 	})
 
@@ -260,21 +275,17 @@ var _ = Describe("setLabelsFromTerminationMessage", func() {
 			},
 		}
 
-		setLabelsFromTerminationMessage(labels, termMsg)
-		Expect(labels).To(HaveKeyWithValue(testKeyExisting, testValueExisting))
+		newLabels := addLabelsFromTerminationMessage(labels, termMsg)
+		Expect(newLabels).To(HaveKeyWithValue(testKeyExisting, testValueExisting))
 	})
 
 	It("should handle nil termMsg", func() {
 		labels := map[string]string{
 			"test": "test",
 		}
-		labelsOriginal := make(map[string]string, len(labels))
-		for k, v := range labels {
-			labelsOriginal[k] = v
-		}
 
-		setLabelsFromTerminationMessage(labels, nil)
-		Expect(labels).To(Equal(labelsOriginal))
+		newLabels := addLabelsFromTerminationMessage(labels, nil)
+		Expect(newLabels).To(Equal(labels))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Instead of changing the labels map that is passed in as parameter to the
setLabelsFromTerminationMessage function, it now returns a modified copy
of the passed in labels map and is renamed to
addLabelsFromTerminationMessage. If the passed in map is nil a new map
will be allocated and initialized.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Follow up to #3103 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

