### PR TITLE
Fix the location of the nightly commit file

### DIFF
--- a/automation/prow_periodic_push.sh
+++ b/automation/prow_periodic_push.sh
@@ -29,4 +29,4 @@ echo ${build_date} > ./_out/build_date
 gsutil cp ./_out/build_date gs://${base_url}/latest${ARCH_SUFFIX}
 
 git show -s --format=%H > ./_out/commit
-gsutil cp ./_out/commit gs://${base_url}/commit${ARCH_SUFFIX}
+gsutil cp ./_out/commit gs://${bucket_dir}/commit${ARCH_SUFFIX}


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly build commit file should be under the specific build directory, but was placed under the parent directory by mistake.

This PR fixes the commit file location.

The right location is:

https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/{latest}/commit

(while "latest" is https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/latest)

The wrong location is here:

https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/containerized-data-importer/commit

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

