### PR TITLE
Add vSphere storagecapabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -108,6 +108,9 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// Infinidat
 	"infinibox-csi-driver/iscsiorfibrechannel": {{rwx, block}, {rwo, block}, {rwo, file}},
 	"infinibox-csi-driver/nfs":                 {{rwx, file}, {rwo, file}},
+	// vSphere
+	"csi.vsphere.vmware.com":     {{rwo, block}, {rwo, file}},
+	"csi.vsphere.vmware.com/nfs": {{rwx, file}, {rwo, block}, {rwo, file}},
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format
@@ -277,6 +280,13 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 		default:
 			return "UNKNOWN"
 		}
+	},
+	"csi.vsphere.vmware.com": func(sc *storagev1.StorageClass) string {
+		fsType := sc.Parameters["csi.storage.k8s.io/fstype"]
+		if strings.Contains(fsType, "nfs") {
+			return "csi.vsphere.vmware.com/nfs"
+		}
+		return "csi.vsphere.vmware.com"
 	},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: Ido Aharon <iaharon@redhat.com>

**What this PR does / why we need it**:
Adding storagecapabilities to vSphere provisioner. 

According to the [VMware documentation](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-4CC48A47-21CC-453C-AC07-5BB95F384B40.html#GUID-4CC48A47-21CC-453C-AC07-5BB95F384B40) and the [compatibility matrices](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D), raw block volumes support only `rwo` access:

> Use only single-access ReadWriteOnce raw block volumes. vSphere Container Storage Plug-in does not support raw block volume that use the ReadWriteMany access mode.

According to Red Hat OpenShift [documentation](https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-rwx_persistent-storage-csi-vsphere) (also from the [VMware docmentation](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-AE27642A-E656-47F6-9BEE-C6263F6BC7E0.html)), vSphere support  `rwx` only if the underlying vSphere environment supports the vSAN file service:

> If the underlying vSphere environment supports the vSAN file service, then vSphere Container Storage Interface (CSI) Driver Operator installed by OpenShift Container Platform supports provisioning of ReadWriteMany (RWX) volumes. If vSAN file service is not configured, then ReadWriteOnce (RWO) is the only access mode available. If you do not have vSAN file service configured, and you request RWX, the volume fails to get created and an error is logged.

(maybe I can check it like [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/b535a5c9c67270a20ac8a8f511b4dc27de9f88f1/example/vanilla-k8s-RWM-filesystem-volumes/example-sc.yaml#L9)?)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[CNV-42269](https://issues.redhat.com/browse/CNV-42269)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add storagecapabilities to vSphere provisioner
```

