### PR TITLE
[release-v1.58] Ensure scratch space is large enough to hold disk image

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -465,7 +465,6 @@ func (r *ImportReconciler) cleanup(pvc *corev1.PersistentVolumeClaim, pod *corev
 }
 
 func (r *ImportReconciler) updatePVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {
-	log.V(1).Info("Annotations are now", "pvc.anno", pvc.GetAnnotations())
 	if err := r.client.Update(context.TODO(), pvc); err != nil {
 		return err
 	}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -469,7 +469,9 @@ var _ = Describe("Update PVC from POD", func() {
 		// Once all controllers are converted, we will use the runtime lib client instead of client-go and retrieval needs to change here.
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1-scratch", Namespace: "default"}, scratchPvc)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(scratchPvc.Spec.Resources).To(Equal(pvc.Spec.Resources))
+		// Since fsOverhead is 0, the scratch space size should be 1Mi aligned close to 1G
+		requestSize := scratchPvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		Expect(requestSize.Value()).To(Equal(int64(999292928)))
 		Expect(scratchPvc.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
 
 		resPvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -49,13 +49,15 @@ import (
 )
 
 const (
-	storageClassName  = "testSC"
-	snapshotClassName = "testSnapClass"
-	cephProvisioner   = "rook-ceph.rbd.csi.ceph.com"
+	scratchStorageClassName = "testScratchSC"
+	snapshotClassName       = "testSnapClass"
+	provisionerName         = "testProvisioner"
+	cephProvisioner         = "rook-ceph.rbd.csi.ceph.com"
 )
 
 var (
 	storageProfileLog = logf.Log.WithName("storageprofile-controller-test")
+	storageClassName  = "testSC"
 )
 
 var _ = Describe("Storage profile controller reconcile loop", func() {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -157,7 +158,7 @@ func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{"ReadWriteOnce"},
-			Resources:   pvc.Spec.Resources,
+			Resources:   *pvc.Spec.Resources.DeepCopy(),
 		},
 	}
 	if storageClassName != "" {
@@ -169,6 +170,24 @@ func newScratchPersistentVolumeClaimSpec(pvc *v1.PersistentVolumeClaim, pod *v1.
 // createScratchPersistentVolumeClaim creates and returns a pointer to a scratch PVC which is created based on the passed-in pvc and storage class name.
 func createScratchPersistentVolumeClaim(client client.Client, pvc *v1.PersistentVolumeClaim, pod *v1.Pod, name, storageClassName string, installerLabels map[string]string, recorder record.EventRecorder) (*v1.PersistentVolumeClaim, error) {
 	scratchPvcSpec := newScratchPersistentVolumeClaimSpec(pvc, pod, name, storageClassName)
+
+	sizeRequest := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	scratchFsOverhead, err := GetFilesystemOverhead(context.TODO(), client, scratchPvcSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get filesystem overhead for scratch PVC")
+	}
+	scratchFsOverheadFloat, _ := strconv.ParseFloat(string(scratchFsOverhead), 64)
+	pvcFsOverhead, err := GetFilesystemOverhead(context.TODO(), client, pvc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get filesystem overhead for original PVC")
+	}
+	pvcFsOverheadFloat, _ := strconv.ParseFloat(string(pvcFsOverhead), 64)
+	expectedVirtualSize := util.GetUsableSpace(pvcFsOverheadFloat, sizeRequest.Value())
+
+	usableSpaceRaw := util.CalculateOverheadSpace(scratchFsOverheadFloat, expectedVirtualSize)
+
+	scratchPvcSpec.Spec.Resources.Requests[corev1.ResourceStorage] = *resource.NewScaledQuantity(usableSpaceRaw, 0)
+
 	util.SetRecommendedLabels(scratchPvcSpec, installerLabels, "cdi-controller")
 	if err := client.Create(context.TODO(), scratchPvcSpec); err != nil {
 		if cc.ErrQuotaExceeded(err) {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -417,6 +417,60 @@ var _ = Describe("check PVC", func() {
 	)
 })
 
+var _ = Describe("createScratchPersistentVolumeClaim", func() {
+	DescribeTable("Should create a scratch PVC of the correct size, taking fs overhead into account", func(scratchOverhead, scOverhead cdiv1.Percent, expectedValue int64) {
+		cdiConfig := createCDIConfigWithStorageClass(common.ConfigName, scratchStorageClassName)
+		cdiConfig.Status.FilesystemOverhead = &cdiv1.FilesystemOverhead{
+			Global: "0.05",
+			StorageClass: map[string]cdiv1.Percent{
+				scratchStorageClassName: scratchOverhead,
+				storageClassName:        scOverhead,
+			},
+		}
+		cl := CreateClient(cdiConfig, CreateStorageClass(scratchStorageClassName, nil), CreateStorageClass(storageClassName, nil))
+		rec := record.NewFakeRecorder(10)
+		By("Create a 1Gi pvc")
+		testPvc := CreatePvcInStorageClass("testPvc", "default", &storageClassName, nil, nil, v1.ClaimBound)
+		testPvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse("1Gi")
+		name := "test-scratchspace-pvc"
+		pod := &v1.Pod{}
+		res, err := createScratchPersistentVolumeClaim(cl, testPvc, pod, name, scratchStorageClassName, nil, rec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		Expect(res.Spec.Resources).ToNot(BeNil())
+		Expect(res.Spec.Resources.Requests.Storage()).ToNot(BeNil())
+		scratchPVCSize := *res.Spec.Resources.Requests.Storage()
+		Expect(scratchPVCSize.Value()).To(Equal(expectedValue * 1024 * 1024))
+	},
+		Entry("same scratch and storage class overhead", cdiv1.Percent("0.03"), cdiv1.Percent("0.03"), int64(1024)),
+		Entry("scratch  > storage class overhead", cdiv1.Percent("0.1"), cdiv1.Percent("0.03"), int64(1104)),
+		Entry("scratch  < storage class overhead", cdiv1.Percent("0.03"), cdiv1.Percent("0.1"), int64(950)),
+	)
+
+	It("Should calculate the correct size for a scratch PVC from a block volume", func() {
+		cdiConfig := createCDIConfigWithStorageClass(common.ConfigName, scratchStorageClassName)
+		cdiConfig.Status.FilesystemOverhead = &cdiv1.FilesystemOverhead{
+			Global: "0.05",
+		}
+		cl := CreateClient(cdiConfig)
+		rec := record.NewFakeRecorder(10)
+		By("Create a 1Gi pvc")
+		testPvc := CreatePvcInStorageClass("testPvc", "default", &storageClassName, nil, nil, v1.ClaimBound)
+		testPvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse("1Gi")
+		block := v1.PersistentVolumeBlock
+		testPvc.Spec.VolumeMode = &block
+		name := "test-scratchspace-pvc"
+		pod := &v1.Pod{}
+		res, err := createScratchPersistentVolumeClaim(cl, testPvc, pod, name, scratchStorageClassName, nil, rec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		Expect(res.Spec.Resources).ToNot(BeNil())
+		Expect(res.Spec.Resources.Requests.Storage()).ToNot(BeNil())
+		scratchPVCSize := *res.Spec.Resources.Requests.Storage()
+		Expect(scratchPVCSize.Value()).To(Equal(int64(1078 * 1024 * 1024)))
+	})
+})
+
 func createDataVolumeWithStorageClass(name, ns, storageClassName string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -126,7 +126,7 @@ func NewNbdkitCurl(nbdkitPidFile, user, password, certDir, socket string, extraH
 	return n, nil
 }
 
-// Keep these in a struct to keep NewNbdkitVddk from going over the argument limit
+// NbdKitVddkPluginArgs Keep these in a struct to keep NewNbdkitVddk from going over the argument limit
 type NbdKitVddkPluginArgs struct {
 	Server     string
 	Username   string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -446,13 +446,19 @@ func AppendZeroWithWrite(outFile *os.File, start, length int64) error {
 	return nil
 }
 
-// GetUsableSpace calculates space to use taking file system overhead into account
+// GetUsableSpace calculates usable space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
 	// +1 always rounds up.
 	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
 	return RoundDown(spaceWithOverhead, DefaultAlignBlockSize)
+}
+
+// CalculateOverheadSpace calculates the space needed to account for filesystem overhead
+func CalculateOverheadSpace(filesystemOverhead float64, availableSpace int64) int64 {
+	spaceWithOverhead := int64(math.Ceil(float64(availableSpace) / (1 - filesystemOverhead)))
+	return RoundUp(spaceWithOverhead, DefaultAlignBlockSize)
 }
 
 // ResolveVolumeMode returns the volume mode if set, otherwise defaults to file system mode

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -496,8 +496,8 @@ var _ = Describe("all clone tests", func() {
 				sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				volumeMode := v1.PersistentVolumeMode(v1.PersistentVolumeFilesystem)
-				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				volumeMode := v1.PersistentVolumeFilesystem
+				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1.2Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDataVolume)


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3384

```release-note
Increased size of scratch space to take fs overhead into account.
```

