### PR TITLE
Fix: checking available image size

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -242,8 +242,8 @@ func checkIfURLIsValid(info *ImgInfo, availableSize int64, image string) error {
 		}
 	}
 
-	if availableSize < info.VirtualSize {
-		return errors.Errorf("virtual image size %d is larger than the reported available storage %d. A larger PVC is required", info.VirtualSize, availableSize)
+	if availableSize > info.VirtualSize {
+		return errors.Errorf("virtual image size %d is smaller than the reported available storage %d. A larger PVC is required", info.VirtualSize, availableSize)
 	}
 	return nil
 }

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Validate", func() {
 		Entry("should return error on bad json", mockExecFunction(badValidateJSON, "", expectedLimits), "unexpected end of JSON input", imageName),
 		Entry("should return error on bad format", mockExecFunction(badFormatValidateJSON, "", expectedLimits), fmt.Sprintf("Invalid format raw2 for image %s", imageName), imageName),
 		Entry("should return error on invalid backing file", mockExecFunction(backingFileValidateJSON, "", expectedLimits), fmt.Sprintf("Image %s is invalid because it has invalid backing file backing-file.qcow2", imageName), imageName),
-		Entry("should return error when PVC is too small", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("virtual image size %d is larger than the reported available storage %d. A larger PVC is required", 52949672960, 42949672960), imageName),
+		Entry("should return error when PVC is too small", mockExecFunction(hugeValidateJSON, "", expectedLimits), fmt.Sprintf("virtual image size %d is smaller than the reported available storage %d. A larger PVC is required", 42949672960, 52949672960), imageName),
 	)
 
 })


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

**What this PR does / why we need it**:

This PR fixes the issue of checking size for the end device.

Currently we check if actual block-volume is larger than requested size in PVC.
However we should check if actual block-volume is smaller than requested size in PVC, because this might blocking the image upload.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubevirt/containerized-data-importer/issues/3159

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: checking available image size
```

