### PR TITLE
Fix uploadproxy override in cluster-sync

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -97,7 +97,7 @@ function wait_cdi_available {
 
 function configure_uploadproxy_override {
   host_port=$(./cluster-up/cli.sh ports uploadproxy | xargs)
-  override="127.0.0.1:$host_port"
+  override="https://127.0.0.1:$host_port"
   _kubectl patch cdi ${CR_NAME} --type=merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
 }
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -980,7 +980,7 @@ func findProxyURLCdiConfig(f *framework.Framework) string {
 	config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	if config.Status.UploadProxyURL != nil {
-		return fmt.Sprintf("https://%s", *config.Status.UploadProxyURL)
+		return *config.Status.UploadProxyURL
 	}
 	return ""
 }

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -979,10 +979,16 @@ func uploadFileNameToPathWithClient(client *http.Client, requestFunc uploadFileN
 func findProxyURLCdiConfig(f *framework.Framework) string {
 	config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	if config.Status.UploadProxyURL != nil {
+	if config.Status.UploadProxyURL == nil {
+		return ""
+	}
+	if strings.HasPrefix(*config.Status.UploadProxyURL, "http://") {
 		return *config.Status.UploadProxyURL
 	}
-	return ""
+	if strings.HasPrefix(*config.Status.UploadProxyURL, "https://") {
+		return *config.Status.UploadProxyURL
+	}
+	return "https://" + *config.Status.UploadProxyURL
 }
 
 func HasEnvironmentVariableFromSecret(pod *v1.Pod, name string, secret *v1.Secret) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempting to use virtctl on this repository's cluster fails:
```
edu@fedora:~/containerized-data-importer$ virtctl image-upload dv hello-example --size=1Gi --image-path cirros-0.6.2-x86_64-disk.img --force-bind
Using existing PVC default/hello-example
the server could not find the requested resource
parse "127.0.0.1:32768": first path segment in URL cannot contain colon
```

This is because the upload proxy override is missing the https prefix:
```
edu@fedora:~/containerized-data-importer$ k describe cdiconfig | grep 'Upload Proxy'
  Upload Proxy URL Override:  127.0.0.1:32814
  Upload Proxy URL:             127.0.0.1:32814
```

After this fix:
```
edu@fedora:~/containerized-data-importer$ k describe cdiconfig | grep 'Upload Proxy'
  Upload Proxy URL Override:  https://127.0.0.1:32814
  Upload Proxy URL:             https://127.0.0.1:32814
```

And image-upload now works:
```
edu@fedora:~/containerized-data-importer$ virtctl image-upload dv hello-example --size=1Gi --image-path cirros-0.6.2-x86_64-disk.img --force-bind --insecure
PVC default/hello-example not found 
DataVolume default/hello-example created
Waiting for PVC hello-example upload pod to be ready...
Pod now ready
Uploading data to https://127.0.0.1:32814

 20.44 MiB / 20.44 MiB [==================================================================================================================================] 100.00% 0s

Uploading data completed successfully, waiting for processing to complete, you can hit ctrl-c without interrupting the progress
Processing completed successfully
Uploading cirros-0.6.2-x86_64-disk.img completed successfully
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Check out the same code in Kubevirt:

https://github.com/kubevirt/kubevirt/blob/main/hack/cluster-deploy.sh#L53-L56


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

