### PR TITLE
Reject DataVolumes and PVCs with storage size smaller than 1MiB

### DIFF
--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/token:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/appscode/jsonpatch:go_default_library",
+        "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned:go_default_library",
         "//vendor/github.com/robfig/cron/v3:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -374,11 +374,19 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(resp.Allowed).To(BeFalse())
 		})
 
+		It("should reject DataVolume with size smaller than 1MiB", func() {
+			dataVolume := newBlankDataVolume("blank")
+			quantity, err := resource.ParseQuantity("9")
+			Expect(err).ToNot(HaveOccurred())
+			dataVolume.Spec.PVC.Resources.Requests["storage"] = quantity
+			resp := validateDataVolumeCreate(dataVolume)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
 		It("should accept DataVolume with Blank source and no content type", func() {
 			dataVolume := newBlankDataVolume("blank")
 			resp := validateDataVolumeCreate(dataVolume)
 			Expect(resp.Allowed).To(BeTrue())
-
 		})
 
 		It("should accept DataVolume with Blank source and kubevirt contentType", func() {

--- a/pkg/controller/datavolume/BUILD.bazel
+++ b/pkg/controller/datavolume/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/token:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
+        "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -46,6 +46,22 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 		Expect(found).To(BeFalse())
 	})
 
+	It("Should return error on PVC with storage size smaller than 1MiB", func() {
+		volumeMode := corev1.PersistentVolumeBlock
+		pvcSpec := &corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			VolumeMode:       &volumeMode,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("9"),
+				},
+			},
+		}
+		err := renderPvcSpecVolumeSize(client, pvcSpec, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("PVC Spec is not valid - storage size should be at least 1MiB"))
+	})
+
 	It("Should return the same volume size (block volume mode)", func() {
 		volumeMode := corev1.PersistentVolumeBlock
 		pvcSpec := &corev1.PersistentVolumeClaimSpec{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Kubevirt disks must be at least 1MiB to work. Smaller sizes are rejected [here](https://github.com/kubevirt/kubevirt/blob/main/pkg/util/util.go#L234). This issue is only reported inside the virt-launcher pod logs, which makes debugging difficult.

This Pull Request modifies our DV and PVC admission webhook to reject storage sizes smaller than 1MiB at an earlier phase, thus improving consistency with Kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-35798 (partially)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reject volumes with storage smaller than 1MiB
```

