### PR TITLE
Fix volume/access mode inferring for temp host assisted source PVC in snapshot clones

### DIFF
--- a/doc/clone-from-volumesnapshot-source.md
+++ b/doc/clone-from-volumesnapshot-source.md
@@ -20,7 +20,10 @@ A much simpler example would be storage that can take around 5-10 minutes to sna
     * Create the restore PVC
     * Set the claim reference of the PV to point to the new target PVC ([namespace-transfer](./namespace-transfer.md))
 - If not possible:
-    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.
+    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.  
+
+    Note: below k8s 1.29 (which has sourceVolumeMode on snapshots) it is advised to annotate the snapshots sources not created by CDI with `cdi.kubevirt.io/storage.import.sourceVolumeMode`  
+    This is because otherwise CDI cannot infer the volume mode to create a temporary restore.
 
 ## Example
 To kick off the process, we need a source volume snapshot.  

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -327,7 +327,7 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 		strategy = *cs
 	} else if args.TargetClaim.Spec.StorageClassName != nil {
 		sp := &cdiv1.StorageProfile{}
-		exists, err := getResource(ctx, p.Client, "", *args.TargetClaim.Spec.StorageClassName, sp)
+		exists, err := getResource(ctx, p.Client, metav1.NamespaceNone, *args.TargetClaim.Spec.StorageClassName, sp)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +546,7 @@ func (p *Planner) planHostAssistedFromSnapshot(ctx context.Context, args *PlanAr
 		return nil, fmt.Errorf("source claim does not exist")
 	}
 
-	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
+	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.Log, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -775,13 +775,25 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
 	return desiredClaim
 }
 
-func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
-	scName, err := getStorageClassNameForTempSourceClaim(ctx, snapshot, client)
+func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, fmt.Errorf("volumeSnapshotContent name not found")
+	}
+	vsc := &snapshotv1.VolumeSnapshotContent{}
+	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+		return nil, err
+	}
+	scName, err := getStorageClassNameForTempSourceClaim(ctx, vsc, client)
+	if err != nil {
+		return nil, err
+	}
+	targetCpy := targetClaim.DeepCopy()
+	fallbackVolumeMode := targetCpy.Spec.VolumeMode
+	volumeMode, err := getVolumeModeForTempSourceClaim(log, snapshot, vsc, fallbackVolumeMode)
 	if err != nil {
 		return nil, err
 	}
 	// Get the appropriate size from the snapshot
-	targetCpy := targetClaim.DeepCopy()
 	if snapshot.Status == nil || snapshot.Status.RestoreSize == nil || snapshot.Status.RestoreSize.Sign() == -1 {
 		return nil, fmt.Errorf("snapshot has no RestoreSize")
 	}
@@ -798,33 +810,35 @@ func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *c
 			Labels:      targetCpy.Labels,
 			Annotations: targetCpy.Annotations,
 		},
-		Spec: targetCpy.Spec,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			// We've found that ReadWriteOnce is consensus among CSI drivers
+			// Although we know this is read only at all times, some drivers disallow mounting a block PVC ReadOnly
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			VolumeMode: volumeMode,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *restoreSize,
+				},
+			},
+		},
 	}
-	desiredClaim.Spec.DataSource = nil
-	desiredClaim.Spec.DataSourceRef = nil
-	desiredClaim.Spec.StorageClassName = &scName
-	desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = *restoreSize
 
 	return desiredClaim, nil
 }
 
-func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (string, error) {
+func getStorageClassNameForTempSourceClaim(ctx context.Context, vsc *snapshotv1.VolumeSnapshotContent, client client.Client) (string, error) {
 	var matches []string
 
-	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
-		return "", fmt.Errorf("volumeSnapshotContent name not found")
-	}
-	volumeSnapshotContent := &snapshotv1.VolumeSnapshotContent{}
-	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, volumeSnapshotContent); err != nil {
-		return "", err
-	}
 	// Attempting to get a storageClass compatible with the source snapshot
 	storageClasses := &storagev1.StorageClassList{}
 	if err := client.List(ctx, storageClasses); err != nil {
 		return "", err
 	}
 	for _, storageClass := range storageClasses.Items {
-		if storageClass.Provisioner == volumeSnapshotContent.Spec.Driver {
+		if storageClass.Provisioner == vsc.Spec.Driver {
 			matches = append(matches, storageClass.Name)
 		}
 	}
@@ -833,4 +847,20 @@ func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapsh
 	}
 	sort.Strings(matches)
 	return matches[0], nil
+}
+
+func getVolumeModeForTempSourceClaim(log logr.Logger, snapshot *snapshotv1.VolumeSnapshot, vsc *snapshotv1.VolumeSnapshotContent, fallback *corev1.PersistentVolumeMode) (*corev1.PersistentVolumeMode, error) {
+	if vsc.Spec.SourceVolumeMode != nil {
+		// Since 1.29 we should always return here
+		// Older versions did not populate this field and thus need more care
+		return vsc.Spec.SourceVolumeMode, nil
+	}
+
+	if v, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; ok {
+		mode := corev1.PersistentVolumeMode(v)
+		return &mode, nil
+	}
+
+	log.V(1).Info("Could not infer source volume mode of snapshot, creating a temporary restore with target PVC volume mode")
+	return fallback, nil
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -217,6 +217,9 @@ const (
 	// AnnDefaultSnapshotClass is the annotation indicating that a snapshot class is the default one
 	AnnDefaultSnapshotClass = "snapshot.storage.kubernetes.io/is-default-class"
 
+	// AnnSourceVolumeMode is the volume mode of the source PVC specified as an annotation on snapshots
+	AnnSourceVolumeMode = AnnAPIGroup + "/storage.import.sourceVolumeMode"
+
 	// AnnOpenShiftImageLookup is the annotation for OpenShift image stream lookup
 	AnnOpenShiftImageLookup = "alpha.image.policy.openshift.io/resolve-names"
 

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -37,6 +37,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +56,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	cdv "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
+	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
 	"kubevirt.io/containerized-data-importer/pkg/operator"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -356,6 +357,17 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			return res, err
 		}
 	} else if snapshot != nil {
+		// Below k8s 1.29 there's no way to know the source volume mode
+		// Let's at least expose this info on our own snapshots
+		if _, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; !ok {
+			volMode, err := inferVolumeModeForSnapshot(ctx, r.client, dataImportCron)
+			if err != nil {
+				return res, err
+			}
+			if volMode != nil {
+				cc.AddAnnotation(snapshot, cc.AnnSourceVolumeMode, string(*volMode))
+			}
+		}
 		if err := r.updateSource(ctx, dataImportCron, snapshot); err != nil {
 			return res, err
 		}
@@ -407,7 +419,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			}
 		}
 	} else if importSucceeded {
-		if err := r.updateDataImportCronSuccessCondition(ctx, dataImportCron, format, snapshot); err != nil {
+		if err := r.updateDataImportCronSuccessCondition(dataImportCron, format, snapshot); err != nil {
 			return res, err
 		}
 	} else if len(imports) > 0 {
@@ -491,7 +503,7 @@ func (r *DataImportCronReconciler) updateSource(ctx context.Context, cron *cdiv1
 
 func (r *DataImportCronReconciler) deleteErroneousDataVolume(ctx context.Context, cron *cdiv1.DataImportCron, dv *cdiv1.DataVolume) error {
 	log := r.log.WithValues("name", dv.Name).WithValues("uid", dv.UID)
-	if cond := cdv.FindConditionByType(cdiv1.DataVolumeRunning, dv.Status.Conditions); cond != nil {
+	if cond := dvc.FindConditionByType(cdiv1.DataVolumeRunning, dv.Status.Conditions); cond != nil {
 		if cond.Status == corev1.ConditionFalse && cond.Reason == common.GenericError {
 			log.Info("Delete DataVolume and reset DesiredDigest due to error", "message", cond.Message)
 			// Unlabel the DV before deleting it, to eliminate reconcile before DIC is updated
@@ -709,6 +721,9 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 			return err
 		}
 		cc.AddAnnotation(desiredSnapshot, AnnLastUseTime, time.Now().UTC().Format(time.RFC3339Nano))
+		if pvc.Spec.VolumeMode != nil {
+			cc.AddAnnotation(desiredSnapshot, cc.AnnSourceVolumeMode, string(*pvc.Spec.VolumeMode))
+		}
 		if err := r.client.Create(ctx, desiredSnapshot); err != nil {
 			return err
 		}
@@ -725,7 +740,7 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 	return nil
 }
 
-func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(ctx context.Context, dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, snapshot *snapshotv1.VolumeSnapshot) error {
+func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, snapshot *snapshotv1.VolumeSnapshot) error {
 	dataImportCron.Status.SourceFormat = &format
 
 	switch format {
@@ -940,14 +955,14 @@ func NewDataImportCronController(mgr manager.Manager, log logr.Logger, importerI
 	if err != nil {
 		return nil, err
 	}
-	if err := addDataImportCronControllerWatches(mgr, dataImportCronController, log); err != nil {
+	if err := addDataImportCronControllerWatches(mgr, dataImportCronController); err != nil {
 		return nil, err
 	}
 	log.Info("Initialized DataImportCron controller")
 	return dataImportCronController, nil
 }
 
-func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Controller, log logr.Logger) error {
+func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Controller) error {
 	if err := c.Watch(source.Kind(mgr.GetCache(), &cdiv1.DataImportCron{}), &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
@@ -1353,4 +1368,58 @@ func GetInitialJobName(cron *cdiv1.DataImportCron) string {
 
 func getSelector(matchLabels map[string]string) (labels.Selector, error) {
 	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: matchLabels})
+}
+
+func inferVolumeModeForSnapshot(ctx context.Context, client client.Client, cron *cdiv1.DataImportCron) (*corev1.PersistentVolumeMode, error) {
+	dv := &cron.Spec.Template
+
+	if explicitVolumeMode := getVolumeModeFromDVSpec(dv); explicitVolumeMode != nil {
+		return explicitVolumeMode, nil
+	}
+
+	accessModes := getAccessModesFromDVSpec(dv)
+	inferredPvc := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: cc.GetStorageClassFromDVSpec(dv),
+			AccessModes:      accessModes,
+			VolumeMode:       ptr.To(cdiv1.PersistentVolumeFromStorageProfile),
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					// Doesn't matter
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	if err := dvc.RenderPvc(ctx, client, inferredPvc); err != nil {
+		return nil, err
+	}
+
+	return inferredPvc.Spec.VolumeMode, nil
+}
+
+// getVolumeModeFromDVSpec returns the volume mode from DataVolume PVC or Storage spec
+func getVolumeModeFromDVSpec(dv *cdiv1.DataVolume) *corev1.PersistentVolumeMode {
+	if dv.Spec.PVC != nil {
+		return dv.Spec.PVC.VolumeMode
+	}
+
+	if dv.Spec.Storage != nil {
+		return dv.Spec.Storage.VolumeMode
+	}
+
+	return nil
+}
+
+// getAccessModesFromDVSpec returns the access modes from DataVolume PVC or Storage spec
+func getAccessModesFromDVSpec(dv *cdiv1.DataVolume) []corev1.PersistentVolumeAccessMode {
+	if dv.Spec.PVC != nil {
+		return dv.Spec.PVC.AccessModes
+	}
+
+	if dv.Spec.Storage != nil {
+		return dv.Spec.Storage.AccessModes
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes with snapshot cloning we have to fall back to host assisted.
To do this, we create a temporary restore from the snapshot and initiate a host assisted clone
from that -> target PVC.
The issue this commit fixes is that we set the wrong access/volume modes on this temporary restore PVC
(we set it to the target's).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Clone from snapshot - fix volume/access mode inferring for temp host assisted source PVC
```
