### PR TITLE
Handle storage class changes automatically in cron controller

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/component-helpers/storage/volume:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -313,6 +314,15 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 		if deleted, err := r.deleteOutdatedPendingPvc(ctx, pvc, desiredStorageClass.Name, dataImportCron.Name); deleted || err != nil {
 			return res, err
 		}
+		currentSc, hasCurrent := dataImportCron.Annotations[AnnStorageClass]
+		desiredSc := desiredStorageClass.Name
+		if hasCurrent && currentSc != desiredSc {
+			r.log.Info("Storage class changed, delete most recent source on the old sc as it's no longer the desired", "currentSc", currentSc, "desiredSc", desiredSc)
+			if err := r.handleStorageClassChange(ctx, dataImportCron, desiredSc); err != nil {
+				return res, err
+			}
+			return reconcile.Result{RequeueAfter: time.Second}, nil
+		}
 		cc.AddAnnotation(dataImportCron, AnnStorageClass, desiredStorageClass.Name)
 	}
 	format, err := r.getSourceFormat(ctx, desiredStorageClass)
@@ -354,7 +364,6 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, fmt.Sprintf("Import DataVolume phase %s", dvPhase), dvPhase)
 		}
 	case pvc != nil && pvc.Status.Phase == corev1.ClaimBound:
-		// TODO: with plain populator PVCs (no DataVolumes) we may need to wait for corev1.Bound
 		if err := handlePopulatedPvc(); err != nil {
 			return res, err
 		}
@@ -671,6 +680,38 @@ func (r *DataImportCronReconciler) createImportDataVolume(ctx context.Context, d
 
 	dv := r.newSourceDataVolume(dataImportCron, dvName)
 	if err := r.client.Create(ctx, dv); err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (r *DataImportCronReconciler) handleStorageClassChange(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass string) error {
+	digest, ok := dataImportCron.Annotations[AnnSourceDesiredDigest]
+	if !ok {
+		// nothing to delete
+		return nil
+	}
+	name, err := createDvName(dataImportCron.Spec.ManagedDataSource, digest)
+	if err != nil {
+		return err
+	}
+	om := metav1.ObjectMeta{Name: name, Namespace: dataImportCron.Namespace}
+	sources := []client.Object{&snapshotv1.VolumeSnapshot{ObjectMeta: om}, &cdiv1.DataVolume{ObjectMeta: om}, &corev1.PersistentVolumeClaim{ObjectMeta: om}}
+	for _, src := range sources {
+		if err := r.client.Delete(ctx, src); cc.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+	for _, src := range sources {
+		if err := r.client.Get(ctx, client.ObjectKeyFromObject(src), src); err == nil || !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("waiting for old sources to get cleaned up: %w", err)
+		}
+	}
+	// Only update desired storage class once garbage collection went through
+	annPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/annotations/%s","value":"%s" }]`, openapicommon.EscapeJsonPointer(AnnStorageClass), desiredStorageClass)
+	err = r.client.Patch(ctx, dataImportCron, client.RawPatch(types.JSONPatchType, []byte(annPatch)))
+	if err != nil {
 		return err
 	}
 
@@ -1113,7 +1154,7 @@ func addDefaultStorageClassUpdateWatch(mgr manager.Manager, c controller.Control
 				log.Info("Update", "sc", obj.GetName(),
 					"default", obj.GetAnnotations()[cc.AnnDefaultStorageClass] == "true",
 					"defaultVirt", obj.GetAnnotations()[cc.AnnDefaultVirtStorageClass] == "true")
-				reqs, err := getReconcileRequestsForDicsWithPendingPvc(ctx, mgr.GetClient())
+				reqs, err := getReconcileRequestsForDicsWithoutExplicitStorageClass(ctx, mgr.GetClient())
 				if err != nil {
 					log.Error(err, "Failed getting DataImportCrons with pending PVCs")
 				}
@@ -1135,7 +1176,7 @@ func addDefaultStorageClassUpdateWatch(mgr manager.Manager, c controller.Control
 	return nil
 }
 
-func getReconcileRequestsForDicsWithPendingPvc(ctx context.Context, c client.Client) ([]reconcile.Request, error) {
+func getReconcileRequestsForDicsWithoutExplicitStorageClass(ctx context.Context, c client.Client) ([]reconcile.Request, error) {
 	dicList := &cdiv1.DataImportCronList{}
 	if err := c.List(ctx, dicList); err != nil {
 		return nil, err
@@ -1146,23 +1187,7 @@ func getReconcileRequestsForDicsWithPendingPvc(ctx context.Context, c client.Cli
 			continue
 		}
 
-		imports := dic.Status.CurrentImports
-		if len(imports) == 0 {
-			continue
-		}
-
-		pvcName := imports[0].DataVolumeName
-		pvc := &corev1.PersistentVolumeClaim{}
-		if err := c.Get(ctx, types.NamespacedName{Namespace: dic.Namespace, Name: pvcName}, pvc); err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-
-		if pvc.Status.Phase == corev1.ClaimPending {
-			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dic.Name, Namespace: dic.Namespace}})
-		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dic.Name, Namespace: dic.Namespace}})
 	}
 
 	return reqs, nil

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -988,9 +988,10 @@ var _ = Describe("All DataImportCron Tests", func() {
 
 		Context("Snapshot source format", func() {
 			snapFormat := cdiv1.DataImportCronSourceFormatSnapshot
+			var sc *storagev1.StorageClass
 
 			BeforeEach(func() {
-				sc := cc.CreateStorageClass(storageClassName, map[string]string{cc.AnnDefaultStorageClass: "true"})
+				sc = cc.CreateStorageClass(storageClassName, map[string]string{cc.AnnDefaultStorageClass: "true"})
 				sp := &cdiv1.StorageProfile{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: storageClassName,
@@ -1010,6 +1011,94 @@ var _ = Describe("All DataImportCron Tests", func() {
 				err := reconciler.client.Get(context.TODO(), client.ObjectKeyFromObject(storageProfile), storageProfile)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			DescribeTable("Should handle sources in the event of storage class change", func(shouldCleanupOldScSource bool) {
+				cron = newDataImportCron(cronName)
+				dataSource = nil
+				dvName := "test-datasource-68b44fc891f3"
+				retentionPolicy := cdiv1.DataImportCronRetainNone
+				cron.Spec.RetentionPolicy = &retentionPolicy
+				cron.Status = cdiv1.DataImportCronStatus{
+					CurrentImports: []cdiv1.ImportStatus{
+						{
+							DataVolumeName: dvName,
+							Digest:         testDigest,
+						},
+					},
+				}
+				cc.AddAnnotation(cron, AnnStorageClass, sc.Name)
+				cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
+				err := reconciler.client.Create(context.TODO(), cron)
+				Expect(err).ToNot(HaveOccurred())
+
+				dataSource = &cdiv1.DataSource{}
+				snap := &snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dvName,
+						Namespace: metav1.NamespaceDefault,
+						Annotations: map[string]string{
+							cc.AnnSourceVolumeMode: "dummy",
+						},
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &dvName,
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: ptr.To[bool](true),
+					},
+				}
+				err = reconciler.client.Create(context.TODO(), snap)
+				Expect(err).ToNot(HaveOccurred())
+
+				verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+
+				// Trigger desired storage class by spawning virt default sc variation
+				virtSc := cc.CreateStorageClass(sc.Name+"-virt", map[string]string{cc.AnnDefaultVirtStorageClass: strconv.FormatBool(shouldCleanupOldScSource)})
+				virtSp := &cdiv1.StorageProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: virtSc.Name,
+					},
+					Status: cdiv1.StorageProfileStatus{
+						DataImportCronSourceFormat: &snapFormat,
+					},
+				}
+				err = reconciler.client.Create(context.TODO(), virtSc)
+				Expect(err).ToNot(HaveOccurred())
+				err = reconciler.client.Create(context.TODO(), virtSp)
+				Expect(err).ToNot(HaveOccurred())
+				if shouldCleanupOldScSource {
+					// simulate first reconcile deleting old sources and requeueing
+					_, err := reconciler.Reconcile(context.TODO(), cronReq)
+					Expect(err).ToNot(HaveOccurred())
+					verifyConditions("After DesiredDigest is set", false, false, false, noImport, outdated, "NotFound", &snapshotv1.VolumeSnapshot{})
+					err = reconciler.client.Get(context.TODO(), cronKey, cron)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cron.Annotations[AnnStorageClass]).To(Equal(virtSc.Name))
+				} else {
+					verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+					err = reconciler.client.Get(context.TODO(), cronKey, cron)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cron.Annotations[AnnStorageClass]).To(Equal(sc.Name))
+				}
+
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
+				if !shouldCleanupOldScSource {
+					Expect(err).ToNot(HaveOccurred())
+					return
+				}
+				// Snapshot created by old storage class is gone
+				Expect(err).To(And(HaveOccurred(), Satisfy(k8serrors.IsNotFound)))
+				dv := &cdiv1.DataVolume{}
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*dv.Spec.Source.Registry.URL).To(Equal(testRegistryURL + "@" + testDigest))
+				Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
+			},
+				Entry("source deleted when appropriate", true),
+				Entry("source not deleted when not appropriate", false),
+			)
 
 			It("Should proceed to at least creating a PVC when no default storage class", func() {
 				// Simulate an environment without default storage class


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Until now we've never performed the necessary adjustments when the desired storage class changed.
Instead, we documented it and relied on the user to perform the cleanup of actual sources.
This commit starts doing that on behalf of the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle desired storage class changes automatically in cron controller by deleting old storage class sources
```
