### PR TITLE
Add s390x support for cdi builder for unit tests

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -24,6 +24,9 @@ ppc64le)
 aarch64* | arm64*)
     ARCH="arm64"
     ;;
+s390x)
+    ARCH="s390x"
+    ;;
 *)
     echo "invalid Arch, only support x86_64, ppc64le, aarch64"
     exit 1

--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -21,11 +21,12 @@ source "${script_dir}"/config.sh
 
 if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
     if [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ]; then
-        BUILDAH_PLATFORM_FLAG="--platform linux/amd64,linux/arm64"
+        BUILDAH_PLATFORM_FLAG="--platform linux/s390x,linux/amd64,linux/arm64"
     else
         echo "No qemu-user-static on host machine, building only native container"
         BUILDAH_PLATFORM_FLAG=""
     fi
+    [ "`uname -m`" == "s390x" ] && BUILDAH_PLATFORM_FLAG="--platform linux/s390x"
 fi
 
 # When this runs during the post-submit job, the PR will have squashed into a single
@@ -53,11 +54,11 @@ if ((POST_SUBMIT)) || [ x"${ADHOC_BUILDER}" != "x" ]; then
 
     #Build the encapsulated compile and test container
     if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
-        (cd ${BUILDER_SPEC} && buildah build ${BUILDAH_PLATFORM_FLAG} --manifest ${BUILDER_MANIFEST} .)
+        (cd ${BUILDER_SPEC} && buildah build ${BUILDAH_PLATFORM_FLAG} --build-arg ARCH=${ARCH} --manifest ${BUILDER_MANIFEST} .)
         buildah manifest push --all ${BUILDER_MANIFEST} docker://${BUILDER_MANIFEST}
         DIGEST=$(podman inspect $(podman images | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $3 }') | jq '.[]["Digest"]')
     else
-        (cd ${BUILDER_SPEC} && docker build --tag ${BUILDER_MANIFEST} .)
+        (cd ${BUILDER_SPEC} && docker build --build-arg ARCH=${ARCH} --tag ${BUILDER_MANIFEST} .)
         docker push ${BUILDER_MANIFEST}
         DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
     fi

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -1,6 +1,8 @@
 FROM quay.io/centos/centos:stream9
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
+ARG ARCH
+
 RUN 	dnf -y install dnf-plugins-core && \
 	dnf config-manager --set-enable crb && dnf update -y && \
 	dnf install -y \
@@ -51,7 +53,11 @@ ENV BAZEL_VERSION 5.4.1
 
 COPY output-bazel-arch.sh /output-bazel-arch.sh
 
-RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-bazel-arch.sh) && chmod u+x /usr/bin/bazel
+# Consider using multi-stage builds here instead
+RUN if test "${ARCH}" != "s390x"; then \
+		curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-bazel-arch.sh) && \
+		chmod u+x /usr/bin/bazel; \
+    fi
 
 # Until we use a version including the fix for this Bazel issue:
 # https://github.com/bazelbuild/bazel/issues/11554


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds s390x support for the builder image, so that the unit tests can run.
Bazel is not necessary for unit testing and not supported for s390x yet, so we skip the installation here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the cause of failure for [Add s390x unit test job #3552](https://github.com/kubevirt/project-infra/pull/3552)
Relates to [add s390x support for kubevirt builder. #11097](https://github.com/kubevirt/kubevirt/pull/11097)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add s390x support for builder image
```

