### PR TITLE
[release-v1.58] Manual backport for VDDK related PRs 3361, 3363, 3385

### DIFF
--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -126,33 +126,43 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	return n, nil
 }
 
+// Keep these in a struct to keep NewNbdkitVddk from going over the argument limit
+type NbdKitVddkPluginArgs struct {
+	Server     string
+	Username   string
+	Password   string
+	Thumbprint string
+	Moref      string
+	Snapshot   string
+}
+
 // NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
-func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref, snapshot string) (NbdkitOperation, error) {
+func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (NbdkitOperation, error) {
 
 	pluginArgs := []string{
 		"libdir=" + nbdVddkLibraryPath,
 	}
-	if server != "" {
-		pluginArgs = append(pluginArgs, "server="+server)
+	if args.Server != "" {
+		pluginArgs = append(pluginArgs, "server="+args.Server)
 	}
-	if username != "" {
-		pluginArgs = append(pluginArgs, "user="+username)
+	if args.Username != "" {
+		pluginArgs = append(pluginArgs, "user="+args.Username)
 	}
-	if password != "" {
-		passwordfile, err := writePasswordFile(password)
+	if args.Password != "" {
+		passwordfile, err := writePasswordFile(args.Password)
 		if err != nil {
 			return nil, err
 		}
 		pluginArgs = append(pluginArgs, "password=+"+passwordfile)
 	}
-	if thumbprint != "" {
-		pluginArgs = append(pluginArgs, "thumbprint="+thumbprint)
+	if args.Thumbprint != "" {
+		pluginArgs = append(pluginArgs, "thumbprint="+args.Thumbprint)
 	}
-	if moref != "" {
-		pluginArgs = append(pluginArgs, "vm=moref="+moref)
+	if args.Moref != "" {
+		pluginArgs = append(pluginArgs, "vm=moref="+args.Moref)
 	}
-	if snapshot != "" {
-		pluginArgs = append(pluginArgs, "snapshot="+snapshot)
+	if args.Snapshot != "" {
+		pluginArgs = append(pluginArgs, "snapshot="+args.Snapshot)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -127,7 +127,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 }
 
 // NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
-func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref string) (NbdkitOperation, error) {
+func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint, moref, snapshot string) (NbdkitOperation, error) {
 
 	pluginArgs := []string{
 		"libdir=" + nbdVddkLibraryPath,
@@ -150,6 +150,9 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 	}
 	if moref != "" {
 		pluginArgs = append(pluginArgs, "vm=moref="+moref)
+	}
+	if snapshot != "" {
+		pluginArgs = append(pluginArgs, "snapshot="+snapshot)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -144,8 +144,9 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 		pluginArgs = append(pluginArgs, "vm=moref="+moref)
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
-	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.controlpath=0")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")
+	pluginArgs = append(pluginArgs, "-D", "vddk.datapath=0")
+	pluginArgs = append(pluginArgs, "-D", "vddk.stats=1")
 	p := getVddkPluginPath()
 	n := &Nbdkit{
 		NbdPidFile: nbdkitPidFile,

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -84,7 +84,7 @@ func NewNbdkit(plugin NbdkitPlugin, nbdkitPidFile string) *Nbdkit {
 }
 
 // NewNbdkitCurl creates a new Nbdkit instance with the curl plugin
-func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
+func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) (NbdkitOperation, error) {
 	var pluginArgs []string
 	var redactArgs []string
 	args := []string{"-r"}
@@ -93,7 +93,11 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 		pluginArgs = append(pluginArgs, "user="+user)
 	}
 	if password != "" {
-		pluginArgs = append(pluginArgs, "password="+password)
+		passwordfile, err := writePasswordFile(password)
+		if err != nil {
+			return nil, err
+		}
+		pluginArgs = append(pluginArgs, "password=+"+passwordfile)
 	}
 	if certDir != "" {
 		pluginArgs = append(pluginArgs, fmt.Sprintf("cainfo=%s/%s", certDir, "tls.crt"))
@@ -119,7 +123,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	n.AddFilter(NbdkitReadAheadFilter)
 	// Should be last filter
 	n.AddFilter(NbdkitRetryFilter)
-	return n
+	return n, nil
 }
 
 // NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
@@ -135,7 +139,11 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 		pluginArgs = append(pluginArgs, "user="+username)
 	}
 	if password != "" {
-		pluginArgs = append(pluginArgs, "password="+password)
+		passwordfile, err := writePasswordFile(password)
+		if err != nil {
+			return nil, err
+		}
+		pluginArgs = append(pluginArgs, "password=+"+passwordfile)
 	}
 	if thumbprint != "" {
 		pluginArgs = append(pluginArgs, "thumbprint="+thumbprint)
@@ -161,6 +169,25 @@ func NewNbdkitVddk(nbdkitPidFile, socket, server, username, password, thumbprint
 		return nil, err
 	}
 	return n, nil
+}
+
+func writePasswordFile(password string) (string, error) {
+	f, err := os.CreateTemp("", "password")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	// This would be nice but we don't want to delete it until
+	// program exit.
+	// defer os.Remove(f.Name())
+
+	if _, err := f.Write([]byte(password)); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 // AddEnvVariable adds an environmental variable to the nbdkit command
@@ -235,9 +262,7 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 
 	quotedArgs := make([]string, len(argsNbdkit))
 	for index, value := range argsNbdkit {
-		if strings.HasPrefix(value, "password=") {
-			quotedArgs[index] = "'password=*****'"
-		} else if isRedacted(value) {
+		if isRedacted(value) {
 			if strings.HasPrefix(value, "header=") {
 				quotedArgs[index] = "'header=/secret redacted/'"
 			} else {
@@ -401,8 +426,8 @@ func (n *Nbdkit) validatePlugin() error {
 type mockNbdkit struct{}
 
 // NewMockNbdkitCurl creates a mock nbdkit curl plugin for testing
-func NewMockNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) NbdkitOperation {
-	return &mockNbdkit{}
+func NewMockNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraHeaders, secretExtraHeaders []string) (NbdkitOperation, error) {
+	return &mockNbdkit{}, nil
 }
 
 func (m *mockNbdkit) StartNbdkit(source string) error {

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -163,6 +163,7 @@ func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (Nbd
 	}
 	if args.Snapshot != "" {
 		pluginArgs = append(pluginArgs, "snapshot="+args.Snapshot)
+		pluginArgs = append(pluginArgs, "transports=file:nbdssl:nbd")
 	}
 	pluginArgs = append(pluginArgs, "--verbose")
 	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -114,7 +114,11 @@ func NewHTTPDataSource(endpoint, accessKey, secKey, certDir string, contentType 
 		brokenForQemuImg: brokenForQemuImg,
 		contentLength:    contentLength,
 	}
-	httpSource.n = createNbdkitCurl(nbdkitPid, accessKey, secKey, certDir, nbdkitSocket, extraHeaders, secretExtraHeaders)
+	httpSource.n, err = createNbdkitCurl(nbdkitPid, accessKey, secKey, certDir, nbdkitSocket, extraHeaders, secretExtraHeaders)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 	// We know this is a counting reader, so no need to check.
 	countingReader := httpReader.(*util.CountingReader)
 	go httpSource.pollProgress(countingReader, 10*time.Minute, time.Second)

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -85,8 +85,8 @@ type NbdKitLogWatcherVddk struct {
 }
 
 // createNbdKitWrapper starts nbdkit and returns a process handle for further management
-func createNbdKitWrapper(vmware *VMwareClient, diskFileName string) (*NbdKitWrapper, error) {
-	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref)
+func createNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
+	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref, snapshot)
 	if err != nil {
 		klog.Errorf("Error validating nbdkit plugins: %v", err)
 		return nil, err
@@ -887,7 +887,7 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 		}
 		klog.Infof("Set disk file name from current snapshot: %s", diskFileName)
 	}
-	nbdkit, err := newNbdKitWrapper(vmware, diskFileName)
+	nbdkit, err := newNbdKitWrapper(vmware, diskFileName, currentCheckpoint)
 	if err != nil {
 		klog.Errorf("Unable to start nbdkit: %v", err)
 		return nil, err

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -86,7 +86,15 @@ type NbdKitLogWatcherVddk struct {
 
 // createNbdKitWrapper starts nbdkit and returns a process handle for further management
 func createNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
-	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, vmware.url.Host, vmware.username, vmware.password, vmware.thumbprint, vmware.moref, snapshot)
+	args := image.NbdKitVddkPluginArgs{
+		Server:     vmware.url.Host,
+		Username:   vmware.username,
+		Password:   vmware.password,
+		Thumbprint: vmware.thumbprint,
+		Moref:      vmware.moref,
+		Snapshot:   snapshot,
+	}
+	n, err := image.NewNbdkitVddk(nbdPidFile, nbdUnixSocket, args)
 	if err != nil {
 		klog.Errorf("Error validating nbdkit plugins: %v", err)
 		return nil, err

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -275,9 +275,9 @@ var _ = Describe("VDDK data source", func() {
 		var returnedDiskName string
 
 		newVddkDataSource = createVddkDataSource
-		newNbdKitWrapper = func(vmware *VMwareClient, fileName string) (*NbdKitWrapper, error) {
+		newNbdKitWrapper = func(vmware *VMwareClient, fileName, snapshot string) (*NbdKitWrapper, error) {
 			returnedDiskName = fileName
-			return createMockNbdKitWrapper(vmware, fileName)
+			return createMockNbdKitWrapper(vmware, fileName, snapshot)
 		}
 		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
 			switch out := result.(type) {
@@ -310,6 +310,38 @@ var _ = Describe("VDDK data source", func() {
 		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk", true),
 		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", "wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk", false),
 	)
+
+	It("should pass snapshot reference through to nbdkit", func() {
+		expectedSnapshot := "snapshot-10"
+
+		var receivedSnapshotRef string
+		newVddkDataSource = createVddkDataSource
+		newNbdKitWrapper = func(vmware *VMwareClient, fileName, snapshot string) (*NbdKitWrapper, error) {
+			receivedSnapshotRef = snapshot
+			return createMockNbdKitWrapper(vmware, fileName, snapshot)
+		}
+
+		currentVMwareFunctions.Properties = func(ctx context.Context, ref types.ManagedObjectReference, property []string, result interface{}) error {
+			switch out := result.(type) {
+			case *mo.VirtualMachine:
+				if property[0] == "config.hardware.device" {
+					out.Config = createVirtualDiskConfig("disk1", 12345)
+				} else if property[0] == "snapshot" {
+					out.Snapshot = createSnapshots(expectedSnapshot, "snapshot-11")
+				}
+			case *mo.VirtualMachineSnapshot:
+				out.Config = *createVirtualDiskConfig("snapshot-disk", 123456)
+				disk := out.Config.Hardware.Device[0].(*types.VirtualDisk)
+				parent := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo).Parent
+				parent.FileName = "snapshot-root"
+			}
+			return nil
+		}
+
+		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "disk1", expectedSnapshot, "", "", v1.PersistentVolumeFilesystem)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(receivedSnapshotRef).To(Equal(expectedSnapshot))
+	})
 
 	It("should find two snapshots and get a list of changed blocks", func() {
 		newVddkDataSource = createVddkDataSource
@@ -628,7 +660,7 @@ func createMockVMwareClient(endpoint string, accessKey string, secKey string, th
 	}, nil
 }
 
-func createMockNbdKitWrapper(vmware *VMwareClient, diskFileName string) (*NbdKitWrapper, error) {
+func createMockNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
 	u, _ := url.Parse("http://vcenter.test")
 	return &NbdKitWrapper{
 		n:      &image.Nbdkit{},

--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -30,7 +30,7 @@ void fakevddk_close(void *handle) {
 int fakevddk_config(const char *key, const char *value) {
     arg_count++;
     if (strcmp(key, "snapshot") == 0) {
-        expected_arg_count = 8;
+        expected_arg_count = 9; // Expect one for 'snapshot' and one for 'transports'
     }
     return 0;
 }

--- a/tools/vddk-test/vddk-test-plugin.c
+++ b/tools/vddk-test/vddk-test-plugin.c
@@ -20,8 +20,8 @@
 
 #define THREAD_MODEL NBDKIT_THREAD_MODEL_SERIALIZE_ALL_REQUESTS
 
-#define EXPECTED_ARG_COUNT 7
 int arg_count = 0;
+int expected_arg_count = 7;
 
 void fakevddk_close(void *handle) {
     close(*((int *) handle));
@@ -29,15 +29,18 @@ void fakevddk_close(void *handle) {
 
 int fakevddk_config(const char *key, const char *value) {
     arg_count++;
+    if (strcmp(key, "snapshot") == 0) {
+        expected_arg_count = 8;
+    }
     return 0;
 }
 
 int fakevddk_config_complete(void) {
     nbdkit_debug("VMware VixDiskLib (1.2.3) Release build-12345");
-    if (arg_count == EXPECTED_ARG_COUNT) {
+    if (arg_count == expected_arg_count) {
         return 0;
     } else {
-        nbdkit_error("Expected %d arguments to fake VDDK test plugin, but got %d!\n", EXPECTED_ARG_COUNT, arg_count);
+        nbdkit_error("Expected %d arguments to fake VDDK test plugin, but got %d!\n", expected_arg_count, arg_count);
         return -1;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add nbdkit command line parameters to improve reliability of multi-stage VDDK imports.
```

