### PR TITLE
Update makefile documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@
 		release-description \
 		bazel-generate bazel-build bazel-build-images bazel-push-images \
 		fossa \
-		lint-metrics
+		lint-metrics	\
+		help
 
 DOCKER?=1
 ifeq (${DOCKER}, 1)
@@ -37,6 +38,18 @@ else
 endif
 # x86_64 aarch64 crossbuild-aarch64
 BUILD_ARCH?=x86_64
+
+.DEFAULT_GOAL := help
+help: ## Print this message and exit
+	@awk 'BEGIN {                                                          \
+		FS = ":.*##";                                                      \
+		printf "USAGE\n\n    make \033[36m<target>\033[0m\n\nTARGETS\n"    \
+	}                                                                      \
+	/^[a-zA-Z_0-9-]+:.*?##/ {                                              \
+		# Print targets and descriptions                                   \
+		printf "    \033[36m%-25s\033[0m%s\n", $$1, $$2                    \
+	}                                                                      \
+	' $(MAKEFILE_LIST)
 
 all: manifests bazel-build-images
 
@@ -177,65 +190,3 @@ fossa:
 lint-metrics:
 	./hack/ci/prom_metric_linter.sh --operator-name="kubevirt" --sub-operator-name="cdi"
 
-help:
-	@echo "Usage: make [Targets ...]"
-	@echo " all "
-	@echo "  : cleans up previous build artifacts, compiles all CDI packages and builds containers"
-	@echo " apidocs "
-	@echo "  : generate client-go code (same as 'make generate') and swagger docs."
-	@echo " build-functest "
-	@echo "  : build the functional tests (content of tests/ subdirectory)."
-	@echo " bazel-build "
-	@echo "  : build all the Go binaries used."
-	@echo " bazel-build-images "
-	@echo "  : build all the container images used (for both CDI and functional tests)."
-	@echo " bazel-generate "
-	@echo "  : generate BUILD files for Bazel."
-	@echo " bazel-push-images "
-	@echo "  : push the built container images to the registry defined in DOCKER_PREFIX"
-	@echo " builder-push "
-	@echo "  : Build and push the builder container image, declared in docker/builder/Dockerfile."
-	@echo " clean "
-	@echo "  : cleans up previous build artifacts"
-	@echo " cluster-up "
-	@echo "  : start a default Kubernetes or Open Shift cluster. set KUBEVIRT_PROVIDER environment variable to either 'k8s-1.18' or 'os-3.11.0' to select the type of cluster. set KUBEVIRT_NUM_NODES to something higher than 1 to have more than one node."
-	@echo " cluster-down "
-	@echo "  : stop the cluster, doing a make cluster-down && make cluster-up will basically restart the cluster into an empty fresh state."
-	@echo " cluster-down-purge "
-	@echo "  : cluster-down and cleanup all cached images from docker registry. Accepts [make variables](#make-variables) DOCKER_PREFIX. Removes all images of the specified repository. If not specified removes localhost repository of current cluster instance."
-	@echo " cluster-sync "
-	@echo "  : builds the controller/importer/cloner, and pushes it into a running cluster. The cluster must be up before running a cluster sync. Also generates a manifest and applies it to the running cluster after pushing the images to it."
-	@echo " deps-update "
-	@echo "  : runs 'go mod tidy' and 'go mod vendor'"
-	@echo " format "
-	@echo "  : execute 'shfmt', 'goimports', and 'go vet' on all CDI packages.  Writes back to the source files."
-	@echo " generate "
-	@echo "  : generate client-go deepcopy functions, clientset, listers and informers."
-	@echo " generate-verify "
-	@echo "  : generate client-go deepcopy functions, clientset, listers and informers and validate codegen."
-	@echo " gomod-update "
-	@echo "  : Update vendored Go code in vendor/ subdirectory."
-	@echo " goveralls "
-	@echo "  : run code coverage tracking system."
-	@echo " coverage"
-	@echo "  : run code coverage report locally."
-	@echo " manifests "
-	@echo "  : generate a cdi-controller and operator manifests in '_out/manifests/'.  Accepts [make variables]\(#make-variables\) DOCKER_TAG, DOCKER_PREFIX, VERBOSITY, PULL_POLICY, CSV_VERSION, QUAY_REPOSITORY, QUAY_NAMESPACE"
-	@echo " openshift-ci-image-push "
-	@echo "  : Build and push the OpenShift CI build+test container image, declared in hack/ci/Dockerfile.ci"
-	@echo " push "
-	@echo "  : compiles, builds, and pushes to the repo passed in 'DOCKER_PREFIX=<my repo>'"
-	@echo " release-description "
-	@echo "  : generate a release announcement detailing changes between 2 commits (typically tags).  Expects 'RELREF' and 'PREREF' to be set"
-	@echo " test "
-	@echo "  : execute all tests (_NOTE:_ 'WHAT' is expected to match the go cli pattern for paths e.g. './pkg/...'.  This differs slightly from rest of the 'make' targets)"
-	@echo " test-unit "
-	@echo "  : Run unit tests."
-	@echo " test-lint "
-	@echo "  : Run gofmt and golint against src files"
-	@echo " test-functional "
-	@echo "  : Run functional tests (in tests/ subdirectory)."
-	@echo " vet	"
-	@echo "  : lint all CDI packages"
-
-.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ help: ## Print this message and exit
 		FS = ":.*##";                                                      \
 		printf "USAGE\n\n    make \033[36m<target>\033[0m\n\nTARGETS\n"    \
 	}                                                                      \
+	/^##@/ {                                                               \
+		# Print section titles                                             \
+		printf "\n  \033[1m%s\033[0m\n", substr($$0, 5)                    \
+	}                                                                      \
 	/^[a-zA-Z_0-9-]+:.*?##/ {                                              \
 		# Print targets and descriptions                                   \
 		printf "    \033[36m%-25s\033[0m%s\n", $$1, $$2                    \

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-.PHONY: help all clean update-codegen generate bootstrap-ginkgo generate-verify gomod-update apidocs deps-update deps-verify rpm-deps build-functest test test-unit test-unit test-functional test-functional goveralls coverage docker-registry-cleanup publish manifests release-description builder-push openshift-ci-image-push cluster-up cluster-down cluster-down-purge cluster-sync-cdi cluster-sync-test-infra cluster-sync bazel-generate bazel-build bazel-push-images push build-docgen generate-doc fossa lint-metrics test-lint vet vulncheck format
-
 DOCKER?=1
 ifeq (${DOCKER}, 1)
 	# use entrypoint.sh (default) as your entrypoint into the container
@@ -188,3 +186,15 @@ gosec:
 
 format: ## Format shell and go source files."
 	${DO_BAZ} "./hack/build/format.sh"
+
+
+.PHONY:	\
+	help all clean \
+	update-codegen generate bootstrap-ginkgo generate-verify gomod-update apidocs \
+	deps-update deps-verify rpm-deps \
+	build-functest test test-unit test-functional goveralls coverage \
+	docker-registry-cleanup publish manifests release-description builder-push openshift-ci-image-push \
+	cluster-up cluster-down cluster-down-purge cluster-sync \
+	bazel-generate bazel-build bazel-build-images bazel-push-images push \
+	build-docgen generate-doc \
+	fossa lint-metrics test-lint vet vulncheck format  \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ endif
 # x86_64 aarch64 crossbuild-aarch64
 BUILD_ARCH?=x86_64
 
+##@ General
 .DEFAULT_GOAL := help
 help: ## Print this message and exit
 	@awk 'BEGIN {                                                          \
@@ -61,10 +62,14 @@ clean: ## Clean up previous build artifacts
 	${DO_BAZ} "./hack/build/build-go.sh clean; rm -rf bin/* _out/* manifests/generated/* .coverprofile release-announcement"
 	${DO_BAZ} bazel clean --expunge
 
+##@ Code generation
 update-codegen: ## Re-create generated code
 	${DO_BAZ} "./hack/update-codegen.sh"
 
 generate: update-codegen bazel-generate generate-doc ## Re-create all generated files
+
+bootstrap-ginkgo: ## Generate Ginkigo testing boilerplate. See `ginkgo bootstrap --help`.
+	${DO_BAZ} ./hack/build/bootstrap-ginkgo.sh
 
 generate-verify: generate bootstrap-ginkgo ## Verify the generated files are up to date
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
@@ -72,6 +77,10 @@ generate-verify: generate bootstrap-ginkgo ## Verify the generated files are up 
 gomod-update: ## Update vendored Go code in vendor/ subdirectory.
 	${DO_BAZ} "./hack/build/dep-update.sh"
 
+apidocs: ## Generate client-go code (same as 'make generate') and swagger docs
+	${DO_BAZ} "./hack/update-codegen.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1beta1 html"
+
+##@ Dependency management
 deps-update: gomod-update bazel-generate ## Runs 'go mod tidy' and 'go mod vendor'
 
 deps-verify: deps-update ## Verify dependencies are up to date
@@ -80,9 +89,7 @@ deps-verify: deps-update ## Verify dependencies are up to date
 rpm-deps: ## Update RPM dependencies
 	${DO_BAZ} "CUSTOM_REPO=${CUSTOM_REPO} ./hack/build/rpm-deps.sh"
 
-apidocs: ## Generate client-go code (same as 'make generate') and swagger docs
-	${DO_BAZ} "./hack/update-codegen.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1beta1 html"
-
+##@ Testing
 build-functest: ## Build the functional tests (content of tests/ subdirectory)
 	${DO_BAZ} ./hack/build/build-functest.sh
 
@@ -96,36 +103,31 @@ test-functional: WHAT = ./tests/...
 test-functional: build-functest ## Run functional tests (in tests/ subdirectory).
 	./hack/build/run-functional-tests.sh ${WHAT} "${TEST_ARGS}"
 
-test-lint: lint-metrics ## Run linter on source files
-	${DO_BAZ} "./hack/build/run-lint-checks.sh"
-	"./hack/ci/language.sh"
-
-docker-registry-cleanup: ## Clean up all cached images from docker registry. Accepts [make variables](#make-variables) DOCKER_PREFIX. Removes all images of the specified repository. If not specified removes localhost repository of current cluster instance.
-	./hack/build/cleanup_docker.sh
-
-publish: manifests push ## Generate a cdi-controller and operator manifests and push the built container images to the registry defined in DOCKER_PREFIX
-
-vet: ## Lint all CDI packages
-	${DO_BAZ} "./hack/build/build-go.sh vet ${WHAT}"
-
-vulncheck: ## Scan Go dependencies for known vulnerabilities.
-	${DO_BAZ} ./hack/build/run-vulncheck.sh
-
-format: ## Format shell and go source files."
-	${DO_BAZ} "./hack/build/format.sh"
-
-manifests: ## Generate a cdi-controller and operator manifests in '_out/manifests/'.  Accepts [make variables]\(#make-variables\) DOCKER_TAG, DOCKER_PREFIX, VERBOSITY, PULL_POLICY, CSV_VERSION, QUAY_REPOSITORY, QUAY_NAMESPACE
-	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
-
 goveralls: test-unit ## Run code coverage tracking system and upload it to coveralls
 	${DO_BAZ} "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BRANCH=${PULL_BASE_REF} CI_PR_NUMBER=${PULL_NUMBER} GIT_ID=${PULL_PULL_SHA} PROW_JOB_ID=${PROW_JOB_ID} ./hack/build/goveralls.sh"
 
 coverage: test-unit ## Run code coverage report locally.
 	./hack/build/coverage.sh
 
+##@ Image management
+docker-registry-cleanup: ## Clean up all cached images from docker registry. Accepts [make variables](#make-variables) DOCKER_PREFIX. Removes all images of the specified repository. If not specified removes localhost repository of current cluster instance.
+	./hack/build/cleanup_docker.sh
+
+publish: manifests push ## Generate a cdi-controller and operator manifests and push the built container images to the registry defined in DOCKER_PREFIX
+
+manifests: ## Generate a cdi-controller and operator manifests in '_out/manifests/'.  Accepts [make variables]\(#make-variables\) DOCKER_TAG, DOCKER_PREFIX, VERBOSITY, PULL_POLICY, CSV_VERSION, QUAY_REPOSITORY, QUAY_NAMESPACE
+	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
+
 release-description: ## Generate a release announcement detailing changes between 2 commits (typically tags).  Expects 'RELREF' and 'PREREF' to be set
 	./hack/build/release-description.sh ${RELREF} ${PREREF}
 
+builder-push: ## Build and push the builder container image, declared in docker/builder/Dockerfile.
+	./hack/build/bazel-build-builder.sh
+
+openshift-ci-image-push: ## Build and push the OpenShift CI build+test container image, declared in hack/ci/Dockerfile.ci
+	./hack/build/osci-image-builder.sh
+
+##@ Local cluster management
 cluster-up: ## Start a default Kubernetes or Open Shift cluster. set KUBEVIRT_PROVIDER environment variable to either 'k8s-1.18' or 'os-3.11.0' to select the type of cluster. set KUBEVIRT_NUM_NODES to something higher than 1 to have more than one node.
 	./cluster-up/up.sh
 
@@ -151,6 +153,7 @@ cluster-sync-test-infra: cluster-clean-test-infra
 
 cluster-sync: cluster-sync-cdi cluster-sync-test-infra ## Build the controller/importer/cloner, and push it into a running cluster. The cluster must be up before running a cluster sync. Also generates a manifest and applies it to the running cluster after pushing the images to it.
 
+##@ Bazel
 bazel-generate: ## Generate BUILD files for Bazel.
 	${DO_BAZ} "BUILD_ARCH=${BUILD_ARCH} ./hack/build/bazel-generate.sh -- staging/src pkg/ tools/ tests/ cmd/ vendor/"
 
@@ -160,9 +163,6 @@ bazel-cdi-generate:
 bazel-build: ## Build all Go binaries.
 	${DO_BAZ} "BUILD_ARCH=${BUILD_ARCH} ./hack/build/bazel-build.sh"
 
-gosec:
-	${DO_BAZ} "GOSEC=${GOSEC} ./hack/build/gosec.sh"
-
 bazel-build-images:	bazel-cdi-generate bazel-build ## Build all the container images used (for both CDI and functional tests)
 	${DO_BAZ} "BUILD_ARCH=${BUILD_ARCH} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build/bazel-build-images.sh"
 
@@ -171,24 +171,32 @@ bazel-push-images: bazel-cdi-generate bazel-build ## Push the built container im
 
 push: bazel-push-images ## Same as bazel-push-images
 
-builder-push: ## Build and push the builder container image, declared in docker/builder/Dockerfile.
-	./hack/build/bazel-build-builder.sh
-
-openshift-ci-image-push: ## Build and push the OpenShift CI build+test container image, declared in hack/ci/Dockerfile.ci
-	./hack/build/osci-image-builder.sh
+##@ Documentation
+build-docgen: ## Build documentation generator
+	${DO_BAZ} "BUILD_ARCH=${BUILD_ARCH} ./hack/build/bazel-build-metricsdocs.sh"
 
 generate-doc: build-docgen ## Generate documentation
 	_out/tools/metricsdocs/metricsdocs > doc/metrics.md
 
-bootstrap-ginkgo: ## Generate Ginkigo testing boilerplate. See `ginkgo bootstrap --help`.
-	${DO_BAZ} ./hack/build/bootstrap-ginkgo.sh
-
-build-docgen: ## Build documentation generator
-	${DO_BAZ} "BUILD_ARCH=${BUILD_ARCH} ./hack/build/bazel-build-metricsdocs.sh"
-
+##@ Linting and code scanning
 fossa: ## Run FOSSA security code scanning
 	${DO_BAZ} "FOSSA_TOKEN_FILE=${FOSSA_TOKEN_FILE} PULL_BASE_REF=${PULL_BASE_REF} CI=${CI} ./hack/fossa.sh"
 
 lint-metrics: ## Run metrics name linter
 	./hack/ci/prom_metric_linter.sh --operator-name="kubevirt" --sub-operator-name="cdi"
 
+test-lint: lint-metrics ## Run linter on source files
+	${DO_BAZ} "./hack/build/run-lint-checks.sh"
+	"./hack/ci/language.sh"
+
+vet: ## Lint all CDI packages
+	${DO_BAZ} "./hack/build/build-go.sh vet ${WHAT}"
+
+vulncheck: ## Scan Go dependencies for known vulnerabilities.
+	${DO_BAZ} ./hack/build/run-vulncheck.sh
+
+gosec:
+	${DO_BAZ} "GOSEC=${GOSEC} ./hack/build/gosec.sh"
+
+format: ## Format shell and go source files."
+	${DO_BAZ} "./hack/build/format.sh"

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-.PHONY: manifests \
-		cluster-up cluster-down cluster-sync \
-		test test-functional test-unit test-lint \
-		publish \
-		vet \
-		format \
-		goveralls \
-		coverage \
-		release-description \
-		bazel-generate bazel-build bazel-build-images bazel-push-images \
-		fossa \
-		lint-metrics	\
-		help
+.PHONY: help all clean update-codegen generate bootstrap-ginkgo generate-verify gomod-update apidocs deps-update deps-verify rpm-deps build-functest test test-unit test-unit test-functional test-functional goveralls coverage docker-registry-cleanup publish manifests release-description builder-push openshift-ci-image-push cluster-up cluster-down cluster-down-purge cluster-sync-cdi cluster-sync-test-infra cluster-sync bazel-generate bazel-build bazel-push-images push build-docgen generate-doc fossa lint-metrics test-lint vet vulncheck format
 
 DOCKER?=1
 ifeq (${DOCKER}, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The documentation on the Makefile was outdated and missing in some cases. This PR solves this in two ways:
- Add documentation to undocumented targets
- Re-design help target to make it easier to stay up-to-date.

Up until now, the `help` target was at the end of the file; easy to miss when adding or updating a target. Now, the help message is autogenerated by an awk script the following way:
- Targets with a comment (`target: dep1 dep2 ## COMMENT`): the comment is used in the help message. Having the help message next to the target hopefully makes it more likely to keep it up to date.
- Sections (`##@ SECTION NAME`) This makes the help message a bit easier to read as there are a lot of targets.

The end result is the following:

![image](https://github.com/kubevirt/containerized-data-importer/assets/47142856/c7e0b190-caee-40ea-93d5-94c58daad35d)

---

![image](https://github.com/kubevirt/containerized-data-importer/assets/47142856/9f8b282d-f986-4207-b5da-d2194e96f59a)

**Which issue(s) this PR fixes**:
CNV-35422

**Special notes for your reviewer**:
Highly recommend reviewing commit by commit as I explain the steps taken.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

