### PR TITLE
[release-v1.57] Fix inferring for temp host assisted source PVC in snapshot clones

### DIFF
--- a/doc/clone-from-volumesnapshot-source.md
+++ b/doc/clone-from-volumesnapshot-source.md
@@ -20,7 +20,10 @@ A much simpler example would be storage that can take around 5-10 minutes to sna
     * Create the restore PVC
     * Set the claim reference of the PV to point to the new target PVC ([namespace-transfer](./namespace-transfer.md))
 - If not possible:
-    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.
+    * Attempt [host-assisted cloning](./clone-datavolume.md) between 2 PVCs where CDI creates a temporary restore PVC (which will be cleaned up) from the snapshot to act as the source.  
+
+    Note: below k8s 1.29 (which has sourceVolumeMode on snapshots) it is advised to annotate the snapshots sources not created by CDI with `cdi.kubevirt.io/storage.import.sourceVolumeMode`  
+    This is because otherwise CDI cannot infer the volume mode to create a temporary restore.
 
 ## Example
 To kick off the process, we need a source volume snapshot.  

--- a/pkg/controller/clone/BUILD.bazel
+++ b/pkg/controller/clone/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//tests/reporters:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -325,7 +325,7 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 		strategy = *cs
 	} else if args.TargetClaim.Spec.StorageClassName != nil {
 		sp := &cdiv1.StorageProfile{}
-		exists, err := getResource(ctx, p.Client, "", *args.TargetClaim.Spec.StorageClassName, sp)
+		exists, err := getResource(ctx, p.Client, metav1.NamespaceNone, *args.TargetClaim.Spec.StorageClassName, sp)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func (p *Planner) planHostAssistedFromSnapshot(ctx context.Context, args *PlanAr
 		return nil, fmt.Errorf("source claim does not exist")
 	}
 
-	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
+	sourceClaimForDumbClone, err := createTempSourceClaim(ctx, args.Log, args.DataSource.Namespace, args.TargetClaim, sourceSnapshot, p.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -773,13 +773,25 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
 	return desiredClaim
 }
 
-func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
-	scName, err := getStorageClassNameForTempSourceClaim(ctx, snapshot, client)
+func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, fmt.Errorf("volumeSnapshotContent name not found")
+	}
+	vsc := &snapshotv1.VolumeSnapshotContent{}
+	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+		return nil, err
+	}
+	scName, err := getStorageClassNameForTempSourceClaim(ctx, vsc, client)
+	if err != nil {
+		return nil, err
+	}
+	targetCpy := targetClaim.DeepCopy()
+	fallbackVolumeMode := targetCpy.Spec.VolumeMode
+	volumeMode, err := getVolumeModeForTempSourceClaim(log, snapshot, vsc, fallbackVolumeMode)
 	if err != nil {
 		return nil, err
 	}
 	// Get the appropriate size from the snapshot
-	targetCpy := targetClaim.DeepCopy()
 	if snapshot.Status == nil || snapshot.Status.RestoreSize == nil || snapshot.Status.RestoreSize.Sign() == -1 {
 		return nil, fmt.Errorf("snapshot has no RestoreSize")
 	}
@@ -796,33 +808,35 @@ func createTempSourceClaim(ctx context.Context, namespace string, targetClaim *c
 			Labels:      targetCpy.Labels,
 			Annotations: targetCpy.Annotations,
 		},
-		Spec: targetCpy.Spec,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			// We've found that ReadWriteOnce is consensus among CSI drivers
+			// Although we know this is read only at all times, some drivers disallow mounting a block PVC ReadOnly
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			VolumeMode: volumeMode,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *restoreSize,
+				},
+			},
+		},
 	}
-	desiredClaim.Spec.DataSource = nil
-	desiredClaim.Spec.DataSourceRef = nil
-	desiredClaim.Spec.StorageClassName = &scName
-	desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = *restoreSize
 
 	return desiredClaim, nil
 }
 
-func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (string, error) {
+func getStorageClassNameForTempSourceClaim(ctx context.Context, vsc *snapshotv1.VolumeSnapshotContent, client client.Client) (string, error) {
 	var matches []string
 
-	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
-		return "", fmt.Errorf("volumeSnapshotContent name not found")
-	}
-	volumeSnapshotContent := &snapshotv1.VolumeSnapshotContent{}
-	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, volumeSnapshotContent); err != nil {
-		return "", err
-	}
 	// Attempting to get a storageClass compatible with the source snapshot
 	storageClasses := &storagev1.StorageClassList{}
 	if err := client.List(ctx, storageClasses); err != nil {
 		return "", err
 	}
 	for _, storageClass := range storageClasses.Items {
-		if storageClass.Provisioner == volumeSnapshotContent.Spec.Driver {
+		if storageClass.Provisioner == vsc.Spec.Driver {
 			matches = append(matches, storageClass.Name)
 		}
 	}
@@ -831,4 +845,20 @@ func getStorageClassNameForTempSourceClaim(ctx context.Context, snapshot *snapsh
 	}
 	sort.Strings(matches)
 	return matches[0], nil
+}
+
+func getVolumeModeForTempSourceClaim(log logr.Logger, snapshot *snapshotv1.VolumeSnapshot, vsc *snapshotv1.VolumeSnapshotContent, fallback *corev1.PersistentVolumeMode) (*corev1.PersistentVolumeMode, error) {
+	if vsc.Spec.SourceVolumeMode != nil {
+		// Since 1.29 we should always return here
+		// Older versions did not populate this field and thus need more care
+		return vsc.Spec.SourceVolumeMode, nil
+	}
+
+	if v, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; ok {
+		mode := corev1.PersistentVolumeMode(v)
+		return &mode, nil
+	}
+
+	log.V(1).Info("Could not infer source volume mode of snapshot, creating a temporary restore with target PVC volume mode")
+	return fallback, nil
 }

--- a/pkg/controller/clone/planner_test.go
+++ b/pkg/controller/clone/planner_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -835,6 +836,56 @@ var _ = Describe("Planner test", func() {
 			validatePrepClaimPhase(planner, args, plan[1])
 			validateHostClonePhase(planner, args, plan[2])
 			validateRebindPhase(planner, args, plan[3])
+		})
+
+		Context("temp host assisted source pvc spec", func() {
+			volumeSnapshotContentWithSourceVolumeMode := func() *snapshotv1.VolumeSnapshotContent {
+				vsc := createDefaultVolumeSnapshotContent()
+				mode := corev1.PersistentVolumeMode("dummy")
+				vsc.Spec.SourceVolumeMode = &mode
+				return vsc
+			}
+
+			snapWithSourceVolumeModeAnnotation := func() *snapshotv1.VolumeSnapshot {
+				snap := createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")
+				cc.AddAnnotation(snap, cc.AnnSourceVolumeMode, "dummyfromann")
+				return snap
+			}
+
+			table.DescribeTable("should pick correct spec for temp host assisted source in clone from snapshot", func(objs []runtime.Object, expectedVolumeMode corev1.PersistentVolumeMode, source *snapshotv1.VolumeSnapshot) {
+				target := createTargetClaim()
+				mode := corev1.PersistentVolumeMode("dummytargetvolmode")
+				target.Spec.VolumeMode = &mode
+				args := &PlanArgs{
+					Strategy:    cdiv1.CloneStrategyHostAssisted,
+					TargetClaim: target,
+					DataSource:  createSnapshotDataSource(),
+					Log:         log,
+				}
+				runtimeObjs := []runtime.Object{cdiConfig, source, createVolumeSnapshotClass()}
+				runtimeObjs = append(runtimeObjs, objs...)
+				planner := createPlanner(runtimeObjs...)
+				plan, err := planner.Plan(context.Background(), args)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(plan).ToNot(BeNil())
+				Expect(plan).To(HaveLen(4))
+				validateSnapshotClonePhase(planner, args, plan[0])
+				validatePrepClaimPhase(planner, args, plan[1])
+				validateHostClonePhase(planner, args, plan[2])
+				validateRebindPhase(planner, args, plan[3])
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.VolumeMode).To(HaveValue(Equal(expectedVolumeMode)))
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.AccessModes).To(ConsistOf(
+					[]corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+				))
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.DataSource).To(BeNil())
+				Expect(plan[0].(*SnapshotClonePhase).DesiredClaim.Spec.DataSourceRef).To(BeNil())
+			},
+				table.Entry("when volumesnapshotcontent has source volume mode", []runtime.Object{volumeSnapshotContentWithSourceVolumeMode(), createStorageClass()}, corev1.PersistentVolumeMode("dummy"), createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")),
+				table.Entry("when volumesnapshotcontent has no source volume mode but annotated with AnnSourceVolumeMode", []runtime.Object{createDefaultVolumeSnapshotContent(), createStorageClass()}, corev1.PersistentVolumeMode("dummyfromann"), snapWithSourceVolumeModeAnnotation()),
+				table.Entry("when neither source volume mode on volumesnapshotcontent nor AnnSourceVolumeMode annotation", []runtime.Object{createDefaultVolumeSnapshotContent(), createStorageClass()}, corev1.PersistentVolumeMode("dummytargetvolmode"), createSourceSnapshot(sourceName, "test-snapshot-content-name", "vsc")),
+			)
 		})
 
 		It("should fail planning host-assisted clone from snapshot when no valid storage class for source PVC is found", func() {

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -211,6 +211,9 @@ const (
 	//AnnDefaultStorageClass is the annotation indicating that a storage class is the default one.
 	AnnDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 
+	// AnnSourceVolumeMode is the volume mode of the source PVC specified as an annotation on snapshots
+	AnnSourceVolumeMode = AnnAPIGroup + "/storage.import.sourceVolumeMode"
+
 	// AnnOpenShiftImageLookup is the annotation for OpenShift image stream lookup
 	AnnOpenShiftImageLookup = "alpha.image.policy.openshift.io/resolve-names"
 

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -56,7 +56,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	cdv "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
+	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring"
 	"kubevirt.io/containerized-data-importer/pkg/operator"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -368,6 +368,17 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			return res, err
 		}
 	} else if snapshot != nil {
+		// Below k8s 1.29 there's no way to know the source volume mode
+		// Let's at least expose this info on our own snapshots
+		if _, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; !ok {
+			volMode, err := r.inferVolumeModeForSnapshot(dataImportCron)
+			if err != nil {
+				return res, err
+			}
+			if volMode != nil {
+				cc.AddAnnotation(snapshot, cc.AnnSourceVolumeMode, string(*volMode))
+			}
+		}
 		if err := r.updateSource(ctx, dataImportCron, snapshot); err != nil {
 			return res, err
 		}
@@ -419,7 +430,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			}
 		}
 	} else if importSucceeded {
-		if err := r.updateDataImportCronSuccessCondition(ctx, dataImportCron, format, snapshot); err != nil {
+		if err := r.updateDataImportCronSuccessCondition(dataImportCron, format, snapshot); err != nil {
 			return res, err
 		}
 	} else if len(imports) > 0 {
@@ -503,7 +514,7 @@ func (r *DataImportCronReconciler) updateSource(ctx context.Context, cron *cdiv1
 
 func (r *DataImportCronReconciler) deleteErroneousDataVolume(ctx context.Context, cron *cdiv1.DataImportCron, dv *cdiv1.DataVolume) error {
 	log := r.log.WithValues("name", dv.Name).WithValues("uid", dv.UID)
-	if cond := cdv.FindConditionByType(cdiv1.DataVolumeRunning, dv.Status.Conditions); cond != nil {
+	if cond := dvc.FindConditionByType(cdiv1.DataVolumeRunning, dv.Status.Conditions); cond != nil {
 		if cond.Status == corev1.ConditionFalse && cond.Reason == common.GenericError {
 			log.Info("Delete DataVolume and reset DesiredDigest due to error", "message", cond.Message)
 			// Unlabel the DV before deleting it, to eliminate reconcile before DIC is updated
@@ -718,6 +729,9 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 			return err
 		}
 		cc.AddAnnotation(desiredSnapshot, AnnLastUseTime, time.Now().UTC().Format(time.RFC3339Nano))
+		if pvc.Spec.VolumeMode != nil {
+			cc.AddAnnotation(desiredSnapshot, cc.AnnSourceVolumeMode, string(*pvc.Spec.VolumeMode))
+		}
 		if err := r.client.Create(ctx, desiredSnapshot); err != nil {
 			return err
 		}
@@ -734,7 +748,7 @@ func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImpor
 	return nil
 }
 
-func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(ctx context.Context, dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, snapshot *snapshotv1.VolumeSnapshot) error {
+func (r *DataImportCronReconciler) updateDataImportCronSuccessCondition(dataImportCron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat, snapshot *snapshotv1.VolumeSnapshot) error {
 	dataImportCron.Status.SourceFormat = &format
 
 	switch format {
@@ -950,14 +964,14 @@ func NewDataImportCronController(mgr manager.Manager, log logr.Logger, importerI
 	if err != nil {
 		return nil, err
 	}
-	if err := addDataImportCronControllerWatches(mgr, dataImportCronController, log); err != nil {
+	if err := addDataImportCronControllerWatches(mgr, dataImportCronController); err != nil {
 		return nil, err
 	}
 	log.Info("Initialized DataImportCron controller")
 	return dataImportCronController, nil
 }
 
-func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Controller, log logr.Logger) error {
+func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Controller) error {
 	if err := c.Watch(&source.Kind{Type: &cdiv1.DataImportCron{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
@@ -1363,4 +1377,15 @@ func GetInitialJobName(cron *cdiv1.DataImportCron) string {
 
 func getSelector(matchLabels map[string]string) (labels.Selector, error) {
 	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: matchLabels})
+}
+
+func (r *DataImportCronReconciler) inferVolumeModeForSnapshot(cron *cdiv1.DataImportCron) (*corev1.PersistentVolumeMode, error) {
+	dv := &cron.Spec.Template
+	//nolint:staticcheck // hack for backport of #3155
+	spec, err := dvc.RenderPvcSpec(r.client, r.recorder, r.log, dv, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec.VolumeMode, nil
 }

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -64,6 +64,19 @@ func renderPvcSpec(client client.Client, recorder record.EventRecorder, log logr
 	return nil, errors.Errorf("datavolume one of {pvc, storage} field is required")
 }
 
+// RenderPvcSpec is an exported version of renderPvcSpec solely for backport purposes of #3155
+//
+// Deprecated: Should not be used, newer versions have RenderPVC
+func RenderPvcSpec(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
+	if dv.Spec.PVC != nil {
+		return dv.Spec.PVC.DeepCopy(), nil
+	} else if dv.Spec.Storage != nil {
+		return pvcFromStorage(client, recorder, log, dv, pvc)
+	}
+
+	return nil, errors.Errorf("datavolume one of {pvc, storage} field is required")
+}
+
 func pvcFromStorage(client client.Client, recorder record.EventRecorder, log logr.Logger, dv *cdiv1.DataVolume, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaimSpec, error) {
 	var pvcSpec *v1.PersistentVolumeClaimSpec
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3155

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-40627

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Clone from snapshot - fix volume/access mode inferring for temp host assisted source PVC
```

