### PR TITLE
Improve http import flow to decide whether to use scratch space or not

### DIFF
--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -174,15 +174,15 @@ func (fr *FormatReaders) fileFormatSelector(hdr *image.Header) {
 			fr.Archived = true
 			fr.ArchiveZstd = true
 		}
-	case "qcow2":
-		r, err = fr.qcow2NopReader(hdr)
-		fr.Convert = true
 	case "xz":
 		r, err = fr.xzReader()
 		if err == nil {
 			fr.Archived = true
 			fr.ArchiveXz = true
 		}
+	case "qcow2":
+		r, err = fr.qcow2NopReader(hdr)
+		fr.Convert = true
 	case "vmdk":
 		r = nil
 		fr.Convert = true

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -133,9 +133,6 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 	if hs.contentType == cdiv1.DataVolumeArchive {
 		return ProcessingPhaseTransferDataDir, nil
 	}
-	if !hs.readers.Convert {
-		return ProcessingPhaseTransferDataFile, nil
-	}
 	if pullMethod, _ := util.ParseEnvVar(common.ImporterPullMethod, false); pullMethod == string(cdiv1.RegistryPullNode) {
 		hs.url, _ = url.Parse(fmt.Sprintf("nbd+unix:///?socket=%s", nbdkitSocket))
 		if err = hs.n.StartNbdkit(hs.endpoint.String()); err != nil {
@@ -143,9 +140,6 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 		}
 		return ProcessingPhaseConvert, nil
 	}
-	// removing check for hs.brokenForQemuImg, and always assuming it is true
-	// revert once we are able to get nbdkit 1.35.8, which contains a fix for the
-	// slow download speed.
 	return ProcessingPhaseTransferScratch, nil
 }
 

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -103,12 +103,12 @@ var _ = Describe("Http data source", func() {
 		Entry("return TransferTarget with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseTransferDataDir, diskimageArchiveData, false),
 	)
 
-	It("calling info with raw gz image should return TransferDataFile", func() {
+	It("calling info with raw gz image should return TransferScratch", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		newPhase, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(newPhase))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(newPhase))
 	})
 
 	DescribeTable("calling transfer should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, scratchPath string, want []byte, wantErr bool) {
@@ -149,20 +149,20 @@ var _ = Describe("Http data source", func() {
 		Entry("return Convert with scratch space and valid qcow file", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseConvert, "", cirrosData, false),
 	)
 
-	It("TransferFile should succeed when writing to valid file, and reading raw gz", func() {
+	It("TransferScratch should succeed when writing to valid file, and reading raw gz", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
-	It("TransferFile should succeed when writing to valid file and reading raw xz", func() {
+	It("TransferScratch should succeed when writing to valid file and reading raw xz", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreXz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
 	It("should get extra headers on creation of new HTTP data source", func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Follow up for https://github.com/kubevirt/containerized-data-importer/pull/3212.

Due to some performance issues discussed in https://github.com/kubevirt/containerized-data-importer/issues/2809, we stopped using nbdkit for most http imports and decided to use our custom scratch space method for most imports. This new behavior introduced minor differences in some specific flows, such as stopping the [conversion](https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/importer/data-processor.go#L268) of uncompressed raw images.

The conversion process made the actual size of raw images significantly smaller, probably because of qemu's handling of sparse images. The import of raw images without conversion ended up causing failures in some tests, as imported images had a significant increase in size.

This PR aims to fix this behavior by using scratch space with more import flows: All archived kubevirt imgs will be transfered direcly to file, while all non-archived kubevirt imgs will be imported to scratch.  

**Example:** 

Fresh image import before this PR:

```sh
sh-5.1$ qemu-img info disk.img 
image: disk.img
file format: raw
virtual size: 70 GiB (75161927680 bytes)
disk size: 55 GiB
```

Fresh image import after this PR (due to convert):

```sh
$ qemu-img info disk.img 
image: disk.img
file format: raw
virtual size: 70 GiB (75161927680 bytes)
disk size: 9.95 GiB
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36026

**Special notes for your reviewer**:

Check https://github.com/kubevirt/containerized-data-importer/issues/2809 and https://github.com/kubevirt/containerized-data-importer/pull/2832 for more context about the original change.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Use scratch space when importing non-archived images 
```

