### PR TITLE
Set default clone strategy for trident to snapshot

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -114,6 +114,8 @@ var SourceFormatsByProvisionerKey = map[string]cdiv1.DataImportCronSourceFormat{
 	"openshift-storage.rbd.csi.ceph.com": cdiv1.DataImportCronSourceFormatSnapshot,
 	"topolvm.cybozu.com":                 cdiv1.DataImportCronSourceFormatSnapshot,
 	"topolvm.io":                         cdiv1.DataImportCronSourceFormatSnapshot,
+	"csi.trident.netapp.io/ontap-nas":    cdiv1.DataImportCronSourceFormatSnapshot,
+	"csi.trident.netapp.io/ontap-san":    cdiv1.DataImportCronSourceFormatSnapshot,
 }
 
 // CloneStrategyByProvisionerKey defines the advised clone strategy for a provisioner
@@ -129,14 +131,14 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"openshift-storage.rbd.csi.ceph.com":    cdiv1.CloneStrategyCsiClone,
 	"cephfs.csi.ceph.com":                   cdiv1.CloneStrategyCsiClone,
 	"openshift-storage.cephfs.csi.ceph.com": cdiv1.CloneStrategyCsiClone,
-	"csi.trident.netapp.io/ontap-nas":       cdiv1.CloneStrategyCsiClone,
-	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategyCsiClone,
 	"pxd.openstorage.org/shared":            cdiv1.CloneStrategyCsiClone,
 	"pxd.openstorage.org":                   cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com/shared":               cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com":                      cdiv1.CloneStrategyCsiClone,
 	"topolvm.cybozu.com":                    cdiv1.CloneStrategyCsiClone,
 	"topolvm.io":                            cdiv1.CloneStrategyCsiClone,
+	"csi.trident.netapp.io/ontap-nas":       cdiv1.CloneStrategySnapshot,
+	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategySnapshot,
 }
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There's a bug in the trident CSI driver that causes a snapshot to be left over following each CSI clone:
https://github.com/NetApp/trident/issues/901
This is becoming a problem rapidly once one hits the snapshot limit per volume (golden image): https://kb.netapp.com/onprem/ontap/os/Maximum_number_of_snapshots_supported_by_ONTAP

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set default clone strategy for trident ONTAP to "snapshot"
```

