### PR TITLE
Fix test failures at port forwarding stop on s390x

### DIFF
--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -100,8 +100,16 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	AfterEach(func() {
 		By("Stop port forwarding")
 		if portForwardCmd != nil {
-			Expect(portForwardCmd.Process.Kill()).To(Succeed())
-			Expect(portForwardCmd.Wait()).To(Succeed())
+			// Check if the process is still running before attempting to kill it
+			if portForwardCmd.Process != nil && portForwardCmd.ProcessState == nil {
+				// Attempt to gracefully terminate the process first
+				err := portForwardCmd.Process.Signal(os.Interrupt)
+				if err != nil {
+					// If the graceful termination fails, try to forcefully kill the process
+					Expect(portForwardCmd.Process.Kill()).To(Succeed())
+				}
+				Expect(portForwardCmd.Wait()).To(Succeed())
+			}
 			portForwardCmd = nil
 		}
 	})
@@ -1060,8 +1068,16 @@ var _ = Describe("Block PV upload Test", Serial, func() {
 	AfterEach(func() {
 		By("Stop port forwarding")
 		if portForwardCmd != nil {
-			Expect(portForwardCmd.Process.Kill()).To(Succeed())
-			Expect(portForwardCmd.Wait()).To(Succeed())
+			// Check if the process is still running before attempting to kill it
+			if portForwardCmd.Process != nil && portForwardCmd.ProcessState == nil {
+				// Attempt to gracefully terminate the process first
+				err := portForwardCmd.Process.Signal(os.Interrupt)
+				if err != nil {
+					// If the graceful termination fails, try to forcefully kill the process
+					Expect(portForwardCmd.Process.Kill()).To(Succeed())
+				}
+				Expect(portForwardCmd.Wait()).To(Succeed())
+			}
 			portForwardCmd = nil
 		}
 
@@ -1159,8 +1175,16 @@ var _ = Describe("CDIConfig manipulation upload tests", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 		By("Stop port forwarding")
 		if portForwardCmd != nil {
-			Expect(portForwardCmd.Process.Kill()).To(Succeed())
-			Expect(portForwardCmd.Wait()).To(Succeed())
+			// Check if the process is still running before attempting to kill it
+			if portForwardCmd.Process != nil && portForwardCmd.ProcessState == nil {
+				// Attempt to gracefully terminate the process first
+				err := portForwardCmd.Process.Signal(os.Interrupt)
+				if err != nil {
+					// If the graceful termination fails, try to forcefully kill the process
+					Expect(portForwardCmd.Process.Kill()).To(Succeed())
+				}
+				Expect(portForwardCmd.Wait()).To(Succeed())
+			}
 			portForwardCmd = nil
 		}
 
@@ -1380,8 +1404,16 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	AfterEach(func() {
 		By("Stop port forwarding")
 		if portForwardCmd != nil {
-			Expect(portForwardCmd.Process.Kill()).To(Succeed())
-			Expect(portForwardCmd.Wait()).To(Succeed())
+			// Check if the process is still running before attempting to kill it
+			if portForwardCmd.Process != nil && portForwardCmd.ProcessState == nil {
+				// Attempt to gracefully terminate the process first
+				err := portForwardCmd.Process.Signal(os.Interrupt)
+				if err != nil {
+					// If the graceful termination fails, try to forcefully kill the process
+					Expect(portForwardCmd.Process.Kill()).To(Succeed())
+				}
+				Expect(portForwardCmd.Wait()).To(Succeed())
+			}
 			portForwardCmd = nil
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Several critical tests are failing on s390x during, what appears to be, a cleanup step:
```
STEP: Stop port forwarding @ 11/06/24 11:18:39.461
  [FAILED] in [AfterEach] - /root/go/src/kubevirt.io/containerized-data-importer/tests/upload_test.go:104 @ 11/06/24 11:18:39.462
  << Timeline

  [FAILED] Expected success, but got an error:
      <*exec.ExitError | 0xc00066ea40>:
      exit status 1
      {
          ProcessState: {
              pid: 1480951,
              status: 256,
              rusage: {
                  Utime: {Sec: 0, Usec: 200995},
                  Stime: {Sec: 0, Usec: 157220},
                  Maxrss: 62104,
                  Ixrss: 0,
                  Idrss: 0,
                  Isrss: 0,
                  Minflt: 2760,
                  Majflt: 0,
                  Nswap: 0,
                  Inblock: 0,
                  Oublock: 0,
                  Msgsnd: 0,
                  Msgrcv: 0,
                  Nsignals: 0,
                  Nvcsw: 9775,
                  Nivcsw: 259,
              },
          },
          Stderr: nil,
      }
  In [AfterEach] at: /root/go/src/kubevirt.io/containerized-data-importer/tests/upload_test.go:104 @ 11/06/24 11:18:39.462
  ```

By trying to terminate the process in a more graceful way, it should be less likely to run into this in the future.


```release-note
NONE
```

