### PR TITLE
VDDK: pass snapshot ID through to nbdkit.

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -127,7 +127,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 }
 
 // NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
-func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref string) (NbdkitOperation, error) {
+func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref, snapshot string) (NbdkitOperation, error) {
 	pluginArgs := []string{
 		"libdir=" + nbdVddkLibraryPath,
 	}
@@ -149,6 +149,9 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 	}
 	if moref != "" {
 		pluginArgs = append(pluginArgs, "vm=moref="+moref)
+	}
+	if snapshot != "" {
+		pluginArgs = append(pluginArgs, "snapshot="+snapshot)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -126,32 +126,42 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	return n, nil
 }
 
+// Keep these in a struct to keep NewNbdkitVddk from going over the argument limit
+type NbdKitVddkPluginArgs struct {
+	Server     string
+	Username   string
+	Password   string
+	Thumbprint string
+	Moref      string
+	Snapshot   string
+}
+
 // NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
-func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref, snapshot string) (NbdkitOperation, error) {
+func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (NbdkitOperation, error) {
 	pluginArgs := []string{
 		"libdir=" + nbdVddkLibraryPath,
 	}
-	if server != "" {
-		pluginArgs = append(pluginArgs, "server="+server)
+	if args.Server != "" {
+		pluginArgs = append(pluginArgs, "server="+args.Server)
 	}
-	if username != "" {
-		pluginArgs = append(pluginArgs, "user="+username)
+	if args.Username != "" {
+		pluginArgs = append(pluginArgs, "user="+args.Username)
 	}
-	if password != "" {
-		passwordfile, err := writePasswordFile(password)
+	if args.Password != "" {
+		passwordfile, err := writePasswordFile(args.Password)
 		if err != nil {
 			return nil, err
 		}
 		pluginArgs = append(pluginArgs, "password=+"+passwordfile)
 	}
-	if thumbprint != "" {
-		pluginArgs = append(pluginArgs, "thumbprint="+thumbprint)
+	if args.Thumbprint != "" {
+		pluginArgs = append(pluginArgs, "thumbprint="+args.Thumbprint)
 	}
-	if moref != "" {
-		pluginArgs = append(pluginArgs, "vm=moref="+moref)
+	if args.Moref != "" {
+		pluginArgs = append(pluginArgs, "vm=moref="+args.Moref)
 	}
-	if snapshot != "" {
-		pluginArgs = append(pluginArgs, "snapshot="+snapshot)
+	if args.Snapshot != "" {
+		pluginArgs = append(pluginArgs, "snapshot="+args.Snapshot)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -162,6 +162,7 @@ func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (Nbd
 	}
 	if args.Snapshot != "" {
 		pluginArgs = append(pluginArgs, "snapshot="+args.Snapshot)
+		pluginArgs = append(pluginArgs, "transports=file:nbdssl:nbd")
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -85,8 +85,8 @@ type NbdKitLogWatcherVddk struct {
 }
 
 // createNbdKitWrapper starts nbdkit and returns a process handle for further management
-func createNbdKitWrapper(vmware *VMwareClient, diskFileName string) (*NbdKitWrapper, error) {
-	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref)
+func createNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
+	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref, snapshot)
 	if err != nil {
 		klog.Errorf("Error validating nbdkit plugins: %v", err)
 		return nil, err
@@ -891,7 +891,7 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 		}
 		klog.Infof("Set disk file name from current snapshot: %s", diskFileName)
 	}
-	nbdkit, err := newNbdKitWrapper(vmware, diskFileName)
+	nbdkit, err := newNbdKitWrapper(vmware, diskFileName, currentCheckpoint)
 	if err != nil {
 		klog.Errorf("Unable to start nbdkit: %v", err)
 		return nil, err

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -86,7 +86,15 @@ type NbdKitLogWatcherVddk struct {
 
 // createNbdKitWrapper starts nbdkit and returns a process handle for further management
 func createNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
-	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref, snapshot)
+	args := image.NbdKitVddkPluginArgs{
+		Server:     vmware.url.Host,
+		Username:   vmware.username,
+		Password:   vmware.password,
+		Thumbprint: vmware.thumbprint,
+		Moref:      vmware.moref,
+		Snapshot:   snapshot,
+	}
+	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, args)
 	if err != nil {
 		klog.Errorf("Error validating nbdkit plugins: %v", err)
 		return nil, err

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -279,9 +279,9 @@ var _ = Describe("VDDK data source", func() {
 		var returnedDiskName string
 
 		newVddkDataSource = createVddkDataSource
-		newNbdKitWrapper = func(vmware *VMwareClient, fileName string) (*NbdKitWrapper, error) {
+		newNbdKitWrapper = func(vmware *VMwareClient, fileName, snapshot string) (*NbdKitWrapper, error) {
 			returnedDiskName = fileName
-			return createMockNbdKitWrapper(vmware, fileName)
+			return createMockNbdKitWrapper(vmware, fileName, snapshot)
 		}
 		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
 			switch out := result.(type) {
@@ -314,6 +314,38 @@ var _ = Describe("VDDK data source", func() {
 		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk", true),
 		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", "wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk", false),
 	)
+
+	It("should pass snapshot reference through to nbdkit", func() {
+		expectedSnapshot := "snapshot-10"
+
+		var receivedSnapshotRef string
+		newVddkDataSource = createVddkDataSource
+		newNbdKitWrapper = func(vmware *VMwareClient, fileName, snapshot string) (*NbdKitWrapper, error) {
+			receivedSnapshotRef = snapshot
+			return createMockNbdKitWrapper(vmware, fileName, snapshot)
+		}
+
+		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
+			switch out := result.(type) {
+			case *mo.VirtualMachine:
+				if property[0] == "config.hardware.device" {
+					out.Config = createVirtualDiskConfig("disk1", 12345)
+				} else if property[0] == "snapshot" {
+					out.Snapshot = createSnapshots(expectedSnapshot, "snapshot-11")
+				}
+			case *mo.VirtualMachineSnapshot:
+				out.Config = *createVirtualDiskConfig("snapshot-disk", 123456)
+				disk := out.Config.Hardware.Device[0].(*types.VirtualDisk)
+				parent := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo).Parent
+				parent.FileName = "snapshot-root"
+			}
+			return nil
+		}
+
+		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "disk1", expectedSnapshot, "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(receivedSnapshotRef).To(Equal(expectedSnapshot))
+	})
 
 	It("should find two snapshots and get a list of changed blocks", func() {
 		newVddkDataSource = createVddkDataSource
@@ -880,7 +912,7 @@ func createMockVMwareClient(endpoint string, accessKey string, secKey string, th
 	}, nil
 }
 
-func createMockNbdKitWrapper(vmware *VMwareClient, diskFileName string) (*NbdKitWrapper, error) {
+func createMockNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
 	u, _ := url.Parse("http://vcenter.test")
 	return &NbdKitWrapper{
 		n:      &image.Nbdkit{},

--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -30,7 +30,7 @@ void fakevddk_close(void *handle) {
 int fakevddk_config(const char *key, const char *value) {
     arg_count++;
     if (strcmp(key, "snapshot") == 0) {
-        expected_arg_count = 8;
+        expected_arg_count = 9; // Expect one for 'snapshot' and one for 'transports'
     }
     return 0;
 }

--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -20,8 +20,8 @@
 
 #define THREAD_MODEL NBDKIT_THREAD_MODEL_SERIALIZE_ALL_REQUESTS
 
-#define EXPECTED_ARG_COUNT 7
 int arg_count = 0;
+int expected_arg_count = 7;
 
 void fakevddk_close(void *handle) {
     close(*((int *) handle));
@@ -29,15 +29,18 @@ void fakevddk_close(void *handle) {
 
 int fakevddk_config(const char *key, const char *value) {
     arg_count++;
+    if (strcmp(key, "snapshot") == 0) {
+        expected_arg_count = 8;
+    }
     return 0;
 }
 
 int fakevddk_config_complete(void) {
     nbdkit_debug("VMware VixDiskLib (1.2.3) Release build-12345");
-    if (arg_count == EXPECTED_ARG_COUNT) {
+    if (arg_count == expected_arg_count) {
         return 0;
     } else {
-        nbdkit_error("Expected %d arguments to fake VDDK test plugin, but got %d!\n", EXPECTED_ARG_COUNT, arg_count);
+        nbdkit_error("Expected %d arguments to fake VDDK test plugin, but got %d!\n", expected_arg_count, arg_count);
         return -1;
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in [CNV-44894](https://issues.redhat.com/browse/CNV-44894), some VMs show `Error 13 (You do not have access rights to this file) ` when attempting to access snapshots for a warm migration. This mostly appears to affect Windows VMs with VMware guest tools installed. Passing the `snapshot` parameter to nbdkit avoids the error and allows delta copies to be applied to a multi-stage data volume.

This pull request adds the `snapshot` parameter to the nbdkit command line when a VDDK data volume is given a checkpoint to copy. It also adds a `transports` parameter to avoid a crash in the VDDK (see [RHEL-54377](https://issues.redhat.com/browse/RHEL-54377)).

**Which issue(s) this PR fixes**:
Fixes [CNV-44894](https://issues.redhat.com/browse/CNV-44894)

**Special notes for your reviewer**:

**Release note**:
```release-note
Add nbdkit command line parameters to improve reliability of multi-stage VDDK imports.
```