### PR TITLE
Deprecate ObjectTransfer feature

### DIFF
--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -18470,7 +18470,7 @@ func schema_pkg_apis_core_v1beta1_ObjectTransfer(ref common.ReferenceCallback) c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ObjectTransfer is the cluster scoped object transfer resource",
+				Description: "Deprecated for removal in v1.\n\nObjectTransfer is the cluster scoped object transfer resource",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/pkg/apiserver/webhooks/transfer-validate.go
+++ b/pkg/apiserver/webhooks/transfer-validate.go
@@ -40,6 +40,8 @@ type objectTransferValidatingWebhook struct {
 	cdiClient cdiclient.Interface
 }
 
+// ObjectTransfer is now deprecated and will be removed in v1.
+// github issue: https://github.com/kubevirt/containerized-data-importer/issues/3417
 func (wh *objectTransferValidatingWebhook) Admit(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	klog.V(3).Infof("Got AdmissionReview %+v", ar)
 
@@ -107,5 +109,8 @@ func (wh *objectTransferValidatingWebhook) Admit(ar admissionv1.AdmissionReview)
 		return toAdmissionResponseError(err)
 	}
 
-	return allowedAdmissionResponse()
+	return &admissionv1.AdmissionResponse{
+		Allowed:  true,
+		Warnings: []string{"ObjectTransfer feature is deprecated, and will be deleted soon"},
+	}
 }

--- a/pkg/apiserver/webhooks/transfer-validate_test.go
+++ b/pkg/apiserver/webhooks/transfer-validate_test.go
@@ -196,7 +196,7 @@ var _ = Describe("ObjectTransfer webhook", func() {
 			}}, nil),
 		)
 
-		It("Should accept good stuff", func() {
+		It("Should accept good stuff with deprecation warning", func() {
 			ot := &cdiv1.ObjectTransfer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ot",
@@ -231,6 +231,8 @@ var _ = Describe("ObjectTransfer webhook", func() {
 
 			resp := validateObjectTransfers(ar, nil, nil)
 			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Warnings).ToNot(BeEmpty())
+			Expect(resp.Warnings[0]).To(ContainSubstring("ObjectTransfer feature is deprecated"))
 		})
 	})
 

--- a/pkg/operator/resources/cluster/BUILD.bazel
+++ b/pkg/operator/resources/cluster/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],

--- a/pkg/operator/resources/cluster/object-transfer.go
+++ b/pkg/operator/resources/cluster/object-transfer.go
@@ -1,10 +1,12 @@
 package cluster
 
 import (
+	"fmt"
 	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/containerized-data-importer/pkg/operator/resources"
 )
@@ -18,5 +20,10 @@ func NewObjectTransferCrd() *extv1.CustomResourceDefinition {
 func createObjectTransferCRD() *extv1.CustomResourceDefinition {
 	crd := extv1.CustomResourceDefinition{}
 	_ = k8syaml.NewYAMLToJSONDecoder(strings.NewReader(resources.CDICRDs["objecttransfer"])).Decode(&crd)
+	for i := range crd.Spec.Versions {
+		deprecationWarning := fmt.Sprintf("cdi.kubevirt.io/%s createObjectTransferCRD is now deprecated and will be removed in v1.", crd.Spec.Versions[i].Name)
+		crd.Spec.Versions[i].Deprecated = true
+		crd.Spec.Versions[i].DeprecationWarning = ptr.To(deprecationWarning)
+	}
 	return &crd
 }

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -7371,7 +7371,11 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ObjectTransfer is the cluster scoped object transfer resource
+        description: |-
+          Deprecated for removal in v1.
+
+
+          ObjectTransfer is the cluster scoped object transfer resource
         properties:
           apiVersion:
             description: |-

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_transfer.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_transfer.go
@@ -25,6 +25,8 @@ import (
 // see https://github.com/kubernetes/code-generator/issues/59
 // +genclient:nonNamespaced
 
+// Deprecated for removal in v1.
+//
 // ObjectTransfer is the cluster scoped object transfer resource
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Added warnings and comments to ObjectTransfer crd and webhook.
Reference to relevant github issue:
https://github.com/kubevirt/containerized-data-importer/issues/3417



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecating ObjectTransfer feature
```

