### PR TITLE
Inject cdi-uploadproxy CA cert into user created routes

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -283,6 +283,35 @@ var _ = Describe("Controller", func() {
 				validateEvents(args.reconciler, createReadyEventValidationMap())
 			})
 
+			It("should update existing route", func() {
+				route := &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-route",
+						Namespace: cdiNamespace,
+						Annotations: map[string]string{
+							"operator.cdi.kubevirt.io/injectUploadProxyCert": "true",
+						},
+					},
+					Spec: routev1.RouteSpec{
+						TLS: &routev1.TLSConfig{},
+					},
+				}
+
+				args := createArgs(route)
+				doReconcile(args)
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+
+				obj, err := getObject(args.client, route)
+				Expect(err).ToNot(HaveOccurred())
+				route = obj.(*routev1.Route)
+
+				Expect(route.Spec.TLS.DestinationCACertificate).Should(Equal(testCertData))
+
+				eventMap := createReadyEventValidationMap()
+				eventMap["Normal UploadProxyRouteInjectSuccess Successfully updated Route destination CA certificate"] = false
+				validateEvents(args.reconciler, eventMap)
+			})
+
 			It("should have CDIOperatorDown", func() {
 				args := createArgs()
 				doReconcile(args)
@@ -1691,9 +1720,10 @@ func createFromArgs(version string) *args {
 	}
 }
 
-func createArgs() *args {
+func createArgs(objs ...client.Object) *args {
 	cdi := createCDI("cdi", "good uid")
-	client := createClient(cdi)
+	objs = append(objs, cdi)
+	client := createClient(objs...)
 	reconciler := createReconciler(client)
 
 	return &args{
@@ -1809,6 +1839,7 @@ func createReconciler(client client.Client) *ReconcileCDI {
 		clusterArgs:    clusterArgs,
 		namespacedArgs: namespacedArgs,
 		certManager:    newFakeCertManager(client, namespace),
+		haveRoutes:     true,
 	}
 	callbackDispatcher := callbacks.NewCallbackDispatcher(log, client, client, scheme.Scheme, namespace)
 	getCache := func() cache.Cache {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Users want to create their own routes but certificate rotation make it difficult to keep them up to date

To take advantage of this feature, routes must meet the following restrictions:

1.  Be in the same namespace as cdi-operator
2. have `operator.cdi.kubevirt.io/injectUploadProxyCert: "true"` annotation


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-31492

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Inject cdi-uploadproxy CA cert into user created routes
```

