### PR TITLE
fix: mismatched type (stat.Bsize to int64)

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -113,7 +113,8 @@ func GetAvailableSpace(path string) (int64, error) {
 	if err != nil {
 		return int64(-1), err
 	}
-	return int64(stat.Bavail) * stat.Bsize, nil
+	//nolint:unconvert
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
 }
 
 // GetAvailableSpaceBlock gets the amount of available space at the block device path specified.


### PR DESCRIPTION
The linter find this error in some archs. Paradoxically it works on x86. This was introduced in the commit
3c06e26bacac7d0de43a8cf20884574c95237423

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x arch enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```

