### PR TITLE
Limit secret caching to CDI namespace

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -413,6 +413,9 @@ func getCacheOptions(apiClient client.Client, cdiNamespace string) cache.Options
 			&v1.ConfigMap{}: {
 				Field: namespaceSelector,
 			},
+			&v1.Secret{}: {
+				Field: namespaceSelector,
+			},
 		},
 	}
 


### PR DESCRIPTION
This is tech debt that was left from https://github.com/kubevirt/containerized-data-importer/pull/3314#discussion_r1660113610;
Basically, the config-controller is broken when using ingress, as the first
GET call for the secret attempts to start caching them, and the RBAC for that is missing.
https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-i-see-errors-like-failed-to-watch-external-type

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3515 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: config controller broken with ingresses
```

