### PR TITLE
Add Longhorn storagecapabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -120,6 +120,9 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.huawei.com/nfs": createAllFSCapabilities(),
 	// KubeSAN
 	"kubesan.gitlab.io": {{rwx, block}, {rox, block}, {rwo, block}, {rwo, file}},
+	// Longhorn
+	"driver.longhorn.io":            {{rwo, block}},
+	"driver.longhorn.io/migratable": {{rwx, block}, {rwo, block}},
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format
@@ -342,6 +345,13 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 		default:
 			return "csi.huawei.com"
 		}
+	},
+	"driver.longhorn.io": func(sc *storagev1.StorageClass) string {
+		migratable := sc.Parameters["migratable"]
+		if migratable == "true" {
+			return "driver.longhorn.io/migratable"
+		}
+		return "driver.longhorn.io"
 	},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: Ido Aharon <iaharon@redhat.com>

**What this PR does / why we need it**:
Adding storagecapabilities to Longhorn.

According to [Longhorn's documentation](https://longhorn.io/docs/1.6.1/nodes-and-volumes/volumes/rwx-volumes/) and other external sources, Longhorn supports `rwx` and `rwo` with `block` volume mode.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[CNV-42268](https://issues.redhat.com/browse/CNV-42268)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding storagecapabilities to the longhorn provisioner
```

