### PR TITLE
[release-v1.57] Manual backport of improve http import flow to decide whether to use scratch space or not

### DIFF
--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -175,15 +175,15 @@ func (fr *FormatReaders) fileFormatSelector(hdr *image.Header) {
 			fr.Archived = true
 			fr.ArchiveZstd = true
 		}
-	case "qcow2":
-		r, err = fr.qcow2NopReader(hdr)
-		fr.Convert = true
 	case "xz":
 		r, err = fr.xzReader()
 		if err == nil {
 			fr.Archived = true
 			fr.ArchiveXz = true
 		}
+	case "qcow2":
+		r, err = fr.qcow2NopReader(hdr)
+		fr.Convert = true
 	case "vmdk":
 		r = nil
 		fr.Convert = true

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -130,9 +130,6 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 	if hs.contentType == cdiv1.DataVolumeArchive {
 		return ProcessingPhaseTransferDataDir, nil
 	}
-	if !hs.readers.Convert {
-		return ProcessingPhaseTransferDataFile, nil
-	}
 	if pullMethod, _ := util.ParseEnvVar(common.ImporterPullMethod, false); pullMethod == string(cdiv1.RegistryPullNode) {
 		hs.url, _ = url.Parse(fmt.Sprintf("nbd+unix:///?socket=%s", nbdkitSocket))
 		if err = hs.n.StartNbdkit(hs.endpoint.String()); err != nil {
@@ -140,9 +137,6 @@ func (hs *HTTPDataSource) Info() (ProcessingPhase, error) {
 		}
 		return ProcessingPhaseConvert, nil
 	}
-	// removing check for hs.brokenForQemuImg, and always assuming it is true
-	// revert once we are able to get nbdkit 1.35.8, which contains a fix for the
-	// slow download speed.
 	return ProcessingPhaseTransferScratch, nil
 }
 

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -103,12 +103,12 @@ var _ = Describe("Http data source", func() {
 		table.Entry("return TransferTarget with archive content type and archive endpoint ", diskimageTarFileName, cdiv1.DataVolumeArchive, ProcessingPhaseTransferDataDir, diskimageArchiveData, false),
 	)
 
-	It("calling info with raw gz image should return TransferDataFile", func() {
+	It("calling info with raw gz image should return TransferScratch", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		newPhase, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(newPhase))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(newPhase))
 	})
 
 	table.DescribeTable("calling transfer should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, scratchPath string, want []byte, wantErr bool) {
@@ -149,20 +149,20 @@ var _ = Describe("Http data source", func() {
 		table.Entry("return Convert with scratch space and valid qcow file", cirrosFileName, cdiv1.DataVolumeKubeVirt, ProcessingPhaseConvert, "", cirrosData, false),
 	)
 
-	It("TransferFile should succeed when writing to valid file, and reading raw gz", func() {
+	It("TransferScratch should succeed when writing to valid file, and reading raw gz", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
-	It("TransferFile should succeed when writing to valid file and reading raw xz", func() {
+	It("TransferScratch should succeed when writing to valid file and reading raw xz", func() {
 		dp, err = NewHTTPDataSource(ts.URL+"/"+tinyCoreXz, "", "", "", cdiv1.DataVolumeKubeVirt)
 		Expect(err).NotTo(HaveOccurred())
 		result, err := dp.Info()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ProcessingPhaseTransferDataFile).To(Equal(result))
+		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
 	})
 
 	It("should get extra headers on creation of new HTTP data source", func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -940,12 +940,15 @@ var _ = Describe("[rfe_id:1115][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		restartsValue, status, err := utils.WaitForPVCAnnotation(f.K8sClient, f.Namespace.Name, pvc, controller.AnnPodRestarts)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(status).To(BeTrue())
-		Expect(restartsValue).To(Equal("0"))
+		// Restarting the pod for scratch space causes a restart in the DataVolume.
+		// This is expected behavior.
+		expectedRestarts := 1
+		Expect(restartsValue).To(Equal(strconv.Itoa(expectedRestarts)))
 
 		By("Verify the number of retries on the datavolume")
 		dv, err = f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(dv.Status.RestartCount).To(BeNumerically("==", 0))
+		Expect(dv.Status.RestartCount).To(BeNumerically("==", expectedRestarts))
 	})
 
 	It("[test_id:3996] Import datavolume with bad url will increase dv retry count", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3219.

We needed to adapt a functional test to account for DV restarts caused by scratch space.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-36026

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Use scratch space when importing non-archived images
```


