### PR TITLE
Add RWX to AWS EBS io2 capabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -70,6 +70,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// AWSElasticBlockStore
 	"kubernetes.io/aws-ebs": {{rwo, block}},
 	"ebs.csi.aws.com":       {{rwo, block}},
+	"ebs.csi.aws.com/io2":   {{rwx, block}, {rwo, block}, {rwo, file}},
 	// AWSElasticFileSystem
 	"efs.csi.aws.com": {{rwx, file}, {rwo, file}},
 	// Azure disk
@@ -353,6 +354,13 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 			return "driver.longhorn.io/migratable"
 		}
 		return "driver.longhorn.io"
+	},
+	"ebs.csi.aws.com": func(sc *storagev1.StorageClass) string {
+		val := sc.Parameters["type"]
+		if val == "io2" {
+			return "ebs.csi.aws.com/io2"
+		}
+		return "ebs.csi.aws.com"
 	},
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Reference:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1799
https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-47514

**Release note**:
```release-note
Add RWX to AWS EBS io2 storage capabilities
```

