### PR TITLE
Handle potential nil pointer in handleSnapshot

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -746,6 +746,9 @@ func (r *DataImportCronReconciler) handleCronFormat(ctx context.Context, dataImp
 }
 
 func (r *DataImportCronReconciler) handleSnapshot(ctx context.Context, dataImportCron *cdiv1.DataImportCron, pvc *corev1.PersistentVolumeClaim, desiredStorageClass *storagev1.StorageClass) error {
+	if pvc == nil {
+		return nil
+	}
 	if sc := pvc.Spec.StorageClassName; sc != nil && *sc != desiredStorageClass.Name {
 		r.log.Info("Attempt to change storage class, will not try making a snapshot of the old PVC")
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the dataimportcron status has an empty currentImports, the returned PVC will be nil and
handleSnapshot will be called. handleSnapshot should check for nil PVC before proceeding.

This can happen when installing CDI and KubeVirt together with ceph on a cloud platform. The cloud platform will have a default storage class, which causes the imports to start. Then ceph becomes ready and switches the default virt class to itself. This then causes the imports to switch and somehow the currentImports is empty which causes the PVC to be nil and that causes a 
nil pointer exception in handleSnapshots.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: nil pointer in handleSnapshot
```

