### PR TITLE
fix: Make valid labels regex less restrictive

### DIFF
--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -399,11 +399,13 @@ var _ = Describe("Import populator tests", func() {
 
 		It("should update target pvc with desired labels from succeeded pvc prime", func() {
 			const (
-				testKubevirtIoKey           = "test.kubevirt.io/test"
-				testKubevirtIoValue         = "testvalue"
-				testKubevirtIoKeyExisting   = "test.kubevirt.io/existing"
-				testKubevirtIoValueExisting = "existing"
-				testUndesiredKey            = "undesired.key"
+				testKubevirtIoKey               = "test.kubevirt.io/test"
+				testKubevirtIoValue             = "testvalue"
+				testInstancetypeKubevirtIoKey   = "instancetype.kubevirt.io/default-preference"
+				testInstancetypeKubevirtIoValue = "testpreference"
+				testKubevirtIoKeyExisting       = "test.kubevirt.io/existing"
+				testKubevirtIoValueExisting     = "existing"
+				testUndesiredKey                = "undesired.key"
 			)
 
 			// The existing key should not be overwritten
@@ -415,6 +417,7 @@ var _ = Describe("Import populator tests", func() {
 			AddAnnotation(pvcPrime, AnnPodPhase, string(corev1.PodSucceeded))
 
 			AddLabel(pvcPrime, testKubevirtIoKey, testKubevirtIoValue)
+			AddLabel(pvcPrime, testInstancetypeKubevirtIoKey, testInstancetypeKubevirtIoValue)
 			AddLabel(pvcPrime, testKubevirtIoKeyExisting, "somethingelse")
 			AddLabel(pvcPrime, testUndesiredKey, testKubevirtIoValue)
 
@@ -443,6 +446,7 @@ var _ = Describe("Import populator tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(updatedPVC.Labels).To(HaveKeyWithValue(testKubevirtIoKey, testKubevirtIoValue))
+			Expect(updatedPVC.Labels).To(HaveKeyWithValue(testInstancetypeKubevirtIoKey, testInstancetypeKubevirtIoValue))
 			Expect(updatedPVC.Labels).To(HaveKeyWithValue(testKubevirtIoKeyExisting, testKubevirtIoValueExisting))
 			Expect(updatedPVC.Labels).ToNot(HaveKey(testUndesiredKey))
 		})

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -64,7 +64,7 @@ const (
 )
 
 var (
-	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/\w+$`)
+	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/[\w-]+$`)
 )
 
 // Interface to store populator-specific methods


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This makes the valid labels regex that is used to restrict labels that are transferred from a prime PVC to an actual PVC less restrictive, so labels like 'instancetype.kubevirt.io/default-preference' are transferred too.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3315 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Properly transfer instancetype labels during containerdisk imports
```

