### PR TITLE
Progress metrics refactor and rename

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -9,10 +9,10 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -13,11 +13,11 @@ import (
 	"strconv"
 
 	"github.com/golang/snappy"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 	prometheusutil "kubevirt.io/containerized-data-importer/pkg/util/prometheus"
 )
@@ -99,20 +99,14 @@ func startPrometheus() {
 	prometheusutil.StartPrometheusEndpoint(certsDirectory)
 }
 
-func createProgressReader(readCloser io.ReadCloser, ownerUID string, totalBytes uint64) io.ReadCloser {
-	progress := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "clone_progress",
-			Help: "The clone progress in percentage",
-		},
-		[]string{"ownerUID"},
-	)
-	prometheus.MustRegister(progress)
-
-	promReader := prometheusutil.NewProgressReader(readCloser, totalBytes, progress, ownerUID)
+func createProgressReader(readCloser io.ReadCloser, ownerUID string, totalBytes uint64) (io.ReadCloser, error) {
+	if err := metrics.SetupMetrics(); err != nil {
+		return nil, err
+	}
+	promReader := prometheusutil.NewProgressReader(readCloser, totalBytes, ownerUID)
 	promReader.StartTimedUpdate()
 
-	return promReader
+	return promReader, nil
 }
 
 func pipeToSnappy(reader io.ReadCloser) io.ReadCloser {
@@ -246,7 +240,11 @@ func main() {
 
 	klog.V(1).Infoln("Starting cloner target")
 
-	reader := pipeToSnappy(createProgressReader(getInputStream(preallocation), ownerUID, uploadBytes))
+	progressReader, err := createProgressReader(getInputStream(preallocation), ownerUID, uploadBytes)
+	if err != nil {
+		klog.Fatalf("Error creating progress reader: %v", err)
+	}
+	reader := pipeToSnappy(progressReader)
 
 	startPrometheus()
 

--- a/cmd/openstack-populator/BUILD.bazel
+++ b/cmd/openstack-populator/BUILD.bazel
@@ -6,13 +6,12 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/cmd/openstack-populator",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/monitoring/metrics/openstack-populator:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata:go_default_library",
         "//vendor/github.com/gophercloud/utils/openstack/clientconfig:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/cmd/ovirt-populator/BUILD.bazel
+++ b/cmd/ovirt-populator/BUILD.bazel
@@ -6,9 +6,8 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/cmd/ovirt-populator",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/monitoring/metrics/ovirt-populator:go_default_library",
         "//pkg/util/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -3,6 +3,9 @@
 ### kubevirt_cdi_clone_pods_high_restart
 The number of CDI clone pods with high restart count. Type: Gauge.
 
+### kubevirt_cdi_clone_progress_total
+The clone progress in percentage. Type: Counter.
+
 ### kubevirt_cdi_cr_ready
 CDI install ready. Type: Gauge.
 
@@ -15,8 +18,14 @@ Number of DataVolumes pending for default storage class to be configured. Type: 
 ### kubevirt_cdi_import_pods_high_restart
 The number of CDI import pods with high restart count. Type: Gauge.
 
+### kubevirt_cdi_openstack_populator_progress_total
+Progress of volume population. Type: Counter.
+
 ### kubevirt_cdi_operator_up
 CDI operator status. Type: Gauge.
+
+### kubevirt_cdi_ovirt_progress_total
+Progress of volume population. Type: Counter.
 
 ### kubevirt_cdi_storageprofile_info
 `StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone. Type: Gauge.

--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -439,7 +439,7 @@ func (r *ForkliftPopulatorReconciler) updateImportProgress(podPhase string, pvc,
 	}
 
 	// We fetch the import progress from the import pod metrics
-	importRegExp := regexp.MustCompile("progress\\{ownerUID\\=\"" + string(pvc.UID) + "\"\\} (\\d{1,3}\\.?\\d*)")
+	importRegExp := regexp.MustCompile("progress_total\\{ownerUID\\=\"" + string(pvc.UID) + "\"\\} (\\d{1,3}\\.?\\d*)")
 	httpClient = cc.BuildHTTPClient(httpClient)
 	progressReport, err := cc.GetProgressReportFromURL(url, importRegExp, httpClient)
 	if err != nil {

--- a/pkg/controller/populators/forklift-populator_test.go
+++ b/pkg/controller/populators/forklift-populator_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Forklift populator tests", func() {
 			pvcPrime.Annotations = map[string]string{AnnImportPod: importPodName}
 
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte(fmt.Sprintf("openstack_populator_progress{ownerUID=\"%v\"} 13.45", targetPvc.GetUID())))
+				_, _ = w.Write([]byte(fmt.Sprintf("kubevirt_cdi_openstack_populator_progress_total{ownerUID=\"%v\"} 13.45", targetPvc.GetUID())))
 				w.WriteHeader(200)
 			}))
 			defer ts.Close()

--- a/pkg/image/BUILD.bazel
+++ b/pkg/image/BUILD.bazel
@@ -13,12 +13,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/system:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/docker/go-units:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
@@ -34,12 +33,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/system:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -27,13 +27,13 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	"kubevirt.io/containerized-data-importer/pkg/system"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -76,13 +76,6 @@ var (
 	qemuIterface     = NewQEMUOperations()
 	re               = regexp.MustCompile(matcherString)
 
-	progress = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "clone_progress",
-			Help: "The clone progress in percentage",
-		},
-		[]string{"ownerUID"},
-	)
 	ownerUID                    string
 	convertPreallocationMethods = [][]string{
 		{"-o", "preallocation=falloc"},
@@ -97,14 +90,8 @@ var (
 )
 
 func init() {
-	if err := prometheus.Register(progress); err != nil {
-		if are := (prometheus.AlreadyRegisteredError{}); errors.As(err, &are) {
-			// A counter for that metric has been registered before.
-			// Use the old counter from now on.
-			progress = are.ExistingCollector.(*prometheus.CounterVec)
-		} else {
-			klog.Errorf("Unable to create prometheus progress counter")
-		}
+	if err := metrics.SetupMetrics(); err != nil {
+		klog.Errorf("Unable to create prometheus progress counter: %v", err)
 	}
 	ownerUID, _ = util.ParseEnvVar(common.OwnerUID, false)
 }
@@ -288,9 +275,9 @@ func reportProgress(line string) {
 		// Don't need to check for an error, the regex made sure its a number we can parse.
 		v, _ := strconv.ParseFloat(matches[1], 64)
 		metric := &dto.Metric{}
-		err := progress.WithLabelValues(ownerUID).Write(metric)
+		err := metrics.WriteCloneProgress(ownerUID, metric)
 		if err == nil && v > 0 && v > *metric.Counter.Value {
-			progress.WithLabelValues(ownerUID).Add(v - *metric.Counter.Value)
+			metrics.AddCloneProgress(ownerUID, v-*metric.Counter.Value)
 		}
 	}
 }

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
-	dto "github.com/prometheus/client_model/go"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -274,10 +273,9 @@ func reportProgress(line string) {
 		klog.V(1).Info(matches[1])
 		// Don't need to check for an error, the regex made sure its a number we can parse.
 		v, _ := strconv.ParseFloat(matches[1], 64)
-		metric := &dto.Metric{}
-		err := metrics.WriteCloneProgress(ownerUID, metric)
-		if err == nil && v > 0 && v > *metric.Counter.Value {
-			metrics.AddCloneProgress(ownerUID, v-*metric.Counter.Value)
+		progress, err := metrics.GetCloneProgress(ownerUID)
+		if err == nil && v > 0 && v > progress {
+			metrics.AddCloneProgress(ownerUID, v-progress)
 		}
 	}
 }

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/image:go_default_library",
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
@@ -41,14 +42,12 @@ go_library(
         "//vendor/github.com/ovirt/go-ovirt-client:go_default_library",
         "//vendor/github.com/ovirt/go-ovirt-client-log-klog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/ulikunitz/xz:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
-            "//vendor/github.com/prometheus/client_model/go:go_default_library",
             "//vendor/github.com/vmware/govmomi:go_default_library",
             "//vendor/github.com/vmware/govmomi/find:go_default_library",
             "//vendor/github.com/vmware/govmomi/object:go_default_library",

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -34,7 +34,6 @@ import (
 	"syscall"
 	"time"
 
-	dto "github.com/prometheus/client_model/go"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -1038,10 +1037,9 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 			previousProgressPercent = currentProgressPercent
 		}
 		v := float64(currentProgressPercent)
-		metric := &dto.Metric{}
-		err = metrics.WriteCloneProgress(ownerUID, metric)
-		if err == nil && v > 0 && v > *metric.Counter.Value {
-			metrics.AddCloneProgress(ownerUID, v-*metric.Counter.Value)
+		progress, err := metrics.GetCloneProgress(ownerUID)
+		if err == nil && v > 0 && v > progress {
+			metrics.AddCloneProgress(ownerUID, v-progress)
 		}
 	}
 

--- a/pkg/monitoring/metrics/cdi-cloner/BUILD.bazel
+++ b/pkg/monitoring/metrics/cdi-cloner/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clone_metrics.go",
+        "metrics.go",
+    ],
+    importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics:go_default_library",
+    ],
+)

--- a/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
@@ -10,30 +10,29 @@ var (
 		cloneProgress,
 	}
 
-	cloneProgress = newCloneProgressCounterVec()
-)
-
-// InitCloneProgressCounterVec initizlizes the cloneProgress metric
-func InitCloneProgressCounterVec() {
-	cloneProgress = newCloneProgressCounterVec()
-}
-
-func newCloneProgressCounterVec() *operatormetrics.CounterVec {
-	return operatormetrics.NewCounterVec(
+	cloneProgress = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_cdi_clone_progress",
 			Help: "The clone progress in percentage",
 		},
 		[]string{"ownerUID"},
 	)
-}
+)
 
 // AddCloneProgress adds value to the cloneProgress metric
 func AddCloneProgress(labelValue string, value float64) {
 	cloneProgress.WithLabelValues(labelValue).Add(value)
 }
 
-// WriteCloneProgress writes the cloneProgress metric into a metric protocol buffer
-func WriteCloneProgress(labelValue string, metric *ioprometheusclient.Metric) error {
-	return cloneProgress.WithLabelValues(labelValue).Write(metric)
+// GetCloneProgress returns the cloneProgress value
+func GetCloneProgress(labelValue string) (float64, error) {
+	dto := &ioprometheusclient.Metric{}
+	if err := cloneProgress.WithLabelValues(labelValue).Write(dto); err != nil {
+		return 0, err
+	}
+	return dto.Counter.GetValue(), nil
+}
+
+func DeleteCloneProgress(labelValue string) {
+	cloneProgress.DeleteLabelValues(labelValue)
 }

--- a/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
@@ -12,7 +12,7 @@ var (
 
 	cloneProgress = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_cdi_clone_progress",
+			Name: "kubevirt_cdi_clone_progress_total",
 			Help: "The clone progress in percentage",
 		},
 		[]string{"ownerUID"},

--- a/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/clone_metrics.go
@@ -1,0 +1,39 @@
+package cdicloner
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	ioprometheusclient "github.com/prometheus/client_model/go"
+)
+
+var (
+	clonerMetrics = []operatormetrics.Metric{
+		cloneProgress,
+	}
+
+	cloneProgress = newCloneProgressCounterVec()
+)
+
+// InitCloneProgressCounterVec initizlizes the cloneProgress metric
+func InitCloneProgressCounterVec() {
+	cloneProgress = newCloneProgressCounterVec()
+}
+
+func newCloneProgressCounterVec() *operatormetrics.CounterVec {
+	return operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_cdi_clone_progress",
+			Help: "The clone progress in percentage",
+		},
+		[]string{"ownerUID"},
+	)
+}
+
+// AddCloneProgress adds value to the cloneProgress metric
+func AddCloneProgress(labelValue string, value float64) {
+	cloneProgress.WithLabelValues(labelValue).Add(value)
+}
+
+// WriteCloneProgress writes the cloneProgress metric into a metric protocol buffer
+func WriteCloneProgress(labelValue string, metric *ioprometheusclient.Metric) error {
+	return cloneProgress.WithLabelValues(labelValue).Write(metric)
+}

--- a/pkg/monitoring/metrics/cdi-cloner/metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/metrics.go
@@ -1,0 +1,20 @@
+package cdicloner
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// SetupMetrics register prometheus metrics
+func SetupMetrics() error {
+	operatormetrics.Register = runtimemetrics.Registry.Register
+	return operatormetrics.RegisterMetrics(
+		clonerMetrics,
+	)
+}
+
+// ListMetrics registered prometheus metrics
+func ListMetrics() []operatormetrics.Metric {
+	return operatormetrics.ListMetrics()
+}

--- a/pkg/monitoring/metrics/cdi-cloner/metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/metrics.go
@@ -9,6 +9,7 @@ import (
 // SetupMetrics register prometheus metrics
 func SetupMetrics() error {
 	operatormetrics.Register = runtimemetrics.Registry.Register
+	operatormetrics.Unregister = runtimemetrics.Registry.Unregister
 	return operatormetrics.RegisterMetrics(
 		clonerMetrics,
 	)

--- a/pkg/monitoring/metrics/cdi-cloner/metrics.go
+++ b/pkg/monitoring/metrics/cdi-cloner/metrics.go
@@ -14,8 +14,3 @@ func SetupMetrics() error {
 		clonerMetrics,
 	)
 }
-
-// ListMetrics registered prometheus metrics
-func ListMetrics() []operatormetrics.Metric {
-	return operatormetrics.ListMetrics()
-}

--- a/pkg/monitoring/metrics/cdi-controller/metrics.go
+++ b/pkg/monitoring/metrics/cdi-controller/metrics.go
@@ -15,8 +15,3 @@ func SetupMetrics() error {
 		dataVolumeMetrics,
 	)
 }
-
-// ListMetrics registered prometheus metrics
-func ListMetrics() []operatormetrics.Metric {
-	return operatormetrics.ListMetrics()
-}

--- a/pkg/monitoring/metrics/openstack-populator/BUILD.bazel
+++ b/pkg/monitoring/metrics/openstack-populator/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "metrics.go",
+        "populator_metrics.go",
+    ],
+    importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/openstack-populator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics:go_default_library",
+    ],
+)

--- a/pkg/monitoring/metrics/openstack-populator/metrics.go
+++ b/pkg/monitoring/metrics/openstack-populator/metrics.go
@@ -1,0 +1,21 @@
+package openstackpopulator
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// SetupMetrics register prometheus metrics
+func SetupMetrics() error {
+	operatormetrics.Register = runtimemetrics.Registry.Register
+	operatormetrics.Unregister = runtimemetrics.Registry.Unregister
+	return operatormetrics.RegisterMetrics(
+		populatorMetrics,
+	)
+}
+
+// ListMetrics registered prometheus metrics
+func ListMetrics() []operatormetrics.Metric {
+	return operatormetrics.ListMetrics()
+}

--- a/pkg/monitoring/metrics/openstack-populator/metrics.go
+++ b/pkg/monitoring/metrics/openstack-populator/metrics.go
@@ -14,8 +14,3 @@ func SetupMetrics() error {
 		populatorMetrics,
 	)
 }
-
-// ListMetrics registered prometheus metrics
-func ListMetrics() []operatormetrics.Metric {
-	return operatormetrics.ListMetrics()
-}

--- a/pkg/monitoring/metrics/openstack-populator/populator_metrics.go
+++ b/pkg/monitoring/metrics/openstack-populator/populator_metrics.go
@@ -1,0 +1,34 @@
+package openstackpopulator
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	ioprometheusclient "github.com/prometheus/client_model/go"
+)
+
+var (
+	populatorMetrics = []operatormetrics.Metric{
+		populatorProgress,
+	}
+
+	populatorProgress = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "openstack_populator_progress",
+			Help: "Progress of volume population",
+		},
+		[]string{"ownerUID"},
+	)
+)
+
+// AddPopulatorProgress adds value to the populatorProgress metric
+func AddPopulatorProgress(labelValue string, value float64) {
+	populatorProgress.WithLabelValues(labelValue).Add(value)
+}
+
+// GetPopulatorProgress returns the populatorProgress value
+func GetPopulatorProgress(labelValue string) (float64, error) {
+	dto := &ioprometheusclient.Metric{}
+	if err := populatorProgress.WithLabelValues(labelValue).Write(dto); err != nil {
+		return 0, err
+	}
+	return dto.Counter.GetValue(), nil
+}

--- a/pkg/monitoring/metrics/openstack-populator/populator_metrics.go
+++ b/pkg/monitoring/metrics/openstack-populator/populator_metrics.go
@@ -12,7 +12,7 @@ var (
 
 	populatorProgress = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "openstack_populator_progress",
+			Name: "kubevirt_cdi_openstack_populator_progress_total",
 			Help: "Progress of volume population",
 		},
 		[]string{"ownerUID"},

--- a/pkg/monitoring/metrics/operator-controller/metrics.go
+++ b/pkg/monitoring/metrics/operator-controller/metrics.go
@@ -13,8 +13,3 @@ func SetupMetrics() error {
 		operatorMetrics,
 	)
 }
-
-// ListMetrics registered prometheus metrics
-func ListMetrics() []operatormetrics.Metric {
-	return operatormetrics.ListMetrics()
-}

--- a/pkg/monitoring/metrics/ovirt-populator/BUILD.bazel
+++ b/pkg/monitoring/metrics/ovirt-populator/BUILD.bazel
@@ -4,9 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "metrics.go",
-        "populator_metrics.go",
+        "populator-metrics.go",
     ],
-    importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/openstack-populator",
+    importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/ovirt-populator",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",

--- a/pkg/monitoring/metrics/ovirt-populator/metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/metrics.go
@@ -1,0 +1,21 @@
+package ovirtpopulator
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// SetupMetrics register prometheus metrics
+func SetupMetrics() error {
+	operatormetrics.Register = runtimemetrics.Registry.Register
+	operatormetrics.Unregister = runtimemetrics.Registry.Unregister
+	return operatormetrics.RegisterMetrics(
+		populatorMetrics,
+	)
+}
+
+// ListMetrics registered prometheus metrics
+func ListMetrics() []operatormetrics.Metric {
+	return operatormetrics.ListMetrics()
+}

--- a/pkg/monitoring/metrics/ovirt-populator/metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/metrics.go
@@ -14,8 +14,3 @@ func SetupMetrics() error {
 		populatorMetrics,
 	)
 }
-
-// ListMetrics registered prometheus metrics
-func ListMetrics() []operatormetrics.Metric {
-	return operatormetrics.ListMetrics()
-}

--- a/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
@@ -1,0 +1,34 @@
+package ovirtpopulator
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	ioprometheusclient "github.com/prometheus/client_model/go"
+)
+
+var (
+	populatorMetrics = []operatormetrics.Metric{
+		populatorProgress,
+	}
+
+	populatorProgress = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "ovirt_progress",
+			Help: "Progress of volume population",
+		},
+		[]string{"ownerUID"},
+	)
+)
+
+// AddPopulatorProgress adds value to the populatorProgress metric
+func AddPopulatorProgress(labelValue string, value float64) {
+	populatorProgress.WithLabelValues(labelValue).Add(value)
+}
+
+// GetPopulatorProgress returns the populatorProgress value
+func GetPopulatorProgress(labelValue string) (float64, error) {
+	dto := &ioprometheusclient.Metric{}
+	if err := populatorProgress.WithLabelValues(labelValue).Write(dto); err != nil {
+		return 0, err
+	}
+	return dto.Counter.GetValue(), nil
+}

--- a/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
@@ -12,7 +12,7 @@ var (
 
 	populatorProgress = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "ovirt_progress",
+			Name: "kubevirt_cdi_ovirt_progress_total",
 			Help: "Progress of volume population",
 		},
 		[]string{"ownerUID"},

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6866,7 +6866,7 @@ status:
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
@@ -6888,14 +6888,19 @@ spec:
           from an Openstack image
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -6941,7 +6946,7 @@ status:
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
@@ -6963,14 +6968,19 @@ spec:
           an oVirt disk
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/pkg/util/prometheus/BUILD.bazel
+++ b/pkg/util/prometheus/BUILD.bazel
@@ -6,10 +6,9 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/util/prometheus",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/util:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
@@ -23,10 +22,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )

--- a/tools/metricsdocs/BUILD.bazel
+++ b/tools/metricsdocs/BUILD.bazel
@@ -6,10 +6,14 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/tools/metricsdocs",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/monitoring/metrics/cdi-controller:go_default_library",
+        "//pkg/monitoring/metrics/openstack-populator:go_default_library",
         "//pkg/monitoring/metrics/operator-controller:go_default_library",
+        "//pkg/monitoring/metrics/ovirt-populator:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//vendor/github.com/machadovilaca/operator-observability/pkg/docs:go_default_library",
+        "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
     ],
 )
 

--- a/tools/metricsdocs/metricsdocs.go
+++ b/tools/metricsdocs/metricsdocs.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 
 	"github.com/machadovilaca/operator-observability/pkg/docs"
+	om "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 
+	cdiClonerMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	cdiMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
+	openstackPopulatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/openstack-populator"
 	operatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller"
+	ovirtPopulatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/ovirt-populator"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring/rules"
 )
 
@@ -46,11 +50,26 @@ func main() {
 		panic(err)
 	}
 
+	err = cdiClonerMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
+	err = openstackPopulatorMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
+	err = ovirtPopulatorMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
 	if err := rules.SetupRules("test"); err != nil {
 		panic(err)
 	}
 
-	docsString := docs.BuildMetricsDocsWithCustomTemplate(operatorMetrics.ListMetrics(), rules.ListRecordingRules(), tpl)
+	docsString := docs.BuildMetricsDocsWithCustomTemplate(om.ListMetrics(), rules.ListRecordingRules(), tpl)
 
 	fmt.Print(docsString)
 }

--- a/tools/prom-metrics-collector/BUILD.bazel
+++ b/tools/prom-metrics-collector/BUILD.bazel
@@ -6,10 +6,14 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/tools/prom-metrics-collector",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/monitoring/metrics/cdi-controller:go_default_library",
+        "//pkg/monitoring/metrics/openstack-populator:go_default_library",
         "//pkg/monitoring/metrics/operator-controller:go_default_library",
+        "//pkg/monitoring/metrics/ovirt-populator:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//vendor/github.com/kubevirt/monitoring/pkg/metrics/parser:go_default_library",
+        "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
     ],
 )
 

--- a/tools/prom-metrics-collector/metrics_json_generator.go
+++ b/tools/prom-metrics-collector/metrics_json_generator.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 
 	"github.com/kubevirt/monitoring/pkg/metrics/parser"
+	om "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 
+	cdiClonerMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	cdiMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
+	openstackPopulatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/openstack-populator"
 	operatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller"
+	ovirtPopulatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/ovirt-populator"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring/rules"
 )
 
@@ -28,13 +32,28 @@ func main() {
 		panic(err)
 	}
 
+	err = cdiClonerMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
+	err = openstackPopulatorMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
+	err = ovirtPopulatorMetrics.SetupMetrics()
+	if err != nil {
+		panic(err)
+	}
+
 	if err := rules.SetupRules("test"); err != nil {
 		panic(err)
 	}
 
 	var metricFamilies []parser.Metric
 
-	metricsList := operatorMetrics.ListMetrics()
+	metricsList := om.ListMetrics()
 	for _, m := range metricsList {
 		if _, isExcludedMetric := excludedMetrics[m.GetOpts().Name]; !isExcludedMetric {
 			metricFamilies = append(metricFamilies, parser.Metric{


### PR DESCRIPTION
**What this PR does / why we need it**:
`clone_progress` and `openstack_populator_progress` and `ovirt_progress` metrics are not in the monitoring package. These metrics are not with correct metrics names, based on the kubevirt and Prometheus metrics naming conventions, they are not documented and are not located under `/pkg/monitoring`. After the code refactoring we should not have Prometheus metrics in other places in the code, other than the `/monitoring/metrics` package, and metrics should be registered using operator-observability package.

In addition, we aligned the progress metric names with the metric naming linter rules: `kubevirt_cdi_clone_progress_total`, `kubevirt_cdi_openstack_populator_progress_total`, `kubevirt_cdi_ovirt_progress_total`.

**Which issue(s) this PR fixes**:
Fixes # https://issues.redhat.com/browse/CNV-36845

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```