### PR TITLE
Add the "latest" endpoint for the nightly manifest

### DIFF
--- a/automation/prow_periodic_push.sh
+++ b/automation/prow_periodic_push.sh
@@ -20,6 +20,10 @@ export DOCKER_TAG="${build_date}_$(git show -s --format=%h)${ARCH_SUFFIX}"
 make manifests
 make bazel-push-images
 
-bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/${build_date}"
+base_url="kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer"
+bucket_dir="${base_url}/${build_date}"
 gsutil cp ./_out/manifests/release/cdi-operator.yaml gs://$bucket_dir/cdi-operator${ARCH_SUFFIX}.yaml
 gsutil cp ./_out/manifests/release/cdi-cr.yaml gs://$bucket_dir/cdi-cr${ARCH_SUFFIX}.yaml
+
+echo ${build_date} > ./_out/build_date
+gsutil cp ./_out/build_date gs://${base_url}/latest${ARCH_SUFFIX}


### PR DESCRIPTION
## What this PR does / why we need it
This will allow user to query (amd64):

curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/latest"

For arm64, it will be:

curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/latest-arm64"

and for s390:

curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/latest-s390x"

That follows kubevirt/kubevirt standard

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

