### PR TITLE
Fix ginkgo build script that breaks postsubmits

### DIFF
--- a/hack/build/build-ginkgo.sh
+++ b/hack/build/build-ginkgo.sh
@@ -6,6 +6,7 @@ source hack/build/common.sh
 source hack/build/config.sh
 
 rm -rf "${TESTS_OUT_DIR}/ginkgo"
+mkdir -p "${TESTS_OUT_DIR}"
 
 bazel build \
     --verbose_failures \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The directory creation was covered by cluster-sync which is not used by postsubmits, and thus they are now broken:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-containerized-data-importer-main/1824607154284269568

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

