### PR TITLE
define container bundles for s390x test images that omit tests for features unsupported in s390x

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -88,6 +88,21 @@ container_bundle(
     },
 )
 
+container_bundle(
+    name = "test-container-images-s390x",
+    images = {
+        "$(container_prefix)/cdi-func-test-bad-webserver:$(container_tag)": "//tools/cdi-func-test-bad-webserver:cdi-func-test-bad-webserver-image",
+        "$(container_prefix)/cdi-func-test-proxy:$(container_tag)": "//tools/cdi-func-test-proxy:cdi-func-test-proxy-image",
+        "$(container_prefix)/cdi-func-test-sample-populator:$(container_tag)": "//tools/cdi-func-test-sample-populator:cdi-func-test-sample-populator-image",
+        "$(container_prefix)/cdi-func-test-file-host-init:$(container_tag)": "//tools/cdi-func-test-file-host-init:cdi-func-test-file-host-init-image",
+        "$(container_prefix)/cdi-func-test-file-host-http:$(container_tag)": "//tools/cdi-func-test-file-host-init:cdi-func-test-file-host-http-image",
+        "$(container_prefix)/cdi-func-test-registry-init:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-init-image",
+        "$(container_prefix)/cdi-func-test-registry-populate:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-populate-image",
+        "$(container_prefix)/cdi-func-test-registry:$(container_tag)": "//tools/cdi-func-test-registry-init:cdi-func-test-registry-image",
+        "$(container_prefix)/vcenter-simulator:$(container_tag)": "//tools/vddk-test:vcenter-simulator",
+    },
+)
+
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 
@@ -95,6 +110,7 @@ load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 alias(
     name = "test-container-images",
     actual = select({
+        "@io_bazel_rules_go//go/platform:linux_s390x":":test-container-images-s390x",
         "@io_bazel_rules_go//go/platform:linux_arm64":":test-container-images-aarch64",
         "//conditions:default":  ":test-container-images-amd64",
     })
@@ -197,6 +213,9 @@ filegroup(
 container_image(
     name = "testimage_base",
     tars = select({
+        "@io_bazel_rules_go//go/platform:linux_s390x": [
+            "//rpm:testimage_s390x",
+        ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//rpm:testimage_aarch64",
         ],
@@ -210,6 +229,9 @@ container_image(
 container_image(
     name = "centos_base",
     tars = select({
+        "@io_bazel_rules_go//go/platform:linux_s390x": [
+            "//rpm:centos_base_s390x",
+        ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//rpm:centos_base_aarch64",
         ],

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 	DO=eval
 	DO_BAZ=eval
 endif
-# x86_64 aarch64 crossbuild-aarch64
+# x86_64 aarch64 crossbuild-aarch64 s390x crossbuild-s390x
 BUILD_ARCH?=x86_64
 
 ##@ General


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Need to build e2e and functional tests for s390x. Therefore need to incorporate a `container bundle` for s390x test images that omits tests for features that are unsupported on s390x such as vddk, ovirt, tinycore and cirros. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3423 

**Special notes for your reviewer**:

@jschintag the test for this mod is in https://gist.github.com/cfilleke/8df35222b7066ac38981e2b7fb2f79d6

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

provides s390x support for functional tests

```

