### PR TITLE
[release-v1.55] Add unsupported provisioners for OCS bucket and Stork snapshot

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -102,14 +102,23 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.ovirt.org": createRWOBlockAndFilesystemCapabilities(),
 }
 
-// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
-const ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+const (
+	// ProvisionerNoobaa is the provisioner string for the Noobaa object bucket provisioner which does not work with CDI
+	ProvisionerNoobaa = "openshift-storage.noobaa.io/obc"
+	// ProvisionerOCSBucket is the provisioner string for the downstream ODF/OCS provisoner for buckets which does not work with CDI
+	ProvisionerOCSBucket = "openshift-storage.ceph.rook.io/bucket"
+	// ProvisionerRookCephBucket is the provisioner string for the upstream Rook Ceph provisoner for buckets which does not work with CDI
+	ProvisionerRookCephBucket = "rook-ceph.ceph.rook.io/bucket"
+	// ProvisionerStorkSnapshot is the provisioner string for the Stork snapshot provisoner which does not work with CDI
+	ProvisionerStorkSnapshot = "stork-snapshot"
+)
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
 var UnsupportedProvisioners = map[string]struct{}{
-	// The following provisioners may be found in Rook/Ceph deployments and are related to object storage
-	"openshift-storage.ceph.rook.io/bucket": {},
-	ProvisionerNoobaa:                       {},
+	ProvisionerOCSBucket:      {},
+	ProvisionerRookCephBucket: {},
+	ProvisionerNoobaa:         {},
+	ProvisionerStorkSnapshot:  {},
 }
 
 // GetCapabilities finds and returns a predefined StorageCapabilities for a given StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #3232 without the operator health impact change.

Add unsupported provisioners that does not work with CDI and shouldn't cause CDIStorageProfilesIncomplete alert.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-41510

**Special notes for your reviewer**:

**Release note**:
```release-note
 Add unsupported provisioners for OCS bucket and Stork snapshot
```

