### PR TITLE
Enable dupword linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+  - dupword
   - durationcheck
   - errname
   - errorlint

--- a/pkg/controller/clone/snap-clone_test.go
+++ b/pkg/controller/clone/snap-clone_test.go
@@ -158,7 +158,7 @@ var _ = Describe("SnapshotClonePhase test", func() {
 			assertNotFound(err)
 		})
 
-		It("should should create the claim when ready", func() {
+		It("should create the claim when ready", func() {
 			snapshot := getSnapshot()
 			snapshot.Status.ReadyToUse = ptr.To[bool](true)
 

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -50,7 +50,7 @@ const (
 	AnnPVCPrimeName = cc.AnnAPIGroup + "/storage.populator.pvcPrime"
 
 	// annMigratedTo annotation is added to a PVC and PV that is supposed to be
-	// dynamically provisioned/deleted by by its corresponding CSI driver
+	// dynamically provisioned/deleted by its corresponding CSI driver
 	// through the CSIMigration feature flags. When this annotation is set the
 	// Kubernetes components will "stand-down" and the external-provisioner will
 	// act on the objects

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -505,7 +505,7 @@ func isPodReady(pod *v1.Pod) bool {
 	return numReady == len(pod.Status.ContainerStatuses)
 }
 
-// createUploadService creates upload service service manifest and sends to server
+// createUploadService creates an upload service manifest and sends it to server
 func (r *UploadReconciler) createUploadService(name string, pvc *v1.PersistentVolumeClaim) (*v1.Service, error) {
 	ns := pvc.Namespace
 	service := r.makeUploadServiceSpec(name, pvc)
@@ -524,7 +524,7 @@ func (r *UploadReconciler) createUploadService(name string, pvc *v1.PersistentVo
 	return service, nil
 }
 
-// makeUploadServiceSpec creates upload service service manifest
+// makeUploadServiceSpec creates upload service manifest
 func (r *UploadReconciler) makeUploadServiceSpec(name string, pvc *v1.PersistentVolumeClaim) *v1.Service {
 	blockOwnerDeletion := true
 	isController := true

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Resize", func() {
 			o := NewQEMUOperations()
 			err = o.Resize("image", quantity, false)
 			Expect(err).To(HaveOccurred())
-			Expect(strings.Contains(err.Error(), "Error resizing image image")).To(BeTrue())
+			Expect(strings.Contains(err.Error(), "Error resizing image")).To(BeTrue())
 		})
 	})
 })

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -597,7 +597,7 @@ var _ = Describe("Controller", func() {
 				Expect(args.reconciler.namespacedArgs.Verbosity).To(Equal(strconv.Itoa(int(expectedValue))))
 			})
 
-			It("can become become ready, un-ready, and ready again", func() {
+			It("can become ready, un-ready, and ready again", func() {
 				var deployment *appsv1.Deployment
 
 				args := createArgs()

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -30,7 +30,7 @@ func (f *Framework) CreatePVCFromDefinition(def *k8sv1.PersistentVolumeClaim) (*
 	return utils.CreatePVCFromDefinition(f.K8sClient, f.Namespace.Name, def)
 }
 
-// CreateBoundPVCFromDefinition is a wrapper around utils.CreatePVCFromDefinition that also force binds pvc on
+// CreateBoundPVCFromDefinition is a wrapper around utils.CreatePVCFromDefinition that also force binds pvc
 // on WaitForFirstConsumer storage class by executing f.ForceBindIfWaitForFirstConsumer(pvc)
 func (f *Framework) CreateBoundPVCFromDefinition(def *k8sv1.PersistentVolumeClaim) *k8sv1.PersistentVolumeClaim {
 	pvc, err := utils.CreatePVCFromDefinition(f.K8sClient, f.Namespace.Name, def)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the dupword linter:

> A linter that checks for duplicate words in the source code (usually miswritten)

https://github.com/Abirdcfly/dupword
https://golangci-lint.run/usage/linters/#dupword

It warns about comments and some strings. It does NOT warn about duplicated code (linter `dupl` does this).

**Special notes for your reviewer**:
-

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable linter dupword to avoid stuttering comments and strings
```

