### PR TITLE
Make bazel binary world executable

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -57,7 +57,7 @@ COPY output-bazel-arch.sh /output-bazel-arch.sh
 # Consider using multi-stage builds here instead
 RUN if test "${ARCH}" != "s390x"; then \
 		curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-bazel-arch.sh) && \
-		chmod u+x /usr/bin/bazel; \
+		chmod +x /usr/bin/bazel; \
     fi
 
 # Until we use a ver including the fix for this Bazel issue:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Apparently some folks are running the builder as non-root and thus cannot use the bazel binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

