### PR TITLE
Handle PunchHole/AppendZeroWithTruncate failures

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -168,6 +168,9 @@ func PunchHole(outFile *os.File, start, length int64) error {
 	return err
 }
 
+// unit test support to simulate failure and fallback to zero writes
+var appendZeroWithTruncateFunc = AppendZeroWithTruncate
+
 // AppendZeroWithTruncate resizes the file to append zeroes, meant only for newly-created (empty and zero-length) regular files.
 func AppendZeroWithTruncate(outFile *os.File, start, length int64) error {
 	klog.V(4).Infof("Truncating %d-bytes from offset %d", length, start)
@@ -228,7 +231,7 @@ func StreamDataToFile(r io.Reader, fileName string, preallocate bool) (int64, in
 
 	if !preallocate {
 		var isDevice bool
-		zeroWriter := AppendZeroWithTruncate
+		zeroWriter := appendZeroWithTruncateFunc
 		isDevice, err = IsDevice(fileName)
 		if err != nil {
 			return 0, 0, err
@@ -261,6 +264,21 @@ func StreamDataToFile(r io.Reader, fileName string, preallocate bool) (int64, in
 
 type zeroWriterFunc func(*os.File, int64, int64) error
 
+func zeroWriterWithFallback(zwf zeroWriterFunc) func(dst *os.File, start, length int64) (int64, error) {
+	return func(dst *os.File, start, length int64) (int64, error) {
+		err := zwf(dst, start, length)
+		if err != nil {
+			klog.Errorf("Error zeroing range in destination file: %v, will write zeros directly", err)
+			err = AppendZeroWithWrite(dst, start, length)
+			if err != nil {
+				return 0, err
+			}
+			return length, nil
+		}
+		return 0, nil
+	}
+}
+
 func copyWithSparseCheck(dst *os.File, src io.Reader, zeroWriter zeroWriterFunc) (int64, int64, error) {
 	klog.Infof("copyWithSparseCheck to %s", dst.Name())
 	const buffSize = 32 * 1024
@@ -268,20 +286,27 @@ func copyWithSparseCheck(dst *os.File, src io.Reader, zeroWriter zeroWriterFunc)
 	zeroBuf := make([]byte, buffSize)
 	writeBuf := make([]byte, buffSize)
 	var writeOffset int64
+	checkZeros := true
+	zeroWriterFunc := zeroWriterWithFallback(zeroWriter)
 	for {
 		nr, er := src.Read(writeBuf)
 		if nr > 0 {
 			var nw int
 			var ew error
-			if bytes.Equal(writeBuf[0:nr], zeroBuf[0:nr]) {
+			var zbw int64
+			if checkZeros && bytes.Equal(writeBuf[0:nr], zeroBuf[0:nr]) {
 				bytesRead += int64(nr)
 			} else {
 				if bytesRead > writeOffset {
-					// zeroWriter func should seek to bytesRead before returning
-					ew = zeroWriter(dst, writeOffset, bytesRead-writeOffset)
+					// func should seek to bytesRead before returning
+					zbw, ew = zeroWriterFunc(dst, writeOffset, bytesRead-writeOffset)
 					if ew != nil {
-						klog.Errorf("Error zeroing range in destination file: %v", ew)
+						klog.Errorf("Error writing zeroes to destination file: %v", ew)
 						return bytesRead, bytesWritten, ew
+					}
+					bytesWritten += zbw
+					if zbw > 0 {
+						checkZeros = false
 					}
 				}
 				nw, ew = dst.Write(writeBuf[0:nr])
@@ -310,10 +335,12 @@ func copyWithSparseCheck(dst *os.File, src io.Reader, zeroWriter zeroWriterFunc)
 		}
 	}
 	if bytesRead > writeOffset {
-		if err := zeroWriter(dst, writeOffset, bytesRead-writeOffset); err != nil {
-			klog.Errorf("Error zeroing range in destination file: %v", err)
+		zbw, err := zeroWriterFunc(dst, writeOffset, bytesRead-writeOffset)
+		if err != nil {
+			klog.Errorf("Error writing zeroes to destination file: %v", err)
 			return bytesRead, bytesWritten, err
 		}
+		bytesWritten += zbw
 	}
 	return bytesRead, bytesWritten, nil
 }

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -134,6 +134,10 @@ var _ = Describe("All tests", func() {
 
 	Describe("StreamDataToFile tests", func() {
 		Context("with tmp directory", func() {
+			const (
+				sparseBoundary int64 = 32 * 1024
+			)
+
 			var destTmp string
 			var err error
 			var random *rand.Rand
@@ -158,8 +162,7 @@ var _ = Describe("All tests", func() {
 
 			DescribeTable("Should stream data to file", func(writeSize int, preallocate bool) {
 				const (
-					totalBytes     int64 = 1024 * 1024
-					sparseBoundary int64 = 32 * 1024
+					totalBytes int64 = 1024 * 1024
 				)
 
 				// validate  writeSize
@@ -207,6 +210,66 @@ var _ = Describe("All tests", func() {
 				Entry("with preallocation 32k block", 32*1024, true),
 				Entry("with preallocation 64k block", 64*1024, true),
 			)
+
+			Context("with fake zero writer", func() {
+
+				fakeAppendWithTruncate := func(outFile *os.File, start, length int64) error {
+					return fmt.Errorf("fake append with truncate")
+				}
+
+				alternatingBytes := func(numRanges int) []byte {
+					var byteBuf bytes.Buffer
+					for i := 0; i < numRanges; i++ {
+						b := byte(0)
+						if i%2 == 0 {
+							b = 1
+						}
+						byteBuf.Write(bytes.Repeat([]byte{b}, int(sparseBoundary)))
+					}
+					return byteBuf.Bytes()
+				}
+
+				leadingZeroes := func(numRanges int) []byte {
+					var byteBuf bytes.Buffer
+					byteBuf.Write(bytes.Repeat([]byte{0}, int(sparseBoundary)))
+					for i := 0; i < numRanges-1; i++ {
+						byteBuf.Write(bytes.Repeat([]byte{1}, int(sparseBoundary)))
+					}
+					return byteBuf.Bytes()
+				}
+
+				trailingZeroes := func(numRanges int) []byte {
+					var byteBuf bytes.Buffer
+					for i := 0; i < numRanges-1; i++ {
+						byteBuf.Write(bytes.Repeat([]byte{1}, int(sparseBoundary)))
+					}
+					byteBuf.Write(bytes.Repeat([]byte{0}, int(sparseBoundary)))
+					return byteBuf.Bytes()
+				}
+
+				AfterEach(func() {
+					appendZeroWithTruncateFunc = AppendZeroWithTruncate
+				})
+
+				DescribeTable("should fallback to writing zeroes if truncate fails", func(fail bool, data []byte, expectedBytesWritten int64) {
+					if fail {
+						appendZeroWithTruncateFunc = fakeAppendWithTruncate
+					}
+
+					destName := filepath.Join(destTmp, "disk.img")
+					bytesRead, bytesWritten, err := StreamDataToFile(bytes.NewReader(data), destName, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bytesRead).To(Equal(sparseBoundary * 4))
+					Expect(bytesWritten).To(Equal(expectedBytesWritten))
+				},
+					Entry("no failure", false, alternatingBytes(4), sparseBoundary*2),
+					Entry("with failure", true, alternatingBytes(4), sparseBoundary*4),
+					Entry("no failure leading", false, leadingZeroes(4), sparseBoundary*3),
+					Entry("no failure trailing", false, trailingZeroes(4), sparseBoundary*3),
+					Entry("with failure leading", true, leadingZeroes(4), sparseBoundary*4),
+					Entry("with failure trailing", true, trailingZeroes(4), sparseBoundary*4),
+				)
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Turns out gcp standard-csi provisioner does not support PunchHole for block devices We should handle these failures and simply write zeros

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle PunchHole/AppendZeroWithTruncate failures
```

