### PR TITLE
feat(DataVolume): Add default instance type labels from VolumeSnapshots and from Registry imports

### DIFF
--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -516,6 +516,21 @@ func updateDataVolumeDefaultInstancetypeLabels(client client.Client, syncState *
 		copyDefaultInstancetypeLabels(dv, pvc.Labels)
 		return nil
 	}
+	if dv.Spec.Source != nil && dv.Spec.Source.Snapshot != nil {
+		snapshot := &snapshotv1.VolumeSnapshot{}
+		key := types.NamespacedName{
+			Name:      dv.Spec.Source.Snapshot.Name,
+			Namespace: dv.Spec.Source.Snapshot.Namespace,
+		}
+		if err := client.Get(context.TODO(), key, snapshot); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		copyDefaultInstancetypeLabels(dv, snapshot.Labels)
+		return nil
+	}
 	if dv.Spec.SourceRef != nil && dv.Spec.SourceRef.Namespace != nil && dv.Spec.SourceRef.Kind == cdiv1.DataVolumeDataSource {
 		ds := &cdiv1.DataSource{}
 		key := types.NamespacedName{

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -531,6 +531,21 @@ func updateDataVolumeDefaultInstancetypeLabels(client client.Client, syncState *
 		copyDefaultInstancetypeLabels(dv, snapshot.Labels)
 		return nil
 	}
+	if dv.Spec.Source != nil && dv.Spec.Source.Registry != nil {
+		pvc := &v1.PersistentVolumeClaim{}
+		key := types.NamespacedName{
+			Name:      dv.Name,
+			Namespace: dv.Namespace,
+		}
+		if err := client.Get(context.TODO(), key, pvc); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		copyDefaultInstancetypeLabels(dv, pvc.Labels)
+		return nil
+	}
 	if dv.Spec.SourceRef != nil && dv.Spec.SourceRef.Namespace != nil && dv.Spec.SourceRef.Kind == cdiv1.DataVolumeDataSource {
 		ds := &cdiv1.DataSource{}
 		key := types.NamespacedName{

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -117,6 +117,7 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 		namespace            = "namespace"
 		sourcePVCName        = "sourcePVC"
 		sourceSnapshotName   = "sourceSnapshot"
+		sourceRegistryName   = "sourceRegistry"
 		sourceDataSourceName = "sourceDataSource"
 	)
 
@@ -124,6 +125,7 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 		fakeClient                     client.Client
 		dataVolumeWithSourcePVC        cdiv1.DataVolume
 		dataVolumeWithSourceSnapshot   cdiv1.DataVolume
+		dataVolumeWithSourceRegistry   cdiv1.DataVolume
 		dataVolumeWithSourceDataSource cdiv1.DataVolume
 	)
 
@@ -165,6 +167,20 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 			},
 		}
 
+		dataVolumeWithSourceRegistry = cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sourceRegistryName,
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					Registry: &cdiv1.DataVolumeSourceRegistry{
+						URL: ptr.To("docker://testurl"),
+					},
+				},
+			},
+		}
+
 		dataVolumeWithSourceDataSource = cdiv1.DataVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "datasource-datavolume",
@@ -189,6 +205,13 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 			&snapshotv1.VolumeSnapshot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceSnapshotName,
+					Namespace: namespace,
+					Labels:    defaultInstancetypeLabelMap,
+				},
+			},
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceRegistryName,
 					Namespace: namespace,
 					Labels:    defaultInstancetypeLabelMap,
 				},
@@ -223,6 +246,7 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 	},
 		Entry("PVC", &dataVolumeWithSourcePVC),
 		Entry("Snapshot", &dataVolumeWithSourceSnapshot),
+		Entry("Registry", &dataVolumeWithSourceRegistry),
 		Entry("dataSource", &dataVolumeWithSourceDataSource),
 	)
 
@@ -242,6 +266,7 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 	},
 		Entry("PVC", &dataVolumeWithSourcePVC),
 		Entry("Snapshot", &dataVolumeWithSourceSnapshot),
+		Entry("Registry", &dataVolumeWithSourceRegistry),
 		Entry("DataSource", &dataVolumeWithSourceDataSource),
 	)
 
@@ -279,6 +304,19 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 				},
 			},
 		}),
+		Entry("Registry", &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "registry-datavolume-unknown",
+				Namespace: namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					Registry: &cdiv1.DataVolumeSourceRegistry{
+						URL: ptr.To("docker://uknown"),
+					},
+				},
+			},
+		}),
 		Entry("DataSource", &cdiv1.DataVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "datasource-datavolume",
@@ -307,6 +345,7 @@ var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {
 	},
 		Entry("PVC", &dataVolumeWithSourcePVC),
 		Entry("Snapshot", &dataVolumeWithSourceSnapshot),
+		Entry("Registry", &dataVolumeWithSourceRegistry),
 		Entry("DataSource", &dataVolumeWithSourceDataSource),
 	)
 })

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -146,6 +146,10 @@ container_image(
     env = {
         "TEST_KUBEVIRT_IO_TEST": "testvalue",
         "TEST_KUBEVIRT_IO_EXISTING": "somethingelse",
+        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE": "test-instancetype",
+        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE_KIND": "VirtualMachineClusterInstancetype",
+        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE": "test-preference",
+        "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE_KIND": "VirtualMachineClusterPreference",
     },
     tars = [":tinycore-tar"],
     visibility = ["//visibility:public"],

--- a/tools/cdi-func-test-registry-init/populate-registry.sh
+++ b/tools/cdi-func-test-registry-init/populate-registry.sh
@@ -76,6 +76,10 @@ function prepareImages {
                 COPY $FILENAME $IMAGE_LOCATION
                 ENV TEST_KUBEVIRT_IO_TEST=testvalue
                 ENV TEST_KUBEVIRT_IO_EXISTING=somethingelse
+                ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE=test-instancetype
+                ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE_KIND=VirtualMachineClusterInstancetype
+                ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE=test-preference
+                ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE_KIND=VirtualMachineClusterPreference
 EOF
 
         rm $FILENAME


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

de5ba85 started updating DataVolumes when reconciled, adding any labels found on PVC or DataSource sources. This PR is a follow up that starts adding labels also from VolumeSnapshots and from Registry imported PVCs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2839

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default instance type labels are now added from cloned VolumeSnapshots to DataVolumes
Default instance type labels are now added from registry imported PVCs to DataVolumes
```

