### PR TITLE
Enable intrange linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   - gofmt
   - goimports
   - govet
+  - intrange
   - misspell
   - nakedret
   - revive

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -46,7 +46,7 @@ func waitForReadyFile() {
 	if readyFile == "" {
 		return
 	}
-	for i := 0; i < readyFileTimeoutSeconds; i++ {
+	for range readyFileTimeoutSeconds {
 		if _, err := os.Stat(readyFile); err == nil {
 			return
 		}

--- a/pkg/apiserver/webhooks/util.go
+++ b/pkg/apiserver/webhooks/util.go
@@ -33,7 +33,7 @@ import (
 func validateNumberOfSources(source interface{}, sourceKind string, field *field.Path) []metav1.StatusCause {
 	numberOfSources := 0
 	s := reflect.ValueOf(source).Elem()
-	for i := 0; i < s.NumField(); i++ {
+	for i := range s.NumField() {
 		if !reflect.ValueOf(s.Field(i).Interface()).IsNil() {
 			numberOfSources++
 		}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -34,7 +34,7 @@ var _ = Describe("TerminationMessage", func() {
 		termMsg := TerminationMessage{
 			Labels: map[string]string{},
 		}
-		for i := 0; i < length-serializationOffset; i++ {
+		for range length - serializationOffset {
 			termMsg.Labels["t"] += "c"
 		}
 

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -277,7 +277,7 @@ func (p *Planner) watchOwned(log logr.Logger, obj client.Object) error {
 			sv := reflect.ValueOf(objList).Elem()
 			iv := sv.FieldByName("Items")
 			var reqs []reconcile.Request
-			for i := 0; i < iv.Len(); i++ {
+			for i := range iv.Len() {
 				o := iv.Index(i).Addr().Interface().(client.Object)
 				reqs = append(reqs, reconcile.Request{
 					NamespacedName: types.NamespacedName{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1832,7 +1832,7 @@ func BulkDeleteResources(ctx context.Context, c client.Client, obj client.Object
 	sv := reflect.ValueOf(obj).Elem()
 	iv := sv.FieldByName("Items")
 
-	for i := 0; i < iv.Len(); i++ {
+	for i := range iv.Len() {
 		obj := iv.Index(i).Addr().Interface().(client.Object)
 		if obj.GetDeletionTimestamp().IsZero() {
 			klog.V(3).Infof("Deleting type %+v %+v", reflect.TypeOf(obj), obj)

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -609,7 +609,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			reconciler = createDataImportCronReconciler(cron)
 			verifyConditions("Before DesiredDigest is set", false, false, false, noImport, noDigest, "", &corev1.PersistentVolumeClaim{})
 
-			for i := 0; i < nPVCs; i++ {
+			for i := range nPVCs {
 				digest := strings.Repeat(strconv.Itoa(i), 12)
 				digests[i] = "sha256:" + digest
 				pvcs[i] = cc.CreatePvc(dataSourceName+"-"+digest, cron.Namespace, nil, nil)

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		storageClass := CreateStorageClassWithProvisioner(storageClassName, nil, nil, cephProvisioner)
 		reconciler = createStorageProfileReconciler(storageClass, createVolumeSnapshotContentCrd(), createVolumeSnapshotClassCrd(), createVolumeSnapshotCrd())
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			snapClass := createSnapshotClass(fmt.Sprintf("snapclass-%d", i), nil, cephProvisioner)
 			err := reconciler.client.Create(context.TODO(), snapClass)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/operator/controller/patches.go
+++ b/pkg/operator/controller/patches.go
@@ -118,7 +118,7 @@ func (c *Customizer) GenericApplyPatches(objects interface{}) error {
 	switch reflect.TypeOf(objects).Kind() {
 	case reflect.Slice:
 		s := reflect.ValueOf(objects)
-		for i := 0; i < s.Len(); i++ {
+		for i := range s.Len() {
 			o := s.Index(i)
 			obj, ok := o.Interface().(runtime.Object)
 			if !ok {

--- a/pkg/system/prlimit_test.go
+++ b/pkg/system/prlimit_test.go
@@ -218,7 +218,7 @@ func doSpinner(args []string) {
 func doHog(args []string) {
 	var arrays [][]byte
 
-	for i := 0; i < (1 << 20); i++ {
+	for range 1 << 20 {
 		bytes := make([]byte, 1024)
 		_, err := rand.Read(bytes)
 		if err != nil {

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Upload server tests", func() {
 				close(ch)
 			}()
 
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				if server.bindPort != 0 {
 					break
 				}

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -322,7 +322,7 @@ var _ = Describe("CDI ingress config tests, using manifests", Serial, func() {
 			}
 			return ""
 		}, time.Second*30, time.Second).Should(Equal(defaultURL))
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			// Check for 20 seconds if the deployment pod crashed.
 			time.Sleep(2 * time.Second)
 			controllerPod, err = utils.FindPodByPrefix(f.K8sClient, f.CdiInstallNs, cdiDeploymentPodPrefix, common.CDILabelSelector)

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2689,7 +2689,7 @@ var _ = Describe("all clone tests", func() {
 			size := "1Gi"
 			createSnapshot(size, &f.SnapshotSCName, volumeMode)
 
-			for i = 0; i < repeat; i++ {
+			for i := range repeat {
 				dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(fmt.Sprintf("clone-from-snap-%d", i), size, snapshot.Namespace, snapshot.Name, &f.SnapshotSCName, &volumeMode)
 				dataVolume.Labels = map[string]string{"test-label-1": "test-label-value-1"}
 				dataVolume.Annotations = map[string]string{"test-annotation-1": "test-annotation-value-1"}
@@ -2699,7 +2699,7 @@ var _ = Describe("all clone tests", func() {
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 			}
 
-			for i = 0; i < repeat; i++ {
+			for i := range repeat {
 				By("Waiting for clone to be completed")
 				dvName := fmt.Sprintf("clone-from-snap-%d", i)
 				err = utils.WaitForDataVolumePhase(f, targetNs.Name, cdiv1.Succeeded, dvName)
@@ -2765,7 +2765,7 @@ var _ = Describe("all clone tests", func() {
 				targetDvSize := "2Gi"
 				createSnapshot(snapSourceSize, &noExpansionStorageClass.Name, volumeMode)
 
-				for i = 0; i < repeat; i++ {
+				for i := range repeat {
 					dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(fmt.Sprintf("clone-from-snap-%d", i), targetDvSize, snapshot.Namespace, snapshot.Name, &noExpansionStorageClass.Name, &volumeMode)
 					By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
 					dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, dataVolume)
@@ -2773,7 +2773,7 @@ var _ = Describe("all clone tests", func() {
 					f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 				}
 
-				for i = 0; i < repeat; i++ {
+				for i := range repeat {
 					dvName := fmt.Sprintf("clone-from-snap-%d", i)
 					By("Waiting for clone to be completed")
 					err = utils.WaitForDataVolumePhase(f, targetNs.Name, cdiv1.Succeeded, dvName)

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -284,7 +284,7 @@ var _ = Describe("DataImportCron", Serial, func() {
 		}, dataImportCronTimeout, pollingInterval).Should(BeTrue(), "cronjob was not created")
 
 		var lastImportDv, currentImportDv string
-		for i := 0; i < repeat; i++ {
+		for i := range repeat {
 			By(fmt.Sprintf("Iter #%d", i))
 			if i > 0 {
 				if createErrorDv {
@@ -477,7 +477,7 @@ var _ = Describe("DataImportCron", Serial, func() {
 		configureStorageProfileResultingFormat(format)
 
 		garbageSources := 3
-		for i := 0; i < garbageSources; i++ {
+		for i := range garbageSources {
 			srcName := fmt.Sprintf("src-garbage-%d", i)
 			By(fmt.Sprintf("Create %s", srcName))
 			switch format {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -330,7 +330,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				repeat = args.repeat
 			}
 
-			for i := 0; i < repeat; i++ {
+			for range repeat {
 				By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -107,7 +107,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 
 	deleteUnknownStorageClasses := func() {
 		By("Delete unknown storage classes")
-		for i := 0; i < numAddedStorageClasses; i++ {
+		for i := range numAddedStorageClasses {
 			name := fmt.Sprintf("unknown-sc-%d", i)
 			_, err := f.K8sClient.StorageV1().StorageClasses().Get(context.TODO(), name, metav1.GetOptions{})
 			if err != nil && errors.IsNotFound(err) {
@@ -243,7 +243,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			numAddedStorageClasses = 2
-			for i := 0; i < numAddedStorageClasses; i++ {
+			for i := range numAddedStorageClasses {
 				_, err = f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), createUnknownStorageClass(fmt.Sprintf("unknown-sc-%d", i), "kubernetes.io/non-existent-provisioner"), metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -256,7 +256,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 			waitForPrometheusAlert(f, "CDIStorageProfilesIncomplete")
 
 			By("Fix profiles to be complete and test metric value equals original")
-			for i := 0; i < numAddedStorageClasses; i++ {
+			for i := range numAddedStorageClasses {
 				profile := &cdiv1.StorageProfile{}
 				err = f.CrClient.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("unknown-sc-%d", i)}, profile)
 				Expect(err).ToNot(HaveOccurred())
@@ -275,7 +275,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 			waitForNoPrometheusAlert(f, "CDIMultipleDefaultVirtStorageClasses")
 
 			numAddedStorageClasses = 2
-			for i := 0; i < numAddedStorageClasses; i++ {
+			for i := range numAddedStorageClasses {
 				sc := createUnknownStorageClass(fmt.Sprintf("unknown-sc-%d", i), "kubernetes.io/non-existent-provisioner")
 				cc.AddAnnotation(sc, cc.AnnDefaultVirtStorageClass, "true")
 				_, err := f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -414,7 +414,7 @@ var _ = Describe("ALL Operator tests", func() {
 			})
 
 			It("[test_id:4986]should remove/install CDI a number of times successfully", func() {
-				for i := 0; i < 5; i++ {
+				for range 5 {
 					err := f.CdiClient.CdiV1beta1().CDIs().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					ensureCDI()

--- a/tests/transfer_test.go
+++ b/tests/transfer_test.go
@@ -296,7 +296,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", Serial, func() 
 			var wg sync.WaitGroup
 			n := 5
 
-			for i := 0; i < n; i++ {
+			for range n {
 				ns, err := f.CreateNamespace(f.NsPrefix, map[string]string{
 					framework.NsPrefixLabel: f.NsPrefix,
 				})
@@ -314,7 +314,7 @@ var _ = Describe("[rfe_id:5630][crit:high]ObjectTransfer tests", Serial, func() 
 
 			wg.Wait()
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				var targetNamespace string
 
 				if createTargetNamespace {

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -121,7 +121,7 @@ func (ft formatTable) initializeTestFiles(inFile, outDir string) error {
 			klog.Infof("Generated file %q\n", p)
 		}(inFile, outDir, fList)
 	}
-	for i := 0; i < cap(sem); i++ {
+	for range cap(sem) {
 		sem <- true
 	}
 	close(errChan)

--- a/tools/cdi-func-test-registry-init/main.go
+++ b/tools/cdi-func-test-registry-init/main.go
@@ -118,7 +118,7 @@ func (ft formatTable) initializeTestFiles(inFile, outDir string) error {
 			klog.Infof("Generated file %q\n", p)
 		}(inFile, outDir, fList)
 	}
-	for i := 0; i < cap(sem); i++ {
+	for range cap(sem) {
 		sem <- true
 	}
 	close(errChan)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This linter ensures we use the new range-over-int construct

OLD:
```go
    for i:=0; i<N; i++ {}
```

NEW:
```go
    for i := range N {}
```
Often it can be simplified further:
```go
    for range N {}
```


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

