### PR TITLE
Add new DV reason: ImagePullFailed

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -293,6 +293,10 @@ const (
 
 	// CDIControllerLeaderElectionHelperName is the name of the configmap that is used as a helper for controller leader election
 	CDIControllerLeaderElectionHelperName = "cdi-controller-leader-election-helper"
+
+	// ImagePullFailureText is the text of the ErrImagePullFailed error. We need it as a common constant because we're using
+	// both to create and to later check the error in the termination text of the importer pod.
+	ImagePullFailureText = "failed to pull image"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "data-processor.go",
+        "errors.go",
         "format-readers.go",
         "gcs-datasource.go",
         "http-datasource.go",

--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -17,7 +17,6 @@ limitations under the License.
 package importer
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 
@@ -61,19 +60,6 @@ const (
 	// ProcessingPhaseMergeDelta is the phase in a multi-stage import where a delta image downloaded to scratch is applied to the base image
 	ProcessingPhaseMergeDelta ProcessingPhase = "MergeDelta"
 )
-
-// ValidationSizeError is an error indication size validation failure.
-type ValidationSizeError struct {
-	err error
-}
-
-func (e ValidationSizeError) Error() string { return e.err.Error() }
-
-// ErrRequiresScratchSpace indicates that we require scratch space.
-var ErrRequiresScratchSpace = fmt.Errorf(common.ScratchSpaceRequired)
-
-// ErrInvalidPath indicates that the path is invalid.
-var ErrInvalidPath = fmt.Errorf("invalid transfer path")
 
 // may be overridden in tests
 var getAvailableSpaceBlockFunc = util.GetAvailableSpaceBlock

--- a/pkg/importer/errors.go
+++ b/pkg/importer/errors.go
@@ -1,0 +1,42 @@
+package importer
+
+import (
+	"fmt"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
+)
+
+// ValidationSizeError is an error indication size validation failure.
+type ValidationSizeError struct {
+	err error
+}
+
+func (e ValidationSizeError) Error() string { return e.err.Error() }
+
+// ErrRequiresScratchSpace indicates that we require scratch space.
+var ErrRequiresScratchSpace = fmt.Errorf(common.ScratchSpaceRequired)
+
+// ErrInvalidPath indicates that the path is invalid.
+var ErrInvalidPath = fmt.Errorf("invalid transfer path")
+
+// ImagePullFailedError indicates that the importer failed to pull an image; This error type wraps the actual error.
+type ImagePullFailedError struct {
+	err error
+}
+
+// NewImagePullFailedError creates new ImagePullFailedError error object, with embedded error.
+//
+// Use the err parameter fot the actual wrapped error
+func NewImagePullFailedError(err error) *ImagePullFailedError {
+	return &ImagePullFailedError{
+		err: err,
+	}
+}
+
+func (err *ImagePullFailedError) Error() string {
+	return fmt.Sprintf("%s: %s", common.ImagePullFailureText, err.err.Error())
+}
+
+func (err *ImagePullFailedError) Unwrap() error {
+	return err.err
+}

--- a/pkg/importer/gcs-datasource.go
+++ b/pkg/importer/gcs-datasource.go
@@ -128,7 +128,7 @@ func (sd *GCSDataSource) Transfer(path string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, ErrInvalidPath
 	}
 
-	err := util.StreamDataToFile(sd.readers.TopReader(), file)
+	err := streamDataToFile(sd.readers.TopReader(), file)
 
 	if err != nil {
 		klog.V(3).Infoln("GCS Importer: Transfer Error: ", err)
@@ -145,7 +145,7 @@ func (sd *GCSDataSource) TransferFile(fileName string) (ProcessingPhase, error) 
 		return ProcessingPhaseError, err
 	}
 
-	err := util.StreamDataToFile(sd.readers.TopReader(), fileName)
+	err := streamDataToFile(sd.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/klog/v2"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -160,7 +161,7 @@ func (hs *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
 		if err != nil || size <= 0 {
 			return ProcessingPhaseError, ErrInvalidPath
 		}
-		err = util.StreamDataToFile(hs.readers.TopReader(), file)
+		err = streamDataToFile(hs.readers.TopReader(), file)
 		if err != nil {
 			return ProcessingPhaseError, err
 		}
@@ -183,7 +184,7 @@ func (hs *HTTPDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		return ProcessingPhaseError, err
 	}
 	hs.readers.StartProgressUpdate()
-	err := util.StreamDataToFile(hs.readers.TopReader(), fileName)
+	err := streamDataToFile(hs.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -136,7 +136,7 @@ func (is *ImageioDataSource) Transfer(path string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, ErrInvalidPath
 	}
 	is.readers.StartProgressUpdate()
-	err = util.StreamDataToFile(is.readers.TopReader(), file)
+	err = streamDataToFile(is.readers.TopReader(), file)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
@@ -181,7 +181,7 @@ func (is *ImageioDataSource) TransferFile(fileName string) (ProcessingPhase, err
 			return ProcessingPhaseError, err
 		}
 	} else {
-		err := util.StreamDataToFile(is.readers.TopReader(), fileName)
+		err := streamDataToFile(is.readers.TopReader(), fileName)
 		if err != nil {
 			return ProcessingPhaseError, err
 		}

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -100,7 +100,7 @@ func (sd *S3DataSource) Transfer(path string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, ErrInvalidPath
 	}
 
-	err := util.StreamDataToFile(sd.readers.TopReader(), file)
+	err := streamDataToFile(sd.readers.TopReader(), file)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
@@ -115,7 +115,7 @@ func (sd *S3DataSource) TransferFile(fileName string) (ProcessingPhase, error) {
 		return ProcessingPhaseError, err
 	}
 
-	err := util.StreamDataToFile(sd.readers.TopReader(), fileName)
+	err := streamDataToFile(sd.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}

--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/klog/v2"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 const (
@@ -76,7 +75,7 @@ func readImageSource(ctx context.Context, sys *types.SystemContext, img string) 
 	src, err := ref.NewImageSource(ctx, sys)
 	if err != nil {
 		klog.Errorf("Could not create image reference: %v", err)
-		return nil, errors.Wrap(err, "Could not create image reference")
+		return nil, NewImagePullFailedError(err)
 	}
 
 	return src, nil
@@ -157,7 +156,7 @@ func processLayer(ctx context.Context,
 				return false, errors.Wrap(err, "Error creating output file's directory")
 			}
 
-			if err := util.StreamDataToFile(tarReader, filepath.Join(destDir, hdr.Name)); err != nil {
+			if err := streamDataToFile(tarReader, filepath.Join(destDir, hdr.Name)); err != nil {
 				klog.Errorf("Error copying file: %v", err)
 				return false, errors.Wrap(err, "Error copying file")
 			}

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog/v2"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -72,7 +73,7 @@ func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
 			//Path provided is invalid.
 			return ProcessingPhaseError, ErrInvalidPath
 		}
-		err = util.StreamDataToFile(ud.readers.TopReader(), file)
+		err = streamDataToFile(ud.readers.TopReader(), file)
 		if err != nil {
 			return ProcessingPhaseError, err
 		}
@@ -94,7 +95,7 @@ func (ud *UploadDataSource) TransferFile(fileName string) (ProcessingPhase, erro
 	if err := CleanAll(fileName); err != nil {
 		return ProcessingPhaseError, err
 	}
-	err := util.StreamDataToFile(ud.readers.TopReader(), fileName)
+	err := streamDataToFile(ud.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
@@ -158,7 +159,7 @@ func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error)
 		//Path provided is invalid.
 		return ProcessingPhaseError, ErrInvalidPath
 	}
-	err = util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), file)
+	err = streamDataToFile(aud.uploadDataSource.readers.TopReader(), file)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}
@@ -173,7 +174,7 @@ func (aud *AsyncUploadDataSource) TransferFile(fileName string) (ProcessingPhase
 	if err := CleanAll(fileName); err != nil {
 		return ProcessingPhaseError, err
 	}
-	err := util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), fileName)
+	err := streamDataToFile(aud.uploadDataSource.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
 	}

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"io"
 	"net/url"
 	"os"
 	"os/signal"
@@ -8,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -81,4 +83,24 @@ func envToLabel(env string) string {
 	label += strings.Join(strings.Split(after, "_"), "-")
 
 	return strings.ToLower(label)
+}
+
+// streamDataToFile provides a function to stream the specified io.Reader to the specified local file
+func streamDataToFile(r io.Reader, fileName string) error {
+	outFile, err := util.OpenFileOrBlockDevice(fileName)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+	klog.V(1).Infof("Writing data...\n")
+	if _, err = io.Copy(outFile, r); err != nil {
+		klog.Errorf("Unable to write file from dataReader: %v\n", err)
+		os.Remove(outFile.Name())
+		if strings.Contains(err.Error(), "no space left on device") {
+			return errors.Wrapf(err, "unable to write to file")
+		}
+		return NewImagePullFailedError(err)
+	}
+	err = outFile.Sync()
+	return err
 }

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
-	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 var _ = Describe("Parse endpoints", func() {
@@ -69,7 +68,7 @@ var _ = Describe("Stream Data To File", func() {
 		if useTmpDir {
 			fileName = filepath.Join(tmpDir, fileName)
 		}
-		err = util.StreamDataToFile(r, fileName)
+		err = streamDataToFile(r, fileName)
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
 		} else {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
@@ -176,23 +177,6 @@ func OpenFileOrBlockDevice(fileName string) (*os.File, error) {
 		return nil, errors.Wrapf(err, "could not open file %q", fileName)
 	}
 	return outFile, nil
-}
-
-// StreamDataToFile provides a function to stream the specified io.Reader to the specified local file
-func StreamDataToFile(r io.Reader, fileName string) error {
-	outFile, err := OpenFileOrBlockDevice(fileName)
-	if err != nil {
-		return err
-	}
-	defer outFile.Close()
-	klog.V(1).Infof("Writing data...\n")
-	if _, err = io.Copy(outFile, r); err != nil {
-		klog.Errorf("Unable to write file from dataReader: %v\n", err)
-		os.Remove(outFile.Name())
-		return errors.Wrapf(err, "unable to write to file")
-	}
-	err = outFile.Sync()
-	return err
 }
 
 // UnArchiveTar unarchives a tar file and streams its files


### PR DESCRIPTION
## What this PR does / why we need it
When the image pull fails, the DataVolume Running condition, will have the Reason field of `ImagePullFailed`, to allow better error handling in code that uses it.

Also, moved the `StreamDataToFile` function from the `util` package to the `importer` package, and made to non-exported. This is done to allow calling the new `NewErrImagePullFailed` function from within `streamDataToFile`, and to avoid import cycle. In addition, the `streamDataToFile` is only used in the `importer` package and so it's better to define it there.

### Release note
```release-note
When the image pull fails, the DataVolume Running condition, will have the Reason field of "ImagePullFailed"
```

```jira-ticket
https://issues.redhat.com/browse/CNV-39603
```
