### PR TITLE
Exclude Unsupported Func-Test Images for s390x

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -181,8 +181,8 @@ if [ "${CDI_SYNC}" == "test-infra" ]; then
   _kubectl apply -f "./_out/manifests/sample-populator.yaml"
   _kubectl apply -f "./_out/manifests/uploadproxy-nodeport.yaml"
 
-  # Check if CPU architecture is s390x
-  if [ "$(uname -m)" != "s390x" ]; then
+  # Disable unsupported functest images for s390x
+  if [ "${ARCHITECTURE}" != "s390x" ]; then
     # Imageio test service:
     _kubectl apply -f "./_out/manifests/imageio.yaml"
     # vCenter (VDDK) test service:

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -180,10 +180,15 @@ if [ "${CDI_SYNC}" == "test-infra" ]; then
   _kubectl apply -f "./_out/manifests/test-proxy.yaml"
   _kubectl apply -f "./_out/manifests/sample-populator.yaml"
   _kubectl apply -f "./_out/manifests/uploadproxy-nodeport.yaml"
-  # Imageio test service:
-  _kubectl apply -f "./_out/manifests/imageio.yaml"
-  # vCenter (VDDK) test service:
-  _kubectl apply -f "./_out/manifests/vcenter.yaml"
+
+  # Check if CPU architecture is s390x
+  if [ "$(uname -m)" != "s390x" ]; then
+    # Imageio test service:
+    _kubectl apply -f "./_out/manifests/imageio.yaml"
+    # vCenter (VDDK) test service:
+    _kubectl apply -f "./_out/manifests/vcenter.yaml"
+  fi
+ 
   if _kubectl get crd securitycontextconstraints.security.openshift.io >/dev/null 2>&1; then
     _kubectl apply -f "./_out/manifests/cdi-testing-scc.yaml"
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`vddk` and `imagio` in not available on s390x and won't be in the near future.
Because of this I propose a exclusion of the corresponding func-test images, when calling `cluster-sync`


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

