### PR TITLE
Filter out generated files from coverage report

### DIFF
--- a/hack/build/run-unit-tests.sh
+++ b/hack/build/run-unit-tests.sh
@@ -26,3 +26,13 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=120s
 test_command="env OPERATOR_DIR=${CDI_DIR} go test -v -coverprofile=.coverprofile -test.timeout 180m ${pkgs} ${test_args:+-args $test_args}"
 echo "${test_command}"
 ${test_command}
+
+# Filter out generated files from coverage report
+# https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source
+FILTER_PATTERN='^// Code generated .* DO NOT EDIT\.\?$'
+GENERATED=$(grep -l "${FILTER_PATTERN}" -r --include="*.go" --exclude-dir="vendor")
+for path in ${GENERATED}; do
+    grep -v "${path}" .coverprofile > .tmp \
+        && mv .tmp .coverprofile           \
+        || true
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As of Go 1.22, packages with no tests are included in the coverage report. For this project, it meant that the coverage plummeted from 61% down to 17%. This is not because of a lack of tests, but rather the inclusion of >60k lines of generated code that are now considered 'relevant lines'. The project size went from 22k to 90k relevant lines, diluting our coverage.

This PR filters out all the generated files from the coverage report, both in Goveralls and locally when running `make coverage`. This is done programmatically rather than using an allowlist/denylist so that we don't need to maintain it.

After this PR, the number of relevant lines becomes 27k, still greater than the pre-Go1.22 metric. This means that we have around 5k lines of code inside packages that have zero tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

