### PR TITLE
webhooks/datavolume: comment about remove check of claim adoption

### DIFF
--- a/pkg/apiserver/webhooks/datavolume-validate.go
+++ b/pkg/apiserver/webhooks/datavolume-validate.go
@@ -492,6 +492,9 @@ func (wh *dataVolumeValidatingWebhook) Admit(ar admissionv1.AdmissionReview) *ad
 				return toAdmissionResponseError(err)
 			}
 		} else {
+			// We are planning to remove the Claim adoption feature gate
+			// https://github.com/kubevirt/containerized-data-importer/issues/3480
+			// once removed we should remove the check for it in this webhook.
 			allow, err := cc.ClaimMayExistBeforeDataVolume(wh.controllerRuntimeClient, pvc, &dv)
 			if err != nil {
 				return toAdmissionResponseError(err)


### PR DESCRIPTION
There is an open issue in github to remove the claim adoption feature gate:
https://github.com/kubevirt/containerized-data-importer/issues/3480 Once the FG is removed we should remove the check in the webhook that verifies if it allowed to have an existing PVC.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

