### PR TITLE
Populators: Add to PVC' exclude velero backup annotation

### DIFF
--- a/pkg/controller/clone/csi-clone.go
+++ b/pkg/controller/clone/csi-clone.go
@@ -108,6 +108,7 @@ func (p *CSIClonePhase) createClaim(ctx context.Context) (*corev1.PersistentVolu
 	desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = sourceSize
 
 	cc.AddAnnotation(desiredClaim, cc.AnnPopulatorKind, cdiv1.VolumeCloneSourceRef)
+	cc.AddAnnotation(desiredClaim, cc.AnnExcludeFromVeleroBackup, "true")
 	if p.OwnershipLabel != "" {
 		AddOwnershipLabel(p.OwnershipLabel, desiredClaim, p.Owner)
 	}

--- a/pkg/controller/clone/csi-clone_test.go
+++ b/pkg/controller/clone/csi-clone_test.go
@@ -156,6 +156,7 @@ var _ = Describe("CSIClonePhase test", func() {
 			Expect(pvc.Spec.DataSourceRef.Namespace).To(BeNil())
 			Expect(pvc.Spec.DataSourceRef.Name).To(Equal(sourceClaim.Name))
 			Expect(pvc.Annotations[cc.AnnPopulatorKind]).To(Equal(cdiv1.VolumeCloneSourceRef))
+			Expect(pvc.Annotations[cc.AnnExcludeFromVeleroBackup]).To(Equal("true"))
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).
 				To(Equal(sourceClaim.Status.Capacity[corev1.ResourceStorage]))
 			Expect(pvc.Labels[p.OwnershipLabel]).To(Equal("uid"))

--- a/pkg/controller/clone/host-clone.go
+++ b/pkg/controller/clone/host-clone.go
@@ -182,6 +182,7 @@ func (p *HostClonePhase) createClaim(ctx context.Context) (*corev1.PersistentVol
 	cc.AddAnnotation(claim, cc.AnnPodRestarts, "0")
 	cc.AddAnnotation(claim, cc.AnnCloneRequest, fmt.Sprintf("%s/%s", p.Namespace, p.SourceName))
 	cc.AddAnnotation(claim, cc.AnnPopulatorKind, cdiv1.VolumeCloneSourceRef)
+	cc.AddAnnotation(claim, cc.AnnExcludeFromVeleroBackup, "true")
 	cc.AddAnnotation(claim, cc.AnnEventSourceKind, p.Owner.GetObjectKind().GroupVersionKind().Kind)
 	cc.AddAnnotation(claim, cc.AnnEventSource, fmt.Sprintf("%s/%s", p.Owner.GetNamespace(), p.Owner.GetName()))
 	if p.OwnershipLabel != "" {

--- a/pkg/controller/clone/host-clone_test.go
+++ b/pkg/controller/clone/host-clone_test.go
@@ -106,6 +106,7 @@ var _ = Describe("HostClonePhase test", func() {
 		Expect(pvc.Annotations[cc.AnnPodRestarts]).To(Equal("0"))
 		Expect(pvc.Annotations[cc.AnnCloneRequest]).To(Equal("ns/source"))
 		Expect(pvc.Annotations[cc.AnnPopulatorKind]).To(Equal(cdiv1.VolumeCloneSourceRef))
+		Expect(pvc.Annotations[cc.AnnExcludeFromVeleroBackup]).To(Equal("true"))
 		Expect(pvc.Labels[p.OwnershipLabel]).To(Equal("uid"))
 		Expect(pvc.Annotations[cc.AnnImmediateBinding]).To(Equal(""))
 		_, ok := pvc.Annotations[cc.AnnPriorityClassName]

--- a/pkg/controller/clone/snap-clone.go
+++ b/pkg/controller/clone/snap-clone.go
@@ -102,6 +102,7 @@ func (p *SnapshotClonePhase) createClaim(ctx context.Context, snapshot *snapshot
 	}
 
 	cc.AddAnnotation(claim, cc.AnnPopulatorKind, cdiv1.VolumeCloneSourceRef)
+	cc.AddAnnotation(claim, cc.AnnExcludeFromVeleroBackup, "true")
 	if p.OwnershipLabel != "" {
 		AddOwnershipLabel(p.OwnershipLabel, claim, p.Owner)
 	}

--- a/pkg/controller/clone/snap-clone_test.go
+++ b/pkg/controller/clone/snap-clone_test.go
@@ -177,6 +177,7 @@ var _ = Describe("SnapshotClonePhase test", func() {
 			Expect(pvc.Spec.DataSourceRef.Namespace).To(BeNil())
 			Expect(pvc.Spec.DataSourceRef.Name).To(Equal(sourceName))
 			Expect(pvc.Annotations[cc.AnnPopulatorKind]).To(Equal(cdiv1.VolumeCloneSourceRef))
+			Expect(pvc.Annotations[cc.AnnExcludeFromVeleroBackup]).To(Equal("true"))
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(restoreSize))
 			Expect(pvc.Labels[p.OwnershipLabel]).To(Equal("uid"))
 		})

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -252,6 +252,9 @@ const (
 	// AnnImmediateBinding provides a const to indicate whether immediate binding should be performed on the PV (overrides global config)
 	AnnImmediateBinding = AnnAPIGroup + "/storage.bind.immediate.requested"
 
+	//AnnExcludeFromVeleroBackup provides a const to indicate whether an object should be excluded from velero backup
+	AnnExcludeFromVeleroBackup = "velero.io/exclude-from-backup"
+
 	// AnnSelectedNode annotation is added to a PVC that has been triggered by scheduler to
 	// be dynamically provisioned. Its value is the name of the selected node.
 	AnnSelectedNode = "volume.kubernetes.io/selected-node"

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -268,6 +268,7 @@ var _ = Describe("Import populator tests", func() {
 			Expect(pvcPrime.GetAnnotations()[AnnImmediateBinding]).To(Equal(""))
 			Expect(pvcPrime.GetAnnotations()[AnnUploadRequest]).To(Equal(""))
 			Expect(pvcPrime.GetAnnotations()[AnnPopulatorKind]).To(Equal(cdiv1.VolumeImportSourceRef))
+			Expect(pvcPrime.GetAnnotations()[AnnExcludeFromVeleroBackup]).To(Equal("true"))
 			Expect(pvcPrime.GetAnnotations()[AnnPreallocationRequested]).To(Equal("true"))
 			Expect(pvcPrime.GetAnnotations()[AnnEndpoint]).To(Equal("http://example.com/data"))
 			Expect(pvcPrime.GetAnnotations()[AnnSource]).To(Equal(SourceHTTP))

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -173,6 +173,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 	labels := make(map[string]string)
 	labels[common.CDILabelKey] = common.CDILabelValue
 	annotations := make(map[string]string)
+	annotations[cc.AnnExcludeFromVeleroBackup] = "true"
 	annotations[cc.AnnImmediateBinding] = ""
 	if waitForFirstConsumer {
 		annotations[cc.AnnSelectedNode] = pvc.Annotations[cc.AnnSelectedNode]

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Expect(pvcPrime.GetAnnotations()[cc.AnnContentType]).To(Equal(contentType))
 		Expect(pvcPrime.GetAnnotations()[cc.AnnPreallocationRequested]).To(Equal(strconv.FormatBool(preallocation)))
 		Expect(pvcPrime.GetAnnotations()[cc.AnnPopulatorKind]).To(Equal(cdiv1.VolumeUploadSourceRef))
+		Expect(pvcPrime.GetAnnotations()[cc.AnnExcludeFromVeleroBackup]).To(Equal("true"))
 
 		_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-pvc", Namespace: metav1.NamespaceDefault}})
 		Expect(err).ToNot(HaveOccurred())
@@ -328,6 +329,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Expect(pvcPrime.GetAnnotations()[cc.AnnImmediateBinding]).To(Equal(""))
 		Expect(pvcPrime.GetAnnotations()[cc.AnnUploadRequest]).To(Equal(""))
 		Expect(pvcPrime.GetAnnotations()[cc.AnnPopulatorKind]).To(Equal(cdiv1.VolumeUploadSourceRef))
+		Expect(pvcPrime.GetAnnotations()[cc.AnnExcludeFromVeleroBackup]).To(Equal("true"))
 		Expect(pvcPrime.Annotations[key]).To(Equal(expectedValue))
 	},
 		Entry("No extra annotations", "", "", ""),


### PR DESCRIPTION
When backing up with Velero if a PVC is terminating then the backup is marked as PartiallyFailed, while the backup is still valid to use and its more of a warning, PVC' should be transparent to the user so have the backup partiallyFailed because of PVC' is a bad user experience. To fix that added to all our PVC' an annotation so it will be excluded from the Velero backup.

```release-note
NONE
```

