### PR TITLE
[release-v1.57] CDIStorageProfilesIncomplete should not impact operator health

### DIFF
--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -201,7 +201,7 @@ func getAlertRules(runbookURLTemplate string) []promv1.Rule {
 			},
 			map[string]string{
 				severityAlertLabelKey:     "info",
-				healthImpactAlertLabelKey: "warning",
+				healthImpactAlertLabelKey: "none",
 				partOfAlertLabelKey:       partOfAlertLabelValue,
 				componentAlertLabelKey:    componentAlertLabelValue,
 			},

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -139,14 +139,23 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"csi.trident.netapp.io/ontap-san":       cdiv1.CloneStrategySnapshot,
 }
 
-// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
-const ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+const (
+	// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
+	ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+	// ProvisionerOCSBucket is the provisioner string for the downstream ODF/OCS provisoner for buckets which does not work with CDI
+	ProvisionerOCSBucket = "openshift-storage.ceph.rook.io/bucket"
+	// ProvisionerRookCephBucket is the provisioner string for the upstream Rook Ceph provisoner for buckets which does not work with CDI
+	ProvisionerRookCephBucket = "rook-ceph.ceph.rook.io/bucket"
+	// ProvisionerStorkSnapshot is the provisioner string for the Stork snapshot provisoner which does not work with CDI
+	ProvisionerStorkSnapshot = "stork-snapshot"
+)
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
 var UnsupportedProvisioners = map[string]struct{}{
-	// The following provisioners may be found in Rook/Ceph deployments and are related to object storage
-	"openshift-storage.ceph.rook.io/bucket": {},
-	ProvisionerNoobaa:                       {},
+	ProvisionerOCSBucket:      {},
+	ProvisionerRookCephBucket: {},
+	ProvisionerNoobaa:         {},
+	ProvisionerStorkSnapshot:  {},
 }
 
 // GetCapabilities finds and returns a predefined StorageCapabilities for a given StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #3232

The alert caused OpenShift Virtualization operator status go degraded.

Add unsupported provisioners that does not work with CDI and shouldn't cause CDIStorageProfilesIncomplete alert.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-39569

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: CDIStorageProfilesIncomplete should not impact operator health
```