### PR TITLE
[release-v1.58] Freeze some go tool versions in corresponding builder

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -43,13 +43,13 @@ RUN \
 	source /etc/profile.d/gimme.sh && \
 	eval $(go env) && \
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.12.0 && \
-	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install golang.org/x/tools/cmd/goimports@v0.14.0 && \
 	go install mvdan.cc/sh/cmd/shfmt@latest && \
 	go install github.com/mattn/goveralls@latest && \
 	go install golang.org/x/lint/golint@latest && \
 	go install github.com/rmohr/go-swagger-utils/swagger-doc@latest && \
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0 && \
-	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.18.1 && \
 	rm -rf "${GOPATH}/pkg"
 
 ENV BAZEL_VERSION 5.4.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The builder on this branch [can't](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-containerized-data-importer-builder/1835304934338203648) be built with `latest` for some tools:
```
go: golang.org/x/tools/cmd/goimports@latest (in golang.org/x/tools@v0.25.0): go.mod:3: invalid go version '1.22.0': must match format 1.23
```
Freezing to current versions in known & working builder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

