### PR TITLE
Standardize setting go.mod to minor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/containerized-data-importer
 
-go 1.22.3
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.36.0

--- a/staging/src/kubevirt.io/containerized-data-importer-api/go.mod
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/containerized-data-importer-api
 
-go 1.22.3
+go 1.22.0
 
 require (
 	k8s.io/api v0.30.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1554,7 +1554,7 @@ k8s.io/utils/ptr
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # kubevirt.io/containerized-data-importer-api v0.0.0 => ./staging/src/kubevirt.io/containerized-data-importer-api
-## explicit; go 1.22.3
+## explicit; go 1.22.0
 kubevirt.io/containerized-data-importer-api/pkg/apis/core
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This seems to be the standard, plus, if we don't do this we break the importing project's go.mod with our preferred specified patch version.
https://github.com/kubevirt/kubevirt/pull/12584/commits/73f66750d10bff34551404803d115469088a8ca7
Hitting an issue at https://github.com/kubevirt/kubevirt/pull/13152/files#r1824875505

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Standardize go.mod to not specify patch version
```

