### PR TITLE
fix: add rook-ceph upstream provisioner string to unsupported providers

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -134,14 +134,21 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"pxd.portworx.com":                      cdiv1.CloneStrategyCsiClone,
 }
 
-// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
-const ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+const (
+	// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
+	ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+	// ProvisionerOCSBucket is the provisioner string for the downstream ODF/OCS provisoner for buckets which does not work with CDI
+	ProvisionerOCSBucket = "openshift-storage.ceph.rook.io/bucket"
+	// ProvisionerRookCephBucket is the provisioner string for the upstream Rook Ceph provisoner for buckets which does not work with CDI
+	ProvisionerRookCephBucket = "rook-ceph.ceph.rook.io/bucket"
+)
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
 var UnsupportedProvisioners = map[string]struct{}{
 	// The following provisioners may be found in Rook/Ceph deployments and are related to object storage
-	"openshift-storage.ceph.rook.io/bucket": {},
-	ProvisionerNoobaa:                       {},
+	ProvisionerOCSBucket:      {},
+	ProvisionerRookCephBucket: {},
+	ProvisionerNoobaa:         {},
 }
 
 // GetCapabilities finds and returns a predefined StorageCapabilities for a given StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the upstream rook-ceph RGW StorageClass bucket provisioner to the compiled-in hashmap of unsupported provisioners for the purposes of metrics reporting.

For additional detail, see discussion on #3166 

**Special notes for your reviewer**:
I also separated out the ODF/OCS RGW StorageClass into a dedicated const so that Noobaa is consistent.

**Release note**:
```release-note
Improve metrics reporting behavior for upstream rook-ceph deployments, identifying RGW bucket provisioners
```

