### PR TITLE
Fix metrics name linter

### DIFF
--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6866,7 +6866,7 @@ status:
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
@@ -6888,14 +6888,19 @@ spec:
           from an Openstack image
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -6941,7 +6946,7 @@ status:
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
@@ -6963,14 +6968,19 @@ spec:
           an oVirt disk
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/tools/prom-metrics-collector/BUILD.bazel
+++ b/tools/prom-metrics-collector/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/monitoring/metrics/operator-controller:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//vendor/github.com/kubevirt/monitoring/pkg/metrics/parser:go_default_library",
+        "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
     ],
 )
 

--- a/tools/prom-metrics-collector/metrics_json_generator.go
+++ b/tools/prom-metrics-collector/metrics_json_generator.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/kubevirt/monitoring/pkg/metrics/parser"
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 
 	cdiMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
-	operatorMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller"
+	controllerMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring/rules"
 )
 
@@ -18,7 +19,7 @@ import (
 var excludedMetrics = map[string]struct{}{}
 
 func main() {
-	err := operatorMetrics.SetupMetrics()
+	err := controllerMetrics.SetupMetrics()
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +35,7 @@ func main() {
 
 	var metricFamilies []parser.Metric
 
-	metricsList := operatorMetrics.ListMetrics()
+	metricsList := operatormetrics.ListMetrics()
 	for _, m := range metricsList {
 		if _, isExcludedMetric := excludedMetrics[m.GetOpts().Name]; !isExcludedMetric {
 			metricFamilies = append(metricFamilies, parser.Metric{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Before this PR, the metrics name linter only listed one group of metrics. It listed metrics with: https://github.com/kubevirt/containerized-data-importer/blob/d2f3903e974b53a69e42d810f6507f783851408a/tools/prom-metrics-collector/metrics_json_generator.go#L37
Which uses https://github.com/kubevirt/containerized-data-importer/blob/d2f3903e974b53a69e42d810f6507f783851408a/tools/prom-metrics-collector/metrics_json_generator.go#L11
and this lists only one group of metrics.
We need to use `"github.com/machadovilaca/operator-observability/pkg/operatormetrics"` and then `operatormetrics.ListMetrics()`, which lists all registered metrics.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->


```release-note
None
```

