### PR TITLE
[release-v1.58] Backport profile tunings for several provisioners

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -110,6 +110,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 var SourceFormatsByProvisionerKey = map[string]cdiv1.DataImportCronSourceFormat{
 	"rook-ceph.rbd.csi.ceph.com":         cdiv1.DataImportCronSourceFormatSnapshot,
 	"openshift-storage.rbd.csi.ceph.com": cdiv1.DataImportCronSourceFormatSnapshot,
+	"topolvm.cybozu.com":                 cdiv1.DataImportCronSourceFormatSnapshot,
+	"topolvm.io":                         cdiv1.DataImportCronSourceFormatSnapshot,
 }
 
 // CloneStrategyByProvisionerKey defines the advised clone strategy for a provisioner
@@ -131,6 +133,8 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"pxd.openstorage.org":                   cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com/shared":               cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com":                      cdiv1.CloneStrategyCsiClone,
+	"topolvm.cybozu.com":                    cdiv1.CloneStrategyCsiClone,
+	"topolvm.io":                            cdiv1.CloneStrategyCsiClone,
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -127,6 +127,10 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"openshift-storage.cephfs.csi.ceph.com": cdiv1.CloneStrategyCsiClone,
 	"csi.trident.netapp.io/ontap-nas":       cdiv1.CloneStrategyCsiClone,
 	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategyCsiClone,
+	"pxd.openstorage.org/shared":            cdiv1.CloneStrategyCsiClone,
+	"pxd.openstorage.org":                   cdiv1.CloneStrategyCsiClone,
+	"pxd.portworx.com/shared":               cdiv1.CloneStrategyCsiClone,
+	"pxd.portworx.com":                      cdiv1.CloneStrategyCsiClone,
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -112,6 +112,8 @@ var SourceFormatsByProvisionerKey = map[string]cdiv1.DataImportCronSourceFormat{
 	"openshift-storage.rbd.csi.ceph.com": cdiv1.DataImportCronSourceFormatSnapshot,
 	"topolvm.cybozu.com":                 cdiv1.DataImportCronSourceFormatSnapshot,
 	"topolvm.io":                         cdiv1.DataImportCronSourceFormatSnapshot,
+	"csi.trident.netapp.io/ontap-nas":    cdiv1.DataImportCronSourceFormatSnapshot,
+	"csi.trident.netapp.io/ontap-san":    cdiv1.DataImportCronSourceFormatSnapshot,
 }
 
 // CloneStrategyByProvisionerKey defines the advised clone strategy for a provisioner
@@ -127,14 +129,14 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"openshift-storage.rbd.csi.ceph.com":    cdiv1.CloneStrategyCsiClone,
 	"cephfs.csi.ceph.com":                   cdiv1.CloneStrategyCsiClone,
 	"openshift-storage.cephfs.csi.ceph.com": cdiv1.CloneStrategyCsiClone,
-	"csi.trident.netapp.io/ontap-nas":       cdiv1.CloneStrategyCsiClone,
-	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategyCsiClone,
 	"pxd.openstorage.org/shared":            cdiv1.CloneStrategyCsiClone,
 	"pxd.openstorage.org":                   cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com/shared":               cdiv1.CloneStrategyCsiClone,
 	"pxd.portworx.com":                      cdiv1.CloneStrategyCsiClone,
 	"topolvm.cybozu.com":                    cdiv1.CloneStrategyCsiClone,
 	"topolvm.io":                            cdiv1.CloneStrategyCsiClone,
+	"csi.trident.netapp.io/ontap-nas":       cdiv1.CloneStrategySnapshot,
+	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategySnapshot,
 }
 
 // ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-41449

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update portworx CSI to have CSI-clone clone strategy
LVMS tuned to default to CSI clones & snapshot dataimportcron sources
Trident ONTAP tuned to default to snapshot clone strategy & snapshot dataimportcron sources
```

