### PR TITLE
Setup ginkgo cli build properly to avoid double dep

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -226,6 +226,16 @@ genrule(
     cmd = "/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $@",
 )
 
+genrule(
+    name = "build-ginkgo",
+    srcs = [
+        "//vendor/github.com/onsi/ginkgo/v2/ginkgo",
+    ],
+    outs = ["ginkgo-copier"],
+    cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
 pkg_tar(
     name = "ca_anchors_tar",
     srcs = [":ca_anchors"],

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ rpm-deps: ## Update RPM dependencies
 
 ##@ Testing
 build-functest: ## Build the functional tests (content of tests/ subdirectory)
+	${DO_BAZ} ./hack/build/build-ginkgo.sh
 	${DO_BAZ} ./hack/build/build-functest.sh
 
 test: test-unit test-functional test-lint ## execute all tests (_NOTE:_ 'WHAT' is expected to match the go cli pattern for paths e.g. './pkg/...'.  This differs slightly from rest of the 'make' targets)

--- a/hack/build/build-functest.sh
+++ b/hack/build/build-functest.sh
@@ -21,6 +21,5 @@ mkdir -p ${TESTS_OUT_DIR}/
 # use vendor
 export GO111MODULE=${GO111MODULE:-off}
 
-ginkgo build ${CDI_DIR}/tests/
+${TESTS_OUT_DIR}/ginkgo build ${CDI_DIR}/tests/
 mv ${CDI_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
-cp -f /go/bin/ginkgo ${TESTS_OUT_DIR}/

--- a/hack/build/build-ginkgo.sh
+++ b/hack/build/build-ginkgo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source hack/build/common.sh
+source hack/build/config.sh
+
+rm -rf "${TESTS_OUT_DIR}/ginkgo"
+
+bazel build \
+    --verbose_failures \
+    --config=${ARCHITECTURE} \
+    //vendor/github.com/onsi/ginkgo/v2/ginkgo:ginkgo
+
+bazel run \
+    --verbose_failures \
+    --config=${ARCHITECTURE} \
+    :build-ginkgo -- ${TESTS_OUT_DIR}/ginkgo

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -29,7 +29,7 @@ FUNC_TEST_PROXY="cdi-func-test-proxy"
 FUNC_TEST_POPULATOR="cdi-func-test-sample-populator"
 
 # update this whenever new builder tag is created
-BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder:2405081150-60b5fa4fc}
+BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-cdi-bazel-builder:2408131802-67ef11da7}
 
 BINARIES="cmd/${OPERATOR} cmd/${CONTROLLER} cmd/${IMPORTER} cmd/${CLONER} cmd/${APISERVER} cmd/${UPLOADPROXY} cmd/${UPLOADSERVER} cmd/${OPERATOR} tools/${FUNC_TEST_INIT} tools/${FUNC_TEST_REGISTRY_INIT} tools/${FUNC_TEST_BAD_WEBSERVER} tools/${FUNC_TEST_PROXY} tools/${FUNC_TEST_POPULATOR}"
 CDI_PKGS="cmd/ pkg/ test/"

--- a/hack/ci/build-functest.sh
+++ b/hack/ci/build-functest.sh
@@ -20,5 +20,5 @@ source "${script_dir}"/../build/common.sh
 mkdir -p ${TESTS_OUT_DIR}/
 # use vendor
 export GO111MODULE=on
-/go/bin/ginkgo build ${CDI_DIR}/tests/
+${TESTS_OUT_DIR}/ginkgo build ${CDI_DIR}/tests/
 mv ${CDI_DIR}/tests/tests.test ${TESTS_OUT_DIR}/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Today we have the ginkgo CLI brought into the builder and also to the project itself. This results in
```
 Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.12.0
  Mismatched package versions found:
    2.17.1 used by tests
```
This commit provides the necessary build adaptations to get rid of the builder ginkgo CLI dependency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

