### PR TITLE
[WIP] Revert to using nbdkit for http conversion imports

### DIFF
--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -94,11 +94,16 @@ var _ = Describe("Http data source", func() {
 		if !wantErr {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(expectedPhase).To(Equal(newPhase))
+			if newPhase == ProcessingPhaseConvert {
+				expectURL, err := url.Parse("nbd+unix:///?socket=/tmp/nbdkit.sock")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expectURL).To(Equal(dp.GetURL()))
+			}
 		} else {
 			Expect(err).To(HaveOccurred())
 		}
 	},
-		Entry("return TransferScratch phase ", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseTransferScratch, cirrosData, false),
+		Entry("return Convert phase ", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseConvert, cirrosData, false),
 		Entry("return TransferTarget with archive content type but not archive endpoint ", cirrosFileName, cdiv1.DataVolumeArchive, ProcessingPhaseTransferDataDir, cirrosData, false),
 		Entry("return TransferTarget with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseTransferDataDir, diskimageArchiveData, false),
 	)

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreQcow2,
 				isHTTPS:       false,
 				withBasicAuth: false,
-				userAgent:     golangUserAgent,
+				userAgent:     nbdKitUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso import dv with a proxied server (http)", importProxyTestArguments{
 				name:          "dv-import-http-proxy",
@@ -213,7 +213,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreIso,
 				isHTTPS:       false,
 				withBasicAuth: false,
-				userAgent:     golangUserAgent,
+				userAgent:     nbdKitUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso.gz import dv with a proxied server (http)", importProxyTestArguments{
 				name:          "dv-import-http-proxy",
@@ -231,7 +231,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreQcow2,
 				isHTTPS:       false,
 				withBasicAuth: true,
-				userAgent:     golangUserAgent,
+				userAgent:     nbdKitUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
 				name:          "dv-import-http-proxy-auth",
@@ -240,7 +240,7 @@ var _ = Describe("Import Proxy tests", func() {
 				imgName:       tinyCoreIso,
 				isHTTPS:       false,
 				withBasicAuth: true,
-				userAgent:     golangUserAgent,
+				userAgent:     nbdKitUserAgent,
 				expected:      BeTrue}),
 			Entry("succeed creating iso.gz import dv with a proxied server (http) with basic autentication", importProxyTestArguments{
 				name:          "dv-import-http-proxy-auth",

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -466,10 +466,7 @@ var _ = Describe("[rfe_id:1118][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		afterCMD(portForwardCmd)
 	})
 
-	// Skipping this test until we can get progress information again. What happens is that the go
-	// http client cannot determine the total size, and thus the prometheus endpoint is not initialized
-	// This causes this test to now fail because the endpoint is not there, skipping for now.
-	PIt("[test_id:4970]Import pod should have prometheus stats available while importing", func() {
+	It("[test_id:4970]Import pod should have prometheus stats available while importing", func() {
 		var endpoint *v1.Endpoints
 		c := f.K8sClient
 		ns := f.Namespace.Name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Due to some performance issues discussed in https://github.com/kubevirt/containerized-data-importer/issues/2809, we stopped using nbdkit for most http imports. This new behavior introduced minor differences in some specific flows, such as stopping the [conversion](https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/importer/data-processor.go#L268) of uncompressed raw images.

The conversion process made the actual size of raw images significantly smaller, probably because of qemu's handling of sparse images. The import of raw images without conversion ended up causing failures in some tests, as imported images had a significant increase in size.

Since nbdkit performance issues have been addressed in v1.35.8 (and now we use v1.36.2), this pull request aims to revert to the old behavior.

**Example:** 

Fresh image import before this PR:

```sh
sh-5.1$ qemu-img info disk.img 
image: disk.img
file format: raw
virtual size: 70 GiB (75161927680 bytes)
disk size: 55 GiB
```

Fresh image import after this PR (due to convert):

```sh
$ qemu-img info disk.img 
image: disk.img
file format: raw
virtual size: 70 GiB (75161927680 bytes)
disk size: 9.95 GiB
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36026

**Special notes for your reviewer**:

Check https://github.com/kubevirt/containerized-data-importer/issues/2809 and https://github.com/kubevirt/containerized-data-importer/pull/2832 for more context about the original change and why it's safe to revert now.

If we prefer to keep this behavior and avoid using nbdkit, an alternative would be to use scratch for uncompressed raw images.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Use nbdkit for http conversion imports
```

