### PR TITLE
[release-v1.55] Backport more targeted cleanup of target/scratch pvcs (#2676)

### DIFF
--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -316,20 +316,6 @@ var _ = Describe("Data Processor", func() {
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 	})
-
-	table.DescribeTable("should avoid cleanup before delta copies", func(dataSource DataSourceInterface, expectedCleanup bool) {
-		tmpDir, err := ioutil.TempDir("", "scratch")
-		Expect(err).ToNot(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
-
-		dp := NewDataProcessor(dataSource, "dest", "dataDir", tmpDir, "1G", 0.055, false)
-		Expect(dp.needsDataCleanup).To(Equal(expectedCleanup))
-	},
-		table.Entry("ImageIO delta copy", &ImageioDataSource{currentSnapshot: "123", previousSnapshot: "123"}, false),
-		table.Entry("ImageIO base copy", &ImageioDataSource{currentSnapshot: "123", previousSnapshot: ""}, true),
-		table.Entry("VDDK delta copy", &VDDKDataSource{CurrentSnapshot: "123", PreviousSnapshot: "123"}, false),
-		table.Entry("VDDK base copy", &VDDKDataSource{CurrentSnapshot: "123", PreviousSnapshot: ""}, true),
-	)
 })
 
 var _ = Describe("Convert", func() {

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -150,12 +150,15 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 // Transfer is called to transfer the data from the source to a scratch location.
 func (hs *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
 	if hs.contentType == cdiv1.DataVolumeKubeVirt {
+		file := filepath.Join(path, tempFile)
+		if err := CleanAll(file); err != nil {
+			return ProcessingPhaseError, err
+		}
 		size, err := util.GetAvailableSpace(path)
 		if size <= int64(0) {
 			//Path provided is invalid.
 			return ProcessingPhaseError, ErrInvalidPath
 		}
-		file := filepath.Join(path, tempFile)
 		err = util.StreamDataToFile(hs.readers.TopReader(), file)
 		if err != nil {
 			return ProcessingPhaseError, err
@@ -175,6 +178,9 @@ func (hs *HTTPDataSource) Transfer(path string) (ProcessingPhase, error) {
 
 // TransferFile is called to transfer the data from the source to the passed in file.
 func (hs *HTTPDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	if err := CleanAll(fileName); err != nil {
+		return ProcessingPhaseError, err
+	}
 	hs.readers.StartProgressUpdate()
 	err := util.StreamDataToFile(hs.readers.TopReader(), fileName)
 	if err != nil {

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -80,6 +80,11 @@ func (rd *RegistryDataSource) Info() (ProcessingPhase, error) {
 
 // Transfer is called to transfer the data from the source registry to a temporary location.
 func (rd *RegistryDataSource) Transfer(path string) (ProcessingPhase, error) {
+	rd.imageDir = filepath.Join(path, containerDiskImageDir)
+	if err := CleanAll(rd.imageDir); err != nil {
+		return ProcessingPhaseError, err
+	}
+
 	size, err := util.GetAvailableSpace(path)
 	if err != nil {
 		return ProcessingPhaseError, err
@@ -88,7 +93,6 @@ func (rd *RegistryDataSource) Transfer(path string) (ProcessingPhase, error) {
 		//Path provided is invalid.
 		return ProcessingPhaseError, ErrInvalidPath
 	}
-	rd.imageDir = filepath.Join(path, containerDiskImageDir)
 
 	klog.V(1).Infof("Copying registry image to scratch space.")
 	err = CopyRegistryImage(rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.certDir, rd.insecureTLS)

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -88,12 +88,17 @@ func (sd *S3DataSource) Info() (ProcessingPhase, error) {
 
 // Transfer is called to transfer the data from the source to a temporary location.
 func (sd *S3DataSource) Transfer(path string) (ProcessingPhase, error) {
+	file := filepath.Join(path, tempFile)
+	if err := CleanAll(file); err != nil {
+		return ProcessingPhaseError, err
+	}
+
 	size, _ := util.GetAvailableSpace(path)
 	if size <= int64(0) {
 		//Path provided is invalid.
 		return ProcessingPhaseError, ErrInvalidPath
 	}
-	file := filepath.Join(path, tempFile)
+
 	err := util.StreamDataToFile(sd.readers.TopReader(), file)
 	if err != nil {
 		return ProcessingPhaseError, err
@@ -105,6 +110,10 @@ func (sd *S3DataSource) Transfer(path string) (ProcessingPhase, error) {
 
 // TransferFile is called to transfer the data from the source to the passed in file.
 func (sd *S3DataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	if err := CleanAll(fileName); err != nil {
+		return ProcessingPhaseError, err
+	}
+
 	err := util.StreamDataToFile(sd.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -59,6 +59,10 @@ func (ud *UploadDataSource) Info() (ProcessingPhase, error) {
 // Transfer is called to transfer the data from the source to the passed in path.
 func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
 	if ud.contentType == cdiv1.DataVolumeKubeVirt {
+		file := filepath.Join(path, tempFile)
+		if err := CleanAll(file); err != nil {
+			return ProcessingPhaseError, err
+		}
 		size, err := util.GetAvailableSpace(path)
 		if err != nil {
 			return ProcessingPhaseError, err
@@ -67,7 +71,6 @@ func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
 			//Path provided is invalid.
 			return ProcessingPhaseError, ErrInvalidPath
 		}
-		file := filepath.Join(path, tempFile)
 		err = util.StreamDataToFile(ud.readers.TopReader(), file)
 		if err != nil {
 			return ProcessingPhaseError, err
@@ -87,6 +90,9 @@ func (ud *UploadDataSource) Transfer(path string) (ProcessingPhase, error) {
 
 // TransferFile is called to transfer the data from the source to the passed in file.
 func (ud *UploadDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	if err := CleanAll(fileName); err != nil {
+		return ProcessingPhaseError, err
+	}
 	err := util.StreamDataToFile(ud.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err
@@ -134,6 +140,10 @@ func (aud *AsyncUploadDataSource) Info() (ProcessingPhase, error) {
 
 // Transfer is called to transfer the data from the source to the passed in path.
 func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error) {
+	file := filepath.Join(path, tempFile)
+	if err := CleanAll(file); err != nil {
+		return ProcessingPhaseError, err
+	}
 	size, err := util.GetAvailableSpace(path)
 	if err != nil {
 		return ProcessingPhaseError, err
@@ -142,7 +152,6 @@ func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error)
 		//Path provided is invalid.
 		return ProcessingPhaseError, ErrInvalidPath
 	}
-	file := filepath.Join(path, tempFile)
 	err = util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), file)
 	if err != nil {
 		return ProcessingPhaseError, err
@@ -155,6 +164,9 @@ func (aud *AsyncUploadDataSource) Transfer(path string) (ProcessingPhase, error)
 
 // TransferFile is called to transfer the data from the source to the passed in file.
 func (aud *AsyncUploadDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	if err := CleanAll(fileName); err != nil {
+		return ProcessingPhaseError, err
+	}
 	err := util.StreamDataToFile(aud.uploadDataSource.readers.TopReader(), fileName)
 	if err != nil {
 		return ProcessingPhaseError, err

--- a/pkg/importer/util.go
+++ b/pkg/importer/util.go
@@ -1,15 +1,12 @@
 package importer
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -27,20 +24,19 @@ func ParseEndpoint(endpt string) (*url.URL, error) {
 	return url.Parse(endpt)
 }
 
-// CleanDir cleans the contents of a directory including its sub directories, but does NOT remove the
-// directory itself.
-func CleanDir(dest string) error {
-	dir, err := ioutil.ReadDir(dest)
-	if err != nil {
-		klog.Errorf("Unable read directory to clean: %s, %v", dest, err)
-		return err
-	}
-	for _, d := range dir {
-		klog.V(1).Infoln("deleting file: " + filepath.Join(dest, d.Name()))
-		err = os.RemoveAll(filepath.Join(dest, d.Name()))
+// CleanAll deletes all files at specified paths (recursively)
+func CleanAll(paths ...string) error {
+	for _, p := range paths {
+		isDevice, err := util.IsDevice(p)
 		if err != nil {
-			klog.Errorf("Unable to delete file: %s, %v", filepath.Join(dest, d.Name()), err)
 			return err
+		}
+
+		if !isDevice {
+			// Remove handles p not existing
+			if err := os.RemoveAll(p); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/importer/util_test.go
+++ b/pkg/importer/util_test.go
@@ -100,22 +100,39 @@ var _ = Describe("Clean dir", func() {
 		os.RemoveAll(tmpDir)
 	})
 
-	It("Should error on cleaning non existing directory", func() {
-		err = CleanDir("/invalid")
-		Expect(err).To(HaveOccurred())
+	It("Should be okay to delete a non existing file", func() {
+		err = CleanAll("/invalid")
+		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Should cleaning files in valid directory", func() {
-		_, err = os.Create(filepath.Join(tmpDir, "newfile1"))
+	It("Should clean a file", func() {
+		f := filepath.Join(tmpDir, "newfile1")
+		_, err = os.Create(f)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = os.Create(filepath.Join(tmpDir, "newfile2"))
+		dir, err := os.ReadDir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
-		dir, err := ioutil.ReadDir(tmpDir)
+		Expect(1).To(Equal(len(dir)))
+		err = CleanAll(f)
+		Expect(err).NotTo(HaveOccurred())
+		dir, err = os.ReadDir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(0).To(Equal(len(dir)))
+	})
+
+	It("Should clean a directory", func() {
+		td := filepath.Join(tmpDir, "xx")
+		err = os.Mkdir(td, os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Create(filepath.Join(td, "newfile1"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Create(filepath.Join(td, "newfile2"))
+		Expect(err).NotTo(HaveOccurred())
+		dir, err := os.ReadDir(td)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(2).To(Equal(len(dir)))
-		err = CleanDir(tmpDir)
+		err = CleanAll(td)
 		Expect(err).NotTo(HaveOccurred())
-		dir, err = ioutil.ReadDir(tmpDir)
+		dir, err = os.ReadDir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(0).To(Equal(len(dir)))
 	})

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -963,6 +963,12 @@ func (vs *VDDKDataSource) IsDeltaCopy() bool {
 
 // TransferFile is called to transfer the data from the source to the file passed in.
 func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	if !vs.IsDeltaCopy() {
+		if err := CleanAll(fileName); err != nil {
+			return ProcessingPhaseError, err
+		}
+	}
+
 	if vs.ChangedBlocks != nil { // Warm migration pre-checks
 		if len(vs.ChangedBlocks.ChangedArea) < 1 { // No changes? Immediately return success.
 			klog.Infof("No changes reported between snapshot %s and snapshot %s, marking transfer complete.", vs.PreviousSnapshot, vs.CurrentSnapshot)

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -167,7 +167,7 @@ var _ = Describe("VDDK data source", func() {
 
 		mockSinkBuffer = bytes.Repeat([]byte{0x00}, int(dp.Size))
 
-		phase, err := dp.TransferFile(".")
+		phase, err := dp.TransferFile("target")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(phase).To(Equal(ProcessingPhaseResize))
 
@@ -193,7 +193,7 @@ var _ = Describe("VDDK data source", func() {
 
 		mockSinkBuffer = bytes.Repeat([]byte{0x00}, int(snap1.Size))
 
-		phase, err := snap1.TransferFile(".")
+		phase, err := snap1.TransferFile("target")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(phase).To(Equal(ProcessingPhaseResize))
 

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -457,9 +457,6 @@ func filesystemCloneProcessor(stream io.ReadCloser, dest string) error {
 
 	// Clone to file system
 	destDir := common.ImporterVolumePath
-	if err := importer.CleanDir(destDir); err != nil {
-		return errors.Wrapf(err, "error removing contents of %s", destDir)
-	}
 	if err := util.UnArchiveTar(newSnappyReadCloser(stream), destDir); err != nil {
 		return errors.Wrapf(err, "error unarchiving to %s", destDir)
 	}

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -321,7 +321,7 @@ func (f *Framework) GetDiskGroup(namespace *k8sv1.Namespace, pvc *k8sv1.Persiste
 
 // VerifyTargetPVCArchiveContent provides a function to check if the number of files extracted from an archive matches the passed in value
 func (f *Framework) VerifyTargetPVCArchiveContent(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim, count string) (bool, error) {
-	cmd := "ls " + utils.DefaultPvcMountPath + " | wc -l"
+	cmd := "ls -I lost+found " + utils.DefaultPvcMountPath + " | wc -l"
 
 	return f.verifyInPod(namespace, pvc, cmd, func(output, stderr string) (bool, error) {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: file count found %s\n", string(output))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Backports PR #2676 
> Rather than cleaning up everything on target/scratch PVCs, only delete what we may have created


**Special notes for your reviewer**:
Pretty much the same as #3200, now one version older.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
More targeted cleanup of target/scratch pvcs (only delete what we may have created)
```

