### PR TITLE
Change clone strategy to avoid PowerStore snapshot limits

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -139,7 +139,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"csi-vxflexos.dellemc.com":                 cdiv1.CloneStrategyCsiClone,
 	"csi-isilon.dellemc.com":                   cdiv1.CloneStrategyCsiClone,
 	"csi-powermax.dellemc.com":                 cdiv1.CloneStrategyCsiClone,
-	"csi-powerstore.dellemc.com":               cdiv1.CloneStrategyCsiClone,
+	"csi-powerstore.dellemc.com":               cdiv1.CloneStrategyHostAssisted,
 	"hspc.csi.hitachi.com":                     cdiv1.CloneStrategyCsiClone,
 	"csi.hpe.com":                              cdiv1.CloneStrategyCsiClone,
 	"spectrumscale.csi.ibm.com":                cdiv1.CloneStrategyCsiClone,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PowerStore has a limit of 32 to 64 writable snapshots which prevents to create more VMs from a base OS.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Dell PowerStore uses `cloneStrategy: copy` over `csi-clone` to avoid array snapshot limits
```

