### PR TITLE
Fix cluster-sync wait_cdi_crd_installed timeout check

### DIFF
--- a/cluster-sync/install.sh
+++ b/cluster-sync/install.sh
@@ -19,7 +19,7 @@ function install_cdi {
 function wait_cdi_crd_installed {
   timeout=$1
   crd_defined=0
-  while [ $crd_defined -eq 0 ] && [ $timeout > 0 ]; do
+  while [ $crd_defined -eq 0 ] && [ $timeout -gt 0 ]; do
       crd_defined=$(_kubectl get customresourcedefinition| grep cdis.cdi.kubevirt.io | wc -l)
       sleep 1
       timeout=$(($timeout-1))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes a line in the cluster-up script that was writing to file `./0` instead of performing a greater-than comparison.

I always had this suspicious file in my git diff and after a couple greps for `> 0`, I found the culprit.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

