### PR TITLE
Reduce frequency of SCC management Events

### DIFF
--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -148,11 +148,15 @@ func reconcileSCC(args *callbacks.ReconcileCallbackArgs) error {
 	}
 
 	cr := args.Resource.(runtime.Object)
-	if err := ensureSCCExists(context.TODO(), args.Logger, args.Client, args.Namespace, common.ControllerServiceAccountName, common.CronJobServiceAccountName); err != nil {
+	updated, err := ensureSCCExists(context.TODO(), args.Logger, args.Client, args.Namespace, common.ControllerServiceAccountName, common.CronJobServiceAccountName)
+	if err != nil {
 		args.Recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf("Failed to ensure SecurityContextConstraint exists, %v", err))
 		return err
 	}
-	args.Recorder.Event(cr, corev1.EventTypeNormal, createResourceSuccess, "Successfully ensured SecurityContextConstraint exists")
+
+	if updated {
+		args.Recorder.Event(cr, corev1.EventTypeNormal, createResourceSuccess, "Successfully ensured SecurityContextConstraint exists")
+	}
 
 	return nil
 }

--- a/pkg/operator/controller/scc.go
+++ b/pkg/operator/controller/scc.go
@@ -69,7 +69,7 @@ func setSCC(scc *secv1.SecurityContextConstraints) {
 	}
 }
 
-func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, saNamespace, saName, cronSaName string) error {
+func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, saNamespace, saName, cronSaName string) (bool, error) {
 	scc := &secv1.SecurityContextConstraints{}
 	userName := fmt.Sprintf("system:serviceaccount:%s:%s", saNamespace, saName)
 	cronUserName := fmt.Sprintf("system:serviceaccount:%s:%s", saNamespace, cronSaName)
@@ -78,14 +78,14 @@ func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, s
 	if meta.IsNoMatchError(err) {
 		// not in openshift
 		logger.V(3).Info("No match error for SCC, must not be in openshift")
-		return nil
+		return false, nil
 	} else if errors.IsNotFound(err) {
 		cr, err := cc.GetActiveCDI(ctx, c)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if cr == nil {
-			return fmt.Errorf("no active CDI")
+			return false, fmt.Errorf("no active CDI")
 		}
 		installerLabels := util.GetRecommendedInstallerLabelsFromCr(cr)
 
@@ -107,12 +107,16 @@ func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, s
 		util.SetRecommendedLabels(scc, installerLabels, "cdi-operator")
 
 		if err = operator.SetOwnerRuntime(c, scc); err != nil {
-			return err
+			return false, err
 		}
 
-		return c.Create(ctx, scc)
+		if err := c.Create(ctx, scc); err != nil {
+			return false, err
+		}
+
+		return true, nil
 	} else if err != nil {
-		return err
+		return false, err
 	}
 
 	origSCC := scc.DeepCopy()
@@ -127,10 +131,14 @@ func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, s
 	}
 
 	if !apiequality.Semantic.DeepEqual(origSCC, scc) {
-		return c.Update(context.TODO(), scc)
+		if err := c.Update(context.TODO(), scc); err != nil {
+			return false, err
+		}
+
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (r *ReconcileCDI) watchSecurityContextConstraints() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

"Successfully ensured SecurityContextConstraint exists" Event was being created every time cdi-operator reconciled.

Reduced to only when SCC is created/updated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduce frequency of SCC management Events
```

