### PR TITLE
Reduce amount of logs fetched by tests that assert on control plane pod logs

### DIFF
--- a/tests/api_validation_test.go
+++ b/tests/api_validation_test.go
@@ -322,7 +322,7 @@ var _ = Describe("[rfe_id:1130][crit:medium][posneg:negative][vendor:cnv-qe@redh
 			By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
 			err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.ImportInProgress, dataVolumeName)
 			if err != nil {
-				f.PrintControllerLog()
+				fmt.Fprintf(GinkgoWriter, "Failed to wait for DataVolume phase: %v", err)
 				dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolumeName, metav1.GetOptions{})
 				Expect(dverr).ToNot(HaveOccurred(), "datavolume %s phase %s", dv.Name, dv.Status.Phase)
 			}

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2597,7 +2597,7 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			annValue, preallocationAnnotationFound, err := utils.WaitForPVCAnnotation(f.K8sClient, targetDataVolume.Namespace, targetPvc, controller.AnnPreallocationRequested)
 			if err != nil {
-				f.PrintControllerLog()
+				fmt.Fprintf(GinkgoWriter, "Failed to wait for PVC annotation: %v", err)
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preallocationAnnotationFound).To(BeTrue())
@@ -2607,7 +2607,7 @@ var _ = Describe("all clone tests", func() {
 
 			annValue, preallocationAnnotationFound, err = utils.WaitForPVCAnnotation(f.K8sClient, targetDataVolume.Namespace, targetPvc, controller.AnnPreallocationApplied)
 			if err != nil {
-				f.PrintControllerLog()
+				fmt.Fprintf(GinkgoWriter, "Failed to wait for PVC annotation: %v", err)
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preallocationAnnotationFound).To(BeTrue())
@@ -3043,7 +3043,7 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 		By("Verify the clone annotation is on the target PVC")
 		_, cloneAnnotationFound, err := utils.WaitForPVCAnnotation(f.K8sClient, targetNs.Name, targetPvc, controller.AnnCloneOf)
 		if err != nil {
-			f.PrintControllerLog()
+			fmt.Fprintf(GinkgoWriter, "Failed to wait for PVC annotation: %v", err)
 		}
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cloneAnnotationFound).To(BeTrue())

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -3141,6 +3141,8 @@ func completeClone(f *framework.Framework, targetNs *v1.Namespace, targetPvc *v1
 }
 
 func cloneOfAnnoExistenceTest(f *framework.Framework, targetNamespaceName string) {
+	beforeClone := time.Now()
+
 	// Create targetPvc
 	By(fmt.Sprintf("Creating target pvc: %s/target-pvc", targetNamespaceName))
 	pvcName := "target-pvc"
@@ -3157,22 +3159,16 @@ func cloneOfAnnoExistenceTest(f *framework.Framework, targetNamespaceName string
 	f.ForceBindIfWaitForFirstConsumer(targetPvc)
 
 	By("Checking no cloning pods were created")
-
-	matchString := fmt.Sprintf("{\"PVC\": {\"name\":\"%s\",\"namespace\":\"%s\"}, \"isUpload\": false, \"isCloneTarget\": true, \"isBound\": true, \"podSucceededFromPVC\": true, \"deletionTimeStamp set?\": false}", pvcName, f.Namespace.Name)
-	Eventually(func() bool {
-		log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-		Expect(err).NotTo(HaveOccurred())
-		return strings.Contains(log, matchString)
-	}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Checking logs explicitly skips PVC")
-	Eventually(func() bool {
-		log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-		Expect(err).NotTo(HaveOccurred())
-		return strings.Contains(log, fmt.Sprintf("{\"PVC\": {\"name\":\"%s\",\"namespace\":\"%s\"}, \"checkPVC(AnnCloneRequest)\": true, \"NOT has annotation(AnnCloneOf)\": false, \"isBound\": true, \"has finalizer?\": false}", pvcName, targetNamespaceName))
-	}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(BeTrue())
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() (string, error) {
+		out, err := f.K8sClient.CoreV1().
+			Pods(f.CdiInstallNs).
+			GetLogs(f.ControllerPod.Name, &corev1.PodLogOptions{SinceTime: &metav1.Time{Time: beforeClone}}).
+			DoRaw(context.Background())
+		return string(out), err
+	}, time.Minute, time.Second).Should(And(
+		ContainSubstring(fmt.Sprintf(`{"PVC": {"name":%q,"namespace":%q}, "isUpload": false, "isCloneTarget": true, "isBound": true, "podSucceededFromPVC": true, "deletionTimeStamp set?": false}`, pvcName, f.Namespace.Name)),
+		ContainSubstring(fmt.Sprintf(`{"PVC": {"name":%q,"namespace":%q}, "checkPVC(AnnCloneRequest)": true, "NOT has annotation(AnnCloneOf)": false, "isBound": true, "has finalizer?": false}`, pvcName, targetNamespaceName)),
+	))
 }
 
 func cleanDv(f *framework.Framework, dv *cdiv1.DataVolume) {
@@ -3272,12 +3268,14 @@ func VerifyGC(f *framework.Framework, dvName, dvNamespace string, checkOwnerRefs
 func VerifyNoGC(f *framework.Framework, dvName, dvNamespace string) {
 	By("Verify DV is not garbage collected")
 	matchString := fmt.Sprintf("DataVolume is not annotated to be garbage collected\t{\"DataVolume\": {\"name\":\"%s\",\"namespace\":\"%s\"}}", dvName, dvNamespace)
-	fmt.Fprintf(GinkgoWriter, "INFO: matchString: [%s]\n", matchString)
-	Eventually(func() string {
-		log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-		Expect(err).NotTo(HaveOccurred())
-		return log
+	Eventually(func() (string, error) {
+		out, err := f.K8sClient.CoreV1().
+			Pods(f.CdiInstallNs).
+			GetLogs(f.ControllerPod.Name, &corev1.PodLogOptions{SinceTime: &metav1.Time{Time: CurrentSpecReport().StartTime}}).
+			DoRaw(context.Background())
+		return string(out), err
 	}, timeout, pollingInterval).Should(ContainSubstring(matchString))
+
 	dv, err := f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(dv.Annotations[controller.AnnDeleteAfterCompletion]).ToNot(Equal("true"))
@@ -3286,13 +3284,15 @@ func VerifyNoGC(f *framework.Framework, dvName, dvNamespace string) {
 // VerifyDisabledGC verifies DV is not deleted when garbage collection is disabled
 func VerifyDisabledGC(f *framework.Framework, dvName, dvNamespace string) {
 	By("Verify DV is not deleted when garbage collection is disabled")
-	matchString := fmt.Sprintf("Garbage Collection is disabled\t{\"DataVolume\": {\"name\":\"%s\",\"namespace\":\"%s\"}}", dvName, dvNamespace)
-	fmt.Fprintf(GinkgoWriter, "INFO: matchString: [%s]\n", matchString)
-	Eventually(func() string {
-		log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-		Expect(err).NotTo(HaveOccurred())
-		return log
+	matchString := fmt.Sprintf("Garbage Collection is disabled\t{\"DataVolume\": {\"name\":%q,\"namespace\":%q}}", dvName, dvNamespace)
+	Eventually(func() (string, error) {
+		out, err := f.K8sClient.CoreV1().
+			Pods(f.CdiInstallNs).
+			GetLogs(f.ControllerPod.Name, &corev1.PodLogOptions{SinceTime: &metav1.Time{Time: CurrentSpecReport().StartTime}}).
+			DoRaw(context.Background())
+		return string(out), err
 	}, timeout, pollingInterval).Should(ContainSubstring(matchString))
+
 	_, err := f.CdiClient.CdiV1beta1().DataVolumes(dvNamespace).Get(context.TODO(), dvName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1651,7 +1651,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))
 			err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, phase, dataVolume.Name)
 			if err != nil {
-				f.PrintControllerLog()
+				fmt.Fprintf(GinkgoWriter, "Failed to wait for DataVolume phase: %v", err)
 				dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				if dverr != nil {
 					Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))
@@ -2829,7 +2829,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By(fmt.Sprintf("waiting for datavolume to match phase %s", string(cdiv1.ImportInProgress)))
 			err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.ImportInProgress, dataVolume.Name)
 			if err != nil {
-				f.PrintControllerLog()
+				fmt.Fprintf(GinkgoWriter, "Failed to wait for DataVolume phase: %v", err)
 				dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				if dverr != nil {
 					Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))

--- a/tests/framework/pod.go
+++ b/tests/framework/pod.go
@@ -1,10 +1,7 @@
 package framework
 
 import (
-	"fmt"
 	"time"
-
-	"github.com/onsi/ginkgo/v2"
 
 	k8sv1 "k8s.io/api/core/v1"
 
@@ -44,19 +41,4 @@ func (f *Framework) FindPodByPrefix(prefix string) (*k8sv1.Pod, error) {
 // FindPodBySuffix is a wrapper around utils.FindPodBySuffix
 func (f *Framework) FindPodBySuffix(suffix string) (*k8sv1.Pod, error) {
 	return utils.FindPodBySuffix(f.K8sClient, f.Namespace.Name, suffix, common.CDILabelSelector)
-}
-
-// PrintControllerLog ...
-func (f *Framework) PrintControllerLog() {
-	f.PrintPodLog(f.ControllerPod.Name, f.CdiInstallNs)
-}
-
-// PrintPodLog ...
-func (f *Framework) PrintPodLog(podName, namespace string) {
-	log, err := f.RunKubectlCommand("logs", podName, "-n", namespace)
-	if err == nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Pod log\n%s\n", log)
-	} else {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: Unable to get pod log, %s\n", err.Error())
-	}
 }

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -608,9 +608,11 @@ func getProxyLog(f *framework.Framework, since time.Time) string {
 	proxyPod, err := utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, proxyServerName, fmt.Sprintf("name=%s", proxyServerName))
 	Expect(err).ToNot(HaveOccurred())
 	fmt.Fprintf(GinkgoWriter, "INFO: Analyzing the proxy pod %s logs\n", proxyPod.Name)
-	log, err := f.RunKubectlCommand("logs", proxyPod.Name, "-n", proxyPod.Namespace, fmt.Sprintf("--since-time=%s", since.Format(time.RFC3339)))
+	log, err := f.K8sClient.CoreV1().Pods(proxyPod.Namespace).GetLogs(proxyPod.Name, &corev1.PodLogOptions{
+		SinceTime: &metav1.Time{Time: since},
+	}).DoRaw(context.Background())
 	Expect(err).ToNot(HaveOccurred())
-	return log
+	return string(log)
 }
 
 func wasPodProxied(imgURL, podIP, userAgent, proxyLog string) bool {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -95,15 +95,17 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		// Make sure the PVC name is unique, we have no guarantee on order and we are not
 		// deleting the PVC at the end of the test, so if another runs first we will fail.
 		pvc, err := f.CreatePVCFromDefinition(utils.NewPVCDefinition("no-import-ann", "1G", nil, nil))
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Verifying PVC with no annotation remains empty")
 		matchString := fmt.Sprintf("PVC annotation not found, skipping pvc\t{\"PVC\": {\"name\":\"%s\",\"namespace\":\"%s\"}, \"annotation\": \"%s\"}", pvc.Name, ns, controller.AnnEndpoint)
-		fmt.Fprintf(GinkgoWriter, "INFO: matchString: [%s]\n", matchString)
-		Eventually(func() string {
-			log, err := f.RunKubectlCommand("logs", f.ControllerPod.Name, "-n", f.CdiInstallNs)
-			Expect(err).NotTo(HaveOccurred())
-			return log
+		Eventually(func() ([]byte, error) {
+			return f.K8sClient.CoreV1().
+				Pods(f.CdiInstallNs).
+				GetLogs(f.ControllerPod.Name, &v1.PodLogOptions{SinceTime: &metav1.Time{Time: CurrentSpecReport().StartTime}}).
+				DoRaw(context.Background())
 		}, controllerSkipPVCCompleteTimeout, assertionPollInterval).Should(ContainSubstring(matchString))
-		Expect(err).ToNot(HaveOccurred())
+
 		// Wait a while to see if CDI puts anything in the PVC.
 		isEmpty, err := framework.VerifyPVCIsEmpty(f, pvc, "")
 		Expect(err).ToNot(HaveOccurred())
@@ -644,18 +646,14 @@ var _ = Describe("Importer Test Suite-Block_device", func() {
 		}, timeout, pollingInterval).Should(BeTrue())
 
 		By("Verify fsync() syscall was made")
-		Eventually(func() bool {
-			log, err := f.RunKubectlCommand("logs", importer.Name, "-n", importer.Namespace)
-			if err != nil {
-				return false
-			}
-			for _, line := range strings.Split(strings.TrimSuffix(log, "\n"), "\n") {
-				if strings.Contains(line, fmt.Sprintf("Successfully completed fsync(%s) syscall", common.WriteBlockPath)) {
-					return true
-				}
-			}
-			return false
-		}, 3*time.Minute, pollingInterval).Should(BeTrue())
+		matchString := fmt.Sprintf("Successfully completed fsync(%s) syscall", common.WriteBlockPath)
+		Eventually(func() (string, error) {
+			out, err := f.K8sClient.CoreV1().
+				Pods(importer.Namespace).
+				GetLogs(importer.Name, &v1.PodLogOptions{SinceTime: &metav1.Time{Time: CurrentSpecReport().StartTime}}).
+				DoRaw(context.Background())
+			return string(out), err
+		}, 3*time.Minute, pollingInterval).Should(ContainSubstring(matchString))
 
 		phase := cdiv1.Succeeded
 		By(fmt.Sprintf("Waiting for datavolume to match phase %s", string(phase)))

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -221,7 +221,7 @@ func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f
 	By(fmt.Sprintf("waiting for datavolume to match phase %s", string(phase)))
 	err := utils.WaitForDataVolumePhase(f, f.Namespace.Name, phase, dataVolume.Name)
 	if err != nil {
-		f.PrintControllerLog()
+		fmt.Fprintf(GinkgoWriter, "Failed to wait for DataVolume phase: %v", err)
 		dv, dverr := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 		if dverr != nil {
 			Fail(fmt.Sprintf("datavolume %s phase %s", dv.Name, dv.Status.Phase))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Several tests get information about the state of the cluster by parsing the logs.

Up until now, we had a loop fetching the entire log history and searching for a specific string on it. Local testing showed running the tests (focussed on a single entry in the table) would cause 8.1 MiB of log data to be fetched and parsed per test (with a subsequent enormous error message on failure. On certain test failure we could expect 364 MiB of logs per failed test (2.8 MiB/get * 0.5 gets/second * 270 second timeout).

I reduced this by exploiting two factors:
  1. Consectuive GETs need only request new logs (8.1Mib -> 2.8MiB)
  2. No need to get logs older than the test itself (2.7MiB -> 60 KiB)

I used this solution for all tests that showed up when grepping for `RunKubectlCommand("logs"`.

Which issue(s) this PR fixes:
Fixes https://issues.redhat.com/browse/CNV-39821

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

