### PR TITLE
Add Huawei storagecapabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -49,9 +49,9 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"cephfs.csi.ceph.com":                   {{rwx, file}},
 	"openshift-storage.cephfs.csi.ceph.com": {{rwx, file}},
 	// LINSTOR
-	"linstor.csi.linbit.com": createLinstorCapabilities(),
+	"linstor.csi.linbit.com": createAllButRWXFileCapabilities(),
 	// DELL Unity XT
-	"csi-unity.dellemc.com":     createDellUnityCapabilities(),
+	"csi-unity.dellemc.com":     createAllButRWXFileCapabilities(),
 	"csi-unity.dellemc.com/nfs": createAllFSCapabilities(),
 	// DELL PowerFlex
 	"csi-vxflexos.dellemc.com":     createDellPowerFlexCapabilities(),
@@ -115,6 +115,9 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// vSphere
 	"csi.vsphere.vmware.com":     {{rwo, block}, {rwo, file}},
 	"csi.vsphere.vmware.com/nfs": {{rwx, file}, {rwo, block}, {rwo, file}},
+	// huawei
+	"csi.huawei.com":     createAllButRWXFileCapabilities(),
+	"csi.huawei.com/nfs": createAllFSCapabilities(),
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format
@@ -329,6 +332,14 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 			return "csi-powermax.dellemc.com"
 		}
 	},
+	"csi.huawei.com": func(sc *storagev1.StorageClass) string {
+		switch sc.Parameters["protocol"] {
+		case "nfs":
+			return "csi.huawei.com/nfs"
+		default:
+			return "csi.huawei.com"
+		}
+	},
 }
 
 func getFSType(sc *storagev1.StorageClass) string {
@@ -343,17 +354,7 @@ func createRbdCapabilities() []StorageCapabilities {
 	}
 }
 
-func createLinstorCapabilities() []StorageCapabilities {
-	return []StorageCapabilities{
-		{rwx, block},
-		{rwo, block},
-		{rwo, file},
-		{rox, block},
-		{rox, file},
-	}
-}
-
-func createDellUnityCapabilities() []StorageCapabilities {
+func createAllButRWXFileCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{rwx, block},
 		{rwo, block},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: Ido Aharon <iaharon@redhat.com>

**What this PR does / why we need it**:
Adding storagecapabilities to the Huawei provisioner. 
According to [eSDK Huawei Storage Kubernetes CSI Plugins V4.3.0 User Guide 02.pdf](https://github.com/kubevirt/containerized-data-importer/files/15321394/eSDK.Huawei.Storage.Kubernetes.CSI.Plugins.V4.3.0.User.Guide.02.pdf), the provisioner string is `csi.huawei.com` and the storage profile is `{ {rwx, file}, {rwo, file}, {rox, file} }` if `sc.Parameters["protocol"] == "nfs" `and `{ {rwx, block}, {rwo, block}, {rwo, file}, {rox, block}, {rox, file} }` otherwise:

> RWO/ROX/RWOP: supported by all types of volumes. RWOP is supported only by kubernetes 1.22 and later versions.
RWX: supported only by Raw Block volumes and NFS volumes

> Parameter: parameters.protocol
Description: Storage protocol. The value is a character string. (iscsi, fc, roce, fc-nvme, nfs, dpc, scsi)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[CNV-41636](https://issues.redhat.com/browse/CNV-41636)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add storagecapabilities to csi.huawei.com provisioner
```

