### PR TITLE
Add KubeSAN capabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -118,6 +118,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// huawei
 	"csi.huawei.com":     createAllButRWXFileCapabilities(),
 	"csi.huawei.com/nfs": createAllFSCapabilities(),
+	// KubeSAN
+	"kubesan.gitlab.io": {{rwx, block}, {rox, block}, {rwo, block}, {rwo, file}},
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format
@@ -152,6 +154,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"infinibox-csi-driver/nfs":                 cdiv1.CloneStrategyCsiClone,
 	"csi.trident.netapp.io/ontap-nas":          cdiv1.CloneStrategySnapshot,
 	"csi.trident.netapp.io/ontap-san":          cdiv1.CloneStrategySnapshot,
+	"kubesan.gitlab.io":                        cdiv1.CloneStrategyCsiClone,
 }
 
 const (


### PR DESCRIPTION
KubeSAN is a CSI plugin for creating volumes on a shared SAN LUN: https://gitlab.com/kubesan/kubesan

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR makes CDI work out of the box with the KubeSAN CSI plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added KubeSAN CSI plugin storage capabilities so the CDI StorageProfile is automatically populated.
```

