### PR TITLE
apidocs: remove gradle dep (builder)

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -26,14 +26,16 @@ RUN 	dnf -y install dnf-plugins-core && \
 	nbdkit-devel \
 	unzip \
 	java-11-openjdk-devel \
+	rubygems \
 	&& dnf clean all
 
-RUN pip3 install --upgrade j2cli operator-courier==2.1.11 && \
-	curl -sL https://services.gradle.org/distributions/gradle-6.6-bin.zip -o gradle-6.6-bin.zip && \
-	mkdir /opt/gradle && \
-	unzip -d /opt/gradle gradle-6.6-bin.zip && \
-	ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
-	rm gradle-6.6-bin.zip
+# Necessary for generation of HTML-formatted API docs (.adoc)
+RUN gem install asciidoctor
+
+# Generates Asciidoc files from swagger.json
+ADD https://storage.googleapis.com/builddeps/swagger2markup-cli-1.3.3.jar /opt/swagger2markup-cli/swagger2markup-cli-1.3.3.jar
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 ENV GIMME_GO_VERSION=1.22.3 GOPATH="/go" GO111MODULE="on"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix flakiness of gradle builds by installing deps in builder container

changes based on: https://github.com/kubevirt/kubevirt/pull/12552

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
apidocs: remove gradle dep (builder)
```

