### PR TITLE
Document device_ownership_from_security_context=true for Containerd v2

### DIFF
--- a/doc/block_cri_ownership_config.md
+++ b/doc/block_cri_ownership_config.md
@@ -8,10 +8,16 @@ This makes it problematic for our workloads to populate block devices, and has m
 As explained in the source below, a solution that is seamless to end-users was chosen by the k8s community, without getting the device plugin vendors involved.  
 The selected approach was to re-use `runAsUser` and `runAsGroup` for devices, with an opt-in config entry for the CRI (`device_ownership_from_security_context`) that ensures no existing deployment breaks.  
 To use CDI, it is advised to opt-in.  
-For containerd:
+For Containerd v1:
 ```toml
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = true
+```
+For Containerd v2:
+```toml
+[plugins]
+  [plugins."io.containerd.cri.v1.runtime"]
     device_ownership_from_security_context = true
 ```
 CRI-O:


### PR DESCRIPTION
Hi, in the [Cozystack](github.com/aenix-io/cozystack) project, we recently upgraded to Containerd v2 and noticed that the old option is no longer functioning. It has now been moved to a different section. I'd like to update the documentation to help others quickly find the solution.

I prepared a set of fixes:
- Original issue https://github.com/aenix-io/cozystack/issues/397
- CDI docs: https://github.com/kubevirt/containerized-data-importer/pull/3452
- Kubernetes docs: https://github.com/kubernetes/website/pull/48198

Cheers

fixes #3455

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Document device_ownership_from_security_context=true for Containerd v2
```