### PR TITLE
Allow dataimportcron snap->pvc automatic source switch

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -319,7 +319,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	if err != nil {
 		return res, err
 	}
-	snapshot, err := r.getSnapshot(ctx, dataImportCron, format)
+	snapshot, err := r.getSnapshot(ctx, dataImportCron)
 	if err != nil {
 		return res, err
 	}
@@ -338,7 +338,8 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 		return nil
 	}
 
-	if dv != nil {
+	switch {
+	case dv != nil:
 		switch dv.Status.Phase {
 		case cdiv1.Succeeded:
 			if err := handlePopulatedPvc(); err != nil {
@@ -352,12 +353,19 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			dvPhase := string(dv.Status.Phase)
 			updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse, fmt.Sprintf("Import DataVolume phase %s", dvPhase), dvPhase)
 		}
-	} else if pvc != nil {
+	case pvc != nil && pvc.Status.Phase == corev1.ClaimBound:
 		// TODO: with plain populator PVCs (no DataVolumes) we may need to wait for corev1.Bound
 		if err := handlePopulatedPvc(); err != nil {
 			return res, err
 		}
-	} else if snapshot != nil {
+	case snapshot != nil:
+		if format == cdiv1.DataImportCronSourceFormatPvc {
+			if err := r.client.Delete(ctx, snapshot); cc.IgnoreNotFound(err) != nil {
+				return res, err
+			}
+			r.log.Info("Snapshot is around even though format switched to PVC, requeueing")
+			return reconcile.Result{RequeueAfter: time.Second}, nil
+		}
 		// Below k8s 1.29 there's no way to know the source volume mode
 		// Let's at least expose this info on our own snapshots
 		if _, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; !ok {
@@ -373,7 +381,7 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 			return res, err
 		}
 		importSucceeded = true
-	} else {
+	default:
 		if len(imports) > 0 {
 			imports = imports[1:]
 			dataImportCron.Status.CurrentImports = imports
@@ -468,11 +476,7 @@ func (r *DataImportCronReconciler) getImportState(ctx context.Context, cron *cdi
 }
 
 // Returns the current import DV if exists, and the last imported PVC
-func (r *DataImportCronReconciler) getSnapshot(ctx context.Context, cron *cdiv1.DataImportCron, format cdiv1.DataImportCronSourceFormat) (*snapshotv1.VolumeSnapshot, error) {
-	if format != cdiv1.DataImportCronSourceFormatSnapshot {
-		return nil, nil
-	}
-
+func (r *DataImportCronReconciler) getSnapshot(ctx context.Context, cron *cdiv1.DataImportCron) (*snapshotv1.VolumeSnapshot, error) {
 	imports := cron.Status.CurrentImports
 	if len(imports) == 0 {
 		return nil, nil
@@ -481,7 +485,7 @@ func (r *DataImportCronReconciler) getSnapshot(ctx context.Context, cron *cdiv1.
 	snapName := imports[0].DataVolumeName
 	snapshot := &snapshotv1.VolumeSnapshot{}
 	if err := r.client.Get(ctx, types.NamespacedName{Namespace: cron.Namespace, Name: snapName}, snapshot); err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
 			return nil, err
 		}
 		return nil, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Recently we've had some back and forth about the appropriate source format for LVMS:
https://github.com/kubevirt/containerized-data-importer/pull/3196
https://github.com/kubevirt/containerized-data-importer/pull/3303
Which presented the need to support a seamless transition between snapshot->PVC sources which was never implemented in hopes that one would not go through such a transition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow dataimportcron snap->pvc automatic source switch
```

