### PR TITLE
Fix build-builder script

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -52,7 +52,7 @@ COPY output-bazel-arch.sh /output-bazel-arch.sh
 
 RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-bazel-arch.sh) && chmod u+x /usr/bin/bazel
 
-# Until we use a version including the fix for this Bazel issue:
+# Until we use a ver including the fix for this Bazel issue:
 # https://github.com/bazelbuild/bazel/issues/11554
 RUN ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There are two issues in the builder script atm
- `./hack/build/bazel-build-builder.sh: line 49: DOCKER_PREFIX: command not found`
- git diff returning non zero will exit the script immediately:
```bash
+ git diff-index --quiet HEAD~1 hack/build/docker
make: *** [Makefile:134: builder-push] Error 1
```
https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/push-containerized-data-importer-builder

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

