### PR TITLE
Suppress CDIDefaultStorageClassDegraded on SNO

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -31,7 +31,7 @@ CDI operator status. Type: Gauge.
 Progress of volume population. Type: Counter.
 
 ### kubevirt_cdi_storageprofile_info
-`StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone. Type: Gauge.
+`StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone, `degraded` indicates it is not optimal for virtualization. Type: Gauge.
 
 ### kubevirt_cdi_upload_pods_high_restart
 The number of CDI upload server pods with high restart count. Type: Gauge.

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -474,7 +474,7 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Entry("provisioner that is known to prefer csi clone", "csi-powermax.dellemc.com", cdiv1.CloneStrategyCsiClone, false),
 	)
 
-	DescribeTable("Should set the StorageProfileStatus metric correctly", func(provisioner string, isComplete bool, count int) {
+	DescribeTable("Should set the StorageProfileStatus metric correctly", func(provisioner string, isComplete bool) {
 		storageClass := CreateStorageClassWithProvisioner(storageClassName, map[string]string{AnnDefaultStorageClass: "true"}, map[string]string{}, provisioner)
 		reconciler = createStorageProfileReconciler(storageClass)
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: storageClassName}})
@@ -488,12 +488,12 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Expect(sp.Status.ClaimPropertySets).To(BeEmpty())
 
 		labels := createLabels(storageClassName, provisioner, isComplete, true, false, false, false, true)
-		Expect(int(metrics.GetStorageProfileStatus(labels))).To(Equal(count))
+		Expect(int(metrics.GetStorageProfileStatus(labels))).To(Equal(1))
+		labels = createLabels(storageClassName, provisioner, !isComplete, true, false, false, false, true)
+		Expect(int(metrics.GetStorageProfileStatus(labels))).To(Equal(0))
 	},
-		Entry("Noobaa (not supported)", storagecapabilities.ProvisionerNoobaa, false, 0),
-		Entry("Noobaa (not supported)", storagecapabilities.ProvisionerNoobaa, true, 1),
-		Entry("Unknown provisioner", "unknown-provisioner", false, 1),
-		Entry("Unknown provisioner", "unknown-provisioner", true, 0),
+		Entry("Noobaa (not supported)", storagecapabilities.ProvisionerNoobaa, true),
+		Entry("Unknown provisioner", "unknown-provisioner", false),
 	)
 
 	DescribeTable("Should set the StorageProfileStatus degraded state correctly", func(accessMode v1.PersistentVolumeAccessMode, isSNO, isDegraded bool) {

--- a/pkg/monitoring/metrics/cdi-controller/storageprofile.go
+++ b/pkg/monitoring/metrics/cdi-controller/storageprofile.go
@@ -14,6 +14,7 @@ const (
 	counterLabelVirtDefault  = "virtdefault"
 	counterLabelRWX          = "rwx"
 	counterLabelSmartClone   = "smartclone"
+	counterLabelDegraded     = "degraded"
 )
 
 var (
@@ -30,7 +31,8 @@ var (
 				"`default` indicates if it's the Kubernetes default storage class, " +
 				"`virtdefault` indicates if it's the default virtualization storage class, " +
 				"`rwx` indicates if the storage class supports `ReadWriteMany`, " +
-				"`smartclone` indicates if it supports snapshot or CSI based clone",
+				"`smartclone` indicates if it supports snapshot or CSI based clone, " +
+				"`degraded` indicates it is not optimal for virtualization",
 		},
 		[]string{
 			counterLabelStorageClass,
@@ -40,6 +42,7 @@ var (
 			counterLabelVirtDefault,
 			counterLabelRWX,
 			counterLabelSmartClone,
+			counterLabelDegraded,
 		},
 	)
 )

--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -96,8 +96,8 @@ var operatorAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "CDIDefaultStorageClassDegraded",
-		Expr: intstr.FromString(`sum(kubevirt_cdi_storageprofile_info{default="true",rwx="true",smartclone="true"} or on() vector(0)) +
-								 sum(kubevirt_cdi_storageprofile_info{virtdefault="true",rwx="true",smartclone="true"} or on() vector(0)) +
+		Expr: intstr.FromString(`sum(kubevirt_cdi_storageprofile_info{default="true",degraded="false"} or on() vector(0)) +
+								 sum(kubevirt_cdi_storageprofile_info{virtdefault="true",degraded="false"} or on() vector(0)) +
 								 on () (0*(sum(kubevirt_cdi_storageprofile_info{default="true"}) or sum(kubevirt_cdi_storageprofile_info{virtdefault="true"}))) == 0`),
 		For: (*promv1.Duration)(ptr.To("5m")),
 		Annotations: map[string]string{

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -146,6 +146,7 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Resources: []string{
 				"proxies",
+				"infrastructures",
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
**What this PR does / why we need it**:
On single-node OpenShift, even if none of the default/virt default storage classes supports `ReadWriteMany` (but supports smart clone), we will not fire the `CDIDefaultStorageClassDegraded` alert. We added `degraded` label to `kubevirt_cdi_storageprofile_info` to simplify the alert expression.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-40665

**Special notes for your reviewer**:

**Release note**:
```release-note
Suppress CDIDefaultStorageClassDegraded alert on SNO
```

