### PR TITLE
feat: Set default host architecture in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ else
 	DO_BAZ=eval
 endif
 # x86_64 aarch64 crossbuild-aarch64 s390x crossbuild-s390x
-BUILD_ARCH?=x86_64
+BUILD_ARCH?=$(shell uname -m)
 
 ##@ General
 .DEFAULT_GOAL := help


### PR DESCRIPTION
When building natively on ARM or s390x, the default architecture is set to x86_64. This can lead to issues, as Bazel may not be able to find the corresponding toolchain, resulting in a failed build process.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: multiarch

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE
NONE
```

