### PR TITLE
Add default containerPort for cdi-apiserver deployment

### DIFF
--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -98,7 +98,8 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string, imagePullSec
 	if replicas > 1 {
 		deployment.Spec.Replicas = &replicas
 	}
-	container := utils.CreateContainer(common.CDIApiServerResourceName, image, verbosity, pullPolicy)
+	container := utils.CreatePortsContainer(common.CDIApiServerResourceName, image, pullPolicy, createAPIServerPorts(common.CDIApiServerResourceName))
+	container.Args = []string{"-v=" + verbosity}
 	container.Env = []corev1.EnvVar{
 		{
 			Name: common.InstallerPartOfLabel,
@@ -194,4 +195,14 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string, imagePullSec
 		},
 	}
 	return deployment
+}
+
+func createAPIServerPorts(name string) []corev1.ContainerPort {
+	return []corev1.ContainerPort{
+		{
+			Name:          name,
+			ContainerPort: 8443,
+			Protocol:      "TCP",
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a use case where we run `kubevirt/cdi` with `HostNetwork=true`

This PR is just adding `containerPort` explicitly when creating the deployment for `cdi-apiserver` so that Kubernetes can pro-actively detect if a pod needs to be assigned to other nodes in case the port is already taken.

**Special notes for your reviewer**:

**Release note**:
```release-note
Explicitly declaring containerPort in cdi-apiserver deployment
```

