### PR TITLE
Suppress alerting for kubernetes.io/no-provisioner

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -174,10 +174,11 @@ const (
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
 var UnsupportedProvisioners = map[string]struct{}{
 	// The following provisioners may be found in Rook/Ceph deployments and are related to object storage
-	ProvisionerOCSBucket:      {},
-	ProvisionerRookCephBucket: {},
-	ProvisionerNoobaa:         {},
-	ProvisionerStorkSnapshot:  {},
+	ProvisionerOCSBucket:                   {},
+	ProvisionerRookCephBucket:              {},
+	ProvisionerNoobaa:                      {},
+	ProvisionerStorkSnapshot:               {},
+	storagehelpers.NotSupportedProvisioner: {},
 }
 
 // GetCapabilities finds and returns a predefined StorageCapabilities for a given StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
Add static provisioning to the `UnsupportedProvisioners` list to reduce alert noise, as it's not helpful in this case. Currently in static provisioning we try to populate the `StorageProfile` with `ClaimPropertySets` based on the existing PVs, and if not found the `CDIStorageProfilesIncomplete` alert is fired.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-44335

**Special notes for your reviewer**:

**Release note**:
```release-note
Suppress alerting for static provisioning
```

