### PR TITLE
Go to completed phase after apply delta on warm import

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -1086,5 +1086,10 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		}
 	}
 
+	if vs.PreviousSnapshot != "" {
+		// Don't resize when applying snapshot deltas as the resize has already happened
+		// when the first snapshot was imported.
+		return ProcessingPhaseComplete, nil
+	}
 	return ProcessingPhaseResize, nil
 }

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -224,7 +224,7 @@ var _ = Describe("VDDK data source", func() {
 
 		phase, err = snap2.TransferFile(".")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(phase).To(Equal(ProcessingPhaseResize))
+		Expect(phase).To(Equal(ProcessingPhaseComplete))
 
 		deltaSum := md5.Sum(mockSinkBuffer) //nolint:gosec // This is test code
 		Expect(changedSourceSum).To(Equal(deltaSum))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of going to resize phase, go directly to completed phase for apply the delta snapshot. Resizing has already happened when importing the initial snapshot.

This will cause validation of the size to not happen every single delta. Since the resize steps validates the available space on the target.

This was causing issues on filesystem volumes where the space was being used and the available space is less than the virtual size of the disk. We don't care about the available space at this point since we already verified there was enough space on the initial snapshot import.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-40584

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Warm imports to filesystem volumes would fail size validation on subsequent snapshots.
```

