### PR TITLE
fix(import-populator): Make copying of annotations more robust

### DIFF
--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -160,7 +160,10 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 
 		if cc.IsPVCComplete(pvcPrime) && cc.IsUnbound(pvc) {
-			// Once the import is succeeded, we copy labels and rebind the PV from PVC to target PVC
+			// Once the import is succeeded, we copy annotations and labels and rebind the PV from PVC to target PVC
+			if pvcCopy, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations); err != nil {
+				return reconcile.Result{}, err
+			}
 			if pvcCopy, err = r.updatePVCWithPVCPrimeLabels(pvcCopy, pvcPrime.GetLabels()); err != nil {
 				return reconcile.Result{}, err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Similar to 2fa5f27, make copying of annotations from a prime PVC to a target PVC more robust, by moving it before rebinding the PV from prime to target. This way we can ensure the annotations are already present once the PVC becomes ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

