### PR TITLE
Add make target to scan for vulnerabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ publish: manifests push
 vet:
 	${DO_BAZ} "./hack/build/build-go.sh vet ${WHAT}"
 
+vulncheck:
+	${DO_BAZ} ./hack/build/run-vulncheck.sh
+
 format:
 	${DO_BAZ} "./hack/build/format.sh"
 

--- a/hack/build/run-vulncheck.sh
+++ b/hack/build/run-vulncheck.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eu
+
+GOVULNCHECK_VERSION="${GOVULNCHECK_VERSION:-latest}"
+
+go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+govulncheck -version ./...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a make target to run a vulnerability scan. In the future it would be a good idea to have this in CI.

At the moment there are 5 vulnerabilitites in our codebase:
<details>
<summary>Show vulnerabilities</summary>

```
./hack/build/bazel-docker.sh ./hack/build/run-vulncheck.sh
CDI_CRI: docker, CDI_CONTAINER_BUILDCMD: docker
Making sure output directory exists...
Starting rsyncd

Rsyncing /home/edu/containerized-data-importer to container
Starting bazel server
Go: go1.21.5
Scanner: govulncheck@v1.1.0
DB: https://vuln.go.dev
DB updated: 2024-04-17 19:55:00 +0000 UTC

Scanning your code and 1292 packages across 144 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Standard library
    Found in: net/http@go1.21.5
    Fixed in: net/http@go1.21.9
    Example traces found:
      #1: pkg/controller/common/util.go:1256:21: common.GetAPIServerKey calls sync.Once.Do, which eventually calls http.CanonicalHeaderKey
      #2: pkg/importer/transport.go:100:21: importer.closeImage calls archive.ociArchiveImageSource.Close, which eventually calls http.Client.CloseIdleConnections
      #3: pkg/importer/imageio-datasource.go:473:35: importer.extentReader.GetRange calls http.Client.Do
      #4: pkg/controller/common/util.go:1659:29: common.GetProgressReportFromURL calls http.Client.Get
      #5: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.Client.PostForm
      #6: pkg/uploadproxy/uploadproxy.go:171:23: uploadproxy.uploadProxyApp.ServeHTTP calls http.HandlerFunc.ServeHTTP
      #7: pkg/importer/imageio-datasource.go:471:20: importer.extentReader.GetRange calls http.Header.Add
      #8: pkg/client/clientset/versioned/typed/upload/v1beta1/uploadtokenrequest.go:191:7: v1beta1.uploadTokenRequests.Patch calls rest.Request.Body, which eventually calls http.Header.Del
      #9: pkg/importer/imageio-datasource.go:478:38: importer.extentReader.GetRange calls http.Header.Get
      #10: cmd/cdi-cloner/clone-source.go:250:17: cdi.main calls http.Header.Set
      #11: pkg/util/util.go:85:24: util.CountingReader.Read calls docker.bodyReader.Read, which eventually calls http.Header.Values
      #12: pkg/importer/vddk-datasource_amd64.go:468:34: importer.FindVM calls object.SearchIndex.FindByUuid, which eventually calls http.Header.WriteSubset
      #13: tools/cdi-func-test-bad-webserver/main.go:99:28: cdi.main calls http.ListenAndServe
      #14: pkg/util/prometheus/prometheus.go:116:35: prometheus.StartPrometheusEndpoint calls http.ListenAndServeTLS
      #15: pkg/importer/imageio-datasource.go:467:33: importer.extentReader.GetRange calls http.NewRequest
      #16: pkg/importer/http-datasource.go:520:40: importer.getServerInfo calls http.NewRequestWithContext
      #17: pkg/util/util.go:85:24: util.CountingReader.Read calls docker.bodyReader.Read, which eventually calls http.ParseTime
      #18: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.ProxyFromEnvironment
      #19: pkg/importer/imageio-datasource.go:1239:31: importer.ImageTransfersServiceResponse.Send calls ovirt.ImageTransfersServiceAddRequest.Send, which eventually calls http.ReadRequest
      #20: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.ReadResponse
      #21: pkg/importer/http-datasource.go:345:19: importer.createHTTPReader calls http.Request.SetBasicAuth
      #22: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.Request.UserAgent
      #23: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.Request.Write
      #24: pkg/importer/s3-datasource.go:164:33: importer.createS3Reader calls s3.S3.GetObject, which eventually calls http.Request.WriteProxy
      #25: pkg/importer/imageio-datasource.go:1239:31: importer.ImageTransfersServiceResponse.Send calls ovirt.ImageTransfersServiceAddRequest.Send, which eventually calls http.Response.Write
      #26: pkg/uploadserver/uploadserver.go:264:19: uploadserver.uploadServerApp.ServeHTTP calls http.ServeMux.ServeHTTP
      #27: pkg/uploadserver/uploadserver.go:194:3: uploadserver.Run calls http.Server.Close
      #28: tools/cdi-func-test-proxy/main.go:71:35: cdi.startServer calls http.Server.ListenAndServe
      #29: pkg/apiserver/apiserver.go:301:38: apiserver.startTLS calls http.Server.ListenAndServeTLS
      #30: pkg/uploadserver/uploadserver.go:196:37: uploadserver.Run calls http.Server.Serve
      #31: pkg/uploadserver/uploadserver.go:185:40: uploadserver.Run calls http.Server.ServeTLS
      #32: pkg/uploadserver/uploadserver.go:204:35: uploadserver.uploadServerApp.Run calls http.Server.Shutdown
      #33: pkg/importer/http-datasource.go:293:60: importer.createHTTPClient calls http.Transport.Clone
      #34: pkg/importer/imageio-datasource.go:1239:31: importer.ImageTransfersServiceResponse.Send calls ovirt.ImageTransfersServiceAddRequest.Send, which eventually calls http.Transport.CloseIdleConnections
      #35: pkg/importer/imageio-datasource.go:1239:31: importer.ImageTransfersServiceResponse.Send calls ovirt.ImageTransfersServiceAddRequest.Send, which eventually calls http.Transport.RoundTrip
      #36: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.body.Close
      #37: pkg/util/util.go:85:24: util.CountingReader.Read calls http.body.Read
      #38: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.bodyEOFSignal.Close
      #39: pkg/util/util.go:85:24: util.CountingReader.Read calls http.bodyEOFSignal.Read
      #40: pkg/util/util.go:85:24: util.CountingReader.Read calls io.LimitedReader.Read, which calls http.bodyLocked.Read
      #41: pkg/util/util.go:386:22: util.Md5sum calls io.Copy, which eventually calls http.bufioFlushWriter.Write
      #42: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.cancelTimerBody.Close
      #43: pkg/util/util.go:85:24: util.CountingReader.Read calls http.cancelTimerBody.Read
      #44: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.checkConnErrorWriter.Write
      #45: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.chunkWriter.Write
      #46: pkg/util/util.go:85:24: util.CountingReader.Read calls io.LimitedReader.Read, which calls http.connReader.Read
      #47: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.expectContinueReader.Close
      #48: pkg/util/util.go:85:24: util.CountingReader.Read calls http.expectContinueReader.Read
      #49: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.gzipReader.Close
      #50: pkg/util/util.go:85:24: util.CountingReader.Read calls http.gzipReader.Read
      #51: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2ConnectionError.Error
      #52: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2ErrCode.String
      #53: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2FrameHeader.String
      #54: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2FrameType.String
      #55: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2FrameWriteRequest.String
      #56: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2GoAwayError.Error
      #57: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2Setting.String
      #58: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2SettingID.String
      #59: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2StreamError.Error
      #60: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.http2chunkWriter.Write
      #61: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2connError.Error
      #62: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2duplicatePseudoHeaderError.Error
      #63: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.http2gzipReader.Close
      #64: pkg/util/util.go:85:24: util.CountingReader.Read calls http.http2gzipReader.Read
      #65: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2headerFieldNameError.Error
      #66: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2headerFieldValueError.Error
      #67: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.http2pseudoHeaderError.Error
      #68: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.http2requestBody.Close
      #69: pkg/util/util.go:85:24: util.CountingReader.Read calls http.http2requestBody.Read
      #70: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls http.http2responseWriter.Write
      #71: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls promhttp.responseWriterDelegator.Write, which eventually calls http.http2responseWriter.WriteHeader
      #72: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls multierr.multiError.Error, which eventually calls http.http2responseWriter.WriteString
      #73: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.http2stickyErrWriter.Write
      #74: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.http2transportResponseBody.Close
      #75: pkg/util/util.go:85:24: util.CountingReader.Read calls http.http2transportResponseBody.Read
      #76: pkg/controller/common/util.go:1652:57: common.GetMetricsURL calls fmt.Sprint, which eventually calls http.http2writeData.String
      #77: pkg/util/util.go:85:24: util.CountingReader.Read calls io.LimitedReader.Read, which calls http.loggingConn.Read
      #78: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.loggingConn.Write
      #79: pkg/util/util.go:85:24: util.CountingReader.Read calls io.LimitedReader.Read, which calls http.maxBytesReader.Read
      #80: pkg/controller/common/util.go:1256:21: common.GetAPIServerKey calls sync.Once.Do, which eventually calls http.onceCloseListener.Close
      #81: pkg/util/util.go:85:24: util.CountingReader.Read calls io.LimitedReader.Read, which calls http.persistConn.Read
      #82: pkg/util/util.go:386:22: util.Md5sum calls io.Copy, which eventually calls http.persistConnWriter.ReadFrom
      #83: pkg/importer/vddk-datasource_amd64.go:711:35: importer.VDDKFileSink.Write calls bufio.Writer.Write, which calls http.persistConnWriter.Write
      #84: pkg/controller/common/util.go:1666:2: common.GetProgressReportFromURL calls http.readTrackingBody.Close
      #85: pkg/util/util.go:85:24: util.CountingReader.Read calls http.readTrackingBody.Read
      #86: pkg/util/util.go:85:24: util.CountingReader.Read calls http.readWriteCloserBody.Read
      #87: pkg/util/util.go:386:22: util.Md5sum calls io.Copy, which eventually calls http.response.ReadFrom
      #88: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls http.response.Write
      #89: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls promhttp.responseWriterDelegator.Write, which eventually calls http.response.WriteHeader
      #90: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls multierr.multiError.Error, which eventually calls http.response.WriteString
      #91: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls http.timeoutWriter.Write
      #92: pkg/apiserver/webhooks/handler.go:162:22: webhooks.admissionHandler.ServeHTTP calls promhttp.responseWriterDelegator.Write, which eventually calls http.timeoutWriter.WriteHeader
      #93: pkg/controller/common/util.go:1426:35: common.ErrQuotaExceeded calls http.transportReadFromServerError.Error

Vulnerability #2: GO-2024-2610
    Errors returned from JSON marshaling may break template escaping in
    html/template
  More info: https://pkg.go.dev/vuln/GO-2024-2610
  Standard library
    Found in: html/template@go1.21.5
    Fixed in: html/template@go1.21.8
    Example traces found:
      #1: pkg/uploadproxy/uploadproxy.go:171:23: uploadproxy.uploadProxyApp.ServeHTTP calls http.HandlerFunc.ServeHTTP, which eventually calls template.Template.Execute
      #2: pkg/uploadproxy/uploadproxy.go:171:23: uploadproxy.uploadProxyApp.ServeHTTP calls http.HandlerFunc.ServeHTTP, which eventually calls template.Template.ExecuteTemplate

Vulnerability #3: GO-2024-2600
    Incorrect forwarding of sensitive headers and cookies on HTTP redirect in
    net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2600
  Standard library
    Found in: net/http@go1.21.5
    Fixed in: net/http@go1.21.8
    Example traces found:
      #1: pkg/importer/imageio-datasource.go:473:35: importer.extentReader.GetRange calls http.Client.Do, which eventually calls cookiejar.Jar.Cookies
      #2: pkg/importer/imageio-datasource.go:473:35: importer.extentReader.GetRange calls http.Client.Do, which eventually calls cookiejar.Jar.SetCookies
      #3: pkg/importer/imageio-datasource.go:473:35: importer.extentReader.GetRange calls http.Client.Do
      #4: pkg/controller/common/util.go:1659:29: common.GetProgressReportFromURL calls http.Client.Get
      #5: pkg/uploadproxy/uploadproxy.go:313:13: uploadproxy.uploadProxyApp.proxyUploadRequest calls httputil.ReverseProxy.ServeHTTP, which eventually calls http.Client.PostForm
      #6: tools/cdi-func-test-bad-webserver/main.go:36:23: cdi.badContentType calls http.Get

Vulnerability #4: GO-2024-2599
    Memory exhaustion in multipart form parsing in net/textproto and net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2599
  Standard library
    Found in: net/textproto@go1.21.5
    Fixed in: net/textproto@go1.21.8
    Example traces found:
      #1: pkg/importer/imageio-datasource.go:1239:31: importer.ImageTransfersServiceResponse.Send calls ovirt.ImageTransfersServiceAddRequest.Send, which eventually calls textproto.Reader.ReadLine
      #2: pkg/util/util.go:85:24: util.CountingReader.Read calls http.body.Read, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #5: GO-2024-2598
    Verify panics on certificates with an unknown public key algorithm in
    crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2024-2598
  Standard library
    Found in: crypto/x509@go1.21.5
    Fixed in: crypto/x509@go1.21.8
    Example traces found:
      #1: pkg/util/util.go:85:24: util.CountingReader.Read calls http.readWriteCloserBody.Read, which eventually calls x509.Certificate.Verify

Your code is affected by 5 vulnerabilities from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 3
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

</details>

I'll work on fixing them in a separate PR.

**Special notes for your reviewer**:
Uses govulncheck
https://go.dev/doc/security/vuln/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

