### PR TITLE
Enable misspell linter and fix spelling errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   enable:
   - ginkgolinter
   - goimports
+  - misspell
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -57,7 +57,7 @@ func init() {
 func getEnvVarOrDie(name string) string {
 	value := os.Getenv(name)
 	if value == "" {
-		klog.Fatalf("Error geting env var %s", name)
+		klog.Fatalf("Error getting env var %s", name)
 	}
 	return value
 }

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -117,8 +117,8 @@ func main() {
 		volumeMode = v1.PersistentVolumeFilesystem
 	}
 
-	// With writeback cache mode it's possible that the process will exit before all writes have been commited to storage.
-	// To guarantee that our write was commited to storage, we make a fsync syscall and ensure success.
+	// With writeback cache mode it's possible that the process will exit before all writes have been committed to storage.
+	// To guarantee that our write was committed to storage, we make a fsync syscall and ensure success.
 	// Also might be a good idea to sync any chmod's we might have done.
 	defer fsyncDataFile(contentType, volumeMode)
 
@@ -362,6 +362,6 @@ func fsyncDataFile(contentType string, volumeMode v1.PersistentVolumeMode) {
 		klog.Errorf("could not fsync following qemu-img writing: %+v", err)
 		os.Exit(1)
 	}
-	klog.V(3).Infof("Successfully completed fsync(%s) syscall, commited to disk\n", dataFile)
+	klog.V(3).Infof("Successfully completed fsync(%s) syscall, committed to disk\n", dataFile)
 	file.Close()
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -795,7 +795,7 @@ func IsPopulated(pvc *corev1.PersistentVolumeClaim, c client.Client) (bool, erro
 	})
 }
 
-// GetPreallocation retuns the preallocation setting for the specified object (DV or VolumeImportSource), falling back to StorageClass and global setting (in this order)
+// GetPreallocation returns the preallocation setting for the specified object (DV or VolumeImportSource), falling back to StorageClass and global setting (in this order)
 func GetPreallocation(ctx context.Context, client client.Client, preallocation *bool) bool {
 	// First, the DV's preallocation
 	if preallocation != nil {

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -325,14 +325,14 @@ var _ = Describe("GetMetricsURL", func() {
 		return pod
 	}
 
-	It("Should suceed with IPv4", func() {
+	It("Should succeed with IPv4", func() {
 		pod := makePod("127.0.0.1", true)
 		url, err := GetMetricsURL(pod)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(url).To(Equal("https://127.0.0.1:8080/metrics"))
 	})
 
-	It("Should suceed with IPv6", func() {
+	It("Should succeed with IPv6", func() {
 		pod := makePod("::1", true)
 		url, err := GetMetricsURL(pod)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -490,7 +490,7 @@ func NewConfigController(mgr manager.Manager, log logr.Logger, uploadProxyServic
 		return nil, err
 	}
 	if err := reconciler.Init(); err != nil {
-		log.Error(err, "Unable to initalize CDIConfig")
+		log.Error(err, "Unable to initialize CDIConfig")
 	}
 	log.Info("Initialized CDI Config object")
 	return configController, nil

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -592,8 +592,8 @@ var _ = Describe("All DataImportCron Tests", func() {
 			verifyDataImportCronOutdatedMetric(cron, isPending, 1)
 			verifyDataImportCronOutdatedMetric(cron, !isPending, 0)
 		},
-			Entry("with DataVolume pending for deafult storage class", true),
-			Entry("with deafult storage class", false),
+			Entry("with DataVolume pending for default storage class", true),
+			Entry("with default storage class", false),
 		)
 
 		It("Should not create DV if PVC exists on DesiredDigest update; Should update DIC and DAS, and GC LRU PVCs", func() {

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -91,9 +91,9 @@ const (
 	SizeDetectionPodCreated = "SizeDetectionPodCreated"
 	// MessageSizeDetectionPodCreated provides a const to indicate that the size-detection pod has been created (message)
 	MessageSizeDetectionPodCreated = "Size-detection pod created"
-	// SizeDetectionPodNotReady reports that the size-detection pod has not finished its exectuion (reason)
+	// SizeDetectionPodNotReady reports that the size-detection pod has not finished its execution (reason)
 	SizeDetectionPodNotReady = "SizeDetectionPodNotReady"
-	// MessageSizeDetectionPodNotReady reports that the size-detection pod has not finished its exectuion (message)
+	// MessageSizeDetectionPodNotReady reports that the size-detection pod has not finished its execution (message)
 	MessageSizeDetectionPodNotReady = "The size detection pod is not finished yet"
 	// ImportPVCNotReady reports that it's not yet possible to access the source PVC (reason)
 	ImportPVCNotReady = "ImportPVCNotReady"

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -625,7 +625,7 @@ func (r *ReconcilerBase) handleStaticVolume(syncState *dvSyncState, log logr.Log
 	for _, v := range volumes {
 		if v == syncState.pvc.Spec.VolumeName {
 			pvcCpy := syncState.pvc.DeepCopy()
-			// handle as "populatedFor" going foreward
+			// handle as "populatedFor" going forward
 			cc.AddAnnotation(pvcCpy, cc.AnnPopulatedFor, syncState.dvMutated.Name)
 			delete(pvcCpy.Annotations, cc.AnnPersistentVolumeList)
 			if err := r.updatePVC(pvcCpy); err != nil {

--- a/pkg/controller/datavolume/snapshot-clone-controller_test.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller_test.go
@@ -187,7 +187,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			tempHostAssistedPvc := CreatePvcInStorageClass(getTempHostAssistedSourcePvcName(dv), snapshot.Namespace, &scName, nil, labels, corev1.ClaimBound)
 			err := setAnnOwnedByDataVolume(tempHostAssistedPvc, dv)
 			Expect(err).ToNot(HaveOccurred())
-			// mimic target PVC being aroud
+			// mimic target PVC being around
 			annotations := map[string]string{
 				AnnCloneToken: "foobar",
 			}

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Import populator tests", func() {
 		},
 			Entry("with pod running phase", string(corev1.PodRunning)),
 			Entry("with pod failed phase", string(corev1.PodFailed)),
-			Entry("with pod succeded phase", string(corev1.PodSucceeded)),
+			Entry("with pod succeeded phase", string(corev1.PodSucceeded)),
 		)
 
 		It("should update target pvc with desired labels from succeeded pvc prime", func() {

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -283,8 +283,8 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Expect(ok).To(BeFalse())
 	},
 		Entry("with pod running phase", string(corev1.PodRunning)),
-		Entry("with pod succeded phase", string(corev1.PodFailed)),
-		Entry("with pod succeded phase", string(corev1.PodSucceeded)),
+		Entry("with pod succeeded phase", string(corev1.PodFailed)),
+		Entry("with pod succeeded phase", string(corev1.PodSucceeded)),
 	)
 
 	DescribeTable("Should create PVC Prime with proper upload annotations", func(key, value, expectedValue string) {

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Data Processor", func() {
 		})
 	})
 
-	It("should allow phase regsitry", func() {
+	It("should allow phase registry", func() {
 		mcdp := &MockCustomizedDataProvider{
 			MockDataProvider: MockDataProvider{
 				infoResponse:     ProcessingPhaseTransferDataDir,

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -1378,7 +1378,7 @@ type DiskSnapshotsServiceListRequest struct {
 	srv *ovirtsdk4.DiskSnapshotsServiceListRequest
 }
 
-// Send returns a reponse from listing disk snapshots
+// Send returns a response from listing disk snapshots
 func (service *DiskSnapshotsServiceListRequest) Send() (DiskSnapshotsServiceListResponseInterface, error) {
 	resp, err := service.srv.Send()
 	return &DiskSnapshotsServiceListResponse{

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -55,7 +55,7 @@ func GetTerminationChannel() <-chan os.Signal {
 	return terminationChannel
 }
 
-// newTerminationChannel should be overriden for unit tests
+// newTerminationChannel should be overridden for unit tests
 var newTerminationChannel = GetTerminationChannel
 
 func envsToLabels(envs []string) map[string]string {

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -178,7 +178,7 @@ var _ = Describe("VDDK data source", func() {
 		Expect(sourceSum).To(Equal(destSum))
 	})
 
-	It("VDDK delta copy should sucessfully apply a delta to a base disk image", func() {
+	It("VDDK delta copy should successfully apply a delta to a base disk image", func() {
 
 		// Copy base disk ("snapshot 1")
 		snap1, err := NewVDDKDataSource("", "", "", "", "", "", "checkpoint-1", "", "", v1.PersistentVolumeFilesystem)

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -984,7 +984,7 @@ var _ = Describe("Controller", func() {
 					return ok
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
 					if !ok {
 						return false
@@ -1023,7 +1023,7 @@ var _ = Describe("Controller", func() {
 					return ok
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
 					if !ok {
 						return false
@@ -1072,7 +1072,7 @@ var _ = Describe("Controller", func() {
 					return false
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
 					if !ok {
 						return false
@@ -1122,7 +1122,7 @@ var _ = Describe("Controller", func() {
 					return false
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
 					if !ok {
 						return false
@@ -1165,7 +1165,7 @@ var _ = Describe("Controller", func() {
 					return false
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					postDep, ok := postUpgradeObj.(*appsv1.Deployment)
 					if !ok {
 						return false
@@ -1198,7 +1198,7 @@ var _ = Describe("Controller", func() {
 					return ok
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					post, ok := postUpgradeObj.(*corev1.Service)
 					if !ok {
 						return false
@@ -1277,7 +1277,7 @@ var _ = Describe("Controller", func() {
 					return ok
 				},
 				func(postUpgradeObj client.Object, deisredObj client.Object) bool { //check resource was upgraded
-					//return true if postUpgrade has teh same fields as desired
+					//return true if postUpgrade has the same fields as desired
 					post, ok := postUpgradeObj.(*corev1.Service)
 					if !ok {
 						return false

--- a/pkg/operator/controller/route.go
+++ b/pkg/operator/controller/route.go
@@ -79,7 +79,7 @@ func ensureUploadProxyRouteExists(ctx context.Context, logger logr.Logger, c cli
 				"cdi.kubevirt.io": "",
 			},
 			Annotations: map[string]string{
-				// long timeout here to make sure client conection doesn't die during qcow->raw conversion
+				// long timeout here to make sure client connection doesn't die during qcow->raw conversion
 				"haproxy.router.openshift.io/timeout": "60m",
 			},
 		},

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -325,7 +325,7 @@ var _ = Describe("all clone tests", func() {
 				nodeList, err := f.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if len(nodeList.Items) < 2 {
-					Skip("Need at least 2 nodes to copy accross nodes")
+					Skip("Need at least 2 nodes to copy across nodes")
 				}
 				nodeMap := make(map[string]bool)
 				for _, node := range nodeList.Items {
@@ -2663,7 +2663,7 @@ var _ = Describe("all clone tests", func() {
 			}
 		})
 
-		DescribeTable("Should sucessfully clone without falling back to host assisted", func(volumeMode v1.PersistentVolumeMode, repeat int, crossNamespace bool) {
+		DescribeTable("Should successfully clone without falling back to host assisted", func(volumeMode v1.PersistentVolumeMode, repeat int, crossNamespace bool) {
 			var i int
 			var err error
 

--- a/tests/imageio-inventory.go
+++ b/tests/imageio-inventory.go
@@ -354,7 +354,7 @@ func createResponseSequences(data *imageIoInventoryData) *bytes.Buffer {
 		},
 	}
 
-	// Add responses to individual transfer finalize requests, just needs HTTP sucess
+	// Add responses to individual transfer finalize requests, just needs HTTP success
 	for index, snapshot := range data.Snapshots {
 		times := 1
 		if index == 1 {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -768,7 +768,7 @@ var _ = Describe("ALL Operator tests", func() {
 				cdiConfig, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Enable non existant featureGate")
+				By("Enable non existent featureGate")
 				cdiConfig.Spec = cdiv1.CDIConfigSpec{
 					FeatureGates: []string{feature},
 				}

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -71,7 +71,7 @@ const (
 	LargePhysicalDiskQcow = "http://cdi-file-host.%s/cirros-large-physical-size.qcow2"
 	// LargePhysicalDiskXz provides a test url for a cirros image with a large physical size, in RAW format, XZ-compressed
 	LargePhysicalDiskXz = "http://cdi-file-host.%s/cirros-large-physical-size.raw.xz"
-	// TarArchiveURL provides a test url for a tar achive file
+	// TarArchiveURL provides a test url for a tar archive file
 	TarArchiveURL = "http://cdi-file-host.%s/archive.tar"
 	// CirrosURL provides the standard cirros image qcow image
 	CirrosURL = "http://cdi-file-host.%s/cirros-qcow2.img"

--- a/tools/cdi-func-test-sample-populator/main.go
+++ b/tools/cdi-func-test-sample-populator/main.go
@@ -135,5 +135,5 @@ func main() {
 		klog.Fatalf("Invalid mode: %s", mode)
 	}
 
-	klog.Infof("CDI sample populator finished succesfully in '%s' mode", mode)
+	klog.Infof("CDI sample populator finished successfully in '%s' mode", mode)
 }


### PR DESCRIPTION
I'd like to take the credit but it just a linter:
```
 golangci-lint run ./... --enable misspell --fix
```

**What this PR does / why we need it**:
Just some housekeeping

**Special notes for your reviewer**:
These could be automated by adding the [`misspell`](https://golangci-lint.run/usage/linters/#misspell) linter to the golangci-lint file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable misspell linter and fix spelling errors in comments and strings
```

