### PR TITLE
CDIStorageProfilesIncomplete should not impact operator health

### DIFF
--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -53,7 +53,7 @@ var operatorAlerts = []promv1.Rule{
 		},
 		Labels: map[string]string{
 			severityAlertLabelKey:        "info",
-			operatorHealthImpactLabelKey: "warning",
+			operatorHealthImpactLabelKey: "none",
 		},
 	},
 	{

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -148,6 +148,8 @@ const (
 	ProvisionerOCSBucket = "openshift-storage.ceph.rook.io/bucket"
 	// ProvisionerRookCephBucket is the provisioner string for the upstream Rook Ceph provisoner for buckets which does not work with CDI
 	ProvisionerRookCephBucket = "rook-ceph.ceph.rook.io/bucket"
+	// ProvisionerStorkSnapshot is the provisioner string for the Stork snapshot provisoner which does not work with CDI
+	ProvisionerStorkSnapshot = "stork-snapshot"
 )
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
@@ -156,6 +158,7 @@ var UnsupportedProvisioners = map[string]struct{}{
 	ProvisionerOCSBucket:      {},
 	ProvisionerRookCephBucket: {},
 	ProvisionerNoobaa:         {},
+	ProvisionerStorkSnapshot:  {},
 }
 
 // GetCapabilities finds and returns a predefined StorageCapabilities for a given StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
The alert caused OpenShift Virtualization operator status go degraded.

In addition add stork-snapshot to unsupported provisioners list, as stork snapshot provisioner does not work with CDI, and shouldn't cause CDIStorageProfilesIncomplete alert.

**Which issue(s) this PR fixes**:
Fixes # https://issues.redhat.com/browse/CNV-39569

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: CDIStorageProfilesIncomplete should not impact operator health
```

