### PR TITLE
Ensure scratch space is large enough to hold disk image

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -470,7 +470,6 @@ func (r *ImportReconciler) cleanup(pvc *corev1.PersistentVolumeClaim, pod *corev
 }
 
 func (r *ImportReconciler) updatePVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
-	log.V(1).Info("Annotations are now", "pvc.anno", pvc.GetAnnotations())
 	if err := r.client.Update(context.TODO(), pvc); err != nil {
 		return err
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -554,7 +554,9 @@ var _ = Describe("Update PVC from POD", func() {
 		// Once all controllers are converted, we will use the runtime lib client instead of client-go and retrieval needs to change here.
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1-scratch", Namespace: "default"}, scratchPvc)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(scratchPvc.Spec.Resources).To(Equal(pvc.Spec.Resources))
+		// Since fsOverhead is 0, the scratch space size should be 1Mi aligned close to 1G
+		requestSize := scratchPvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		Expect(requestSize.Value()).To(Equal(int64(999292928)))
 		Expect(scratchPvc.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
 
 		resPvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -52,10 +52,11 @@ import (
 )
 
 const (
-	storageClassName  = "testSC"
-	snapshotClassName = "testSnapClass"
-	provisionerName   = "testProvisioner"
-	cephProvisioner   = "rook-ceph.rbd.csi.ceph.com"
+	storageClassName        = "testSC"
+	scratchStorageClassName = "testScratchSC"
+	snapshotClassName       = "testSnapClass"
+	provisionerName         = "testProvisioner"
+	cephProvisioner         = "rook-ceph.rbd.csi.ceph.com"
 )
 
 var (

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -159,7 +159,7 @@ func newScratchPersistentVolumeClaimSpec(pvc *corev1.PersistentVolumeClaim, pod 
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"},
-			Resources:   pvc.Spec.Resources,
+			Resources:   *pvc.Spec.Resources.DeepCopy(),
 		},
 	}
 	if storageClassName != "" {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -29,6 +29,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -170,6 +171,24 @@ func newScratchPersistentVolumeClaimSpec(pvc *corev1.PersistentVolumeClaim, pod 
 // createScratchPersistentVolumeClaim creates and returns a pointer to a scratch PVC which is created based on the passed-in pvc and storage class name.
 func createScratchPersistentVolumeClaim(client client.Client, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod, name, storageClassName string, installerLabels map[string]string, recorder record.EventRecorder) (*corev1.PersistentVolumeClaim, error) {
 	scratchPvcSpec := newScratchPersistentVolumeClaimSpec(pvc, pod, name, storageClassName)
+
+	sizeRequest := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	scratchFsOverhead, err := GetFilesystemOverhead(context.TODO(), client, scratchPvcSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get filesystem overhead for scratch PVC")
+	}
+	scratchFsOverheadFloat, _ := strconv.ParseFloat(string(scratchFsOverhead), 64)
+	pvcFsOverhead, err := GetFilesystemOverhead(context.TODO(), client, pvc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get filesystem overhead for original PVC")
+	}
+	pvcFsOverheadFloat, _ := strconv.ParseFloat(string(pvcFsOverhead), 64)
+	expectedVirtualSize := util.GetUsableSpace(pvcFsOverheadFloat, sizeRequest.Value())
+
+	usableSpaceRaw := util.CalculateOverheadSpace(scratchFsOverheadFloat, expectedVirtualSize)
+
+	scratchPvcSpec.Spec.Resources.Requests[corev1.ResourceStorage] = *resource.NewScaledQuantity(usableSpaceRaw, 0)
+
 	util.SetRecommendedLabels(scratchPvcSpec, installerLabels, "cdi-controller")
 	if err := client.Create(context.TODO(), scratchPvcSpec); err != nil {
 		if cc.ErrQuotaExceeded(err) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -240,13 +240,18 @@ func Md5sum(filePath string) (string, error) {
 	return hex.EncodeToString(hashInBytes), nil
 }
 
-// GetUsableSpace calculates space to use taking file system overhead into account
+// GetUsableSpace calculates usable space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
 	// +1 always rounds up.
 	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
 	return RoundDown(spaceWithOverhead, DefaultAlignBlockSize)
+}
+
+func CalculateOverheadSpace(filesystemOverhead float64, availableSpace int64) int64 {
+	spaceWithOverhead := int64(math.Ceil(float64(availableSpace) / (1 - filesystemOverhead)))
+	return RoundUp(spaceWithOverhead, DefaultAlignBlockSize)
 }
 
 // ResolveVolumeMode returns the volume mode if set, otherwise defaults to file system mode

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -516,7 +516,7 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				volumeMode := v1.PersistentVolumeFilesystem
-				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.2Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 				targetDV.Spec.Preallocation = &desiredPreallocation
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It is possible the source image is fully allocated and in that case the scratch space would not be large enough to hold the disk image. This takes fsOverhead into account when calculating the scratch space size.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increased size of scratch space to take fs overhead into account.
```

