### PR TITLE
updating documentation to reflect the ability to use the upload source and the archive contentType as a valid combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ CDI only supports certain combinations of `source` and `contentType` as indicate
 * `http` &rarr; `kubevirt`, `archive`
 * `registry` &rarr; `kubevirt`
 * `pvc` &rarr; Not applicable - content is cloned
-* `upload` &rarr; `kubevirt`
+* `upload` &rarr; `kubevirt`, `archive`
 * `imageio` &rarr; `kubevirt`
 * `vddk` &rarr; `kubevirt`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the README to reflect that the `upload` source and `archive` contentType is a valid combination when using the CDI.  The feature already has a test in place (https://github.com/kubevirt/containerized-data-importer/blob/main/tests/upload_test.go#L353-L429) and I have tested it as well with the latest `virtctl image-upload` command. 

**Special notes for your reviewer**:
This was discussed on the #virtualization slack channel here: https://kubernetes.slack.com/archives/C8ED7RKFE/p1721845792329019

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

