### PR TITLE
Run unit-tests without bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test: test-unit test-functional test-lint ## execute all tests (_NOTE:_ 'WHAT' i
 
 test-unit: WHAT = ./pkg/... ./cmd/...
 test-unit: ## Run unit tests.
-	${DO_BAZ} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
+	${DO} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
 
 test-functional: WHAT = ./tests/...
 test-functional: build-functest ## Run functional tests (in tests/ subdirectory).

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -22,6 +22,11 @@ source "${script_dir}"/config.sh
 
 WORK_DIR="/go/src/kubevirt.io/containerized-data-importer"
 
+if [ ! -d "${CACHE_DIR}" ]; then
+  echo "Creating cache directory: ${CACHE_DIR}"
+  mkdir -p "${CACHE_DIR}"
+fi
+
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"
 ${CDI_CRI} run ${USE_TTY} \


### PR DESCRIPTION
**What this PR does / why we need it**:

As we don't really need bazel for the unit tests I'd run them using `in-docker.sh` instead of `bazel-docker.sh`
This would also solve some issues on `s390x` where bazel is currently not available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/project-infra/pull/3552

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

