### PR TITLE
[release-v1.58] Fix inferring for temp host assisted source PVC in snapshot clones

### DIFF
--- a/doc/clone-from-volumesnapshot-source.md
+++ b/doc/clone-from-volumesnapshot-source.md
@@ -20,7 +20,10 @@ A much simpler example would be storage that can take around 5-10 minutes to sna
     * Create the restore PVC
     * Set the claim reference of the PV to point to the new target PVC ([namespace-transfer](./namespace-transfer.md))
 - If not possible:
-    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.
+    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.  
+
+    Note: below k8s 1.29 (which has sourceVolumeMode on snapshots) it is advised to annotate the snapshots sources not created by CDI with `cdi.kubevirt.io/storage.import.sourceVolumeMode`  
+    This is because otherwise CDI cannot infer the volume mode to create a temporary restore.
 
 ## Example
 To kick off the process, we need a source volume snapshot.  

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -325,7 +325,7 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 		strategy = *cs
 	} else if args.TargetClaim.Spec.StorageClassName != nil {
 		sp := &cdiv1.StorageProfile{}
-		exists, err := getResource(ctx, p.Client, "", *args.TargetClaim.Spec.StorageClassName, sp)
+		exists, err := getResource(ctx, p.Client, metav1.NamespaceNone, *args.TargetClaim.Spec.StorageClassName, sp)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func (p *Planner) planHostAssistedFromSnapshot(ctx context.Context, args *PlanAr
 		return nil, fmt.Errorf("source claim does not exist")
 	}
 
-	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
+	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.Log, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -773,13 +773,25 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
 	return desiredClaim
 }
 
-func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
-	scName, err := getStorageClassNameForTempSourceClaim(ctx, snapshot, client)
+func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, fmt.Errorf("volumeSnapshotContent name not found")
+	}
+	vsc := &snapshotv1.VolumeSnapshotContent{}
+	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+		return nil, err
+	}
+	scName, err := getStorageClassNameForTempSourceClaim(ctx, vsc, client)
+	if err != nil {
+		return nil, err
+	}
+	targetCpy := targetClaim.DeepCopy()
+	fallbackVolumeMode := targetCpy.Spec.VolumeMode
+	volumeMode, err := getVolumeModeForTempSourceClaim(log, snapshot, vsc, fallbackVolumeMode)
 	if err != nil {
 		return nil, err
 	}
 	// Get the appropriate size from the snapshot
-	targetCpy := targetClaim.DeepCopy()
 	if snapshot.Status == nil || snapshot.Status.RestoreSize == nil || snapshot.Status.RestoreSize.Sign() == -1 {
 		return nil, fmt.Errorf("snapshot has no RestoreSize")
 	}
@@ -796,33 +808,35 @@ func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *c
 			Labels:      targetCpy.Labels,
 			Annotations: targetCpy.Annotations,
 		},
-		Spec: targetCpy.Spec,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			// We've found that ReadWriteOnce is consensus among CSI drivers
+			// Although we know this is read only at all times, some drivers disallow mounting a block PVC ReadOnly
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			VolumeMode: volumeMode,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *restoreSize,
+				},
+			},
+		},
 	}
-	desiredClaim.Spec.DataSource = nil
-	desiredClaim.Spec.DataSourceRef = nil
-	desiredClaim.Spec.StorageClassName = &scName
-	desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = *restoreSize
 
 	return desiredClaim, nil
 }
 
-func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (string, error) {
+func getStorageClassNameForTempSourceClaim(ctx context.Context, vsc *snapshotv1.VolumeSnapshotContent, client client.Client) (string, error) {
 	var matches []string
 
-	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
-		return "", fmt.Errorf("volumeSnapshotContent name not found")
-	}
-	volumeSnapshotContent := &snapshotv1.VolumeSnapshotContent{}
-	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, volumeSnapshotContent); err != nil {
-		return "", err
-	}
 	// Attempting to get a storageClass compatible with the source snapshot
 	storageClasses := &storagev1.StorageClassList{}
 	if err := client.List(ctx, storageClasses); err != nil {
 		return "", err
 	}
 	for _, storageClass := range storageClasses.Items {
-		if storageClass.Provisioner == volumeSnapshotContent.Spec.Driver {
+		if storageClass.Provisioner == vsc.Spec.Driver {
 			matches = append(matches, storageClass.Name)
 		}
 	}
@@ -831,4 +845,20 @@ func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapsh
 	}
 	sort.Strings(matches)
 	return matches[0], nil
+}
+
+func getVolumeModeForTempSourceClaim(log logr.Logger, snapshot *snapshotv1.VolumeSnapshot, vsc *snapshotv1.VolumeSnapshotContent, fallback *corev1.PersistentVolumeMode) (*corev1.PersistentVolumeMode, error) {
+	if vsc.Spec.SourceVolumeMode != nil {
+		// Since 1.29 we should always return here
+		// Older versions did not populate this field and thus need more care
+		return vsc.Spec.SourceVolumeMode, nil
+	}
+
+	if v, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; ok {
+		mode := corev1.PersistentVolumeMode(v)
+		return &mode, nil
+	}
+
+	log.V(1).Info("Could not infer source volume mode of snapshot, creating a temporary restore with target PVC volume mode")
+	return fallback, nil
 }

--- a/pkg/controller/clone/planner_test.go
+++ b/pkg/controller/clone/planner_test.go
@@ -846,6 +846,56 @@ var _ = Describe("Planner test", func() {
 			validateRebindPhase(planner, args, plan[3])
 		})
 
+		Context("temp host assisted source pvc spec", func() {
+			volumeSnapshotContentWithSourceVolumeMode := func() *snapshotv1.VolumeSnapshotContent {
+				vsc := createDefaultVolumeSnapshotContent()
+				mode := corev1.PersistentVolumeMode("dummy")
+				vsc.Spec.SourceVolumeMode = &mode
+				return vsc
+			}
+
+			snapWithSourceVolumeModeAnnotation := func() *snapshotv1.VolumeSnapshot {
+				snap := createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")
+				cc.AddAnnotation(snap, cc.AnnSourceVolumeMode, "dummyfromann")
+				return snap
+			}
+
+			DescribeTable("should pick correct spec for temp host assisted source in clone from snapshot", func(objs []runtime.Object, expectedVolumeMode corev1.PersistentVolumeMode, source *snapshotv1.VolumeSnapshot) {
+				target := createTargetClaim()
+				mode := corev1.PersistentVolumeMode("dummytargetvolmode")
+				target.Spec.VolumeMode = &mode
+				args := &PlanArgs{
+					Strategy:    cdiv1.CloneStrategyHostAssisted,
+					TargetClaim: target,
+					DataSource:  createSnapshotDataSource(),
+					Log:         log,
+				}
+				runtimeObjs := []runtime.Object{cdiConfig, source, createVolumeSnapshotClass()}
+				runtimeObjs = append(runtimeObjs, objs...)
+				planner = createPlanner(runtimeObjs...)
+				plan, err := planner.Plan(context.Background(), args)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(plan).ToNot(BeNil())
+				Expect(plan).To(HaveLen(4))
+				validateSnapshotClonePhase(planner, args, plan[0])
+				validatePrepClaimPhase(planner, args, plan[1])
+				validateHostClonePhase(planner, args, plan[2])
+				validateRebindPhase(planner, args, plan[3])
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.VolumeMode).To(HaveValue(Equal(expectedVolumeMode)))
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.AccessModes).To(ConsistOf(
+					[]corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+				))
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.DataSource).To(BeNil())
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.DataSourceRef).To(BeNil())
+			},
+				Entry("when volumesnapshotcontent has source volume mode", []runtime.Object{volumeSnapshotContentWithSourceVolumeMode(), createStorageClass()}, corev1.PersistentVolumeMode("dummy"), createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")),
+				Entry("when volumesnapshotcontent has no source volume mode but annotated with AnnSourceVolumeMode", []runtime.Object{createDefaultVolumeSnapshotContent(), createStorageClass()}, corev1.PersistentVolumeMode("dummyfromann"), snapWithSourceVolumeModeAnnotation()),
+				Entry("when neither source volume mode on volumesnapshotcontent nor AnnSourceVolumeMode annotation", []runtime.Object{createDefaultVolumeSnapshotContent(), createStorageClass()}, corev1.PersistentVolumeMode("dummytargetvolmode"), createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")),
+			)
+		})
+
 		It("should fail planning host-assisted clone from snapshot when no valid storage class for source PVC is found", func() {
 			source := createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")
 			target := createTargetClaim()

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -217,6 +217,9 @@ const (
 	// AnnDefaultSnapshotClass is the annotation indicating that a snapshot class is the default one
 	AnnDefaultSnapshotClass = "snapshot.storage.kubernetes.io/is-default-class"
 
+	// AnnSourceVolumeMode is the volume mode of the source PVC specified as an annotation on snapshots
+	AnnSourceVolumeMode = AnnAPIGroup + "/storage.import.sourceVolumeMode"
+
 	// AnnOpenShiftImageLookup is the annotation for OpenShift image stream lookup
 	AnnOpenShiftImageLookup = "alpha.image.policy.openshift.io/resolve-names"
 

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -35,6 +35,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +51,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	cdv "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
+	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 )
 
 var (
@@ -740,7 +741,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(*dv.Spec.Source.Registry.URL).To(Equal("docker://" + testDockerRef))
 			Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
 			dv.Status.Phase = cdiv1.Succeeded
-			dv.Status.Conditions = cdv.UpdateReadyCondition(dv.Status.Conditions, corev1.ConditionTrue, "", "")
+			dv.Status.Conditions = dvc.UpdateReadyCondition(dv.Status.Conditions, corev1.ConditionTrue, "", "")
 			err = reconciler.client.Update(context.TODO(), dv)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -893,12 +894,19 @@ var _ = Describe("All DataImportCron Tests", func() {
 
 			BeforeEach(func() {
 				sc := cc.CreateStorageClass(storageClassName, map[string]string{cc.AnnDefaultStorageClass: "true"})
+				mode := corev1.PersistentVolumeMode("dummyfromsp")
 				sp := &cdiv1.StorageProfile{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: storageClassName,
 					},
 					Status: cdiv1.StorageProfileStatus{
 						DataImportCronSourceFormat: &snapFormat,
+						ClaimPropertySets: []cdiv1.ClaimPropertySet{
+							{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								VolumeMode:  &mode,
+							},
+						},
 					},
 				}
 				reconciler = createDataImportCronReconciler(sc, sp, createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
@@ -975,6 +983,8 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
 
 				pvc := cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
+				mode := corev1.PersistentVolumeMode("dummy")
+				pvc.Spec.VolumeMode = &mode
 				err = reconciler.client.Create(context.TODO(), pvc)
 				Expect(err).ToNot(HaveOccurred())
 				// DV GCed after hitting succeeded
@@ -988,6 +998,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 				snap := &snapshotv1.VolumeSnapshot{}
 				err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(snap.Annotations[cc.AnnSourceVolumeMode]).To(Equal("dummy"))
 				snap.Status = &snapshotv1.VolumeSnapshotStatus{
 					ReadyToUse: pointer.Bool(true),
 				}
@@ -1163,6 +1174,68 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
+
+			It("Should set snapshot source volume mode annotation on carried-over-upgrade snapshot", func() {
+				cron = newDataImportCron(cronName)
+				dataSource = nil
+				retentionPolicy := cdiv1.DataImportCronRetainNone
+				cron.Spec.RetentionPolicy = &retentionPolicy
+				err := reconciler.client.Create(context.TODO(), cron)
+				Expect(err).ToNot(HaveOccurred())
+				verifyConditions("Before DesiredDigest is set", false, false, false, noImport, noDigest, "", &snapshotv1.VolumeSnapshot{})
+
+				cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
+				err = reconciler.client.Update(context.TODO(), cron)
+				Expect(err).ToNot(HaveOccurred())
+				dataSource = &cdiv1.DataSource{}
+				verifyConditions("After DesiredDigest is set", false, false, false, noImport, outdated, noSource, &snapshotv1.VolumeSnapshot{})
+
+				imports := cron.Status.CurrentImports
+				Expect(imports).ToNot(BeNil())
+				Expect(imports).ToNot(BeEmpty())
+				dvName := imports[0].DataVolumeName
+				Expect(dvName).ToNot(BeEmpty())
+				digest := imports[0].Digest
+				Expect(digest).To(Equal(testDigest))
+
+				dv := &cdiv1.DataVolume{}
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*dv.Spec.Source.Registry.URL).To(Equal(testRegistryURL + "@" + testDigest))
+				Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
+
+				// DV GCed after hitting succeeded
+				err = reconciler.client.Delete(context.TODO(), dv)
+				Expect(err).ToNot(HaveOccurred())
+				pvc := cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
+				// Snap already exists, without the source volume mode annotation
+				readyToUse := true
+				snap := &snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvc.Name,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &pvc.Name,
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: &readyToUse,
+					},
+				}
+				err = reconciler.client.Create(context.TODO(), snap)
+				Expect(err).ToNot(HaveOccurred())
+
+				verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+
+				snap = &snapshotv1.VolumeSnapshot{}
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*snap.Status.ReadyToUse).To(BeTrue())
+				Expect(*snap.Spec.Source.PersistentVolumeClaimName).To(Equal(dvName))
+				Expect(snap.Annotations[cc.AnnSourceVolumeMode]).To(Equal("dummyfromsp"))
+			})
 		})
 	})
 })
@@ -1263,7 +1336,13 @@ func newDataImportCron(name string) *cdiv1.DataImportCron {
 							PullMethod: &registryPullNodesource,
 						},
 					},
-					Storage: &cdiv1.StorageSpec{},
+					Storage: &cdiv1.StorageSpec{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1Gi"),
+							},
+						},
+					},
 				},
 			},
 			Schedule:          defaultSchedule,

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -64,6 +64,19 @@ func renderPvcSpec(client client.Client, recorder record.EventRecorder, log logr
 	return nil, errors.Errorf("datavolume one of {pvc, storage} field is required")
 }
 
+// RenderPvcSpec is an exported version of renderPvcSpec solely for backport purposes of #3155
+//
+// Deprecated: Should not be used, newer versions have RenderPVC
+func RenderPvcSpec(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
+	if dv.Spec.PVC != nil {
+		return dv.Spec.PVC.DeepCopy(), nil
+	} else if dv.Spec.Storage != nil {
+		return pvcFromStorage(client, recorder, log, dv, pvc)
+	}
+
+	return nil, errors.Errorf("datavolume one of {pvc, storage} field is required")
+}
+
 func pvcFromStorage(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
 	var pvcSpec *v1.PersistentVolumeClaimSpec
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3155

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I have exported RenderPvcSpec (under deprecated notice) as that seems to be the least intrusive

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Clone from snapshot - fix volume/access mode inferring for temp host assisted source PVC
```

