### PR TITLE
Add s390x and native BUILD_ARCH in periodic automation

### DIFF
--- a/automation/prow_periodic_push.sh
+++ b/automation/prow_periodic_push.sh
@@ -2,9 +2,24 @@
 set -e
 build_date="$(date +%Y%m%d)"
 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
-export DOCKER_TAG="${build_date}_$(git show -s --format=%h)-arm64"
+
+case $BUILD_ARCH in
+  crossbuild-s390x|s390x)
+    ARCH_SUFFIX="-s390x"
+    ;;
+  crossbuild-aarch64|aarch64)
+    ARCH_SUFFIX="-arm64"
+    ;;
+  *)
+    echo "No BUILD_ARCH or ${BUILD_ARCH}, assuming amd64"
+    ;;
+esac
+
+export DOCKER_TAG="${build_date}_$(git show -s --format=%h)${ARCH_SUFFIX}"
+
 make manifests
 make bazel-push-images
+
 bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/${build_date}"
-gsutil cp ./_out/manifests/release/cdi-operator.yaml gs://$bucket_dir/cdi-operator-arm64.yaml
-gsutil cp ./_out/manifests/release/cdi-cr.yaml gs://$bucket_dir/cdi-cr-arm64.yaml
+gsutil cp ./_out/manifests/release/cdi-operator.yaml gs://$bucket_dir/cdi-operator${ARCH_SUFFIX}.yaml
+gsutil cp ./_out/manifests/release/cdi-cr.yaml gs://$bucket_dir/cdi-cr${ARCH_SUFFIX}.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
As a prerequisite for the s390x nightly build prow job (https://github.com/kubevirt/project-infra/pull/3627), an additional `BUILD_ARCH` is necessary. 
I decided to catch the architecture (_e.g. s390x_) and the crossbuild version (_e.g. crossbuild_s390x_)  to give the CI the freedom to either change the `BUILD_ARCH` parameter in the future or support native builds.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add s390x nightly build automation
```

