### PR TITLE
Fix uploading for block devices that exceed requested size

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -363,12 +363,12 @@ func (dp *DataProcessor) calculateTargetSize() int64 {
 			klog.Error(err)
 		}
 		targetQuantity = resource.NewScaledQuantity(size, 0)
-	}
-	if dp.requestImageSize != "" {
-		klog.V(1).Infof("Request image size not empty.\n")
-		newImageSizeQuantity := resource.MustParse(dp.requestImageSize)
-		minQuantity := util.MinQuantity(targetQuantity, &newImageSizeQuantity)
-		targetQuantity = &minQuantity
+		if dp.requestImageSize != "" {
+			klog.V(1).Infof("Request image size not empty.\n")
+			newImageSizeQuantity := resource.MustParse(dp.requestImageSize)
+			minQuantity := util.MinQuantity(targetQuantity, &newImageSizeQuantity)
+			targetQuantity = &minQuantity
+		}
 	}
 	klog.V(1).Infof("Target size %s.\n", targetQuantity.String())
 	targetSize := targetQuantity.Value()


### PR DESCRIPTION
**What this PR does / why we need it**:

Various storage providers may provision block devices larger than the size requested by the user. This is often due to LVM or ZFS rounding up to the nearest extent size. (see https://github.com/LINBIT/linstor-server/issues/421#issuecomment-2407406702 and https://github.com/kubevirt/containerized-data-importer/issues/3159#issuecomment-2410182504)

Currently, CDI checks the requested size in the PVC and fails the upload if the original block device is larger than the requested size. 

This PR changes logic to take requestImageSize into account only for filesystem volumes

**Which issue(s) this PR fixes**:

Another try to fix https://github.com/kubevirt/containerized-data-importer/issues/3159

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix uploading for block devices that exceed requested size
```

