### PR TITLE
Handle lost sparseness in non http data sources

### DIFF
--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -55,7 +56,7 @@ func (er *execReader) Close() error {
 }
 
 func init() {
-	flag.StringVar(&contentType, "content-type", "", "filesystem-clone|blockdevice-clone")
+	flag.StringVar(&contentType, "content-type", "", fmt.Sprintf("%s|%s", common.FilesystemCloneContentType, common.BlockdeviceClone))
 	flag.StringVar(&mountPoint, "mount", "", "pvc mount point")
 	flag.Uint64Var(&uploadBytes, "upload-bytes", 0, "approx number of bytes in input")
 	klog.InitFlags(nil)
@@ -132,7 +133,7 @@ func pipeToSnappy(reader io.ReadCloser) io.ReadCloser {
 
 func validateContentType() {
 	switch contentType {
-	case "filesystem-clone", "blockdevice-clone":
+	case common.FilesystemCloneContentType, common.BlockdeviceClone:
 	default:
 		klog.Fatalf("Invalid content-type %q", contentType)
 	}
@@ -197,13 +198,13 @@ func newTarReader(preallocation bool) (io.ReadCloser, error) {
 
 func getInputStream(preallocation bool) io.ReadCloser {
 	switch contentType {
-	case "filesystem-clone":
+	case common.FilesystemCloneContentType:
 		rc, err := newTarReader(preallocation)
 		if err != nil {
 			klog.Fatalf("Error creating tar reader for %q: %+v", mountPoint, err)
 		}
 		return rc
-	case "blockdevice-clone":
+	case common.BlockdeviceClone:
 		rc, err := os.Open(mountPoint)
 		if err != nil {
 			klog.Fatalf("Error opening block device %q: %+v", mountPoint, err)

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -51,10 +51,6 @@ func (ud *UploadDataSource) Info() (ProcessingPhase, error) {
 	if ud.contentType == cdiv1.DataVolumeArchive {
 		return ProcessingPhaseTransferDataDir, nil
 	}
-	if !ud.readers.Convert {
-		// Uploading a raw file, we can write that directly to the target.
-		return ProcessingPhaseTransferDataFile, nil
-	}
 	return ProcessingPhaseTransferScratch, nil
 }
 

--- a/pkg/importer/upload-datasource_test.go
+++ b/pkg/importer/upload-datasource_test.go
@@ -71,14 +71,14 @@ var _ = Describe("Upload data source", func() {
 		Expect(ProcessingPhaseTransferDataDir).To(Equal(result))
 	})
 
-	It("Info should return TransferData, when passed in a valid raw image", func() {
+	It("Info should return TransferScratch, when passed in a valid raw image", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(tinyCoreFilePath)
 		Expect(err).NotTo(HaveOccurred())
 		ud = NewUploadDataSource(file, dvKubevirt)
 		result, err := ud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
 	DescribeTable("calling transfer should", func(fileName string, dvContentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, scratchPath string, want []byte, wantErr bool) {
@@ -136,7 +136,7 @@ var _ = Describe("Upload data source", func() {
 		ud = NewUploadDataSource(sourceFile, dvKubevirt)
 		result, err := ud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 		result, err = ud.TransferFile(filepath.Join(tmpDir, "file"), false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ProcessingPhaseResize).To(Equal(result))
@@ -149,7 +149,7 @@ var _ = Describe("Upload data source", func() {
 		ud = NewUploadDataSource(sourceFile, dvKubevirt)
 		result, err := ud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 		result, err = ud.TransferFile("/invalidpath/invalidfile", false)
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
@@ -204,14 +204,14 @@ var _ = Describe("Async Upload data source", func() {
 		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
-	It("Info should return TransferData, when passed in a valid raw image", func() {
+	It("Info should return TransferScratch, when passed in a valid raw image", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(tinyCoreFilePath)
 		Expect(err).NotTo(HaveOccurred())
 		aud = NewAsyncUploadDataSource(file)
 		result, err := aud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
 	DescribeTable("calling transfer should", func(fileName, scratchPath string, want []byte, wantErr bool) {
@@ -260,7 +260,7 @@ var _ = Describe("Async Upload data source", func() {
 		aud = NewAsyncUploadDataSource(sourceFile)
 		result, err := aud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 		result, err = aud.TransferFile(filepath.Join(tmpDir, "file"), false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ProcessingPhaseValidatePause).To(Equal(result))
@@ -274,7 +274,7 @@ var _ = Describe("Async Upload data source", func() {
 		aud = NewAsyncUploadDataSource(sourceFile)
 		result, err := aud.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 		result, err = aud.TransferFile("/invalidpath/invalidfile", false)
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//tests/framework:go_default_library",
         "//tests/reporter:go_default_library",
         "//tests/utils:go_default_library",
+        "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",

--- a/tests/framework/pvc.go
+++ b/tests/framework/pvc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -284,24 +283,15 @@ func (f *Framework) VerifyBlankDisk(namespace *k8sv1.Namespace, pvc *k8sv1.Persi
 }
 
 // VerifySparse checks a disk image being sparse after creation/resize.
-func (f *Framework) VerifySparse(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim, imagePath string) (bool, error) {
+func (f *Framework) VerifySparse(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim, imagePath string, originalVirtualSize int64) (bool, error) {
 	var info image.ImgInfo
-	var imageContentSize int64
 	err := f.GetImageInfo(namespace, pvc, imagePath, &info)
 	if err != nil {
 		return false, err
 	}
-	// qemu-img info gives us ActualSize but that is size on disk
-	// which isn't important to us in this comparison; we compare content size
-	err = f.GetImageContentSize(namespace, pvc, imagePath, &imageContentSize)
-	if err != nil {
-		return false, err
-	}
-	if info.ActualSize-imageContentSize >= units.MiB {
-		return false, fmt.Errorf("Diff between content size %d and size on disk %d is significant, something's not right", imageContentSize, info.ActualSize)
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: VerifySparse comparison: Virtual: %d vs Content: %d\n", info.VirtualSize, imageContentSize)
-	return info.VirtualSize >= imageContentSize, nil
+	fmt.Fprintf(ginkgo.GinkgoWriter, "INFO: VerifySparse comparison: OriginalVirtual: %d vs SizeOnDisk: %d\n", originalVirtualSize, info.ActualSize)
+	// The size on disk of a sparse image is significantly lower than the image's virtual size
+	return originalVirtualSize-info.ActualSize >= units.MB, nil
 }
 
 // VerifyFSOverhead checks whether virtual size is smaller than actual size. That means FS Overhead has been accounted for.
@@ -541,26 +531,6 @@ func (f *Framework) GetImageInfo(namespace *k8sv1.Namespace, pvc *k8sv1.Persiste
 			klog.Errorf("Invalid JSON:\n%s\n", output)
 			return false, err
 		}
-
-		return true, nil
-	})
-
-	return err
-}
-
-// GetImageContentSize returns the content size (as opposed to size on disk) of an image
-func (f *Framework) GetImageContentSize(namespace *k8sv1.Namespace, pvc *k8sv1.PersistentVolumeClaim, imagePath string, imageSize *int64) error {
-	cmd := fmt.Sprintf("du -s --apparent-size -B 1 %s | cut -f 1", imagePath)
-
-	_, err := f.verifyInPod(namespace, pvc, cmd, func(output, stderr string) (bool, error) {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "CMD (%s) output %s\n", cmd, output)
-
-		size, err := strconv.ParseInt(output, 10, 64)
-		if err != nil {
-			klog.Errorf("Invalid image content size:\n%s\n", output)
-			return false, err
-		}
-		*imageSize = size
 
 		return true, nil
 	})

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/docker/go-units"
 	"github.com/google/uuid"
 
 	v1 "k8s.io/api/core/v1"
@@ -125,7 +126,7 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		By("Verify the image contents")
 		Expect(f.VerifyBlankDisk(f.Namespace, pvc)).To(BeTrue())
 		By("Verifying the image is sparse")
-		Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+		Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileSize)).To(BeTrue())
 		By("Verifying permissions are 660")
 		Expect(f.VerifyPermissions(f.Namespace, pvc)).To(BeTrue(), "Permissions on disk image are not 660")
 		if utils.DefaultStorageCSIRespectsFsGroup {
@@ -1523,7 +1524,7 @@ var _ = Describe("Import populator", func() {
 		}
 	})
 
-	DescribeTable("should import fileSystem PVC", func(expectedMD5 string, volumeImportSourceFunc func(cdiv1.DataVolumeContentType, bool) error, preallocation, webhookRendering bool) {
+	DescribeTable("should import fileSystem PVC", func(expectedMD5 string, originalVirtualSize int, volumeImportSourceFunc func(cdiv1.DataVolumeContentType, bool) error, preallocation, webhookRendering bool) {
 		pvc = importPopulationPVCDefinition()
 
 		if webhookRendering {
@@ -1556,7 +1557,7 @@ var _ = Describe("Import populator", func() {
 			Expect(ok).To(BeTrue())
 		} else {
 			By("Verifying the image is sparse")
-			Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+			Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, int64(originalVirtualSize))).To(BeTrue())
 		}
 
 		if utils.DefaultStorageCSIRespectsFsGroup {
@@ -1581,17 +1582,17 @@ var _ = Describe("Import populator", func() {
 			return err != nil && k8serrors.IsNotFound(err)
 		}, timeout, pollingInterval).Should(BeTrue())
 	},
-		Entry("[test_id:11001]with HTTP image and preallocation", utils.TinyCoreMD5, createHTTPImportPopulatorCR, true, false),
-		Entry("[test_id:11002]with HTTP image without preallocation", utils.TinyCoreMD5, createHTTPImportPopulatorCR, false, false),
-		Entry("[rfe_id:10985][crit:high][test_id:11003]with HTTP image and preallocation, with incomplete PVC webhook rendering", utils.TinyCoreMD5, createHTTPImportPopulatorCR, true, true),
-		Entry("[test_id:11004]with Registry image and preallocation", utils.TinyCoreMD5, createRegistryImportPopulatorCR, true, false),
-		Entry("[test_id:11005]with Registry image without preallocation", utils.TinyCoreMD5, createRegistryImportPopulatorCR, false, false),
-		Entry("[test_id:11006]with ImageIO image with preallocation", Label("ImageIO"), Serial, utils.ImageioMD5, createImageIOImportPopulatorCR, true, false),
-		Entry("[test_id:11007]with ImageIO image without preallocation", Label("ImageIO"), Serial, utils.ImageioMD5, createImageIOImportPopulatorCR, false, false),
-		Entry("[test_id:11008]with VDDK image with preallocation", Label("VDDK"), utils.VcenterMD5, createVDDKImportPopulatorCR, true, false),
-		Entry("[test_id:11009]with VDDK image without preallocation", Label("VDDK"), utils.VcenterMD5, createVDDKImportPopulatorCR, false, false),
-		Entry("[test_id:11010]with Blank image with preallocation", utils.BlankMD5, createBlankImportPopulatorCR, true, false),
-		Entry("[test_id:11011]with Blank image without preallocation", utils.BlankMD5, createBlankImportPopulatorCR, false, false),
+		Entry("[test_id:11001]with HTTP image and preallocation", utils.TinyCoreMD5, utils.UploadFileSize, createHTTPImportPopulatorCR, true, false),
+		Entry("[test_id:11002]with HTTP image without preallocation", utils.TinyCoreMD5, utils.UploadFileSize, createHTTPImportPopulatorCR, false, false),
+		Entry("[rfe_id:10985][crit:high][test_id:11003]with HTTP image and preallocation, with incomplete PVC webhook rendering", utils.TinyCoreMD5, utils.UploadFileSize, createHTTPImportPopulatorCR, true, true),
+		Entry("[test_id:11004]with Registry image and preallocation", utils.TinyCoreMD5, utils.UploadFileSize, createRegistryImportPopulatorCR, true, false),
+		Entry("[test_id:11005]with Registry image without preallocation", utils.TinyCoreMD5, utils.UploadFileSize, createRegistryImportPopulatorCR, false, false),
+		Entry("[test_id:11006]with ImageIO image with preallocation", Label("ImageIO"), Serial, utils.ImageioMD5, utils.CirrosRawFileSize, createImageIOImportPopulatorCR, true, false),
+		Entry("[test_id:11007]with ImageIO image without preallocation", Label("ImageIO"), Serial, utils.ImageioMD5, utils.CirrosRawFileSize, createImageIOImportPopulatorCR, false, false),
+		Entry("[test_id:11008]with VDDK image with preallocation", Label("VDDK"), utils.VcenterMD5, utils.CirrosRawFileSize, createVDDKImportPopulatorCR, true, false),
+		Entry("[test_id:11009]with VDDK image without preallocation", Label("VDDK"), utils.VcenterMD5, utils.CirrosRawFileSize, createVDDKImportPopulatorCR, false, false),
+		Entry("[test_id:11010]with Blank image with preallocation", utils.BlankMD5, units.MiB, createBlankImportPopulatorCR, true, false),
+		Entry("[test_id:11011]with Blank image without preallocation", utils.BlankMD5, units.MiB, createBlankImportPopulatorCR, false, false),
 	)
 
 	DescribeTable("should import Block PVC", func(expectedMD5 string, volumeImportSourceFunc func(cdiv1.DataVolumeContentType, bool) error) {
@@ -1619,7 +1620,7 @@ var _ = Describe("Import populator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(expectedMD5))
 		By("Verifying the image is sparse")
-		Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultPvcMountPath)).To(BeTrue())
+		Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultPvcMountPath, utils.UploadFileSize)).To(BeTrue())
 
 		By("Verify 100.0% annotation")
 		progress, ok, err := utils.WaitForPVCAnnotation(f.K8sClient, f.Namespace.Name, pvc, controller.AnnPopulatorProgress)

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1525,6 +1525,10 @@ var _ = Describe("Import populator", func() {
 	})
 
 	DescribeTable("should import fileSystem PVC", func(expectedMD5 string, originalVirtualSize int, volumeImportSourceFunc func(cdiv1.DataVolumeContentType, bool) error, preallocation, webhookRendering bool) {
+		// ImageIO raw images are not passed through any sparsification mechanism
+		// VDDK ones do, but the fake plugin used for testing lies that they're not
+		skipSparseCheckIDs := []string{"[test_id:11007]", "[test_id:11009]"}
+
 		pvc = importPopulationPVCDefinition()
 
 		if webhookRendering {
@@ -1550,12 +1554,19 @@ var _ = Describe("Import populator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(md5).To(Equal(expectedMD5))
 
+		var excluded bool
+		for _, id := range skipSparseCheckIDs {
+			if strings.Contains(CurrentSpecReport().LeafNodeText, id) {
+				excluded = true
+				break
+			}
+		}
 		if preallocation {
 			By("Verifying the image is preallocated")
 			ok, err := f.VerifyImagePreallocated(f.Namespace, pvc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeTrue())
-		} else {
+		} else if !excluded {
 			By("Verifying the image is sparse")
 			Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, int64(originalVirtualSize))).To(BeTrue())
 		}

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Transport Tests", func() {
 				}
 			}
 			By("Verifying the image is sparse")
-			Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+			Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileSize)).To(BeTrue())
 		} else {
 			By("Verify PVC status annotation says failed")
 			found, err := utils.WaitPVCPodStatusRunning(f.K8sClient, pvc)

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -193,7 +193,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred())
 				Expect(same).To(BeTrue())
 				By("Verifying the image is sparse")
-				Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+				Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileSize)).To(BeTrue())
 				if utils.DefaultStorageCSIRespectsFsGroup {
 					// CSI storage class, it should respect fsGroup
 					By("Checking that disk image group is qemu")
@@ -492,7 +492,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						Expect(err).ToNot(HaveOccurred())
 						Expect(same).To(BeTrue())
 						By("Verifying the image is sparse")
-						Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+						Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileSize)).To(BeTrue())
 						if utils.DefaultStorageCSIRespectsFsGroup {
 							// CSI storage class, it should respect fsGroup
 							By("Checking that disk image group is qemu")
@@ -566,7 +566,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred())
 				Expect(same).To(BeTrue())
 				By("Verifying the image is sparse")
-				Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath)).To(BeTrue())
+				Expect(f.VerifySparse(f.Namespace, pvc, utils.DefaultImagePath, utils.UploadFileSize)).To(BeTrue())
 				if utils.DefaultStorageCSIRespectsFsGroup {
 					// CSI storage class, it should respect fsGroup
 					By("Checking that disk image group is qemu")

--- a/tests/utils/upload.go
+++ b/tests/utils/upload.go
@@ -41,6 +41,8 @@ const (
 
 	// UploadFileSize is the size of UploadFile
 	UploadFileSize = 18874368
+	// CirrosRawFileSize is the size of cirros.raw
+	CirrosRawFileSize = 46137344
 
 	// UploadFileMD5 is the expected MD5 of the uploaded file
 	UploadFileMD5 = "2a7a52285c846314d1dbd79e9818270d"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Handle some non-http sources where we lose sparseness similarly to https://github.com/kubevirt/containerized-data-importer/pull/3219

For this to be complete, we must fix the broken check for sparseness in e2e, to help us test against regression.
The first issue is that we look at content size since #2168,
which is not beneficial in the sparseness check as opposed to disk usage.

The second issue is that the check we have in tests for sparseness is not honest because of the "equal to" part.
The virtual size has to be strictly greater than the size on disk.

The third issue is that we almost always resize which results in significantly larger virtual size.
What we really care about is comparing against the original virtual size of the image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

