### PR TITLE
Stop handling error phase as "unknown" in clone-populator

### DIFF
--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -426,7 +426,7 @@ var populatorPhaseMap = map[string]cdiv1.DataVolumePhase{
 	clone.RebindPhaseName:        cdiv1.RebindInProgress,
 	clone.SnapshotClonePhaseName: cdiv1.CloneFromSnapshotSourceInProgress,
 	clone.SnapshotPhaseName:      cdiv1.SnapshotForSmartCloneInProgress,
-	//clone.ErrorPhaseName:         cdiv1.Error, // Want to hold off on this for now
+	clone.ErrorPhaseName:         cdiv1.Failed,
 }
 
 func (r *CloneReconcilerBase) updateStatusPhaseForPopulator(pvc *corev1.PersistentVolumeClaim, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
@@ -437,7 +437,10 @@ func (r *CloneReconcilerBase) updateStatusPhaseForPopulator(pvc *corev1.Persiste
 		//dataVolumeCopy.Status.Phase = cdiv1.Unknown // hold off on this for now
 		return nil
 	}
-	dataVolumeCopy.Status.Phase = dvPhase
+	// Avoid setting DV to failed for consistency with non-populator flow
+	if dvPhase != cdiv1.Failed {
+		dataVolumeCopy.Status.Phase = dvPhase
+	}
 	r.setEventForPhase(dataVolumeCopy, dvPhase, event)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Until now, the clone populator handled the error phase as "unknown". This triggered a minor log flood with the `Unknown populator phase` message, which wasn't descriptive enough.

To avoid this, we are now handling the phase as the others but still avoiding changing DV phase for consistency with the non-populator flow. If necessary, now a proper event will be recorded in the DataVolume. This addresses this card: https://issues.redhat.com/browse/CNV-35802.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-35802 (partially)

**Special notes for your reviewer**:

Still in progress, let's see how tests behave.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop handling error phase as "unknown" in clone-populator
```

