### PR TITLE
pkg/importer: Increase number of nbdkit lines logged

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -65,7 +65,7 @@ var newNbdKitLogWatcher = createNbdKitLogWatcher
 const (
 	nbdUnixSocket = "/tmp/nbd.sock"
 	nbdPidFile    = "/tmp/nbd.pid"
-	maxLogLines   = 30
+	maxLogLines   = 1000
 )
 
 var vddkVersion string


### PR DESCRIPTION
30 is far too small.  For "chatty" plugins like VDDK many more debugging lines will be printed for simple open calls.  For debugging it is vital that we do not lose this information.  Ideally I would set this to infinity.

Related: https://issues.redhat.com/browse/CNV-44894

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VDDK datasource: Increase number of nbdkit lines logged
```

CC @mrnold 
