### PR TITLE
nbdkit datapath debug

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -143,7 +143,6 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 		pluginArgs = append(pluginArgs, "vm=moref="+moref)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
-	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.controlpath=0")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")
 	p := getVddkPluginPath()
 	n := &Nbdkit{

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -144,6 +144,8 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")
+	pluginArgs = append(pluginArgs, "-D", "vddk.datapath=0")
+	pluginArgs = append(pluginArgs, "-D", "vddk.stats=1")
 	p := getVddkPluginPath()
 	n := &Nbdkit{
 		NbdPidFile: nbdkitPidFile,


### PR DESCRIPTION
Generally use the recommended mix of -D (debug) flags for nbdkit VDDK plugin.  The result is less noisy while containing much useful information.

See also:
https://libguestfs.org/nbdkit-vddk-plugin.1.html#Troubleshooting-performance-problems

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

