### PR TITLE
Update DataVolume doc references from the 'pvc' API to the 'storage' API

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -31,8 +31,6 @@ spec:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   contentType: kubevirt
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi
@@ -50,8 +48,6 @@ spec:
          url: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz"
   contentType: archive
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi
@@ -67,8 +63,6 @@ spec:
   source:
       registry: "docker://kubevirt/fedora-cloud-registry-disk-demo"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi
@@ -91,8 +85,6 @@ spec:
   source:
       blank: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -30,7 +30,7 @@ spec:
       http:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   contentType: kubevirt
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -49,7 +49,7 @@ spec:
       http:
          url: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz"
   contentType: archive
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -66,7 +66,7 @@ metadata:
 spec:
   source:
       registry: "docker://kubevirt/fedora-cloud-registry-disk-demo"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -90,7 +90,7 @@ metadata:
 spec:
   source:
       blank: {}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/blank-raw-image.md
+++ b/doc/blank-raw-image.md
@@ -16,7 +16,7 @@ metadata:
 spec:
   source:
       blank: {}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/blank-raw-image.md
+++ b/doc/blank-raw-image.md
@@ -17,8 +17,6 @@ spec:
   source:
       blank: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/doc/clone-block-datavolume.md
+++ b/doc/clone-block-datavolume.md
@@ -21,7 +21,7 @@ spec:
     pvc:
       namespace: "source-ns"
       name: "source-datavolume"
-  pvc:
+  storage:
     volumeMode: Block
     accessModes:
       - ReadWriteOnce

--- a/doc/clone-block-datavolume.md
+++ b/doc/clone-block-datavolume.md
@@ -23,9 +23,6 @@ spec:
       name: "source-datavolume"
   storage:
     volumeMode: Block
-    resources:
-      requests:
-        storage: 1Gi
 ```
 
 Deploy the DataVolume manifest:

--- a/doc/clone-block-datavolume.md
+++ b/doc/clone-block-datavolume.md
@@ -23,8 +23,6 @@ spec:
       name: "source-datavolume"
   storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/doc/clone-datavolume.md
+++ b/doc/clone-datavolume.md
@@ -22,8 +22,6 @@ spec:
       namespace: source-ns
       name: source-datavolume
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/doc/clone-datavolume.md
+++ b/doc/clone-datavolume.md
@@ -21,7 +21,7 @@ spec:
     pvc:
       namespace: source-ns
       name: source-datavolume
-  storage:
+  storage: {}
 ```
 
 Deploy the DataVolume manifest:

--- a/doc/clone-datavolume.md
+++ b/doc/clone-datavolume.md
@@ -22,9 +22,6 @@ spec:
       namespace: source-ns
       name: source-datavolume
   storage:
-    resources:
-      requests:
-        storage: 500Mi
 ```
 
 Deploy the DataVolume manifest:

--- a/doc/clone-datavolume.md
+++ b/doc/clone-datavolume.md
@@ -21,7 +21,7 @@ spec:
     pvc:
       namespace: source-ns
       name: source-datavolume
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/clone-from-volumesnapshot-source.md
+++ b/doc/clone-from-volumesnapshot-source.md
@@ -77,8 +77,6 @@ spec:
       name: golden-volumesnapshot
   storage:
     storageClassName: rook-ceph-block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 9Gi

--- a/doc/datavolume-annotations.md
+++ b/doc/datavolume-annotations.md
@@ -22,7 +22,7 @@ spec:
   source:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -49,7 +49,7 @@ spec:
   source:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -81,7 +81,7 @@ spec:
   source:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/datavolume-annotations.md
+++ b/doc/datavolume-annotations.md
@@ -23,8 +23,6 @@ spec:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -50,8 +48,6 @@ spec:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -82,8 +78,6 @@ spec:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -54,7 +54,7 @@ spec:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img" # S3 or GCS
          secretRef: "" # Optional
          certConfigMap: "" # Optional
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -90,7 +90,7 @@ spec:
          url: "http://server/archive.tar"
          secretRef: "" # Optional
    contentType: "archive"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -112,7 +112,7 @@ spec:
          extraHeaders:
          - "X-First-Header: 12345"
          - "X-Another-Header: abcde"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -136,7 +136,7 @@ spec:
          secretExtraHeaders:
            - "first-secret"
            - "second-secret"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -169,7 +169,7 @@ metadata:
   name: "example-clone-dv"
 spec:
   source:
-      pvc:
+      storage:
         name: source-pvc
         namespace: example-ns
   storage:
@@ -208,7 +208,7 @@ metadata:
 spec:
   source:
     upload: {}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -226,7 +226,7 @@ metadata:
 spec:
   source:
     blank: {}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -248,7 +248,7 @@ spec:
          secretRef: "endpoint-secret"
          certConfigMap: "tls-certs"
          diskId: "1"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -275,7 +275,7 @@ spec:
            thumbprint: "20:6C:8A:5D:44:40:B3:79:4B:28:EA:76:13:60:90:6E:49:D9:D9:A3" # SSL fingerprint of vCenter/ESX host
            secretRef: "vddk-credentials"
            initImageURL: "registry:5000/vddk-init:latest"
-    pvc:
+    storage:
        accessModes:
          - ReadWriteOnce
        resources:
@@ -312,7 +312,7 @@ metadata:
       current: "1c44c27e-d2d8-49c4-841a-cc26c4b1e406"
     - previous: "1c44c27e-d2d8-49c4-841a-cc26c4b1e406"
       current: "c55bb7bb-20f2-46b5-a7f3-11fd6010b7d0"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -344,7 +344,7 @@ spec:
         previous: ""
       - current: "snapshot-2"
         previous: "snapshot-1"
-    pvc:
+    storage:
        accessModes:
          - ReadWriteOnce
        resources:
@@ -459,7 +459,7 @@ spec:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img" # S3 or GCS
          secretRef: "" # Optional
          certConfigMap: "" # Optional
-  pvc:
+  storage:
     volumeMode: Block
     accessModes:
       - ReadWriteOnce
@@ -496,8 +496,8 @@ metadata:
 spec:
   priorityClassName: kubevirt
   source:
-   ....
-  pvc:
+    ...
+  storage:
     ...
 ```
 
@@ -532,7 +532,7 @@ spec:
       creationTimestamp: null
       name: fedora-dv
     spec:
-      pvc:
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -69,7 +69,7 @@ spec:
 ```
 
 ### Storage
-The `storage` type is similar to `pvc` but it allows you to ommit some parameters.
+The `storage` type is similar to `pvc` but it allows you to omit some parameters.
 
 > [!TIP]
 > With the storage API, CDI computes virtualization-specific defaults for optional
@@ -83,13 +83,13 @@ or implicitly as explained in the previous paragraph), CDI will take the file sy
 overhead into account and request a PVC big enough to fit both an image and the file
 system metadata. This logic only applies to the `DataVolume.spec.storage`.
 
-If you skip the `storageClassName` name parameter, CDI will prioritize the default
+If you skip the `storageClassName` parameter, CDI will prioritize the default
 virtualization storage class over k8s' default. You can define your default
 virtualization storage class by annotating it with
 `storageclass.kubevirt.io/is-default-virt-class` set to `"true"`.
 
 This example shows a request for a PVC with at least 1Gi of storage. Other fields are
-left for CDI to fill.
+left for CDI to fill in.
 ```yaml
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -78,14 +78,15 @@ The `storage` type is similar to `pvc` but it allows you to ommit some parameter
 If you skip the `volumeMode` parameter, CDI will search for a default value in the
 StorageProfile. See also: [storage profile documentation](storageprofile.md).
 
+If the volume mode is set to `fileSystem` (either explicitly with `volumeMode: fileSystem`,
+or implicitly as explained in the previous paragraph), CDI will take the file system
+overhead into account and request a PVC big enough to fit both an image and the file
+system metadata. This logic only applies to the `DataVolume.spec.storage`.
+
 If you skip the `storageClassName` name parameter, CDI will prioritize the default
 virtualization storage class over k8s' default. You can define your default
 virtualization storage class by annotating it with
 `storageclass.kubevirt.io/is-default-virt-class` set to `"true"`.
-
-If you request storage with `volumeMode: fileSystem`, CDI will take the file system
-overhead into account and request a PVC big enough to fit both an image and the
-file system metadata. This logic only applies to the `DataVolume.spec.storage`.
 
 This example shows a request for a PVC with at least 1Gi of storage. Other fields are
 left for CDI to fill.

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -40,7 +40,7 @@ The following statuses are possible.
 
 ## Target Storage/PVC
 
-There are two ways to request a storage - by using either the `pvc` or the `storage` section in the DataVolume resource yaml.
+There are two ways to request storage - by using either the `pvc` or the `storage` section in the DataVolume resource yaml.
 Both result in CDI creating a PVC resource, but there are some differences in how they work.
 
 > [!NOTE] 

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -431,7 +431,7 @@ spec:
         storage: 1Gi
 ```
 
-`Storage` can request specific size the same way as `pvc`. When requesting a storage with the fileSystem volumeMode CDI 
+With `storage`, you can request a specific size the same way as with `pvc`. When requesting a storage with the fileSystem volumeMode CDI 
 takes into account the file system overhead and requests PVC big enough to fit an image and file system metadata. 
 This logic is only applied for the DataVolume.spec.storage. 
 

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -55,8 +55,6 @@ spec:
          secretRef: "" # Optional
          certConfigMap: "" # Optional
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"
@@ -91,8 +89,6 @@ spec:
          secretRef: "" # Optional
    contentType: "archive"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"
@@ -113,8 +109,6 @@ spec:
          - "X-First-Header: 12345"
          - "X-Another-Header: abcde"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"
@@ -137,8 +131,6 @@ spec:
            - "first-secret"
            - "second-secret"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"
@@ -173,8 +165,6 @@ spec:
         name: source-pvc
         namespace: example-ns
   storage:
-    accessModes:
-      - ReadWriteOnce
 ```
 
 However, when using the [pvc](#pvc) API, the user needs to specify the right amount of space to allocate for the new DV, or the clone will not be able to complete.
@@ -209,8 +199,6 @@ spec:
   source:
     upload: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -227,8 +215,6 @@ spec:
   source:
     blank: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -249,8 +235,6 @@ spec:
          certConfigMap: "tls-certs"
          diskId: "1"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "500Mi"
@@ -313,8 +297,6 @@ metadata:
     - previous: "1c44c27e-d2d8-49c4-841a-cc26c4b1e406"
       current: "c55bb7bb-20f2-46b5-a7f3-11fd6010b7d0"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "32Gi"
@@ -424,8 +406,6 @@ spec:
   source:
     blank: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -461,8 +441,6 @@ spec:
          certConfigMap: "" # Optional
   storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -22,8 +22,6 @@ spec:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -21,7 +21,7 @@ spec:
   source:
       http:
          url: "http://mirrors.nav.ro/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -87,7 +87,7 @@ spec:
   source:
     registry:
       url: "docker://kubevirt/fedora-cloud-registry-disk-demo"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -168,7 +168,7 @@ spec:
     registry:
       url: "docker://kubevirt/cirros-container-disk-demo:devel"
       pullMethod: node
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:
@@ -188,7 +188,7 @@ spec:
     registry:
       imageStream: rhel8-guest-is
       pullMethod: node
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/doc/image-from-registry.md
+++ b/doc/image-from-registry.md
@@ -88,8 +88,6 @@ spec:
     registry:
       url: "docker://kubevirt/fedora-cloud-registry-disk-demo"
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi
@@ -169,8 +167,6 @@ spec:
       url: "docker://kubevirt/cirros-container-disk-demo:devel"
       pullMethod: node
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi
@@ -189,8 +185,6 @@ spec:
       imageStream: rhel8-guest-is
       pullMethod: node
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi

--- a/doc/import-block-pv.md
+++ b/doc/import-block-pv.md
@@ -64,7 +64,7 @@ spec:
   source:
       http:
          url: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso"
-  pvc:
+  storage:
     volumeMode: Block
     accessModes:
       - ReadWriteOnce

--- a/doc/import-block-pv.md
+++ b/doc/import-block-pv.md
@@ -66,8 +66,6 @@ spec:
          url: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso"
   storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/doc/local-storage-selector.md
+++ b/doc/local-storage-selector.md
@@ -88,7 +88,7 @@ spec:
   source:
       http:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     selector:

--- a/doc/local-storage-selector.md
+++ b/doc/local-storage-selector.md
@@ -89,8 +89,6 @@ spec:
       http:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
   storage:
-    accessModes:
-      - ReadWriteOnce
     selector:
       matchLabels:
         node: node01

--- a/doc/preallocation.md
+++ b/doc/preallocation.md
@@ -25,7 +25,7 @@ metadata:
 spec:
   source:
     ...
-  pvc:
+  storage:
     ...
   preallocation: true
 ```

--- a/doc/upload.md
+++ b/doc/upload.md
@@ -77,8 +77,6 @@ spec:
   source:
       upload: {}
   storage:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/doc/upload.md
+++ b/doc/upload.md
@@ -76,7 +76,7 @@ metadata:
 spec:
   source:
       upload: {}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/manifests/example/blank-image-datavolume.yaml
+++ b/manifests/example/blank-image-datavolume.yaml
@@ -6,9 +6,7 @@ metadata:
 spec:
   source:
       blank: {}
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/clone-block-datavolume.yaml
+++ b/manifests/example/clone-block-datavolume.yaml
@@ -7,10 +7,5 @@ spec:
     pvc:
       namespace: default
       name: import-kubevirt-block-datavolume
-  pvc:
+  storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi

--- a/manifests/example/clone-datavolume.yaml
+++ b/manifests/example/clone-datavolume.yaml
@@ -8,9 +8,4 @@ spec:
     pvc:
       namespace: source-ns
       name: source-datavolume
-  pvc:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 500Mi
+  storage:

--- a/manifests/example/import-archive-block-datavolume.yaml
+++ b/manifests/example/import-archive-block-datavolume.yaml
@@ -8,10 +8,8 @@ spec:
       http:
          url: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz" #This url is just an example. You should change this to your destination url
   contentType: archive
-  pvc:
+  storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/import-archive-datavolume.yaml
+++ b/manifests/example/import-archive-datavolume.yaml
@@ -8,9 +8,7 @@ spec:
       http:
          url: "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz" #This url is just an example. You should change this to your destination url
   contentType: archive
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/import-kubevirt-block-datavolume.yaml
+++ b/manifests/example/import-kubevirt-block-datavolume.yaml
@@ -6,7 +6,7 @@ spec:
   source:
     http:
       url: "http://distro.ibiblio.org/tinycorelinux/9.x/x86/release/Core-current.iso"
-  pvc:
+  storage:
     # Optional: Set the storage class or omit to accept the default
     storageClassName: local
     volumeMode: Block

--- a/manifests/example/import-kubevirt-datavolume-gcs.yaml
+++ b/manifests/example/import-kubevirt-datavolume-gcs.yaml
@@ -8,9 +8,7 @@ spec:
       gcs:
          url: "gs://bucket/file.img"
          secretRef: "gcs-secret"
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/import-kubevirt-datavolume-secret.yaml
+++ b/manifests/example/import-kubevirt-datavolume-secret.yaml
@@ -8,9 +8,7 @@ spec:
       http:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
          secretRef: endpoint-secret #If you are using the endpoint-secret.yaml example.
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/import-kubevirt-datavolume.yaml
+++ b/manifests/example/import-kubevirt-datavolume.yaml
@@ -7,9 +7,7 @@ spec:
   source:
       http:
          url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/registry-image-block-datavolume.yaml
+++ b/manifests/example/registry-image-block-datavolume.yaml
@@ -7,10 +7,8 @@ spec:
   source:
     registry:
       url: "docker://kubevirt/fedora-cloud-registry-disk-demo"
-  pvc:
+  storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi

--- a/manifests/example/registry-image-datavolume.yaml
+++ b/manifests/example/registry-image-datavolume.yaml
@@ -7,9 +7,7 @@ spec:
   source:
     registry:
       url: "docker://kubevirt/fedora-cloud-registry-disk-demo"
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 5Gi

--- a/manifests/example/upload-block-datavolume.yaml
+++ b/manifests/example/upload-block-datavolume.yaml
@@ -5,10 +5,8 @@ metadata:
 spec:
   source:
       upload: {}
-  pvc:
+  storage:
     volumeMode: Block
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi

--- a/manifests/example/upload-datavolume.yaml
+++ b/manifests/example/upload-datavolume.yaml
@@ -6,9 +6,7 @@ metadata:
 spec:
   source:
       upload: {}
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/templates/upgrade-testing-artifacts.yaml.in
+++ b/manifests/templates/upgrade-testing-artifacts.yaml.in
@@ -16,9 +16,7 @@ spec:
   source:
       http:
          url: "http://cdi-file-host.{{ .Namespace }}/tinyCore.iso"
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 500Mi

--- a/manifests/templates/upgrade-testing-artifacts.yaml.in
+++ b/manifests/templates/upgrade-testing-artifacts.yaml.in
@@ -17,6 +17,8 @@ spec:
       http:
          url: "http://cdi-file-host.{{ .Namespace }}/tinyCore.iso"
   storage:
+    accessModes:
+      - ReadWriteOnce
     resources:
       requests:
         storage: 500Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Updates `DataVolume` examples and documentation so they use the `storage` API instead of the `pvc` API, except for a couple of places where the use of `pvc` is relevant (to contrast it to the `storage` API).

Furthermore:
- Removed the `ReadWriteOnce` argument as it is set by default when using the storage API.
- Removed the storage resources requests when cloning from a PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://issues.redhat.com/browse/CNV-38189

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

