### PR TITLE
Take target PVC selector into account when creating PVC prime

### DIFF
--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -199,6 +199,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 			Resources:        pvc.Spec.Resources,
 			StorageClassName: pvc.Spec.StorageClassName,
 			VolumeMode:       pvc.Spec.VolumeMode,
+			Selector:         pvc.Spec.Selector,
 		},
 	}
 	pvcPrime.OwnerReferences = []metav1.OwnerReference{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Today we completely disregard a selector being set on the target PVC,
which results in incorrect binding for anyone looking to use that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3369 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Take target PVC selector into account when creating PVC prime
```

