### PR TITLE
Remove git diff, refine plattform check for multiarch builder

### DIFF
--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -22,12 +22,10 @@ source "${script_dir}"/config.sh
 if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
     BUILDAH_PLATFORM_FLAG="--platform linux/amd64"
     
-    # Check for qemu-user-static for arm64
     if rpm -qa | grep -q qemu-user-static-aarch64; then
         BUILDAH_PLATFORM_FLAG="${BUILDAH_PLATFORM_FLAG},linux/arm64"
     fi
     
-    # Check for qemu-user-static for s390x
     if rpm -qa | grep -q qemu-user-static-s390x; then
         BUILDAH_PLATFORM_FLAG="${BUILDAH_PLATFORM_FLAG},linux/s390x"
     fi
@@ -43,7 +41,7 @@ fi
 # to use DOCKER_PREFIX as it is set in config.sh and used elsewhere in
 # the build system, to introduce a little more consistency
 
-if [ $diffret -ne 0 ] || [ x"${ADHOC_BUILDER}" != "x" ]; then
+if [ x"${ADHOC_BUILDER}" != "x" ]; then
     BUILDER_SPEC="${BUILD_DIR}/docker/builder"
     UNTAGGED_BUILDER_IMAGE="${DOCKER_PREFIX}/kubevirt-cdi-bazel-builder"
     BUILDER_TAG=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)

--- a/hack/build/bazel-build-builder.sh
+++ b/hack/build/bazel-build-builder.sh
@@ -33,32 +33,27 @@ if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
     echo "Building with $BUILDAH_PLATFORM_FLAG"
 fi
 
-# The other circumstance in which we need to build the builder image is
-# in the course of test and development of the builder image itself.
-# we'll signal this circumstance by setting the env variable ADHOC_BUILDER
-#
-# also instead of hard-coding the UNTAGGED_BUILDER_IMAGE, we're going
+
+# Instead of hard-coding the UNTAGGED_BUILDER_IMAGE, we're going
 # to use DOCKER_PREFIX as it is set in config.sh and used elsewhere in
 # the build system, to introduce a little more consistency
 
-if [ x"${ADHOC_BUILDER}" != "x" ]; then
-    BUILDER_SPEC="${BUILD_DIR}/docker/builder"
-    UNTAGGED_BUILDER_IMAGE="${DOCKER_PREFIX}/kubevirt-cdi-bazel-builder"
-    BUILDER_TAG=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
-    BUILDER_MANIFEST=${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG}
-    echo "export BUILDER_IMAGE=$BUILDER_MANIFEST"
+BUILDER_SPEC="${BUILD_DIR}/docker/builder"
+UNTAGGED_BUILDER_IMAGE="${DOCKER_PREFIX}/kubevirt-cdi-bazel-builder"
+BUILDER_TAG=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
+BUILDER_MANIFEST=${UNTAGGED_BUILDER_IMAGE}:${BUILDER_TAG}
+echo "export BUILDER_IMAGE=$BUILDER_MANIFEST"
 
-    #Build the encapsulated compile and test container
-    if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
-        (cd ${BUILDER_SPEC} && buildah build ${BUILDAH_PLATFORM_FLAG} --build-arg ARCH=${ARCH} --manifest ${BUILDER_MANIFEST} .)
-        buildah manifest push --all ${BUILDER_MANIFEST} docker://${BUILDER_MANIFEST}
-        DIGEST=$(podman inspect $(podman images | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $3 }') | jq '.[]["Digest"]')
-    else
-        (cd ${BUILDER_SPEC} && docker build --build-arg ARCH=${ARCH} --tag ${BUILDER_MANIFEST} .)
-        docker push ${BUILDER_MANIFEST}
-        DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
-    fi
-
-    echo "Image: ${BUILDER_MANIFEST}"
-    echo "Digest: ${DIGEST}"
+#Build the encapsulated compile and test container
+if [ "${CDI_CONTAINER_BUILDCMD}" = "buildah" ]; then
+    (cd ${BUILDER_SPEC} && buildah build ${BUILDAH_PLATFORM_FLAG} --build-arg ARCH=${ARCH} --manifest ${BUILDER_MANIFEST} .)
+    buildah manifest push --all ${BUILDER_MANIFEST} docker://${BUILDER_MANIFEST}
+    DIGEST=$(podman inspect $(podman images | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $3 }') | jq '.[]["Digest"]')
+else
+    (cd ${BUILDER_SPEC} && docker build --build-arg ARCH=${ARCH} --tag ${BUILDER_MANIFEST} .)
+    docker push ${BUILDER_MANIFEST}
+    DIGEST=$(docker images --digests | grep ${UNTAGGED_BUILDER_IMAGE} | grep ${BUILDER_TAG} | awk '{ print $4 }')
 fi
+
+echo "Image: ${BUILDER_MANIFEST}"
+echo "Digest: ${DIGEST}"


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue building the builder image with emulation.

The git diff check seemed to prevent the build to run, which should also be done in prow.

The Plattform check is made more readable as well as use the rpm list instead of a specific location.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

