### PR TITLE
[release-v1.55] Test CI for etcd failures on older versions

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -328,6 +328,7 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 
 			if _, ok := pvc.Annotations[AnnImportPod]; ok {
 				// Create importer pod, make sure the PVC owns it.
+				// test
 				if err := r.createImporterPod(pvc); err != nil {
 					return reconcile.Result{}, err
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We've been seeing these alot:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/3418/pull-containerized-data-importer-e2e-ceph-wffc/1831130026351792128 (stderr has `ERROR: checking pvc target-dv phase failed: etcdserver: request timed out`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

