### PR TITLE
[release-v1.59] manual backport of 'forklift: rename API group'

### DIFF
--- a/doc/cdi-populators.md
+++ b/doc/cdi-populators.md
@@ -154,12 +154,12 @@ spec:
   dataSourceRef:
     name: ovirt-pop
     kind: OvirtVolumePopulator
-    apiGroup: forklift.konveyor.io
+    apiGroup: forklift.cdi.kubevirt.io
   resources:
     requests:
       storage: 13G
 ---
-apiVersion: forklift.konveyor.io/v1beta1
+apiVersion: forklift.cdi.kubevirt.io/v1beta1
 kind: OvirtVolumePopulator
 metadata:
   name: ovirt-pop
@@ -194,15 +194,15 @@ spec:
       storage: 1Gi
   volumeMode: Filesystem
   dataSource:
-    apiGroup: forklift.konveyor.io
+    apiGroup: forklift.cdi.kubevirt.io
     kind: OpenstackVolumePopulator
     name: openstack-image-cr
   dataSourceRef:
-    apiGroup: forklift.konveyor.io
+    apiGroup: forklift.cdi.kubevirt.io
     kind: OpenstackVolumePopulator
     name: openstack-image-cr
 ---
-apiVersion: "forklift.konveyor.io/v1beta1"
+apiVersion: "forklift.cdi.kubevirt.io/v1beta1"
 kind: OpenstackVolumePopulator
 metadata:
   name: openstack-image-cr

--- a/pkg/client/clientset/versioned/typed/forklift/v1beta1/forklift_client.go
+++ b/pkg/client/clientset/versioned/typed/forklift/v1beta1/forklift_client.go
@@ -32,7 +32,7 @@ type ForkliftV1beta1Interface interface {
 	OvirtVolumePopulatorsGetter
 }
 
-// ForkliftV1beta1Client is used to interact with features provided by the forklift.konveyor.io group.
+// ForkliftV1beta1Client is used to interact with features provided by the forklift.cdi.kubevirt.io group.
 type ForkliftV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -81,7 +81,7 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	case v1beta1.SchemeGroupVersion.WithResource("volumeuploadsources"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Cdi().V1beta1().VolumeUploadSources().Informer()}, nil
 
-		// Group=forklift.konveyor.io, Version=v1beta1
+		// Group=forklift.cdi.kubevirt.io, Version=v1beta1
 	case forkliftv1beta1.SchemeGroupVersion.WithResource("openstackvolumepopulators"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Forklift().V1beta1().OpenstackVolumePopulators().Informer()}, nil
 	case forkliftv1beta1.SchemeGroupVersion.WithResource("ovirtvolumepopulators"):

--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -37,7 +37,7 @@ const (
 	devicePath             = "/dev/block"
 )
 
-const apiGroup = "forklift.konveyor.io"
+const apiGroup = "forklift.cdi.kubevirt.io"
 
 var (
 	supportedPopulators = map[string]client.Object{

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1832,8 +1832,8 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.CustomResourceDefinition volumeimportsources.cdi.kubevirt.io"] = false
 	match[normalCreateSuccess+" *v1.CustomResourceDefinition volumeuploadsources.cdi.kubevirt.io"] = false
 	match[normalCreateSuccess+" *v1.CustomResourceDefinition volumeclonesources.cdi.kubevirt.io"] = false
-	match[normalCreateSuccess+" *v1.CustomResourceDefinition ovirtvolumepopulators.forklift.konveyor.io"] = false
-	match[normalCreateSuccess+" *v1.CustomResourceDefinition openstackvolumepopulators.forklift.konveyor.io"] = false
+	match[normalCreateSuccess+" *v1.CustomResourceDefinition ovirtvolumepopulators.forklift.cdi.kubevirt.io"] = false
+	match[normalCreateSuccess+" *v1.CustomResourceDefinition openstackvolumepopulators.forklift.cdi.kubevirt.io"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.ClusterRoleBinding cdi-uploadproxy"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi-cronjob"] = false

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -267,7 +267,7 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"forklift.konveyor.io",
+				"forklift.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"ovirtvolumepopulators",

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6989,9 +6989,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
-  name: openstackvolumepopulators.forklift.konveyor.io
+  name: openstackvolumepopulators.forklift.cdi.kubevirt.io
 spec:
-  group: forklift.konveyor.io
+  group: forklift.cdi.kubevirt.io
   names:
     kind: OpenstackVolumePopulator
     listKind: OpenstackVolumePopulatorList
@@ -7064,9 +7064,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
-  name: ovirtvolumepopulators.forklift.konveyor.io
+  name: ovirtvolumepopulators.forklift.cdi.kubevirt.io
 spec:
-  group: forklift.konveyor.io
+  group: forklift.cdi.kubevirt.io
   names:
     kind: OvirtVolumePopulator
     listKind: OvirtVolumePopulatorList

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/register.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/register.go
@@ -2,5 +2,5 @@ package forklift
 
 const (
 	// GroupName to hold the string name for the forklift project
-	GroupName = "forklift.konveyor.io"
+	GroupName = "forklift.cdi.kubevirt.io"
 )

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1/doc.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1/doc.go
@@ -3,5 +3,5 @@
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/konveyor/forklift-controller/pkg/apis
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=forklift.konveyor.io
+// +groupName=forklift.cdi.kubevirt.io
 package v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since forklift 2.7 has to support OCP 4.15 we'll have 2 competing controllers, this PR changes the API group for CDI's so forklift can distinguish between them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename API group for forklift controllers to forklift.cdi.kubevirt.io
```

