### PR TITLE
Fix qemu O_DIRECT refusing unit tests

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -121,8 +121,6 @@ fi
 if [ -n "$DOCKER_CA_CERT_FILE" ]; then
     volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
 fi
-# add tmpfs path for testing purposes
-volumes="$volumes --tmpfs /mnt/cditmpfs"
 
 # Ensure that a bazel server is running
 if [ -z "$(${CDI_CRI} ps --format '{{.Names}}' | grep ${BAZEL_BUILDER_SERVER})" ]; then

--- a/pkg/image/directio.go
+++ b/pkg/image/directio.go
@@ -26,17 +26,47 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// OSInterface collects system level operations that need to be mocked out
+// during tests.
+type OSInterface interface {
+	Stat(path string) (os.FileInfo, error)
+	Remove(path string) error
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+}
+
+// RealOS is used to dispatch the real system level operations.
+type RealOS struct{}
+
+// Stat will call os.Stat to get the FileInfo for a given path
+func (RealOS) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// Remove will call os.Remove to remove the path.
+func (RealOS) Remove(path string) error {
+	return os.Remove(path)
+}
+
+// OpenFile will call os.OpenFile to return the file.
+func (RealOS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
 // DirectIOChecker checks if a certain destination supports direct I/O (bypassing page cache)
 type DirectIOChecker interface {
 	CheckBlockDevice(path string) (bool, error)
 	CheckFile(path string) (bool, error)
 }
 
-type directIOChecker struct{}
+type directIOChecker struct {
+	OSInterface OSInterface
+}
 
 // NewDirectIOChecker returns a new direct I/O checker
-func NewDirectIOChecker() DirectIOChecker {
-	return &directIOChecker{}
+func NewDirectIOChecker(osInterface OSInterface) DirectIOChecker {
+	return &directIOChecker{
+		OSInterface: osInterface,
+	}
 }
 
 func (c *directIOChecker) CheckBlockDevice(path string) (bool, error) {
@@ -45,10 +75,10 @@ func (c *directIOChecker) CheckBlockDevice(path string) (bool, error) {
 
 func (c *directIOChecker) CheckFile(path string) (bool, error) {
 	flags := syscall.O_RDONLY
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	if _, err := c.OSInterface.Stat(path); errors.Is(err, os.ErrNotExist) {
 		// try to create the file and perform the check
 		flags = flags | syscall.O_CREAT
-		defer os.Remove(path)
+		defer removeTempFileAndCheckErr(c.OSInterface, path)
 	}
 	return c.check(path, flags)
 }
@@ -56,12 +86,12 @@ func (c *directIOChecker) CheckFile(path string) (bool, error) {
 // based on https://github.com/kubevirt/kubevirt/blob/c4fc4ab72a868399f5331438f35b8c33e7dd0720/pkg/virt-launcher/virtwrap/converter/converter.go#L346
 func (c *directIOChecker) check(path string, flags int) (bool, error) {
 	// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-	f, err := os.OpenFile(path, flags|syscall.O_DIRECT, 0600)
+	f, err := c.OSInterface.OpenFile(path, flags|syscall.O_DIRECT, 0600)
 	if err != nil {
 		// EINVAL is returned if the filesystem does not support the O_DIRECT flag
 		if perr := (&os.PathError{}); errors.As(err, &perr) && errors.Is(perr, syscall.EINVAL) {
 			// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-			f, err := os.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
+			f, err := c.OSInterface.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
 			if err == nil {
 				defer closeIOAndCheckErr(f)
 				return false, nil
@@ -76,5 +106,11 @@ func (c *directIOChecker) check(path string, flags int) (bool, error) {
 func closeIOAndCheckErr(c io.Closer) {
 	if ferr := c.Close(); ferr != nil {
 		klog.Errorf("Error when closing file: \n%s\n", ferr)
+	}
+}
+
+func removeTempFileAndCheckErr(osInterface OSInterface, path string) {
+	if ferr := osInterface.Remove(path); ferr != nil {
+		klog.Errorf("Error when removing file: \n%s\n", ferr)
 	}
 }

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -85,7 +85,7 @@ var (
 		{"--preallocation=falloc"},
 		{"--preallocation=full"},
 	}
-	odirectChecker = NewDirectIOChecker()
+	odirectChecker = NewDirectIOChecker(RealOS{})
 )
 
 func init() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
These tests relied on tmpfs not supporting direct IO, but that has changed recently with https://github.com/torvalds/linux/commit/e88e0d366f9cfbb810b0c8509dc5d130d5a53e02.
Refactored the direct IO utils in a way that allows testing without real filesystems.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

