### PR TITLE
Fix PVC deletion logic in populators

### DIFF
--- a/pkg/controller/clone/csi-clone_test.go
+++ b/pkg/controller/clone/csi-clone_test.go
@@ -177,6 +177,7 @@ var _ = Describe("CSIClonePhase test", func() {
 			It("should succeed (immediate bind)", func() {
 				desired := getDesiredClaim()
 				desired.Spec.VolumeName = "vol"
+				desired.Status.Phase = corev1.ClaimBound
 				p := createCSIClonePhase(sourceClaim, getStorageClass(), desired)
 
 				result, err := p.Reconcile(context.Background())

--- a/pkg/controller/clone/planner_test.go
+++ b/pkg/controller/clone/planner_test.go
@@ -186,6 +186,7 @@ var _ = Describe("Planner test", func() {
 	createSourceClaim := func() *corev1.PersistentVolumeClaim {
 		s := createClaim(sourceName)
 		s.Spec.VolumeName = volumeName
+		s.Status.Phase = corev1.ClaimBound
 		s.Status.Capacity = corev1.ResourceList{
 			corev1.ResourceStorage: s.Spec.Resources.Requests[corev1.ResourceStorage],
 		}

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -72,11 +72,6 @@ func (p *PrepClaimPhase) Reconcile(ctx context.Context) (*reconcile.Result, erro
 
 	if !hasActual {
 		if cc.IsBound(actualClaim) {
-			// PVC is bound but its status hasn't been updated yet.
-			// We'll reconcile again once the status is updated.
-			if actualClaim.Status.Phase == corev1.ClaimPending {
-				return &reconcile.Result{}, nil
-			}
 			return nil, fmt.Errorf("actual PVC size missing")
 		}
 

--- a/pkg/controller/clone/prep-claim_test.go
+++ b/pkg/controller/clone/prep-claim_test.go
@@ -226,6 +226,7 @@ var _ = Describe("PrepClaimPhase test", func() {
 			claim := getClaim()
 			cc.AddAnnotation(claim, cc.AnnSelectedNode, "node1")
 			claim.Spec.Resources.Requests[corev1.ResourceStorage] = defaultRequestSize
+			claim.Status.Phase = corev1.ClaimPending
 
 			p := createPrepClaimPhase(claim)
 

--- a/pkg/controller/clone/rebind_test.go
+++ b/pkg/controller/clone/rebind_test.go
@@ -107,6 +107,7 @@ var _ = Describe("RebindPhase test", func() {
 		It("should succeed if target is bound", func() {
 			target := createTarget()
 			target.Spec.VolumeName = pvName
+			target.Status.Phase = corev1.ClaimBound
 
 			p := createRebindPhase(target)
 			result, err := p.Reconcile(context.Background())
@@ -158,6 +159,7 @@ var _ = Describe("RebindPhase test", func() {
 				volume := createVolume()
 				source := createSource()
 				source.Spec.VolumeName = volume.Name
+				source.Status.Phase = corev1.ClaimBound
 				p := createRebindPhase(createTarget(), source, volume)
 				result, err := p.Reconcile(context.Background())
 				Expect(err).ToNot(HaveOccurred())
@@ -178,6 +180,7 @@ var _ = Describe("RebindPhase test", func() {
 				volume.Spec.ClaimRef.Name = "foo"
 				source := createSource()
 				source.Spec.VolumeName = volume.Name
+				source.Status.Phase = corev1.ClaimBound
 				p := createRebindPhase(createTarget(), source, volume)
 				result, err := p.Reconcile(context.Background())
 				Expect(err).To(HaveOccurred())

--- a/pkg/controller/clone/snap-clone_test.go
+++ b/pkg/controller/clone/snap-clone_test.go
@@ -197,6 +197,7 @@ var _ = Describe("SnapshotClonePhase test", func() {
 			It("should succeed (immediate bind)", func() {
 				desired := getDesiredClaim()
 				desired.Spec.VolumeName = "vol"
+				desired.Status.Phase = corev1.ClaimBound
 				p := createSnapshotClonePhase(getStorageClass(), desired)
 
 				result, err := p.Reconcile(context.Background())

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1580,7 +1580,7 @@ func InflateSizeWithOverhead(ctx context.Context, c client.Client, imgSize int64
 
 // IsBound returns if the pvc is bound
 func IsBound(pvc *corev1.PersistentVolumeClaim) bool {
-	return pvc.Spec.VolumeName != ""
+	return pvc != nil && pvc.Status.Phase == corev1.ClaimBound
 }
 
 // IsUnbound returns if the pvc is not bound yet

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1588,6 +1588,11 @@ func IsUnbound(pvc *corev1.PersistentVolumeClaim) bool {
 	return !IsBound(pvc)
 }
 
+// IsLost returns if the pvc is lost
+func IsLost(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc != nil && pvc.Status.Phase == corev1.ClaimLost
+}
+
 // IsImageStream returns true if registry source is ImageStream
 func IsImageStream(pvc *corev1.PersistentVolumeClaim) bool {
 	return pvc.Annotations[AnnRegistryImageStream] == "true"

--- a/pkg/controller/datavolume/static-volume_test.go
+++ b/pkg/controller/datavolume/static-volume_test.go
@@ -255,6 +255,7 @@ var _ = Describe("checkStaticVolume Tests", func() {
 		pvc := newPendingPVC(dv, pv)
 		pvc.Spec.VolumeName = pv.Name
 		pv.Status.Phase = corev1.VolumeBound
+		pvc.Status.Phase = corev1.ClaimBound
 		reconciler, client := args.newReconciler(dv, pv, pvc)
 		_, err := reconciler.Reconcile(context.TODO(), requestFunc(dv))
 		Expect(err).ToNot(HaveOccurred())
@@ -278,6 +279,7 @@ var _ = Describe("checkStaticVolume Tests", func() {
 		pvc := newPendingPVC(dv, pv)
 		pvc.Spec.VolumeName = "foobar"
 		pv.Status.Phase = corev1.VolumeBound
+		pvc.Status.Phase = corev1.ClaimBound
 		reconciler, client := args.newReconciler(dv, pv, pvc)
 		_, err := reconciler.Reconcile(context.TODO(), requestFunc(dv))
 		Expect(err).To(HaveOccurred())

--- a/pkg/controller/populators/forklift-populator_test.go
+++ b/pkg/controller/populators/forklift-populator_test.go
@@ -273,6 +273,8 @@ var _ = Describe("Forklift populator tests", func() {
 			AnnPodRetainAfterCompletion: "true",
 			AnnPodPhase:                 string(corev1.PodSucceeded),
 		}
+		pvcPrime.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimLost}
+
 		pv := &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pv",

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -291,6 +291,7 @@ var _ = Describe("Import populator tests", func() {
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
 			pvcPrime := getPVCPrime(targetPvc, nil)
 			pvcPrime.Annotations = map[string]string{AnnPodRetainAfterCompletion: "true"}
+			pvcPrime.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimLost}
 
 			By("Reconcile")
 			reconciler = createImportPopulatorReconciler(targetPvc, pvcPrime, volumeImportSource, sc)

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -291,6 +291,7 @@ var _ = Describe("Import populator tests", func() {
 			volumeImportSource := getVolumeImportSource(true, metav1.NamespaceDefault)
 			pvcPrime := getPVCPrime(targetPvc, nil)
 			pvcPrime.Annotations = map[string]string{AnnPodRetainAfterCompletion: "true"}
+			targetPvc.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound}
 			pvcPrime.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimLost}
 
 			By("Reconcile")

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -296,7 +296,7 @@ func (r *ReconcilerBase) reconcile(req reconcile.Request, populator populatorCon
 	}
 
 	// Making sure to clean PVC' once population is completed
-	if cc.IsPVCComplete(pvc) && !cc.IsMultiStageImportInProgress(pvc) {
+	if cc.IsPVCComplete(pvc) && cc.IsBound(pvc) && !cc.IsMultiStageImportInProgress(pvc) {
 		res, err = r.reconcileCleanup(pvcPrime)
 	}
 

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -342,10 +342,10 @@ func (r *ReconcilerBase) reconcileCommon(pvc *corev1.PersistentVolumeClaim, popu
 		return nil, err
 	}
 
-	// If PVC' doesn't exist and target PVC is not bound, we should create the PVC' to start the population.
+	// If PVC' doesn't exist and target PVC is rebindable, we should create the PVC' to start the population.
 	// We still return nil as we'll get called again once PVC' exists.
 	// If target PVC is bound, we don't really need to populate anything.
-	if cc.IsUnbound(pvc) {
+	if cc.IsUnbound(pvc) && !cc.IsLost(pvc) {
 		_, err := r.createPVCPrime(pvc, populationSource, nodeName != "", populator.updatePVCForPopulation)
 		if err != nil {
 			r.recorder.Eventf(pvc, corev1.EventTypeWarning, errCreatingPVCPrime, err.Error())

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		pvc.Spec.VolumeName = "test-pv"
 		cc.AddAnnotation(pvc, cc.AnnPodPhase, string(corev1.PodSucceeded))
 		pvcPrime := newUploadPopulatorPVC(PVCPrimeName(pvc))
+		pvcPrime.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimLost}
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)
 		scName := "test-sc"

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		pvc.Spec.VolumeName = "test-pv"
 		cc.AddAnnotation(pvc, cc.AnnPodPhase, string(corev1.PodSucceeded))
 		pvcPrime := newUploadPopulatorPVC(PVCPrimeName(pvc))
+		pvc.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound}
 		pvcPrime.Status = corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimLost}
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)

--- a/pkg/controller/transfer/pvc.go
+++ b/pkg/controller/transfer/pvc.go
@@ -43,7 +43,7 @@ func (h *pvcTransferHandler) ReconcilePending(ot *cdiv1.ObjectTransfer) (time.Du
 		return 0, nil
 	}
 
-	if cc.IsUnbound(pvc) || pvc.Status.Phase != corev1.ClaimBound {
+	if cc.IsUnbound(pvc) {
 		if err := h.reconciler.setAndUpdateCompleteCondition(ot, corev1.ConditionFalse, "PVC not bound", ""); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This Pull Request ensures that we only proceed with PVC' deletion after confirming the target PVC is rebound.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-45479

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix PVC deletion logic in CDI populators
```

