### PR TITLE
Properly handle DataVolume preallocation setting for all host assisted (copy) clones

### DIFF
--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -128,7 +128,7 @@ func formReadCloser(r *http.Request) (io.ReadCloser, error) {
 	return filePart, nil
 }
 
-func isCloneTraget(contentType string) bool {
+func isCloneTarget(contentType string) bool {
 	return contentType == common.BlockdeviceClone || contentType == common.FilesystemCloneContentType
 }
 
@@ -420,7 +420,7 @@ func (app *uploadServerApp) uploadHandlerAsync(irc imageReadCloser) http.Handler
 			defer close(app.doneChan)
 			app.done = true
 			app.preallocationApplied = processor.PreallocationApplied()
-			app.cloneTarget = isCloneTraget(cdiContentType)
+			app.cloneTarget = isCloneTarget(cdiContentType)
 			klog.Infof("Wrote data to %s", app.config.Destination)
 		}()
 
@@ -456,7 +456,7 @@ func (app *uploadServerApp) processUpload(irc imageReadCloser, w http.ResponseWr
 
 	app.done = true
 	app.preallocationApplied = preallocationApplied
-	app.cloneTarget = isCloneTraget(cdiContentType)
+	app.cloneTarget = isCloneTarget(cdiContentType)
 	close(app.doneChan)
 
 	if dvContentType == cdiv1.DataVolumeArchive {
@@ -479,8 +479,8 @@ func (app *uploadServerApp) uploadArchiveHandler(irc imageReadCloser) http.Handl
 }
 
 func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string) (*importer.DataProcessor, error) {
-	if sourceContentType == common.FilesystemCloneContentType {
-		return nil, fmt.Errorf("async filesystem clone not supported")
+	if isCloneTarget(sourceContentType) {
+		return nil, fmt.Errorf("async clone not supported")
 	}
 
 	uds := importer.NewAsyncUploadDataSource(newContentReader(stream, sourceContentType))
@@ -489,76 +489,124 @@ func newAsyncUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string,
 }
 
 func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, sourceContentType string, dvContentType cdiv1.DataVolumeContentType) (bool, error) {
+	stream = newContentReader(stream, sourceContentType)
 	if sourceContentType == common.FilesystemCloneContentType {
-		return false, filesystemCloneProcessor(stream, dest)
+		return filesystemCloneProcessor(stream, dest)
 	}
 
 	// Clone block device to block device or file system
-	uds := importer.NewUploadDataSource(newContentReader(stream, sourceContentType), dvContentType)
+	uds := importer.NewUploadDataSource(stream, dvContentType)
 	processor := importer.NewDataProcessor(uds, dest, common.ImporterVolumePath, common.ScratchDataDir, imageSize, filesystemOverhead, preallocation, "")
 	err := processor.ProcessData()
 	return processor.PreallocationApplied(), err
 }
 
 // Clone file system to block device or file system
-func filesystemCloneProcessor(stream io.ReadCloser, dest string) error {
+func filesystemCloneProcessor(stream io.ReadCloser, dest string) (bool, error) {
 	// Clone to block device
 	if dest == common.WriteBlockPath {
-		if err := untarToBlockdev(newSnappyReadCloser(stream), dest); err != nil {
-			return errors.Wrapf(err, "error unarchiving to %s", dest)
+		tarImageReader, err := newTarDiskImageReader(stream)
+		if err != nil {
+			stream.Close()
+			return false, err
 		}
-		return nil
+		defer tarImageReader.Close()
+
+		if err := writeToBlockdev(tarImageReader, dest); err != nil {
+			return false, errors.Wrapf(err, "error unarchiving to %s", dest)
+		}
+		return false, nil
 	}
+
+	defer stream.Close()
 
 	// Clone to file system
 	destDir := common.ImporterVolumePath
-	if err := util.UnArchiveTar(newSnappyReadCloser(stream), destDir); err != nil {
-		return errors.Wrapf(err, "error unarchiving to %s", destDir)
+	if err := util.UnArchiveTar(stream, destDir); err != nil {
+		return false, errors.Wrapf(err, "error unarchiving to %s", destDir)
 	}
+	return true, nil
+}
+
+func writeToBlockdev(stream io.ReadCloser, dest string) error {
+	f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, os.ModeDevice|os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	written, err := io.Copy(f, stream)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Written %d", written)
 	return nil
 }
 
-func untarToBlockdev(stream io.Reader, dest string) error {
+type closeWrapper struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (c *closeWrapper) Close() error {
+	var err error
+	for _, closer := range c.closers {
+		if e := closer.Close(); e != nil {
+			err = e
+		}
+	}
+	return err
+}
+
+type tarDiskImageReader struct {
+	tr           *tar.Reader
+	size, offset int64
+}
+
+func (r *tarDiskImageReader) Read(p []byte) (int, error) {
+	if r.offset >= r.size {
+		return 0, io.EOF
+	}
+	remaining := r.size - r.offset
+	if int(remaining) < len(p) {
+		p = p[:remaining]
+	}
+	n, err := r.tr.Read(p)
+	r.offset += int64(n)
+	klog.V(3).Infof("Read %d bytes, offset %d, size %d", n, r.offset, r.size)
+	return n, err
+}
+
+func newTarDiskImageReader(stream io.ReadCloser) (io.ReadCloser, error) {
 	tr := tar.NewReader(stream)
 	for {
 		header, err := tr.Next()
-		switch {
-		case err == io.EOF:
-			return nil
-		case err != nil:
-			return err
-		case header == nil:
-			continue
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
 		}
 		if !strings.Contains(header.Name, common.DiskImageName) {
 			continue
 		}
-		switch header.Typeflag {
-		case tar.TypeReg, tar.TypeGNUSparse:
-			klog.Infof("Untaring %d bytes to %s", header.Size, dest)
-			f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, os.ModeDevice|os.ModePerm)
-			if err != nil {
-				return err
-			}
-			written, err := io.CopyN(f, tr, header.Size)
-			if err != nil {
-				return err
-			}
-			klog.Infof("Written %d", written)
-			f.Close()
-			return nil
-		}
+		return &closeWrapper{
+			Reader:  &tarDiskImageReader{tr: tr, size: header.Size},
+			closers: []io.Closer{stream},
+		}, nil
 	}
+	return nil, fmt.Errorf("no disk image found in tar")
 }
 
 func newContentReader(stream io.ReadCloser, contentType string) io.ReadCloser {
-	if contentType == common.BlockdeviceClone {
+	if isCloneTarget(contentType) {
 		return newSnappyReadCloser(stream)
 	}
-
 	return stream
 }
 
 func newSnappyReadCloser(stream io.ReadCloser) io.ReadCloser {
-	return io.NopCloser(snappy.NewReader(stream))
+	return &closeWrapper{
+		Reader:  snappy.NewReader(stream),
+		closers: []io.Closer{stream},
+	}
 }

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["util.go"],
+    srcs = [
+        "file.go",
+        "util.go",
+    ],
     importpath = "kubevirt.io/containerized-data-importer/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
@@ -20,6 +23,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "file_test.go",
         "util_suite_test.go",
         "util_test.go",
     ],

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,217 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"k8s.io/klog/v2"
+)
+
+// OpenFileOrBlockDevice opens the destination data file, whether it is a block device or regular file
+func OpenFileOrBlockDevice(fileName string) (*os.File, error) {
+	var outFile *os.File
+	blockSize, err := GetAvailableSpaceBlock(fileName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error determining if block device exists")
+	}
+	if blockSize >= 0 {
+		// Block device found and size determined.
+		outFile, err = os.OpenFile(fileName, os.O_EXCL|os.O_WRONLY, os.ModePerm)
+	} else {
+		// Attempt to create the file with name filePath.  If it exists, fail.
+		outFile, err = os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.ModePerm)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not open file %q", fileName)
+	}
+	return outFile, nil
+}
+
+// CopyFile copies a file from one location to another.
+func CopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+// LinkFile symlinks the source to the target
+func LinkFile(source, target string) error {
+	out, err := exec.Command("/usr/bin/ln", "-s", source, target).CombinedOutput()
+	if err != nil {
+		fmt.Printf("out [%s]\n", string(out))
+		return err
+	}
+	return nil
+}
+
+// CopyDir copies a dir from one location to another.
+func CopyDir(source string, dest string) error {
+	// get properties of source dir
+	sourceinfo, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	// create dest dir
+	err = os.MkdirAll(dest, sourceinfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	directory, _ := os.Open(source)
+	objects, err := directory.Readdir(-1)
+
+	for _, obj := range objects {
+		src := filepath.Join(source, obj.Name())
+		dst := filepath.Join(dest, obj.Name())
+
+		if obj.IsDir() {
+			// create sub-directories - recursively
+			err = CopyDir(src, dst)
+			if err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			// perform copy
+			err = CopyFile(src, dst)
+			if err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+	return err
+}
+
+// GetAvailableSpace gets the amount of available space at the path specified.
+func GetAvailableSpace(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return int64(-1), err
+	}
+	return int64(stat.Bavail) * stat.Bsize, nil
+}
+
+// GetAvailableSpaceBlock gets the amount of available space at the block device path specified.
+func GetAvailableSpaceBlock(deviceName string) (int64, error) {
+	// Check if the file exists and is a device file.
+	if ok, err := IsDevice(deviceName); !ok || err != nil {
+		return int64(-1), err
+	}
+
+	// Device exists, attempt to get size.
+	cmd := exec.Command(blockdevFileName, "--getsize64", deviceName)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return int64(-1), errors.Errorf("%v, %s", err, errBuf.String())
+	}
+	i, err := strconv.ParseInt(strings.TrimSpace(out.String()), 10, 64)
+	if err != nil {
+		return int64(-1), err
+	}
+	return i, nil
+}
+
+// IsDevice returns true if it's a device file
+func IsDevice(deviceName string) (bool, error) {
+	info, err := os.Stat(deviceName)
+	if err == nil {
+		return (info.Mode() & os.ModeDevice) != 0, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+// Three functions for zeroing a range in the destination file:
+
+// PunchHole attempts to zero a range in a file with fallocate, for block devices and pre-allocated files.
+func PunchHole(outFile *os.File, start, length int64) error {
+	klog.Infof("Punching %d-byte hole at offset %d", length, start)
+	flags := uint32(unix.FALLOC_FL_PUNCH_HOLE | unix.FALLOC_FL_KEEP_SIZE)
+	err := syscall.Fallocate(int(outFile.Fd()), flags, start, length)
+	if err == nil {
+		_, err = outFile.Seek(length, io.SeekCurrent) // Just to move current file position
+	}
+	return err
+}
+
+// AppendZeroWithTruncate resizes the file to append zeroes, meant only for newly-created (empty and zero-length) regular files.
+func AppendZeroWithTruncate(outFile *os.File, start, length int64) error {
+	klog.Infof("Truncating %d-bytes from offset %d", length, start)
+	end, err := outFile.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if start != end {
+		return errors.Errorf("starting offset %d does not match previous ending offset %d, cannot safely append zeroes to this file using truncate", start, end)
+	}
+	err = outFile.Truncate(start + length)
+	if err != nil {
+		return err
+	}
+	_, err = outFile.Seek(0, io.SeekEnd)
+	return err
+}
+
+var zeroBuffer []byte
+
+// AppendZeroWithWrite just does normal file writes to the destination, a slow but reliable fallback option.
+func AppendZeroWithWrite(outFile *os.File, start, length int64) error {
+	klog.Infof("Writing %d zero bytes at offset %d", length, start)
+	offset, err := outFile.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	if start != offset {
+		return errors.Errorf("starting offset %d does not match previous ending offset %d, cannot safely append zeroes to this file using write", start, offset)
+	}
+	if zeroBuffer == nil { // No need to re-allocate this on every write
+		zeroBuffer = bytes.Repeat([]byte{0}, 32<<20)
+	}
+	count := int64(0)
+	for count < length {
+		blockSize := int64(len(zeroBuffer))
+		remaining := length - count
+		if remaining < blockSize {
+			blockSize = remaining
+		}
+		written, err := outFile.Write(zeroBuffer[:blockSize])
+		if err != nil {
+			return errors.Wrapf(err, "unable to write %d zeroes at offset %d: %v", length, start+count, err)
+		}
+		count += int64(written)
+	}
+	return nil
+}

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -2,8 +2,11 @@ package util
 
 import (
 	"bytes"
+	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,112 +21,192 @@ var (
 	fileDir, _ = filepath.Abs(TestImagesDir)
 )
 
-var _ = Describe("Copy files", func() {
-	var destTmp string
-	var err error
-
-	BeforeEach(func() {
-		destTmp, err = os.MkdirTemp("", "dest")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		err = os.RemoveAll(destTmp)
-		Expect(err).NotTo(HaveOccurred())
-		os.Remove("test.txt")
-	})
-
-	It("Should copy file from source to dest, with valid source and dest", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		sourceMd5, err := Md5sum(filepath.Join(TestImagesDir, "content.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		targetMd5, err := Md5sum(filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sourceMd5).Should(Equal(targetMd5))
-	})
-
-	It("Should not copy file from source to dest, with invalid source", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar22"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("Should not copy file from source to dest, with invalid target", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("Zero out ranges in files", func() {
-	var testFile *os.File
-	var testData []byte
-	testData = append(testData, bytes.Repeat([]byte{0x55}, 1024)...)
-	testData = append(testData, bytes.Repeat([]byte{0xAA}, 1024)...)
-	testData = append(testData, bytes.Repeat([]byte{0xFF}, 1024)...)
-
-	BeforeEach(func() {
+var _ = Describe("All tests", func() {
+	var _ = Describe("Copy files", func() {
+		var destTmp string
 		var err error
 
-		testFile, err = os.CreateTemp("", "test")
-		Expect(err).ToNot(HaveOccurred())
-		written, err := testFile.Write(testData)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(written).To(Equal(len(testData)))
+		BeforeEach(func() {
+			destTmp, err = os.MkdirTemp("", "dest")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err = os.RemoveAll(destTmp)
+			Expect(err).NotTo(HaveOccurred())
+			os.Remove("test.txt")
+		})
+
+		It("Should copy file from source to dest, with valid source and dest", func() {
+			err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join(destTmp, "target.tar"))
+			Expect(err).ToNot(HaveOccurred())
+			sourceMd5, err := Md5sum(filepath.Join(TestImagesDir, "content.tar"))
+			Expect(err).ToNot(HaveOccurred())
+			targetMd5, err := Md5sum(filepath.Join(destTmp, "target.tar"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sourceMd5).Should(Equal(targetMd5))
+		})
+
+		It("Should not copy file from source to dest, with invalid source", func() {
+			err = CopyFile(filepath.Join(TestImagesDir, "content.tar22"), filepath.Join(destTmp, "target.tar"))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should not copy file from source to dest, with invalid target", func() {
+			err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
-	AfterEach(func() {
-		testFile.Close()
-		os.Remove(testFile.Name())
+	var _ = Describe("Zero out ranges in files", func() {
+		var testFile *os.File
+		var testData []byte
+		testData = append(testData, bytes.Repeat([]byte{0x55}, 1024)...)
+		testData = append(testData, bytes.Repeat([]byte{0xAA}, 1024)...)
+		testData = append(testData, bytes.Repeat([]byte{0xFF}, 1024)...)
+
+		BeforeEach(func() {
+			var err error
+
+			testFile, err = os.CreateTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			written, err := testFile.Write(testData)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(written).To(Equal(len(testData)))
+		})
+
+		AfterEach(func() {
+			testFile.Close()
+			os.Remove(testFile.Name())
+		})
+
+		It("Should successfully zero a range with fallocate", func() {
+			start := 512
+			length := 100
+			end := start + length
+			err := PunchHole(testFile, int64(start), int64(length))
+			Expect(err).ToNot(HaveOccurred())
+			err = testFile.Sync()
+			Expect(err).ToNot(HaveOccurred())
+			err = testFile.Close()
+			Expect(err).ToNot(HaveOccurred())
+			data, err := os.ReadFile(testFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(HaveLen(len(testData)))
+			comparison := bytes.Compare(data[start:end], bytes.Repeat([]byte{0}, length))
+			Expect(comparison).To(Equal(0))
+			comparison = bytes.Compare(data[0:start], testData[0:start])
+			Expect(comparison).To(Equal(0))
+			comparison = bytes.Compare(data[end:], testData[end:])
+			Expect(comparison).To(Equal(0))
+		})
+
+		DescribeTable("Should successfully append zeroes to a file", func(appendFunction func(f *os.File, start, length int64) error) {
+			length := 1024
+			err := appendFunction(testFile, int64(len(testData)), int64(length))
+			Expect(err).ToNot(HaveOccurred())
+			err = testFile.Sync()
+			Expect(err).ToNot(HaveOccurred())
+			err = testFile.Close()
+			Expect(err).ToNot(HaveOccurred())
+			data, err := os.ReadFile(testFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(HaveLen(len(testData) + length))
+			comparison := bytes.Compare(data[:len(testData)], testData)
+			Expect(comparison).To(Equal(0))
+			comparison = bytes.Compare(data[len(testData):], bytes.Repeat([]byte{0}, length))
+			Expect(comparison).To(Equal(0))
+		},
+			Entry("using truncate", AppendZeroWithTruncate),
+			Entry("using write", AppendZeroWithWrite),
+		)
+
+		DescribeTable("Should fail to append zeroes to a file using seek if it already has data at the specified starting index", func(appendFunction func(f *os.File, start, length int64) error) {
+			length := 1024
+			err := appendFunction(testFile, 0, int64(length))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(MatchRegexp(".*cannot safely append.*"))
+		},
+			Entry("using truncate", AppendZeroWithTruncate),
+			Entry("using write", AppendZeroWithWrite),
+		)
 	})
 
-	It("Should successfully zero a range with fallocate", func() {
-		start := 512
-		length := 100
-		end := start + length
-		err := PunchHole(testFile, int64(start), int64(length))
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Sync()
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Close()
-		Expect(err).ToNot(HaveOccurred())
-		data, err := os.ReadFile(testFile.Name())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveLen(len(testData)))
-		comparison := bytes.Compare(data[start:end], bytes.Repeat([]byte{0}, length))
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[0:start], testData[0:start])
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[end:], testData[end:])
-		Expect(comparison).To(Equal(0))
+	Describe("StreamDataToFile tests", func() {
+		Context("with tmp directory", func() {
+			var destTmp string
+			var err error
+			var random *rand.Rand
+
+			BeforeEach(func() {
+				seed := time.Now().UnixNano()
+				By(fmt.Sprintf("Random Seed: %d", seed))
+				// #nosec G404 - seed is not used for cryptographic purposes
+				random = rand.New(rand.NewSource(seed))
+				destTmp, err = os.MkdirTemp("", "dest")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				err = os.RemoveAll(destTmp)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			randBool := func() bool {
+				return random.Intn(2) == 1
+			}
+
+			DescribeTable("Should stream data to file", func(writeSize int, preallocate bool) {
+				const (
+					totalBytes     int64 = 1024 * 1024
+					sparseBoundary int64 = 32 * 1024
+				)
+
+				// validate  writeSize
+				Expect(totalBytes % int64(writeSize)).To(Equal(int64(0)))
+
+				writeMap := make(map[int64]bool)
+				destName := filepath.Join(destTmp, "disk.img")
+				byteBuf := bytes.NewBuffer(make([]byte, 0, totalBytes))
+				expectedBytesWritten := totalBytes
+
+				for curOffset := int64(0); curOffset < totalBytes; curOffset += int64(writeSize) {
+					b := byte(0)
+					if randBool() {
+						if !preallocate {
+							boundaryEnd := curOffset + int64(writeSize)
+							for boundaryStart := curOffset; boundaryStart < boundaryEnd; boundaryStart += sparseBoundary {
+								sparseOffset := boundaryStart / sparseBoundary
+								writeMap[sparseOffset] = true
+							}
+						}
+						b = 1
+					}
+					byteBuf.Write(bytes.Repeat([]byte{b}, writeSize))
+				}
+
+				if !preallocate {
+					expectedBytesWritten = int64(len(writeMap)) * sparseBoundary
+				}
+
+				bytesRead, bytesWritten, err := StreamDataToFile(bytes.NewReader(byteBuf.Bytes()), destName, preallocate)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesRead).To(Equal(totalBytes))
+				Expect(bytesWritten).To(Equal(expectedBytesWritten))
+
+				fileData, err := os.ReadFile(destName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fileData).To(Equal(byteBuf.Bytes()))
+			},
+				Entry("without preallocation 4k block", 4*1024, false),
+				Entry("without preallocation 16k block", 16*1024, false),
+				Entry("without preallocation 32k block", 32*1024, false),
+				Entry("without preallocation 64k block", 64*1024, false),
+				Entry("without preallocation 128k block", 128*1024, false),
+				Entry("with preallocation 16k block", 16*1024, true),
+				Entry("with preallocation 32k block", 32*1024, true),
+				Entry("with preallocation 64k block", 64*1024, true),
+			)
+		})
 	})
-
-	DescribeTable("Should successfully append zeroes to a file", func(appendFunction func(f *os.File, start, length int64) error) {
-		length := 1024
-		err := appendFunction(testFile, int64(len(testData)), int64(length))
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Sync()
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Close()
-		Expect(err).ToNot(HaveOccurred())
-		data, err := os.ReadFile(testFile.Name())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveLen(len(testData) + length))
-		comparison := bytes.Compare(data[:len(testData)], testData)
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[len(testData):], bytes.Repeat([]byte{0}, length))
-		Expect(comparison).To(Equal(0))
-	},
-		Entry("using truncate", AppendZeroWithTruncate),
-		Entry("using write", AppendZeroWithWrite),
-	)
-
-	DescribeTable("Should fail to append zeroes to a file using seek if it already has data at the specified starting index", func(appendFunction func(f *os.File, start, length int64) error) {
-		length := 1024
-		err := appendFunction(testFile, 0, int64(length))
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).Should(MatchRegexp(".*cannot safely append.*"))
-	},
-		Entry("using truncate", AppendZeroWithTruncate),
-		Entry("using write", AppendZeroWithWrite),
-	)
 })

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,129 @@
+package util
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	pattern       = "^[a-zA-Z0-9]+$"
+	TestImagesDir = "../../tests/images"
+)
+
+var (
+	fileDir, _ = filepath.Abs(TestImagesDir)
+)
+
+var _ = Describe("Copy files", func() {
+	var destTmp string
+	var err error
+
+	BeforeEach(func() {
+		destTmp, err = os.MkdirTemp("", "dest")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err = os.RemoveAll(destTmp)
+		Expect(err).NotTo(HaveOccurred())
+		os.Remove("test.txt")
+	})
+
+	It("Should copy file from source to dest, with valid source and dest", func() {
+		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join(destTmp, "target.tar"))
+		Expect(err).ToNot(HaveOccurred())
+		sourceMd5, err := Md5sum(filepath.Join(TestImagesDir, "content.tar"))
+		Expect(err).ToNot(HaveOccurred())
+		targetMd5, err := Md5sum(filepath.Join(destTmp, "target.tar"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sourceMd5).Should(Equal(targetMd5))
+	})
+
+	It("Should not copy file from source to dest, with invalid source", func() {
+		err = CopyFile(filepath.Join(TestImagesDir, "content.tar22"), filepath.Join(destTmp, "target.tar"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should not copy file from source to dest, with invalid target", func() {
+		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("Zero out ranges in files", func() {
+	var testFile *os.File
+	var testData []byte
+	testData = append(testData, bytes.Repeat([]byte{0x55}, 1024)...)
+	testData = append(testData, bytes.Repeat([]byte{0xAA}, 1024)...)
+	testData = append(testData, bytes.Repeat([]byte{0xFF}, 1024)...)
+
+	BeforeEach(func() {
+		var err error
+
+		testFile, err = os.CreateTemp("", "test")
+		Expect(err).ToNot(HaveOccurred())
+		written, err := testFile.Write(testData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(written).To(Equal(len(testData)))
+	})
+
+	AfterEach(func() {
+		testFile.Close()
+		os.Remove(testFile.Name())
+	})
+
+	It("Should successfully zero a range with fallocate", func() {
+		start := 512
+		length := 100
+		end := start + length
+		err := PunchHole(testFile, int64(start), int64(length))
+		Expect(err).ToNot(HaveOccurred())
+		err = testFile.Sync()
+		Expect(err).ToNot(HaveOccurred())
+		err = testFile.Close()
+		Expect(err).ToNot(HaveOccurred())
+		data, err := os.ReadFile(testFile.Name())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveLen(len(testData)))
+		comparison := bytes.Compare(data[start:end], bytes.Repeat([]byte{0}, length))
+		Expect(comparison).To(Equal(0))
+		comparison = bytes.Compare(data[0:start], testData[0:start])
+		Expect(comparison).To(Equal(0))
+		comparison = bytes.Compare(data[end:], testData[end:])
+		Expect(comparison).To(Equal(0))
+	})
+
+	DescribeTable("Should successfully append zeroes to a file", func(appendFunction func(f *os.File, start, length int64) error) {
+		length := 1024
+		err := appendFunction(testFile, int64(len(testData)), int64(length))
+		Expect(err).ToNot(HaveOccurred())
+		err = testFile.Sync()
+		Expect(err).ToNot(HaveOccurred())
+		err = testFile.Close()
+		Expect(err).ToNot(HaveOccurred())
+		data, err := os.ReadFile(testFile.Name())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveLen(len(testData) + length))
+		comparison := bytes.Compare(data[:len(testData)], testData)
+		Expect(comparison).To(Equal(0))
+		comparison = bytes.Compare(data[len(testData):], bytes.Repeat([]byte{0}, length))
+		Expect(comparison).To(Equal(0))
+	},
+		Entry("using truncate", AppendZeroWithTruncate),
+		Entry("using write", AppendZeroWithWrite),
+	)
+
+	DescribeTable("Should fail to append zeroes to a file using seek if it already has data at the specified starting index", func(appendFunction func(f *os.File, start, length int64) error) {
+		length := 1024
+		err := appendFunction(testFile, 0, int64(length))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).Should(MatchRegexp(".*cannot safely append.*"))
+	},
+		Entry("using truncate", AppendZeroWithTruncate),
+		Entry("using write", AppendZeroWithWrite),
+	)
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,20 +6,15 @@ import (
 	"crypto/md5" //nolint:gosec // This is not a security-sensitive use case
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"math"
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -106,80 +101,12 @@ func GetAvailableSpaceByVolumeMode(volumeMode v1.PersistentVolumeMode) (int64, e
 	return GetAvailableSpace(common.ImporterVolumePath)
 }
 
-// GetAvailableSpace gets the amount of available space at the path specified.
-func GetAvailableSpace(path string) (int64, error) {
-	var stat syscall.Statfs_t
-	err := syscall.Statfs(path, &stat)
-	if err != nil {
-		return int64(-1), err
-	}
-	return int64(stat.Bavail) * stat.Bsize, nil
-}
-
-// GetAvailableSpaceBlock gets the amount of available space at the block device path specified.
-func GetAvailableSpaceBlock(deviceName string) (int64, error) {
-	// Check if the file exists and is a device file.
-	if ok, err := IsDevice(deviceName); !ok || err != nil {
-		return int64(-1), err
-	}
-
-	// Device exists, attempt to get size.
-	cmd := exec.Command(blockdevFileName, "--getsize64", deviceName)
-	var out bytes.Buffer
-	var errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	err := cmd.Run()
-	if err != nil {
-		return int64(-1), errors.Errorf("%v, %s", err, errBuf.String())
-	}
-	i, err := strconv.ParseInt(strings.TrimSpace(out.String()), 10, 64)
-	if err != nil {
-		return int64(-1), err
-	}
-	return i, nil
-}
-
-// IsDevice returns true if it's a device file
-func IsDevice(deviceName string) (bool, error) {
-	info, err := os.Stat(deviceName)
-	if err == nil {
-		return (info.Mode() & os.ModeDevice) != 0, nil
-	}
-
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-
-	return false, err
-}
-
 // MinQuantity calculates the minimum of two quantities.
 func MinQuantity(availableSpace, imageSize *resource.Quantity) resource.Quantity {
 	if imageSize.Cmp(*availableSpace) == 1 {
 		return *availableSpace
 	}
 	return *imageSize
-}
-
-// OpenFileOrBlockDevice opens the destination data file, whether it is a block device or regular file
-func OpenFileOrBlockDevice(fileName string) (*os.File, error) {
-	var outFile *os.File
-	blockSize, err := GetAvailableSpaceBlock(fileName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error determining if block device exists")
-	}
-	if blockSize >= 0 {
-		// Block device found and size determined.
-		outFile, err = os.OpenFile(fileName, os.O_EXCL|os.O_WRONLY, os.ModePerm)
-	} else {
-		// Attempt to create the file with name filePath.  If it exists, fail.
-		outFile, err = os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.ModePerm)
-	}
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not open file %q", fileName)
-	}
-	return outFile, nil
 }
 
 // UnArchiveTar unarchives a tar file and streams its files
@@ -206,27 +133,6 @@ func UnArchiveTar(reader io.Reader, destDir string) error {
 	return nil
 }
 
-// CopyFile copies a file from one location to another.
-func CopyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-	return out.Close()
-}
-
 // WriteTerminationMessage writes the passed in message to the default termination message file
 func WriteTerminationMessage(message string) error {
 	return WriteTerminationMessageToFile(common.PodTerminationMessageFile, message)
@@ -243,54 +149,6 @@ func WriteTerminationMessageToFile(file, message string) error {
 		if err != nil {
 			return errors.Wrap(err, "could not create termination message file")
 		}
-	}
-	return nil
-}
-
-// CopyDir copies a dir from one location to another.
-func CopyDir(source string, dest string) error {
-	// get properties of source dir
-	sourceinfo, err := os.Stat(source)
-	if err != nil {
-		return err
-	}
-
-	// create dest dir
-	err = os.MkdirAll(dest, sourceinfo.Mode())
-	if err != nil {
-		return err
-	}
-
-	directory, _ := os.Open(source)
-	objects, err := directory.Readdir(-1)
-
-	for _, obj := range objects {
-		src := filepath.Join(source, obj.Name())
-		dst := filepath.Join(dest, obj.Name())
-
-		if obj.IsDir() {
-			// create sub-directories - recursively
-			err = CopyDir(src, dst)
-			if err != nil {
-				fmt.Println(err)
-			}
-		} else {
-			// perform copy
-			err = CopyFile(src, dst)
-			if err != nil {
-				fmt.Println(err)
-			}
-		}
-	}
-	return err
-}
-
-// LinkFile symlinks the source to the target
-func LinkFile(source, target string) error {
-	out, err := exec.Command("/usr/bin/ln", "-s", source, target).CombinedOutput()
-	if err != nil {
-		fmt.Printf("out [%s]\n", string(out))
-		return err
 	}
 	return nil
 }
@@ -380,68 +238,6 @@ func Md5sum(filePath string) (string, error) {
 
 	hashInBytes := hash.Sum(nil)[:16]
 	return hex.EncodeToString(hashInBytes), nil
-}
-
-// Three functions for zeroing a range in the destination file:
-
-// PunchHole attempts to zero a range in a file with fallocate, for block devices and pre-allocated files.
-func PunchHole(outFile *os.File, start, length int64) error {
-	klog.Infof("Punching %d-byte hole at offset %d", length, start)
-	flags := uint32(unix.FALLOC_FL_PUNCH_HOLE | unix.FALLOC_FL_KEEP_SIZE)
-	err := syscall.Fallocate(int(outFile.Fd()), flags, start, length)
-	if err == nil {
-		_, err = outFile.Seek(length, io.SeekCurrent) // Just to move current file position
-	}
-	return err
-}
-
-// AppendZeroWithTruncate resizes the file to append zeroes, meant only for newly-created (empty and zero-length) regular files.
-func AppendZeroWithTruncate(outFile *os.File, start, length int64) error {
-	klog.Infof("Truncating %d-bytes from offset %d", length, start)
-	end, err := outFile.Seek(0, io.SeekEnd)
-	if err != nil {
-		return err
-	}
-	if start != end {
-		return errors.Errorf("starting offset %d does not match previous ending offset %d, cannot safely append zeroes to this file using truncate", start, end)
-	}
-	err = outFile.Truncate(start + length)
-	if err != nil {
-		return err
-	}
-	_, err = outFile.Seek(0, io.SeekEnd)
-	return err
-}
-
-var zeroBuffer []byte
-
-// AppendZeroWithWrite just does normal file writes to the destination, a slow but reliable fallback option.
-func AppendZeroWithWrite(outFile *os.File, start, length int64) error {
-	klog.Infof("Writing %d zero bytes at offset %d", length, start)
-	offset, err := outFile.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return err
-	}
-	if start != offset {
-		return errors.Errorf("starting offset %d does not match previous ending offset %d, cannot safely append zeroes to this file using write", start, offset)
-	}
-	if zeroBuffer == nil { // No need to re-allocate this on every write
-		zeroBuffer = bytes.Repeat([]byte{0}, 32<<20)
-	}
-	count := int64(0)
-	for count < length {
-		blockSize := int64(len(zeroBuffer))
-		remaining := length - count
-		if remaining < blockSize {
-			blockSize = remaining
-		}
-		written, err := outFile.Write(zeroBuffer[:blockSize])
-		if err != nil {
-			return errors.Wrapf(err, "unable to write %d zeroes at offset %d: %v", length, start+count, err)
-		}
-		count += int64(written)
-	}
-	return nil
 }
 
 // GetUsableSpace calculates space to use taking file system overhead into account

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bytes"
 	"encoding/base64"
 	"os"
 	"path/filepath"
@@ -11,15 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-)
-
-const (
-	pattern       = "^[a-zA-Z0-9]+$"
-	TestImagesDir = "../../tests/images"
-)
-
-var (
-	fileDir, _ = filepath.Abs(TestImagesDir)
 )
 
 var _ = Describe("Util", func() {
@@ -114,115 +104,6 @@ var _ = Describe("Compare quantities", func() {
 	})
 })
 
-var _ = Describe("Copy files", func() {
-	var destTmp string
-	var err error
-
-	BeforeEach(func() {
-		destTmp, err = os.MkdirTemp("", "dest")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		err = os.RemoveAll(destTmp)
-		Expect(err).NotTo(HaveOccurred())
-		os.Remove("test.txt")
-	})
-
-	It("Should copy file from source to dest, with valid source and dest", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		sourceMd5, err := Md5sum(filepath.Join(TestImagesDir, "content.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		targetMd5, err := Md5sum(filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sourceMd5).Should(Equal(targetMd5))
-	})
-
-	It("Should not copy file from source to dest, with invalid source", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar22"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("Should not copy file from source to dest, with invalid target", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("Zero out ranges in files", func() {
-	var testFile *os.File
-	var testData []byte
-	testData = append(testData, bytes.Repeat([]byte{0x55}, 1024)...)
-	testData = append(testData, bytes.Repeat([]byte{0xAA}, 1024)...)
-	testData = append(testData, bytes.Repeat([]byte{0xFF}, 1024)...)
-
-	BeforeEach(func() {
-		var err error
-
-		testFile, err = os.CreateTemp("", "test")
-		Expect(err).ToNot(HaveOccurred())
-		written, err := testFile.Write(testData)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(written).To(Equal(len(testData)))
-	})
-
-	AfterEach(func() {
-		testFile.Close()
-		os.Remove(testFile.Name())
-	})
-
-	It("Should successfully zero a range with fallocate", func() {
-		start := 512
-		length := 100
-		end := start + length
-		err := PunchHole(testFile, int64(start), int64(length))
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Sync()
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Close()
-		Expect(err).ToNot(HaveOccurred())
-		data, err := os.ReadFile(testFile.Name())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveLen(len(testData)))
-		comparison := bytes.Compare(data[start:end], bytes.Repeat([]byte{0}, length))
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[0:start], testData[0:start])
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[end:], testData[end:])
-		Expect(comparison).To(Equal(0))
-	})
-
-	DescribeTable("Should successfully append zeroes to a file", func(appendFunction func(f *os.File, start, length int64) error) {
-		length := 1024
-		err := appendFunction(testFile, int64(len(testData)), int64(length))
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Sync()
-		Expect(err).ToNot(HaveOccurred())
-		err = testFile.Close()
-		Expect(err).ToNot(HaveOccurred())
-		data, err := os.ReadFile(testFile.Name())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveLen(len(testData) + length))
-		comparison := bytes.Compare(data[:len(testData)], testData)
-		Expect(comparison).To(Equal(0))
-		comparison = bytes.Compare(data[len(testData):], bytes.Repeat([]byte{0}, length))
-		Expect(comparison).To(Equal(0))
-	},
-		Entry("using truncate", AppendZeroWithTruncate),
-		Entry("using write", AppendZeroWithWrite),
-	)
-
-	DescribeTable("Should fail to append zeroes to a file using seek if it already has data at the specified starting index", func(appendFunction func(f *os.File, start, length int64) error) {
-		length := 1024
-		err := appendFunction(testFile, 0, int64(length))
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).Should(MatchRegexp(".*cannot safely append.*"))
-	},
-		Entry("using truncate", AppendZeroWithTruncate),
-		Entry("using write", AppendZeroWithWrite),
-	)
-})
 var _ = Describe("Usable Space calculation", func() {
 
 	const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently the DataVolume preallocation setting is only honored in filesystem->filesystem clones.  This PR adds support for:

filesystem->block
block->block
block->filesystem

It does this by breaking the image stream into 32k blocks.  If a block is all zeros, then the zeros will not be directly written.  Instead, zero ranges will be coalesced and the appropriate API for the target will be called to "mark" the zero range.  For filesystem volumes, truncate is called.  For block devices, the "hole punch" API is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-39213

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Properly handle DataVolume preallocation setting for all host assisted (copy) clones
```

