### PR TITLE
fix: propagating mesh annotations to transient pods

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -548,10 +548,8 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 			Name:      cloneSourcePodName,
 			Namespace: sourcePvcNamespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy:                  "yes",
-				AnnOwnerRef:                      ownerRefAnno,
-				cc.AnnPodSidecarInjectionIstio:   sourcePvc.Annotations[cc.AnnPodSidecarInjectionIstio],
-				cc.AnnPodSidecarInjectionLinkerd: sourcePvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
+				cc.AnnCreatedBy: "yes",
+				AnnOwnerRef:     ownerRefAnno,
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue, //filtered by the podInformer

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -548,8 +548,10 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 			Name:      cloneSourcePodName,
 			Namespace: sourcePvcNamespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy: "yes",
-				AnnOwnerRef:     ownerRefAnno,
+				cc.AnnCreatedBy:                  "yes",
+				AnnOwnerRef:                      ownerRefAnno,
+				cc.AnnPodSidecarInjectionIstio:   sourcePvc.Annotations[cc.AnnPodSidecarInjectionIstio],
+				cc.AnnPodSidecarInjectionLinkerd: sourcePvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue, //filtered by the podInformer

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -720,7 +720,7 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 	}
 
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
-	cc.SetAllowedAnnotations(pod, targetPvc.ObjectMeta)
+	cc.CopyAllowedAnnotations(targetPvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	return pod
 }

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -720,7 +720,7 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 	}
 
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
-	cc.SetPvcAllowedAnnotations(pod, targetPvc)
+	cc.SetAllowedAnnotations(pod, targetPvc.ObjectMeta)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	return pod
 }

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -206,7 +206,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 		AddOwnershipLabel(p.OwnershipLabel, pod, p.Owner)
 	}
 
-	cc.SetAllowedAnnotations(pod, pvc.ObjectMeta)
+	cc.CopyAllowedAnnotations(pvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	if err := p.Client.Create(ctx, pod); err != nil {

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -206,7 +206,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 		AddOwnershipLabel(p.OwnershipLabel, pod, p.Owner)
 	}
 
-	cc.SetPvcAllowedAnnotations(pod, pvc)
+	cc.SetAllowedAnnotations(pod, pvc.ObjectMeta)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	if err := p.Client.Create(ctx, pod); err != nil {

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -147,9 +147,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 			Name:      name,
 			Namespace: pvc.Namespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy:                  "yes",
-				cc.AnnPodSidecarInjectionIstio:   pvc.Annotations[cc.AnnPodSidecarInjectionIstio],
-				cc.AnnPodSidecarInjectionLinkerd: pvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
+				cc.AnnCreatedBy: "yes",
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue,
@@ -208,6 +206,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 		AddOwnershipLabel(p.OwnershipLabel, pod, p.Owner)
 	}
 
+	cc.SetPvcAllowedAnnotations(pod, pvc)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	if err := p.Client.Create(ctx, pod); err != nil {

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -147,7 +147,9 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 			Name:      name,
 			Namespace: pvc.Namespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy: "yes",
+				cc.AnnCreatedBy:                  "yes",
+				cc.AnnPodSidecarInjectionIstio:   pvc.Annotations[cc.AnnPodSidecarInjectionIstio],
+				cc.AnnPodSidecarInjectionLinkerd: pvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:       common.CDILabelValue,

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2124,16 +2124,17 @@ func OwnedByDataVolume(obj metav1.Object) bool {
 	return owner != nil && owner.Kind == "DataVolume"
 }
 
-// SetAllowedAnnotations applies source object annotations on the given obj
-func SetAllowedAnnotations(obj metav1.Object, sourceMeta metav1.ObjectMeta) {
+// CopyAllowedAnnotations copies the allowed annotations from the source object
+// to the destination object
+func CopyAllowedAnnotations(srcObj, dstObj metav1.Object) {
 	for ann, def := range allowedAnnotations {
-		val, ok := sourceMeta.Annotations[ann]
+		val, ok := srcObj.GetAnnotations()[ann]
 		if !ok && def != "" {
 			val = def
 		}
 		if val != "" {
-			klog.V(1).Info("Applying annotation", "Name", obj.GetName(), ann, val)
-			AddAnnotation(obj, ann, val)
+			klog.V(1).Info("Applying annotation", "Name", dstObj.GetName(), ann, val)
+			AddAnnotation(dstObj, ann, val)
 		}
 	}
 }

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -632,7 +632,7 @@ func (r *PvcCloneReconciler) makeSizeDetectionPodSpec(
 		return nil
 	}
 	// Generate individual specs
-	objectMeta := makeSizeDetectionObjectMeta(sourcePvc, dv)
+	objectMeta := makeSizeDetectionObjectMeta(sourcePvc)
 	volume := makeSizeDetectionVolumeSpec(sourcePvc.Name)
 	container := r.makeSizeDetectionContainerSpec(volume.Name)
 	if container == nil {
@@ -683,10 +683,14 @@ func (r *PvcCloneReconciler) makeSizeDetectionPodSpec(
 }
 
 // makeSizeDetectionObjectMeta creates and returns the object metadata for the size-detection pod
-func makeSizeDetectionObjectMeta(sourcePvc *corev1.PersistentVolumeClaim, dataVolume *cdiv1.DataVolume) *metav1.ObjectMeta {
+func makeSizeDetectionObjectMeta(sourcePvc *corev1.PersistentVolumeClaim) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      sizeDetectionPodName(sourcePvc),
 		Namespace: sourcePvc.Namespace,
+		Annotations: map[string]string{
+			cc.AnnPodSidecarInjectionIstio:   sourcePvc.Annotations[cc.AnnPodSidecarInjectionIstio],
+			cc.AnnPodSidecarInjectionLinkerd: sourcePvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
+		},
 		Labels: map[string]string{
 			common.CDILabelKey:       common.CDILabelValue,
 			common.CDIComponentLabel: common.ImporterPodName,

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -677,7 +677,7 @@ func (r *PvcCloneReconciler) makeSizeDetectionPodSpec(
 		pod.Annotations[cc.AnnOwnerUID] = string(dv.UID)
 	}
 
-	cc.SetAllowedAnnotations(pod, dv.ObjectMeta)
+	cc.CopyAllowedAnnotations(dv, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	return pod

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -677,6 +677,7 @@ func (r *PvcCloneReconciler) makeSizeDetectionPodSpec(
 		pod.Annotations[cc.AnnOwnerUID] = string(dv.UID)
 	}
 
+	cc.SetPvcAllowedAnnotations(pod, sourcePvc)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	return pod

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -688,10 +688,6 @@ func makeSizeDetectionObjectMeta(sourcePvc *corev1.PersistentVolumeClaim) *metav
 	return &metav1.ObjectMeta{
 		Name:      sizeDetectionPodName(sourcePvc),
 		Namespace: sourcePvc.Namespace,
-		Annotations: map[string]string{
-			cc.AnnPodSidecarInjectionIstio:   sourcePvc.Annotations[cc.AnnPodSidecarInjectionIstio],
-			cc.AnnPodSidecarInjectionLinkerd: sourcePvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
-		},
 		Labels: map[string]string{
 			common.CDILabelKey:       common.CDILabelValue,
 			common.CDIComponentLabel: common.ImporterPodName,

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -677,7 +677,7 @@ func (r *PvcCloneReconciler) makeSizeDetectionPodSpec(
 		pod.Annotations[cc.AnnOwnerUID] = string(dv.UID)
 	}
 
-	cc.SetPvcAllowedAnnotations(pod, sourcePvc)
+	cc.SetAllowedAnnotations(pod, dv.ObjectMeta)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 
 	return pod

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -920,7 +920,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 		pod.Annotations[cc.AnnOpenShiftImageLookup] = "*"
 	}
 
-	cc.SetPvcAllowedAnnotations(pod, args.pvc)
+	cc.SetAllowedAnnotations(pod, args.pvc.ObjectMeta)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	// We explicitly define a NodeName for dynamically provisioned PVCs
 	// when the PVC is being handled by a populator (PVC')

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -875,9 +875,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			Name:      podName,
 			Namespace: args.pvc.Namespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy:                  "yes",
-				cc.AnnPodSidecarInjectionIstio:   args.pvc.Annotations[cc.AnnPodSidecarInjectionIstio],
-				cc.AnnPodSidecarInjectionLinkerd: args.pvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
+				cc.AnnCreatedBy: "yes",
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:        common.CDILabelValue,

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -920,7 +920,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 		pod.Annotations[cc.AnnOpenShiftImageLookup] = "*"
 	}
 
-	cc.SetAllowedAnnotations(pod, args.pvc.ObjectMeta)
+	cc.CopyAllowedAnnotations(args.pvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 	// We explicitly define a NodeName for dynamically provisioned PVCs
 	// when the PVC is being handled by a populator (PVC')

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -875,7 +875,9 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			Name:      podName,
 			Namespace: args.pvc.Namespace,
 			Annotations: map[string]string{
-				cc.AnnCreatedBy: "yes",
+				cc.AnnCreatedBy:                  "yes",
+				cc.AnnPodSidecarInjectionIstio:   args.pvc.Annotations[cc.AnnPodSidecarInjectionIstio],
+				cc.AnnPodSidecarInjectionLinkerd: args.pvc.Annotations[cc.AnnPodSidecarInjectionLinkerd],
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:        common.CDILabelValue,

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -207,7 +207,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 			Kind:    "PersistentVolumeClaim",
 		}),
 	}
-	cc.SetPvcAllowedAnnotations(pvcPrime, pvc)
+	cc.SetAllowedAnnotations(pvcPrime, pvc.ObjectMeta)
 	util.SetRecommendedLabels(pvcPrime, r.installerLabels, "cdi-controller")
 
 	// We use the populator-specific pvcModifierFunc to add required annotations

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -207,7 +207,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 			Kind:    "PersistentVolumeClaim",
 		}),
 	}
-	cc.SetAllowedAnnotations(pvcPrime, pvc.ObjectMeta)
+	cc.CopyAllowedAnnotations(pvc, pvcPrime)
 	util.SetRecommendedLabels(pvcPrime, r.installerLabels, "cdi-controller")
 
 	// We use the populator-specific pvcModifierFunc to add required annotations

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -765,7 +765,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 		},
 	}
 
-	cc.SetPvcAllowedAnnotations(pod, args.PVC)
+	cc.SetAllowedAnnotations(pod, args.PVC.ObjectMeta)
 	cc.SetNodeNameIfPopulator(args.PVC, &pod.Spec)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -741,9 +741,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			Name:      args.Name,
 			Namespace: args.PVC.Namespace,
 			Annotations: map[string]string{
-				annCreatedByUpload:               "yes",
-				cc.AnnPodSidecarInjectionIstio:   args.PVC.Annotations[cc.AnnPodSidecarInjectionIstio],
-				cc.AnnPodSidecarInjectionLinkerd: args.PVC.Annotations[cc.AnnPodSidecarInjectionLinkerd],
+				annCreatedByUpload: "yes",
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:              common.CDILabelValue,

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -741,7 +741,9 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			Name:      args.Name,
 			Namespace: args.PVC.Namespace,
 			Annotations: map[string]string{
-				annCreatedByUpload: "yes",
+				annCreatedByUpload:               "yes",
+				cc.AnnPodSidecarInjectionIstio:   args.PVC.Annotations[cc.AnnPodSidecarInjectionIstio],
+				cc.AnnPodSidecarInjectionLinkerd: args.PVC.Annotations[cc.AnnPodSidecarInjectionLinkerd],
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:              common.CDILabelValue,

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -765,7 +765,7 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 		},
 	}
 
-	cc.SetAllowedAnnotations(pod, args.PVC.ObjectMeta)
+	cc.CopyAllowedAnnotations(args.PVC, pod)
 	cc.SetNodeNameIfPopulator(args.PVC, &pod.Spec)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -328,7 +328,7 @@ var _ = Describe("[Istio] Namespace sidecar injection", Serial, func() {
 		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		// A single service mesh provider is deployed so either Istio or Linkerd, not both.
 		dataVolume.Annotations[controller.AnnPodSidecarInjectionIstio] = "true"
-		dataVolume.Annotations[controller.AnnPodSidecarInjectionLinkerd] = "true"
+		dataVolume.Annotations[controller.AnnPodSidecarInjectionLinkerd] = "enabled"
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Mesh annotations are not replicating to pods set by the DV/PVCs. Allows users to unmesh these pods by default.

- Prep claim pod.
- Size detection pod.
- Importer pod.
- Clone source pod.
- Upload pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mesh annotations now copied from the DV/PVCs to the following pods.

- Prep claim pod.
- Size detection pod.
- Importer pod.
- Clone source pod.
- Upload pod.
```

