### PR TITLE
Fix flaking cert rotation unit test

### DIFF
--- a/hack/build/run-unit-tests.sh
+++ b/hack/build/run-unit-tests.sh
@@ -14,10 +14,12 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-set -euo pipefail
+set -exuo pipefail
 
 source hack/build/config.sh
 source hack/build/common.sh
+
+date
 
 # parsetTestOpts sets 'pkgs' and test_args
 parseTestOpts "${@}"

--- a/pkg/operator/controller/certrotation.go
+++ b/pkg/operator/controller/certrotation.go
@@ -185,7 +185,7 @@ func (cm *certManager) ensureCertConfig(secret *corev1.Secret, certConfig cdicer
 
 	// force refresh
 	if _, ok := secretCpy.Annotations[certrotation.CertificateNotAfterAnnotation]; ok {
-		secretCpy.Annotations[certrotation.CertificateNotAfterAnnotation] = time.Now().UTC().Format(time.RFC3339)
+		secretCpy.Annotations[certrotation.CertificateNotAfterAnnotation] = time.Now().Format(time.RFC3339)
 	}
 	secretCpy.Annotations[annCertConfig] = configString
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The theory is that the worker that runs unit tests is not always UTC based, so this fails when it's not. https://github.com/kubevirt/containerized-data-importer/blob/e75b580646ec2813002fe93eca4152c041b41941/pkg/operator/controller/certrotation.go#L188

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

