### PR TITLE
bug fix nginx arch in BUILD.bazel

### DIFF
--- a/tools/cdi-func-test-file-host-init/BUILD.bazel
+++ b/tools/cdi-func-test-file-host-init/BUILD.bazel
@@ -92,7 +92,7 @@ container_image(
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_s390x": [
             ":nginx-conf-tar",
-            "//rpm:testimage_aarch64",
+            "//rpm:testimage_s390x",
         ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             ":nginx-conf-tar",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
s390x nginx in functional tests helper images needs to be installed when `BUILD_ARCH` is `s390x` or `crossbuild-s390x`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

