### PR TITLE
forklift: fix metrics report

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -24,7 +24,7 @@ Progress of volume population. Type: Counter.
 ### kubevirt_cdi_operator_up
 CDI operator status. Type: Gauge.
 
-### kubevirt_cdi_ovirt_progress_total
+### kubevirt_cdi_ovirt_populator_progress_total
 Progress of volume population. Type: Counter.
 
 ### kubevirt_cdi_storageprofile_info

--- a/pkg/monitoring/metrics/openstack-populator/BUILD.bazel
+++ b/pkg/monitoring/metrics/openstack-populator/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
     deps = [
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
-        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/openstack-populator/metrics.go
+++ b/pkg/monitoring/metrics/openstack-populator/metrics.go
@@ -2,14 +2,10 @@ package openstackpopulator
 
 import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-
-	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // SetupMetrics register prometheus metrics
 func SetupMetrics() error {
-	operatormetrics.Register = runtimemetrics.Registry.Register
-	operatormetrics.Unregister = runtimemetrics.Registry.Unregister
 	return operatormetrics.RegisterMetrics(
 		populatorMetrics,
 	)

--- a/pkg/monitoring/metrics/ovirt-populator/BUILD.bazel
+++ b/pkg/monitoring/metrics/ovirt-populator/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
     deps = [
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
-        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/ovirt-populator/metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/metrics.go
@@ -2,14 +2,10 @@ package ovirtpopulator
 
 import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-
-	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // SetupMetrics register prometheus metrics
 func SetupMetrics() error {
-	operatormetrics.Register = runtimemetrics.Registry.Register
-	operatormetrics.Unregister = runtimemetrics.Registry.Unregister
 	return operatormetrics.RegisterMetrics(
 		populatorMetrics,
 	)

--- a/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
+++ b/pkg/monitoring/metrics/ovirt-populator/populator-metrics.go
@@ -12,7 +12,7 @@ var (
 
 	populatorProgress = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_cdi_ovirt_progress_total",
+			Name: "kubevirt_cdi_ovirt_populator_progress_total",
 			Help: "Progress of volume population",
 		},
 		[]string{"ownerUID"},


### PR DESCRIPTION
- Use default implementation for metric registration, otherwise it was not registered and the metrics weren't reported

- Rename kubevirt_cdi_ovirt_progress_total to kubevirt_cdi_ovirt_populator_progress_total for consistency

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix progress reporting for forklift populators
```

