### PR TITLE
Double number of e2e parallel nodes from 3 to 6

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -97,7 +97,7 @@ fi
     export TESTS_WORKDIR=${CDI_DIR}/tests
     ginkgo_args="--trace --timeout=8h"
     if [[ -n "$CDI_E2E_FOCUS" || -n "$CDI_E2E_SKIP" ]]; then
-        ginkgo_args="${ginkgo_args} --nodes=3 --v"
+        ginkgo_args="${ginkgo_args} --nodes=6 --v"
     else
         ginkgo_args="${ginkgo_args} --v"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We have some feedback from testing CDI on a different platform that this can work tests-wise
(but of course, not resource-wise, which we will see here).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

