### PR TITLE
Enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
   - nakedret
   - revive
   - unconvert
+  - usestdlibvars
   - whitespace
 
 run:

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -250,7 +250,7 @@ func main() {
 
 	client := createHTTPClient(clientKey, clientCert, serverCert)
 
-	req, _ := http.NewRequest("POST", url, reader)
+	req, _ := http.NewRequest(http.MethodPost, url, reader)
 
 	if contentType != "" {
 		req.Header.Set("x-cdi-content-type", contentType)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -130,7 +130,7 @@ func doGetRequest(url string) *httptest.ResponseRecorder {
 	app := &cdiAPIApp{}
 	app.composeUploadTokenAPI()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	Expect(err).ToNot(HaveOccurred())
 	rr := httptest.NewRecorder()
 
@@ -351,7 +351,7 @@ var _ = Describe("API server tests", func() {
 			tokenGenerator:    newUploadTokenGenerator(signingKey)}
 		app.composeUploadTokenAPI()
 
-		req, err := http.NewRequest("POST",
+		req, err := http.NewRequest(http.MethodPost,
 			"/apis/upload.cdi.kubevirt.io/v1beta1/namespaces/default/uploadtokenrequests",
 			bytes.NewReader(serializedRequest))
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/apiserver/auth-config_test.go
+++ b/pkg/apiserver/auth-config_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Auth config tests", func() {
 		Expect(secret.Labels[common.AppKubernetesComponentLabel]).To(Equal("storage"))
 		Expect(secret.Labels[common.AppKubernetesVersionLabel]).To(Equal(installerLabels[common.AppKubernetesVersionLabel]))
 
-		req, err := http.NewRequest("GET", "/apis", nil)
+		req, err := http.NewRequest(http.MethodGet, "/apis", nil)
 		Expect(err).ToNot(HaveOccurred())
 		rr := httptest.NewRecorder()
 

--- a/pkg/apiserver/webhooks/datavolume-validate_test.go
+++ b/pkg/apiserver/webhooks/datavolume-validate_test.go
@@ -1259,7 +1259,7 @@ func validateAdmissionReview(ar *admissionv1.AdmissionReview, objects ...runtime
 
 func serve(ar *admissionv1.AdmissionReview, handler http.Handler) *admissionv1.AdmissionResponse {
 	reqBytes, _ := json.Marshal(ar)
-	req, err := http.NewRequest("POST", "/foobar", bytes.NewReader(reqBytes))
+	req, err := http.NewRequest(http.MethodPost, "/foobar", bytes.NewReader(reqBytes))
 	Expect(err).ToNot(HaveOccurred())
 
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1660,7 +1660,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.SetUID("b856691e-1038-11e9-a5ab-525500d15501")
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _ = fmt.Fprintf(w, "import_progress{ownerUID=\"%v\"} 13.45", dv.GetUID()) // ignore error here
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
 			ep, err := url.Parse(ts.URL)
@@ -1679,7 +1679,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			dv.Status.Progress = cdiv1.DataVolumeProgress("2.3%")
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(fmt.Sprintf("import_progress{ownerUID=\"%v\"} 13.45", "b856691e-1038-11e9-a5ab-55500d15501")))
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
 			ep, err := url.Parse(ts.URL)

--- a/pkg/controller/populators/forklift-populator_test.go
+++ b/pkg/controller/populators/forklift-populator_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Forklift populator tests", func() {
 
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(fmt.Sprintf("kubevirt_cdi_openstack_populator_progress_total{ownerUID=\"%v\"} 13.45", targetPvc.GetUID())))
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
 			ep, err := url.Parse(ts.URL)

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -571,7 +571,7 @@ var _ = Describe("Import populator tests", func() {
 
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(fmt.Sprintf("import_progress{ownerUID=\"%v\"} 13.45", targetPvc.GetUID())))
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
 			ep, err := url.Parse(ts.URL)

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -330,7 +330,7 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 		brokenForQemuImg = true
 	}
 	// http.NewRequest can only return error on invalid METHOD, or invalid url. Here the METHOD is always GET, and the url is always valid, thus error cannot happen.
-	req, _ := http.NewRequest("GET", ep.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, ep.String(), nil)
 
 	addExtraheaders(req, allExtraHeaders)
 
@@ -343,9 +343,9 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 	if err != nil {
 		return nil, uint64(0), true, errors.Wrap(err, "HTTP request errored")
 	}
-	if resp.StatusCode != 200 {
-		klog.Errorf("http: expected status code 200, got %d", resp.StatusCode)
-		return nil, uint64(0), true, errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
+	if want := http.StatusOK; resp.StatusCode != want {
+		klog.Errorf("http: expected status code %d, got %d", want, resp.StatusCode)
+		return nil, uint64(0), true, errors.Errorf("expected status code %d, got %d. Status: %s", want, resp.StatusCode, resp.Status)
 	}
 
 	if contentType == cdiv1.DataVolumeKubeVirt {
@@ -403,7 +403,7 @@ func (hs *HTTPDataSource) pollProgress(reader *util.CountingReader, idleTime, po
 }
 
 func getContentLength(client *http.Client, ep *url.URL, accessKey, secKey string, extraHeaders []string) (uint64, error) {
-	req, err := http.NewRequest("HEAD", ep.String(), nil)
+	req, err := http.NewRequest(http.MethodHead, ep.String(), nil)
 	if err != nil {
 		return uint64(0), errors.Wrap(err, "could not create HTTP request")
 	}
@@ -419,9 +419,9 @@ func getContentLength(client *http.Client, ep *url.URL, accessKey, secKey string
 		return uint64(0), errors.Wrap(err, "HTTP request errored")
 	}
 
-	if resp.StatusCode != 200 {
-		klog.Errorf("http: expected status code 200, got %d", resp.StatusCode)
-		return uint64(0), errors.Errorf("expected status code 200, got %d. Status: %s", resp.StatusCode, resp.Status)
+	if want := http.StatusOK; resp.StatusCode != want {
+		klog.Errorf("http: expected status code %d, got %d", want, resp.StatusCode)
+		return uint64(0), errors.Errorf("expected status code %d, got %d. Status: %s", want, resp.StatusCode, resp.Status)
 	}
 
 	for k, v := range resp.Header {
@@ -511,7 +511,7 @@ func getExtraHeadersFromSecrets() ([]string, error) {
 }
 
 func getServerInfo(ctx context.Context, infoURL string) (*common.ServerInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", infoURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, infoURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct request for containerimage-server info")
 	}

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Http data source", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, _ = w.Write(body)
 			} else {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}))
 		dp, err = NewHTTPDataSource(ts2.URL+"/"+tinyCoreGz, "", "", "", cdiv1.DataVolumeKubeVirt)
@@ -294,7 +294,7 @@ var _ = Describe("Http reader", func() {
 	It("should pass auth info in request if set", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user, pass, ok := r.BasicAuth()
-			defer w.WriteHeader(200)
+			defer w.WriteHeader(http.StatusOK)
 			Expect(ok).To(BeTrue())
 			Expect("user").To(Equal(user))
 			Expect("password").To(Equal(pass))
@@ -378,7 +378,7 @@ var _ = Describe("Http reader", func() {
 
 	It("should continue even if HEAD is rejected, but mark broken for qemu-img", func() {
 		redirTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "HEAD" {
+			if r.Method == http.MethodHead {
 				w.WriteHeader(http.StatusForbidden)
 			} else {
 				defer w.WriteHeader(http.StatusOK)
@@ -423,7 +423,7 @@ var _ = Describe("Http reader", func() {
 
 	It("should fail if server returns error code", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer ts.Close()
 		ep, err := url.Parse(ts.URL)
@@ -437,9 +437,9 @@ var _ = Describe("Http reader", func() {
 	It("should pass through extra headers", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, exists := r.Header["Extra-Header"]; exists {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			} else {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}))
 		defer ts.Close()

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -465,7 +465,7 @@ func (reader *extentReader) GetRange(start, end int64) (io.ReadCloser, error) {
 		klog.Infof("Range request extends past end of image, trimming to %d", end)
 	}
 
-	request, err := http.NewRequest("GET", reader.transferURL, nil)
+	request, err := http.NewRequest(http.MethodGet, reader.transferURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create range request")
 	}
@@ -562,7 +562,7 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 
 	var reader io.ReadCloser
 	if extentsFeature {
-		req, err := http.NewRequest("GET", transferURL+"/extents", nil)
+		req, err := http.NewRequest(http.MethodGet, transferURL+"/extents", nil)
 		if err != nil {
 			return nil, uint64(0), it, conn, err
 		}
@@ -598,7 +598,7 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 			size:        int64(total),
 		}
 	} else {
-		req, err := http.NewRequest("GET", transferURL, nil)
+		req, err := http.NewRequest(http.MethodGet, transferURL, nil)
 		if err != nil {
 			return nil, uint64(0), it, conn, errors.Wrap(err, "Sending request failed")
 		}

--- a/pkg/uploadproxy/uploadproxy_test.go
+++ b/pkg/uploadproxy/uploadproxy_test.go
@@ -75,7 +75,7 @@ func getHTTPClientConfig() *httpClientConfig {
 }
 
 func newProxyRequest(path, authHeaderValue string) *http.Request {
-	req, err := http.NewRequest("POST", path, strings.NewReader("data"))
+	req, err := http.NewRequest(http.MethodPost, path, strings.NewReader("data"))
 	Expect(err).ToNot(HaveOccurred())
 
 	if authHeaderValue != "" {
@@ -85,7 +85,7 @@ func newProxyRequest(path, authHeaderValue string) *http.Request {
 }
 
 func newProxyHeadRequest(authHeaderValue string) *http.Request {
-	req, err := http.NewRequest("HEAD", common.UploadPathSync, nil)
+	req, err := http.NewRequest(http.MethodHead, common.UploadPathSync, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 	if authHeaderValue != "" {
@@ -245,7 +245,7 @@ var _ = Describe("submit request and check status", func() {
 		Entry("Malformed auth header: invalid prefix", "Beereer valid", http.StatusBadRequest),
 	)
 	It("Test healthz", func() {
-		req, err := http.NewRequest("GET", healthzPath, nil)
+		req, err := http.NewRequest(http.MethodGet, healthzPath, nil)
 		Expect(err).ToNot(HaveOccurred())
 		submitRequestAndCheckStatus(req, http.StatusOK, nil)
 	})
@@ -264,7 +264,7 @@ var _ = Describe("submit request and check status", func() {
 	)
 
 	It("Test healthz", func() {
-		req, err := http.NewRequest("GET", healthzPath, nil)
+		req, err := http.NewRequest(http.MethodGet, healthzPath, nil)
 		Expect(err).ToNot(HaveOccurred())
 		submitRequestAndCheckStatus(req, http.StatusOK, nil)
 	})

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -272,7 +272,7 @@ func (app *uploadServerApp) healthzHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (app *uploadServerApp) validateShouldHandleRequest(w http.ResponseWriter, r *http.Request) bool {
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusNotFound)
 		return false
 	}
@@ -317,7 +317,7 @@ func (app *uploadServerApp) validateShouldHandleRequest(w http.ResponseWriter, r
 
 func (app *uploadServerApp) uploadHandlerAsync(irc imageReadCloser) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "HEAD" {
+		if r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusOK)
 			return
 		}

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -185,7 +185,7 @@ func replaceAsyncProcessorFunc(replacement func(io.ReadCloser, string, string, f
 var _ = Describe("Upload server tests", func() {
 	It("GET fails", func() {
 		withProcessorSuccess(func() {
-			req, err := http.NewRequest("GET", common.UploadPathSync, nil)
+			req, err := http.NewRequest(http.MethodGet, common.UploadPathSync, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			rr := httptest.NewRecorder()
@@ -199,7 +199,7 @@ var _ = Describe("Upload server tests", func() {
 	})
 
 	It("healthz", func() {
-		req, err := http.NewRequest("GET", healthzPath, nil)
+		req, err := http.NewRequest(http.MethodGet, healthzPath, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		rr := httptest.NewRecorder()
@@ -215,7 +215,7 @@ var _ = Describe("Upload server tests", func() {
 
 	DescribeTable("Process unavailable", func(uploadPath string) {
 		withProcessorSuccess(func() {
-			req, err := http.NewRequest("POST", uploadPath, strings.NewReader("data"))
+			req, err := http.NewRequest(http.MethodPost, uploadPath, strings.NewReader("data"))
 			Expect(err).ToNot(HaveOccurred())
 
 			rr := httptest.NewRecorder()
@@ -237,7 +237,7 @@ var _ = Describe("Upload server tests", func() {
 
 	DescribeTable("Completion conflict", func(uploadPath string) {
 		withAsyncProcessorSuccess(func() {
-			req, err := http.NewRequest("POST", uploadPath, strings.NewReader("data"))
+			req, err := http.NewRequest(http.MethodPost, uploadPath, strings.NewReader("data"))
 			Expect(err).ToNot(HaveOccurred())
 
 			rr := httptest.NewRecorder()
@@ -259,7 +259,7 @@ var _ = Describe("Upload server tests", func() {
 
 	It("Success", func() {
 		withProcessorSuccess(func() {
-			req, err := http.NewRequest("POST", common.UploadPathSync, strings.NewReader("data"))
+			req, err := http.NewRequest(http.MethodPost, common.UploadPathSync, strings.NewReader("data"))
 			Expect(err).ToNot(HaveOccurred())
 
 			rr := httptest.NewRecorder()
@@ -308,7 +308,7 @@ var _ = Describe("Upload server tests", func() {
 
 	DescribeTable("Stream fail", func(processorFunc func(func()), uploadPath string) {
 		processorFunc(func() {
-			req, err := http.NewRequest("POST", uploadPath, strings.NewReader("data"))
+			req, err := http.NewRequest(http.MethodPost, uploadPath, strings.NewReader("data"))
 			Expect(err).ToNot(HaveOccurred())
 
 			rr := httptest.NewRecorder()
@@ -395,7 +395,7 @@ func newFormRequest(path string) *http.Request {
 	err = w.Close()
 	Expect(err).ToNot(HaveOccurred())
 
-	req, err := http.NewRequest("POST", path, &b)
+	req, err := http.NewRequest(http.MethodPost, path, &b)
 	Expect(err).ToNot(HaveOccurred())
 
 	req.Header.Set("Content-Type", w.FormDataContentType())

--- a/tests/apiserver_test.go
+++ b/tests/apiserver_test.go
@@ -56,7 +56,7 @@ var _ = Describe("cdi-apiserver tests", Serial, func() {
 			}
 
 			Eventually(func() error {
-				req, err := http.NewRequest("GET", url, nil)
+				req, err := http.NewRequest(http.MethodGet, url, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				resp, err := client.Do(req)
@@ -130,7 +130,7 @@ var _ = Describe("cdi-apiserver tests", Serial, func() {
 				},
 			}
 			requestFunc := func() string {
-				req, err := http.NewRequest("GET", url, nil)
+				req, err := http.NewRequest(http.MethodGet, url, nil)
 				if err != nil {
 					return err.Error()
 				}

--- a/tests/framework/prometheus.go
+++ b/tests/framework/prometheus.go
@@ -87,7 +87,7 @@ func (f *Framework) MakePrometheusHTTPRequest(endpoint string) *http.Response {
 		},
 	}
 	gomega.Eventually(func() bool {
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/%s", url, endpoint), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/%s", url, endpoint), nil)
 		if err != nil {
 			return false
 		}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -797,7 +797,7 @@ func formRequestFunc(url, fileName string) (*http.Request, error) {
 	pipeReader, pipeWriter := io.Pipe()
 	multipartWriter := multipart.NewWriter(pipeWriter)
 
-	req, err := http.NewRequest("POST", url, pipeReader)
+	req, err := http.NewRequest(http.MethodPost, url, pipeReader)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ func binaryRequestFunc(url, fileName string) (*http.Request, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, f)
+	req, err := http.NewRequest(http.MethodPost, url, f)
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func testBadRequestFunc(url, fileName string) (*http.Request, error) {
 		return nil, err
 	}
 	lr := LimitThenErrorReader(f, 2048)
-	req, err := http.NewRequest("POST", url, lr)
+	req, err := http.NewRequest(http.MethodPost, url, lr)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cdi-func-test-bad-webserver/main.go
+++ b/tools/cdi-func-test-bad-webserver/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func failHEAD(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "HEAD" {
+	if r.Method == http.MethodHead {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
@@ -19,7 +19,7 @@ func failHEAD(w http.ResponseWriter, r *http.Request) {
 }
 
 func flaky(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "GET" && incrementAndGetCounter()%4 == 3 {
+	if r.Method == http.MethodGet && incrementAndGetCounter()%4 == 3 {
 		fmt.Printf("Method: %s, Redirecting\n", r.Method)
 		redirect(w, r)
 
@@ -71,7 +71,7 @@ func noAcceptRanges(w http.ResponseWriter, r *http.Request) {
 
 func redirect(w http.ResponseWriter, r *http.Request) {
 	redirectURL := getEquivalentFileHostURL(r.URL.String())
-	http.Redirect(w, r, redirectURL, 301)
+	http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
 }
 
 func getEquivalentFileHostURL(url string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This linter recommends using standard library variables rather than magic constants, so for example `201` is replaced with `http.StatusAccept`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

