### PR TITLE
CNV-51521 | Fix Incomplete transfer of change blocks leads to data corruption

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -437,25 +437,34 @@ func (vmware *VMwareClient) FindDiskFromName(fileName string) (*types.VirtualDis
 
 // FindSnapshotDiskName finds the name of the given disk at the time the snapshot was taken
 func (vmware *VMwareClient) FindSnapshotDiskName(snapshotRef *types.ManagedObjectReference, diskID string) (string, error) {
+	disk, err := vmware.FindSnapshotDisk(snapshotRef, diskID)
+	if err != nil {
+		return "", err
+	}
+	device := disk.GetVirtualDevice()
+	backing := device.Backing.(types.BaseVirtualDeviceFileBackingInfo)
+	info := backing.GetVirtualDeviceFileBackingInfo()
+	return info.FileName, nil
+}
+
+// FindSnapshotDisk finds the name of the given disk at the time the snapshot was taken
+func (vmware *VMwareClient) FindSnapshotDisk(snapshotRef *types.ManagedObjectReference, diskID string) (*types.VirtualDisk, error) {
 	var snapshot mo.VirtualMachineSnapshot
 	err := vmware.vm.Properties(vmware.context, *snapshotRef, []string{"config.hardware.device"}, &snapshot)
 	if err != nil {
 		klog.Errorf("Unable to get snapshot properties: %v", err)
-		return "", err
+		return nil, err
 	}
 
 	for _, device := range snapshot.Config.Hardware.Device {
 		switch disk := device.(type) {
 		case *types.VirtualDisk:
 			if disk.DiskObjectId == diskID {
-				device := disk.GetVirtualDevice()
-				backing := device.Backing.(types.BaseVirtualDeviceFileBackingInfo)
-				info := backing.GetVirtualDeviceFileBackingInfo()
-				return info.FileName, nil
+				return disk, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find disk image with ID %s in snapshot %s", diskID, snapshotRef.Value)
+	return nil, fmt.Errorf("Could not find disk image with ID %s in snapshot %s", diskID, snapshotRef.Value)
 }
 
 // FindVM takes the UUID of the VM to migrate and finds its MOref
@@ -855,6 +864,11 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 	// then get the list of changed blocks from VMware for a delta copy.
 	var changed *types.DiskChangeInfo
 	if currentSnapshot != nil && previousCheckpoint != "" {
+		disk, err := vmware.FindSnapshotDisk(currentSnapshot, backingFileObject.DiskObjectId)
+		if err != nil {
+			klog.Errorf("Could not find matching disk in current snapshot: %v", err)
+			return nil, err
+		}
 		// QueryChangedDiskAreas needs to be called multiple times to get all possible disk changes.
 		// Experimentation shows it returns maximally 2000 changed blocks. If the disk has more than
 		// 2000 changed blocks we need to query the next chunk of the blocks starting from previous.
@@ -878,12 +892,17 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 					klog.Errorf("Failed to query changed areas: %s", err)
 					return nil, err
 				}
-				klog.Infof("%d changed areas reported at offset %d", len(response.Returnval.ChangedArea), changed.Length)
+				klog.Infof("%d changed areas reported at offset %d with data length %d", len(response.Returnval.ChangedArea), changed.Length, response.Returnval.Length)
 				if len(response.Returnval.ChangedArea) == 0 { // No more changes
 					break
 				}
 				changed.ChangedArea = append(changed.ChangedArea, response.Returnval.ChangedArea...)
 				changed.Length += response.Returnval.Length
+				// The start offset should not be the size of the disk otherwise the QueryChangedDiskAreas will fail
+				if changed.Length >= disk.CapacityInBytes {
+					klog.Infof("the offset %d is greater or equal to disk capacity %d", changed.Length, disk.CapacityInBytes)
+					break
+				}
 			}
 		} else { // Previous checkpoint is a snapshot
 			previousSnapshot, err := vmware.vm.FindSnapshot(vmware.context, previousCheckpoint)
@@ -899,12 +918,17 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 						klog.Errorf("Unable to query changed areas: %s", err)
 						return nil, err
 					}
-					klog.Infof("%d changed areas reported at offset %d", len(changedAreas.ChangedArea), changed.Length)
+					klog.Infof("%d changed areas reported at offset %d with data length %d", len(changedAreas.ChangedArea), changed.Length, changedAreas.Length)
 					if len(changedAreas.ChangedArea) == 0 {
 						break
 					}
 					changed.ChangedArea = append(changed.ChangedArea, changedAreas.ChangedArea...)
 					changed.Length += changedAreas.Length
+					// The start offset should not be the size of the disk otherwise the QueryChangedDiskAreas will fail
+					if changed.Length >= disk.CapacityInBytes {
+						klog.Infof("the offset %d is greater or equal to disk capacity %d", changed.Length, disk.CapacityInBytes)
+						break
+					}
 				}
 			}
 		}

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -254,6 +254,7 @@ var _ = Describe("VDDK data source", func() {
 			return nil
 		}
 
+		counter := 0
 		changeInfo := types.DiskChangeInfo{
 			StartOffset: 0,
 			Length:      1000,
@@ -265,6 +266,12 @@ var _ = Describe("VDDK data source", func() {
 			},
 		}
 		QueryChangedDiskAreas = func(ctx context.Context, r soap.RoundTripper, req *types.QueryChangedDiskAreas) (*types.QueryChangedDiskAreasResponse, error) {
+			if counter > 0 {
+				return &types.QueryChangedDiskAreasResponse{
+					Returnval: types.DiskChangeInfo{},
+				}, nil
+			}
+			counter++
 			return &types.QueryChangedDiskAreasResponse{
 				Returnval: changeInfo,
 			}, nil
@@ -379,24 +386,25 @@ var _ = Describe("VDDK data source", func() {
 			}
 			return nil, errors.New("could not find snapshot")
 		}
+		changedBlockList := types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      10240,
+			ChangedArea: []types.DiskChangeExtent{
+				{
+					Start:  1024,
+					Length: 512,
+				},
+				{
+					Start:  4096,
+					Length: 4096,
+				},
+			},
+		}
 		counter := 0
 		currentVMwareFunctions.QueryChangedDiskAreas = func(ctx context.Context, baseSnapshot *types.ManagedObjectReference, changedSnapshot *types.ManagedObjectReference, disk *types.VirtualDisk, offset int64) (types.DiskChangeInfo, error) {
 			var resp types.DiskChangeInfo
 			if counter == 0 {
-				resp = types.DiskChangeInfo{
-					StartOffset: 0,
-					Length:      10240,
-					ChangedArea: []types.DiskChangeExtent{
-						{
-							Start:  1024,
-							Length: 512,
-						},
-						{
-							Start:  4096,
-							Length: 4096,
-						},
-					},
-				}
+				resp = changedBlockList
 			} else {
 				resp = types.DiskChangeInfo{
 					StartOffset: 10240,

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -511,12 +511,12 @@ var _ = Describe("VDDK data source", func() {
 			switch out := result.(type) {
 			case *mo.VirtualMachine:
 				if property[0] == "config.hardware.device" {
-					out.Config = createVirtualDiskConfig(diskName, 12345)
+					out.Config = createVirtualDiskConfigWithSize(diskName, 12345, 9563078656)
 				} else if property[0] == "snapshot" {
 					out.Snapshot = snapshots
 				}
 			case *mo.VirtualMachineSnapshot:
-				out.Config = *createVirtualDiskConfig("snapshotdisk", 123456)
+				out.Config = *createVirtualDiskConfigWithSize("snapshotdisk", 123456, 9563078656)
 			}
 			return nil
 		}
@@ -1033,6 +1033,27 @@ func createVirtualDiskConfig(fileName string, key int32) *types.VirtualMachineCo
 			Device: []types.BaseVirtualDevice{
 				&types.VirtualDisk{
 					DiskObjectId: "test-1",
+					VirtualDevice: types.VirtualDevice{
+						Key: key,
+						Backing: &types.VirtualDiskFlatVer1BackingInfo{
+							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+								FileName: fileName,
+							},
+							Parent: &types.VirtualDiskFlatVer1BackingInfo{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func createVirtualDiskConfigWithSize(fileName string, key int32, size int64) *types.VirtualMachineConfigInfo {
+	return &types.VirtualMachineConfigInfo{
+		Hardware: types.VirtualHardware{
+			Device: []types.BaseVirtualDevice{
+				&types.VirtualDisk{
+					DiskObjectId:    "test-1",
+					CapacityInBytes: size,
 					VirtualDevice: types.VirtualDevice{
 						Key: key,
 						Backing: &types.VirtualDiskFlatVer1BackingInfo{


### PR DESCRIPTION
**Fix**: Query the changed areas by every 2000 block chunks, combine the chunks together and request the next QueryChangedDiskAreas to start from the end of the last block. Once the QueryChangedDiskAreas returns less than 2000 blocks we know that it was the last chunk and can continue with the disk import.

**What this PR does / why we need it**:
**Issue**: When the user has a large disk with over 2000 changed blocks the QueryChangedDiskAreas returns only first 2000 changed blocks. The disk is not getting all the changes from the VMware Change Block Tracking and this can cause disk corruption.

**Which issue(s) this PR fixes**
Fixes https://issues.redhat.com/browse/CNV-51521

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VDDK Fix Incomplete transfer of change blocks leads to data corruption
```

