### PR TITLE
Enable unconvert linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,11 @@ linters:
   - goimports
   - misspell
   - unconvert
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   - ginkgolinter
   - goimports
   - misspell
+  - unconvert
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true

--- a/pkg/apiserver/webhooks/populators-validate_test.go
+++ b/pkg/apiserver/webhooks/populators-validate_test.go
@@ -363,7 +363,7 @@ func newVolumeUploadSource(contentType cdiv1.DataVolumeContentType) *cdiv1.Volum
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: cdiv1.VolumeUploadSourceSpec{
-			ContentType: cdiv1.DataVolumeContentType(contentType),
+			ContentType: contentType,
 		},
 	}
 }
@@ -375,7 +375,7 @@ func newVolumeImportSource(contentType cdiv1.DataVolumeContentType, source *cdiv
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: cdiv1.VolumeImportSourceSpec{
-			ContentType: cdiv1.DataVolumeContentType(contentType),
+			ContentType: contentType,
 			Source:      source,
 		},
 	}

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -159,7 +159,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 				{
 					Name:            "dummy",
 					Image:           p.Image,
-					ImagePullPolicy: corev1.PullPolicy(p.PullPolicy),
+					ImagePullPolicy: p.PullPolicy,
 					Command:         []string{"/bin/bash"},
 					Args:            []string{"-c", "echo", "'hello cdi'"},
 				},

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -950,7 +950,7 @@ func validateTokenData(tokenData *token.Payload, srcNamespace, srcName, targetNa
 
 // validateContentTypes compares the content type of a clone DV against its source PVC's one
 func validateContentTypes(sourcePVC *corev1.PersistentVolumeClaim, spec *cdiv1.DataVolumeSpec) (bool, cdiv1.DataVolumeContentType, cdiv1.DataVolumeContentType) {
-	sourceContentType := cdiv1.DataVolumeContentType(GetPVCContentType(sourcePVC))
+	sourceContentType := GetPVCContentType(sourcePVC)
 	targetContentType := spec.ContentType
 	if targetContentType == "" {
 		targetContentType = cdiv1.DataVolumeKubeVirt
@@ -1225,7 +1225,7 @@ func CreatePvcInStorageClass(name, ns string, storageClassName *string, annotati
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany, corev1.ReadWriteOnce},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1G"),
+					corev1.ResourceStorage: resource.MustParse("1G"),
 				},
 			},
 			StorageClassName: storageClassName,

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -1081,7 +1081,7 @@ func createClusterWideProxyCAConfigMap(certBytes string) *corev1.ConfigMap {
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: ClusterWideProxyConfigMapName, Namespace: ClusterWideProxyConfigMapNameSpace},
 		Immutable:  new(bool),
-		Data:       map[string]string{ClusterWideProxyConfigMapKey: string(certBytes)},
+		Data:       map[string]string{ClusterWideProxyConfigMapKey: certBytes},
 		BinaryData: map[string][]byte{},
 	}
 	return configMap

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1700,7 +1700,7 @@ var _ = Describe("All DataVolume Tests", func() {
 		largeOverhead   = float64(0.75)
 	)
 	DescribeTable("GetRequiredSpace should return properly enlarged sizes,", func(imageSize int64, overhead float64) {
-		for testedSize := int64(imageSize - 1024); testedSize < imageSize+1024; testedSize++ {
+		for testedSize := imageSize - 1024; testedSize < imageSize+1024; testedSize++ {
 			alignedImageSpace := imageSize
 			if testedSize > imageSize {
 				alignedImageSpace = imageSize + Mi

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	sourceInUseRequeueDuration = time.Duration(5 * time.Second)
+	sourceInUseRequeueDuration = 5 * time.Second
 
 	pvcCloneControllerName = "datavolume-pvc-clone-controller"
 

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -804,7 +804,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			// Prepare the source PVC with the required annotations
 			pvc := CreatePvcInStorageClass("test", metav1.NamespaceDefault, &scName, annKubevirt, nil, corev1.ClaimBound)
 			pvc.Annotations[AnnVirtualImageSize] = "100" // Mock value
-			pvc.Annotations[AnnSourceCapacity] = string(pvc.Status.Capacity.Storage().String())
+			pvc.Annotations[AnnSourceCapacity] = pvc.Status.Capacity.Storage().String()
 			reconciler := createCloneReconciler(dv, pvc, storageProfile, sc)
 
 			// Get the expected value

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -615,7 +615,7 @@ func setAnnOwnedByDataVolume(dest, obj metav1.Object) error {
 // CheckVolumeSatisfyClaim checks if the volume requested by the claim satisfies the requirements of the claim
 // adapted from k8s.io/kubernetes/pkg/controller/volume/persistentvolume/pv_controller.go
 func CheckVolumeSatisfyClaim(volume *v1.PersistentVolume, claim *v1.PersistentVolumeClaim) error {
-	requestedQty := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	requestedQty := claim.Spec.Resources.Requests[v1.ResourceStorage]
 	requestedSize := requestedQty.Value()
 
 	// check if PV's DeletionTimeStamp is set, if so, return error.

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -389,7 +389,7 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		anno[cc.AnnCurrentPodID] = string(pod.ObjectMeta.UID)
 	}
 
-	anno[cc.AnnImportPod] = string(pod.Name)
+	anno[cc.AnnImportPod] = pod.Name
 	if !scratchSpaceRequired {
 		// No scratch space required, update the phase based on the pod. If we require scratch space we don't want to update the
 		// phase, because the pod might terminate cleanly and mistakenly mark the import complete.

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1117,7 +1117,7 @@ func createImportTestEnv(podEnvVar *importPodEnvVar, uid string) []corev1.EnvVar
 		},
 		{
 			Name:  common.OwnerUID,
-			Value: string(uid),
+			Value: uid,
 		},
 		{
 			Name:  common.FilesystemOverheadVar,

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -348,7 +348,7 @@ func newUploadPopulatorPVC(name string) *corev1.PersistentVolumeClaim {
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1Gi"),
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
 				},
 			},
 			DataSourceRef: &corev1.TypedObjectReference{

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -537,7 +537,7 @@ func CreatePv(name string, storageClassName string) *v1.PersistentVolume {
 		Spec: v1.PersistentVolumeSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany, v1.ReadWriteOnce},
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse("1G"),
+				v1.ResourceStorage: resource.MustParse("1G"),
 			},
 			StorageClassName: storageClassName,
 			VolumeMode:       &volumeMode,

--- a/pkg/operator/controller/route.go
+++ b/pkg/operator/controller/route.go
@@ -91,7 +91,7 @@ func ensureUploadProxyRouteExists(ctx context.Context, logger logr.Logger, c cli
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationReencrypt,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-				DestinationCACertificate:      string(cert),
+				DestinationCACertificate:      cert,
 			},
 		},
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -109,7 +109,7 @@ func GetAvailableSpace(path string) (int64, error) {
 	if err != nil {
 		return int64(-1), err
 	}
-	return int64(stat.Bavail) * int64(stat.Bsize), nil
+	return int64(stat.Bavail) * stat.Bsize, nil
 }
 
 // GetAvailableSpaceBlock gets the amount of available space at the block device path specified.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -233,9 +233,9 @@ var _ = Describe("Usable Space calculation", func() {
 		largeOverhead   = float64(0.75)
 	)
 	DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {
-		for i := int64(virtualSize - 1024); i < virtualSize+1024; i++ {
+		for i := virtualSize - 1024; i < virtualSize+1024; i++ {
 			// Requested space is virtualSize rounded up to 1Mi alignment / (1 - overhead) rounded up
-			requestedSpace := int64(float64(RoundUp(i, DefaultAlignBlockSize)+1) / float64(1-overhead))
+			requestedSpace := int64(float64(RoundUp(i, DefaultAlignBlockSize)+1) / (1 - overhead))
 			if i <= virtualSize {
 				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize))
 			} else {

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -45,7 +45,7 @@ func (v *versionValue) IsBoolFlag() bool {
 }
 
 func (v *versionValue) Get() interface{} {
-	return versionValue(*v)
+	return *v
 }
 
 func (v *versionValue) Set(s string) error {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -499,7 +499,7 @@ var _ = Describe("all clone tests", func() {
 				sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
@@ -590,7 +590,7 @@ var _ = Describe("all clone tests", func() {
 				// should clone from fs to fs using the same size in spec.storage.size
 				// source pvc might be bigger than the size, but the clone should work
 				// as the actual data is the same
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 
 				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
@@ -833,7 +833,7 @@ var _ = Describe("all clone tests", func() {
 				})
 
 				It("should report correct status for smart/CSI clones", func() {
-					volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+					volumeMode := v1.PersistentVolumeFilesystem
 
 					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 					dataVolume.Spec.Storage.VolumeMode = &volumeMode
@@ -880,7 +880,7 @@ var _ = Describe("all clone tests", func() {
 				})
 
 				It("should succeed smart/CSI clones with immediate bind requested", func() {
-					volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+					volumeMode := v1.PersistentVolumeFilesystem
 
 					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 					dataVolume.Spec.Storage.VolumeMode = &volumeMode
@@ -1170,7 +1170,7 @@ var _ = Describe("all clone tests", func() {
 		//	3. 'HostAssisted' is used as clone strategy.
 		Context("Clone with empty size using the size-detection pod", func() {
 			diskImagePath := filepath.Join(testBaseDir, testFile)
-			volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+			volumeMode := v1.PersistentVolumeFilesystem
 
 			deleteAndWaitForVerifierPod := func() {
 				By("Deleting verifier pod")
@@ -1528,8 +1528,8 @@ var _ = Describe("all clone tests", func() {
 
 		Context("Clone without a source PVC", func() {
 			diskImagePath := filepath.Join(testBaseDir, testFile)
-			fsVM := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
-			blockVM := v1.PersistentVolumeMode(v1.PersistentVolumeBlock)
+			fsVM := v1.PersistentVolumeFilesystem
+			blockVM := v1.PersistentVolumeBlock
 
 			deleteAndWaitForVerifierPod := func() {
 				By("Deleting verifier pod")
@@ -2725,10 +2725,10 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(same).To(BeTrue())
 		},
-			Entry("[test_id:9703] with filesystem single clone", v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem), 1, true),
-			Entry("[test_id:9708] with filesystem multiple clones", v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem), 5, false),
-			Entry("[test_id:9709] with block single clone", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 1, false),
-			Entry("[test_id:9710] with block multiple clones", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 5, false),
+			Entry("[test_id:9703] with filesystem single clone", v1.PersistentVolumeFilesystem, 1, true),
+			Entry("[test_id:9708] with filesystem multiple clones", v1.PersistentVolumeFilesystem, 5, false),
+			Entry("[test_id:9709] with block single clone", v1.PersistentVolumeBlock, 1, false),
+			Entry("[test_id:9710] with block multiple clones", v1.PersistentVolumeBlock, 5, false),
 		)
 
 		Context("Fallback to host assisted", func() {
@@ -2806,10 +2806,10 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(same).To(BeTrue())
 			},
-				Entry("[test_id:9714] with filesystem single clone", v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem), 1, true),
-				Entry("[test_id:9715] with filesystem multiple clones", v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem), 5, false),
-				Entry("[test_id:9716] with block single clone", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 1, false),
-				Entry("[test_id:9717] with block multiple clones", v1.PersistentVolumeMode(v1.PersistentVolumeBlock), 5, false),
+				Entry("[test_id:9714] with filesystem single clone", v1.PersistentVolumeFilesystem, 1, true),
+				Entry("[test_id:9715] with filesystem multiple clones", v1.PersistentVolumeFilesystem, 5, false),
+				Entry("[test_id:9716] with block single clone", v1.PersistentVolumeBlock, 1, false),
+				Entry("[test_id:9717] with block multiple clones", v1.PersistentVolumeBlock, 5, false),
 			)
 		})
 
@@ -2835,7 +2835,7 @@ var _ = Describe("all clone tests", func() {
 				var err error
 
 				size := "1Gi"
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 				dvName := "clone-from-snap"
 				createSnapshot(size, &wffcStorageClass.Name, volumeMode)
 
@@ -2863,7 +2863,7 @@ var _ = Describe("all clone tests", func() {
 					Skip("Clone from volumesnapshot does not work without snapshot capable storage")
 				}
 				size := "1Gi"
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 				By("Create the clone before the source snapshot")
 				cloneDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("clone-from-snap", size, f.Namespace.Name, "snap-"+dataVolumeName, &f.SnapshotSCName, &volumeMode)
 				cloneDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
@@ -2901,7 +2901,7 @@ var _ = Describe("all clone tests", func() {
 				}
 
 				recommendedSnapSize := "2Gi"
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 
 				By("Create source snapshot")
 				createSnapshot(recommendedSnapSize, &f.SnapshotSCName, volumeMode)
@@ -2920,7 +2920,7 @@ var _ = Describe("all clone tests", func() {
 				}
 
 				size := "1Gi"
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+				volumeMode := v1.PersistentVolumeFilesystem
 				createSnapshot(size, &f.SnapshotSCName, volumeMode)
 
 				targetDS := utils.NewSnapshotDataSource("test-datasource", snapshot.Namespace, snapshot.Name, snapshot.Namespace)

--- a/tests/external_population_test.go
+++ b/tests/external_population_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeMode(corev1.PersistentVolumeFilesystem), nil, dataSourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dataSourceRef)
 			controller.AddAnnotation(dataVolume, controller.AnnDeleteAfterCompletion, "false")
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -176,7 +176,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock), nil, dataSourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeBlock, nil, dataSourceRef)
 			controller.AddAnnotation(dataVolume, controller.AnnDeleteAfterCompletion, "false")
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
@@ -204,7 +204,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeMode(corev1.PersistentVolumeFilesystem), nil, dummySourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dummySourceRef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -244,7 +244,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating target datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeMode(corev1.PersistentVolumeFilesystem), dataSource, nil)
+			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeFilesystem, dataSource, nil)
 			dataVolume.Spec.Storage.StorageClassName = nil
 			controller.AddAnnotation(dataVolume, controller.AnnDeleteAfterCompletion, "false")
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -308,7 +308,7 @@ var _ = Describe("Population tests", func() {
 
 			By(fmt.Sprintf("Creating target datavolume %s", dataVolumeName))
 			// PVC API because some provisioners only allow exact match between source size and restore size
-			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, snapshot.Status.RestoreSize.String(), f.SnapshotSCName, corev1.PersistentVolumeMode(corev1.PersistentVolumeFilesystem), dataSource, nil)
+			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, snapshot.Status.RestoreSize.String(), f.SnapshotSCName, corev1.PersistentVolumeFilesystem, dataSource, nil)
 			controller.AddAnnotation(dataVolume, controller.AnnDeleteAfterCompletion, "false")
 			dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -332,7 +332,7 @@ func (f *Framework) GetRESTConfigForServiceAccount(namespace, name string) (*res
 	return &rest.Config{
 		Host:        f.RestConfig.Host,
 		APIPath:     f.RestConfig.APIPath,
-		BearerToken: string(token),
+		BearerToken: token,
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: true,
 		},

--- a/tests/framework/nfs-utils.go
+++ b/tests/framework/nfs-utils.go
@@ -74,7 +74,7 @@ func NfsPvDef(index int, prefix, serviceIP, size string) *corev1.PersistentVolum
 				corev1.ReadWriteMany,
 			},
 			Capacity: corev1.ResourceList{
-				corev1.ResourceName(corev1.ResourceStorage): resource.MustParse(size),
+				corev1.ResourceStorage: resource.MustParse(size),
 			},
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				NFS: &corev1.NFSVolumeSource{

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -250,7 +250,7 @@ func (f *Framework) GetMD5(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolu
 		return "", err
 	}
 
-	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: md5sum found %s\n", string(output[:32]))
+	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: md5sum found %s\n", output[:32])
 	// Don't delete pod, other verification might happen.
 	return output[:32], nil
 }
@@ -277,7 +277,7 @@ func (f *Framework) VerifyBlankDisk(namespace *k8sv1.Namespace, pvc *k8sv1.Persi
 
 	return f.verifyInPod(namespace, pvc, cmd, func(output, stderr string) (bool, error) {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: empty file check %s\n", output)
-		return strings.Compare("All zeros", string(output)) == 0, nil
+		return strings.Compare("All zeros", output) == 0, nil
 	})
 }
 
@@ -388,7 +388,7 @@ func (f *Framework) VerifyTargetPVCArchiveContent(namespace *k8sv1.Namespace, pv
 	cmd := "ls -I lost+found " + utils.DefaultPvcMountPath + " | wc -l"
 
 	return f.verifyInPod(namespace, pvc, cmd, func(output, stderr string) (bool, error) {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: file count found %s\n", string(output))
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: file count found %s\n", output)
 		return strings.Compare(count, output) == 0, nil
 	})
 }
@@ -536,7 +536,7 @@ func (f *Framework) GetImageInfo(namespace *k8sv1.Namespace, pvc *k8sv1.Persiste
 
 		err := json.Unmarshal([]byte(output), info)
 		if err != nil {
-			klog.Errorf("Invalid JSON:\n%s\n", string(output))
+			klog.Errorf("Invalid JSON:\n%s\n", output)
 			return false, err
 		}
 
@@ -555,7 +555,7 @@ func (f *Framework) GetImageContentSize(namespace *k8sv1.Namespace, pvc *k8sv1.P
 
 		size, err := strconv.ParseInt(output, 10, 64)
 		if err != nil {
-			klog.Errorf("Invalid image content size:\n%s\n", string(output))
+			klog.Errorf("Invalid image content size:\n%s\n", output)
 			return false, err
 		}
 		*imageSize = size

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1159,11 +1159,11 @@ var _ = Describe("ALL Operator tests", func() {
 					prioClass = osUserCrit.Name
 				}
 				// Deployment
-				verifyPodPriorityClass(cdiDeploymentPodPrefix, string(prioClass), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiDeploymentPodPrefix, prioClass, common.CDILabelSelector)
 				// API server
-				verifyPodPriorityClass(cdiApiServerPodPrefix, string(prioClass), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiApiServerPodPrefix, prioClass, common.CDILabelSelector)
 				// Upload server
-				verifyPodPriorityClass(cdiUploadProxyPodPrefix, string(prioClass), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiUploadProxyPodPrefix, prioClass, common.CDILabelSelector)
 				By("Verifying there is just a single cdi controller pod")
 				Eventually(func() error {
 					_, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, common.CDILabelSelector)
@@ -1203,11 +1203,11 @@ var _ = Describe("ALL Operator tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				By("Verifying the CDI control plane is updated")
 				// Deployment
-				verifyPodPriorityClass(cdiDeploymentPodPrefix, string(osUserCrit.Name), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiDeploymentPodPrefix, osUserCrit.Name, common.CDILabelSelector)
 				// API server
-				verifyPodPriorityClass(cdiApiServerPodPrefix, string(osUserCrit.Name), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiApiServerPodPrefix, osUserCrit.Name, common.CDILabelSelector)
 				// Upload server
-				verifyPodPriorityClass(cdiUploadProxyPodPrefix, string(osUserCrit.Name), common.CDILabelSelector)
+				verifyPodPriorityClass(cdiUploadProxyPodPrefix, osUserCrit.Name, common.CDILabelSelector)
 			})
 		})
 	})

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1377,7 +1377,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		fsOverhead := "0.055" // The default value
 		tests.SetFilesystemOverhead(f, fsOverhead, fsOverhead)
 
-		volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
+		volumeMode := v1.PersistentVolumeFilesystem
 		accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 		dvName := "upload-dv"
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -324,7 +324,7 @@ func NewDataVolumeWithImageioImport(dataVolumeName string, size string, httpURL 
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -353,7 +353,7 @@ func NewDataVolumeWithImageioWarmImport(dataVolumeName string, size string, http
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -363,7 +363,7 @@ func NewDataVolumeWithImageioWarmImport(dataVolumeName string, size string, http
 
 // NewDataVolumeWithHTTPImportToBlockPV initializes a DataVolume struct with HTTP annotations to import to block PV
 func NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName string, size string, httpURL, storageClassName string) *cdiv1.DataVolume {
-	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
+	volumeMode := corev1.PersistentVolumeBlock
 	dataVolume := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
@@ -380,7 +380,7 @@ func NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName string, size string, ht
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -404,7 +404,7 @@ func NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName 
 				DataSourceRef:    dataSourceRef,
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -428,7 +428,7 @@ func NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, size, sto
 				DataSourceRef:    dataSourceRef,
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -439,7 +439,7 @@ func NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, size, sto
 
 // NewDataVolumeCloneToBlockPV initializes a DataVolume for block cloning
 func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespace, srcName, storageClassName string) *cdiv1.DataVolume {
-	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
+	volumeMode := corev1.PersistentVolumeBlock
 	dataVolume := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
@@ -457,7 +457,7 @@ func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespac
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -485,7 +485,7 @@ func NewDataVolumeCloneToBlockPVStorageAPI(dataVolumeName string, size string, s
 				StorageClassName: &storageClassName,
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -509,7 +509,7 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -532,7 +532,7 @@ func NewDataVolumeForUploadWithStorageAPI(dataVolumeName string, size string) *c
 			Storage: &cdiv1.StorageSpec{
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -555,7 +555,7 @@ func NewDataVolumeForBlankRawImage(dataVolumeName, size string) *cdiv1.DataVolum
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -565,7 +565,7 @@ func NewDataVolumeForBlankRawImage(dataVolumeName, size string) *cdiv1.DataVolum
 
 // NewDataVolumeForBlankRawImageBlock initializes a DataVolume struct for creating blank raw image for a block device
 func NewDataVolumeForBlankRawImageBlock(dataVolumeName, size string, storageClassName string) *cdiv1.DataVolume {
-	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
+	volumeMode := corev1.PersistentVolumeBlock
 	dataVolume := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataVolumeName,
@@ -580,7 +580,7 @@ func NewDataVolumeForBlankRawImageBlock(dataVolumeName, size string, storageClas
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -607,7 +607,7 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -703,7 +703,7 @@ func NewDataVolumeForSnapshotCloning(dataVolumeName, size, namespace, snapshot s
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -736,7 +736,7 @@ func NewDataVolumeForSnapshotCloningAndStorageSpec(dataVolumeName, size, namespa
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -768,7 +768,7 @@ func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registr
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -778,7 +778,7 @@ func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registr
 
 // ModifyDataVolumeWithImportToBlockPV modifies a DataVolume struct for import to a block PV
 func ModifyDataVolumeWithImportToBlockPV(dataVolume *cdiv1.DataVolume, storageClassName string) *cdiv1.DataVolume {
-	volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeBlock)
+	volumeMode := corev1.PersistentVolumeBlock
 	dataVolume.Spec.PVC.VolumeMode = &volumeMode
 	dataVolume.Spec.PVC.StorageClassName = &storageClassName
 	return dataVolume
@@ -804,7 +804,7 @@ func NewDataVolumeWithVddkImport(dataVolumeName string, size string, backingFile
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -838,7 +838,7 @@ func NewDataVolumeWithVddkWarmImport(dataVolumeName string, size string, backing
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -977,7 +977,7 @@ func NewDataVolumeWithArchiveContent(dataVolumeName string, size string, httpURL
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},
@@ -1002,7 +1002,7 @@ func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, 
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+						k8sv1.ResourceStorage: resource.MustParse(size),
 					},
 				},
 			},

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -244,7 +244,7 @@ func isExpectedNode(clientSet *kubernetes.Clientset, nodeName, podName, namespac
 			}
 			return false, err
 		}
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Checking Node name: %s\n", string(pod.Spec.NodeName))
+		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Checking Node name: %s\n", pod.Spec.NodeName)
 		if pod.Spec.NodeName == nodeName {
 			return true, nil
 		}

--- a/tests/utils/pv.go
+++ b/tests/utils/pv.go
@@ -45,7 +45,7 @@ func NewPVDefinition(pvName, size, storageClassName, node string, labels map[str
 			AccessModes:                   []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 			PersistentVolumeReclaimPolicy: k8sv1.PersistentVolumeReclaimDelete,
 			Capacity: k8sv1.ResourceList{
-				k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+				k8sv1.ResourceStorage: resource.MustParse(size),
 			},
 			PersistentVolumeSource: k8sv1.PersistentVolumeSource{
 				Local: &k8sv1.LocalVolumeSource{

--- a/tests/utils/pvc.go
+++ b/tests/utils/pvc.go
@@ -165,7 +165,7 @@ func NewPVCDefinitionWithSelector(pvcName, size, storageClassName string, select
 			AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 			Resources: k8sv1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+					k8sv1.ResourceStorage: resource.MustParse(size),
 				},
 			},
 			Selector: &metav1.LabelSelector{
@@ -193,7 +193,7 @@ func NewPVCDefinition(pvcName string, size string, annotations, labels map[strin
 			AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 			Resources: k8sv1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceName(k8sv1.ResourceStorage): resource.MustParse(size),
+					k8sv1.ResourceStorage: resource.MustParse(size),
 				},
 			},
 		},

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 				snapshot := utils.NewVolumeSnapshot("snap-"+pvc.Name, pvc.Namespace, pvc.Name, &snapClass.Name)
 				err = f.CrClient.Create(context.TODO(), snapshot)
 				Expect(err).ToNot(HaveOccurred())
-				volumeMode := corev1.PersistentVolumeMode(corev1.PersistentVolumeFilesystem)
+				volumeMode := corev1.PersistentVolumeFilesystem
 				targetDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("target-dv", "1Gi", snapshot.Namespace, snapshot.Name, nil, &volumeMode)
 
 				client, err := f.GetCdiClientForServiceAccount(targetNamespace.Name, serviceAccountName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables the `unconvert` golangci-lint linter, and fixes all its warnings.

**Special notes for your reviewer**:
This linter's doc describes it as:

> The unconvert program analyzes Go packages to identify unnecessary type conversions; i.e., expressions T(x) where x already has type T.

- https://golangci-lint.run/usage/linters/#unconvert
- https://github.com/mdempsky/unconvert?tab=readme-ov-file#about

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable unconvert linter and remove all redundant type conversions
```

