### PR TITLE
Prevent a panic in test clean-up

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -157,6 +157,9 @@ func BuildTestSuite() {
 
 	SynchronizedAfterSuite(func() {}, func() {
 		client := framework.ClientsInstance.K8sClient
+		if client == nil {
+			return
+		}
 
 		Eventually(func() []corev1.Namespace {
 			nsList, _ := utils.GetTestNamespaceList(client, framework.NsPrefixLabel)


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid panic in tests.

During test setup, pointer framework.ClientsInstance.K8sClient is assigned.  During the test AfterSuite phase, an Eventually loop accesses this pointer.

If the test fails before this assignment, the after-suite will panic.

Pointer assignment:
    https://github.com/kubevirt/containerized-data-importer/blob/b6392df9bf943f00c70ae71d37106cc12a576f19/tests/tests_suite_test.go#L123
Panic in AfterSuite, when calling GetTestNamespaceList:
    https://github.com/kubevirt/containerized-data-importer/blob/b6392df9bf943f00c70ae71d37106cc12a576f19/tests/tests_suite_test.go#L162
Which defereferences the client pointer in client.CoreV1():
    https://github.com/kubevirt/containerized-data-importer/blob/b6392df9bf943f00c70ae71d37106cc12a576f19/tests/utils/common.go#L136

**Special notes for your reviewer**:
I believe this is similar to this PR: https://github.com/kubevirt/containerized-data-importer/pull/3294

**Release note**:
```release-note
NONE
```

