### PR TITLE
[release-v1.58] Add watch for DataImportCron-labeled PVCs deletion

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -1041,6 +1041,17 @@ func addDataImportCronControllerWatches(mgr manager.Manager, c controller.Contro
 		return err
 	}
 
+	if err := c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}},
+		handler.EnqueueRequestsFromMapFunc(mapSourceObjectToCron),
+		predicate.Funcs{
+			CreateFunc: func(event.CreateEvent) bool { return false },
+			UpdateFunc: func(event.UpdateEvent) bool { return false },
+			DeleteFunc: func(e event.DeleteEvent) bool { return getCronName(e.Object) != "" },
+		},
+	); err != nil {
+		return err
+	}
+
 	if err := c.Watch(&source.Kind{Type: &cdiv1.StorageProfile{}},
 		handler.EnqueueRequestsFromMapFunc(mapStorageProfileToCron),
 		predicate.Funcs{


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #3285

When the DataImportCron last import DV is manually deleted, the controller reconciles, but due to k8s default background cascading deletion, the PVC may still temporarily exist, so the controller will not re-create the DV even after the PVC is deleted, unless it reconciles due to other watched CR like DataSource. In the scenario of CNV-39688, since we move from pvc source format to snapshot, the DataSource won’t update until a snapshot is created, which will never happen. To solve it we add a watch for deletion of DataImportCron-labeled PVCs. The change was tested locally, but since it required two storage classes it’s currently out of scope for the existing CI lanes, so it requires tier-2 test.

**Which issue(s) this PR fixes**:
Fixes # https://issues.redhat.com/browse/CNV-42129

**Special notes for your reviewer**:

**Release note**:
```release-note
BugFix: On deletion of the last import DV of DataImportCron with Snapshot source format, re-create an import DV
```