### PR TITLE
Enable nakedret linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   - ginkgolinter
   - goimports
   - misspell
+  - nakedret
   - unconvert
 
 issues:
@@ -12,8 +13,10 @@ issues:
   max-same-issues: 0
 
 linters-settings:
-  ginkgolinter:
-    forbid-focus-container: true
   errorlint:
     # We want to allow for usage of %v to avoid leaking implementation details
     errorf: false
+  ginkgolinter:
+    forbid-focus-container: true
+  nakedret:
+    max-func-lines: 0

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -730,17 +730,15 @@ func ParseCloneRequestAnnotation(pvc *corev1.PersistentVolumeClaim) (exists bool
 	var ann string
 	ann, exists = pvc.Annotations[cc.AnnCloneRequest]
 	if !exists {
-		return
+		return false, "", ""
 	}
 
 	sp := strings.Split(ann, "/")
 	if len(sp) != 2 {
-		exists = false
-		return
+		return false, "", ""
 	}
 
-	namespace, name = sp[0], sp[1]
-	return
+	return true, sp[0], sp[1]
 }
 
 // ValidateCanCloneSourceAndTargetContentType validates the pvcs passed has the same content type.

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1501,16 +1501,14 @@ func NewImportDataVolume(name string) *cdiv1.DataVolume {
 func GetCloneSourceInfo(dv *cdiv1.DataVolume) (sourceType, sourceName, sourceNamespace string) {
 	// Cloning sources are mutually exclusive
 	if dv.Spec.Source.PVC != nil {
-		sourceType = "pvc"
-		sourceName = dv.Spec.Source.PVC.Name
-		sourceNamespace = dv.Spec.Source.PVC.Namespace
-	} else if dv.Spec.Source.Snapshot != nil {
-		sourceType = "snapshot"
-		sourceName = dv.Spec.Source.Snapshot.Name
-		sourceNamespace = dv.Spec.Source.Snapshot.Namespace
+		return "pvc", dv.Spec.Source.PVC.Name, dv.Spec.Source.PVC.Namespace
 	}
 
-	return
+	if dv.Spec.Source.Snapshot != nil {
+		return "snapshot", dv.Spec.Source.Snapshot.Name, dv.Spec.Source.Snapshot.Namespace
+	}
+
+	return "", "", ""
 }
 
 // IsWaitForFirstConsumerEnabled tells us if we should respect "real" WFFC behavior or just let our worker pods randomly spawn

--- a/pkg/controller/datasource-controller.go
+++ b/pkg/controller/datasource-controller.go
@@ -239,10 +239,9 @@ func addDataSourceControllerWatches(mgr manager.Manager, c controller.Controller
 		return err
 	}
 
-	mapToDataSource := func(ctx context.Context, obj client.Object) (reqs []reconcile.Request) {
-		reqs = appendMatchingDataSourceRequests(ctx, dataSourcePvcField, obj, reqs)
-		reqs = appendMatchingDataSourceRequests(ctx, dataSourceSnapshotField, obj, reqs)
-		return
+	mapToDataSource := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		reqs := appendMatchingDataSourceRequests(ctx, dataSourcePvcField, obj, nil)
+		return appendMatchingDataSourceRequests(ctx, dataSourceSnapshotField, obj, reqs)
 	}
 
 	if err := c.Watch(source.Kind(mgr.GetCache(), &cdiv1.DataVolume{}),

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -551,17 +551,18 @@ func addCloneWithoutSourceWatch(mgr manager.Manager, datavolumeController contro
 	}
 
 	// Function to reconcile DVs that match the selected fields
-	dataVolumeMapper := func(ctx context.Context, obj client.Object) (reqs []reconcile.Request) {
+	dataVolumeMapper := func(ctx context.Context, obj client.Object) []reconcile.Request {
 		dvList := &cdiv1.DataVolumeList{}
 		namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 		matchingFields := client.MatchingFields{indexingKey: namespacedName.String()}
 		if err := mgr.GetClient().List(ctx, dvList, matchingFields); err != nil {
-			return
+			return nil
 		}
+		var reqs []reconcile.Request
 		for _, dv := range dvList.Items {
 			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name}})
 		}
-		return
+		return reqs
 	}
 
 	if err := datavolumeController.Watch(source.Kind(mgr.GetCache(), typeToWatch),

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -152,17 +152,18 @@ func addDataSourceWatch(mgr manager.Manager, c controller.Controller) error {
 		return err
 	}
 
-	mapToDataVolume := func(ctx context.Context, obj client.Object) (reqs []reconcile.Request) {
+	mapToDataVolume := func(ctx context.Context, obj client.Object) []reconcile.Request {
 		var dvs cdiv1.DataVolumeList
 		matchingFields := client.MatchingFields{dvDataSourceField: getKey(obj.GetNamespace(), obj.GetName())}
 		if err := mgr.GetClient().List(ctx, &dvs, matchingFields); err != nil {
 			c.GetLogger().Error(err, "Unable to list DataVolumes", "matchingFields", matchingFields)
-			return
+			return nil
 		}
+		var reqs []reconcile.Request
 		for _, dv := range dvs.Items {
 			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name}})
 		}
-		return
+		return reqs
 	}
 
 	if err := c.Watch(source.Kind(mgr.GetCache(), &cdiv1.DataSource{}),

--- a/pkg/controller/storageprofile-controller.go
+++ b/pkg/controller/storageprofile-controller.go
@@ -421,19 +421,20 @@ func addStorageProfileControllerWatches(mgr manager.Manager, c controller.Contro
 		return err
 	}
 
-	mapSnapshotClassToProfile := func(ctx context.Context, obj client.Object) (reqs []reconcile.Request) {
+	mapSnapshotClassToProfile := func(ctx context.Context, obj client.Object) []reconcile.Request {
 		var scList storagev1.StorageClassList
 		if err := mgr.GetClient().List(ctx, &scList); err != nil {
 			c.GetLogger().Error(err, "Unable to list StorageClasses")
-			return
+			return nil
 		}
 		vsc := obj.(*snapshotv1.VolumeSnapshotClass)
+		var reqs []reconcile.Request
 		for _, sc := range scList.Items {
 			if sc.Provisioner == vsc.Driver {
 				reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: sc.Name}})
 			}
 		}
-		return
+		return reqs
 	}
 	if err := mgr.GetClient().List(context.TODO(), &snapshotv1.VolumeSnapshotClassList{}, &client.ListOptions{Limit: 1}); err != nil {
 		if meta.IsNoMatchError(err) {

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -485,7 +485,7 @@ func mockExecFunction(output, errString string, expectedLimits *system.ProcessLi
 			err = errors.New(errString)
 		}
 
-		return
+		return bytes, err
 	}
 }
 
@@ -502,7 +502,7 @@ func mockExecFunctionStrict(output, errString string, expectedLimits *system.Pro
 			err = errors.New(errString)
 		}
 
-		return
+		return bytes, err
 	}
 }
 
@@ -525,7 +525,7 @@ func mockExecFunctionTwoCalls(output, errString string, expectedLimits *system.P
 			err = errors.New(errString)
 		}
 
-		return
+		return bytes, err
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -260,7 +260,7 @@ func WriteTerminationMessageToFile(file, message string) error {
 }
 
 // CopyDir copies a dir from one location to another.
-func CopyDir(source string, dest string) (err error) {
+func CopyDir(source string, dest string) error {
 	// get properties of source dir
 	sourceinfo, err := os.Stat(source)
 	if err != nil {
@@ -294,7 +294,7 @@ func CopyDir(source string, dest string) (err error) {
 			}
 		}
 	}
-	return
+	return err
 }
 
 // LinkFile symlinks the source to the target

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -762,16 +762,16 @@ type limitThenErrorReader struct {
 	n int64     // max bytes remaining
 }
 
-func (l *limitThenErrorReader) Read(p []byte) (n int, err error) {
+func (l *limitThenErrorReader) Read(p []byte) (int, error) {
 	if l.n <= 0 {
 		return 0, ErrTestFake // EOF
 	}
 	if int64(len(p)) > l.n {
 		p = p[0:l.n]
 	}
-	n, err = l.r.Read(p)
+	n, err := l.r.Read(p)
 	l.n -= int64(n)
-	return
+	return n, err
 }
 
 func startUploadProxyPortForward(f *framework.Framework) (string, *exec.Cmd, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

> Checks that functions with naked returns are not longer than a maximum
> size (can be zero).

https://github.com/alexkohler/nakedret

Relevant from the GO style guide:
> Naked returns are okay if the function is a handful of lines. Once
> it’s a medium sized function, be explicit with your return values.

https://go.dev/wiki/CodeReviewComments#named-result-parameters

I think a naked return is never easier to read than a regular return,
so I set the linter to always complain about it. Disagreements are
welcome.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable nakedret linter and populate all naked returns.
```

