### PR TITLE
Expose Upload Proxy certificate in CDI Config status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3961,6 +3961,10 @@
       "description": "The calculated storage class to be used for scratch space",
       "type": "string"
      },
+     "uploadProxyCA": {
+      "description": "UploadProxyCA is the certificate authority of the upload proxy",
+      "type": "string"
+     },
      "uploadProxyURL": {
       "description": "The calculated upload proxy URL",
       "type": "string"

--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/go.uber.org/zap/zapcore:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -407,6 +408,9 @@ func getCacheOptions(apiClient client.Client, cdiNamespace string) cache.Options
 				Field: namespaceSelector,
 			},
 			&batchv1.Job{}: {
+				Field: namespaceSelector,
+			},
+			&v1.ConfigMap{}: {
 				Field: namespaceSelector,
 			},
 		},

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -15420,6 +15420,13 @@ func schema_pkg_apis_core_v1beta1_CDIConfigStatus(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"uploadProxyCA": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UploadProxyCA is the certificate authority of the upload proxy",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"importProxy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImportProxy contains importer pod proxy configuration.",

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -4959,6 +4959,10 @@ spec:
               scratchSpaceStorageClass:
                 description: The calculated storage class to be used for scratch space
                 type: string
+              uploadProxyCA:
+                description: UploadProxyCA is the certificate authority of the upload
+                  proxy
+                type: string
               uploadProxyURL:
                 description: The calculated upload proxy URL
                 type: string

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -1025,6 +1025,8 @@ type CDIConfigSpec struct {
 type CDIConfigStatus struct {
 	// The calculated upload proxy URL
 	UploadProxyURL *string `json:"uploadProxyURL,omitempty"`
+	// UploadProxyCA is the certificate authority of the upload proxy
+	UploadProxyCA *string `json:"uploadProxyCA,omitempty"`
 	// ImportProxy contains importer pod proxy configuration.
 	// +optional
 	ImportProxy *ImportProxy `json:"importProxy,omitempty"`

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -518,6 +518,7 @@ func (CDIConfigStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                               "CDIConfigStatus provides the most recently observed status of the CDI Config resource",
 		"uploadProxyURL":                 "The calculated upload proxy URL",
+		"uploadProxyCA":                  "UploadProxyCA is the certificate authority of the upload proxy",
 		"importProxy":                    "ImportProxy contains importer pod proxy configuration.\n+optional",
 		"scratchSpaceStorageClass":       "The calculated storage class to be used for scratch space",
 		"defaultPodResourceRequirements": "ResourceRequirements describes the compute resource requirements.",

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *CDIConfigStatus) DeepCopyInto(out *CDIConfigStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.UploadProxyCA != nil {
+		in, out := &in.UploadProxyCA, &out.UploadProxyCA
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImportProxy != nil {
 		in, out := &in.ImportProxy, &out.ImportProxy
 		*out = new(ImportProxy)


### PR DESCRIPTION
**What this PR does / why we need it**:
As a VM owner I want to upload a VM disk to my cluster without needing to use an unsecured TLS connection. I want to import the upload proxy cert into my client.

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/CNV-21214

**Special notes for your reviewer**:
None of the config controller code is covered by tests, I tried to add test for `watchUploadProxyCA` but it was too much boilerplate and I didn't know what I was doing.

The reconciler is well tested (at least the happy paths) so I could add my own test easily.

**Release note**:

```release-note
Expose the upload-proxy's certificate in the CDI config status
```

