### PR TITLE
unit-test, arm64: Add memory limit for prlimit test

### DIFF
--- a/pkg/system/prlimit_test.go
+++ b/pkg/system/prlimit_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Process Limits", func() {
 
 	realLimits := &ProcessLimitValues{1 << 30, 10}
 
-	//workaround for https://github.com/kubevirt/containerized-data-importer/issues/3341
-	if runtime.GOARCH == "s390x" {
+	//workaround for issue #3341 and #3467
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "arm64" {
 		realLimits = &ProcessLimitValues{1 << 31, 10}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the prlimit unit test error on Arm64 platform

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3467

**Release note**:
```release-note
NONE
```

