### PR TITLE
cdi-uploadserver: healthcheck and application use same port

### DIFF
--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -856,8 +856,9 @@ func (r *UploadReconciler) makeUploadPodContainers(args UploadPodArgs, resourceR
 						Path: "/healthz",
 						Port: intstr.IntOrString{
 							Type:   intstr.Int,
-							IntVal: 8080,
+							IntVal: 8443,
 						},
+						Scheme: corev1.URISchemeHTTPS,
 					},
 				},
 				InitialDelaySeconds: 2,

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -806,8 +806,9 @@ func createUploadClonePod(pvc *corev1.PersistentVolumeClaim, clientName string) 
 								Path: "/healthz",
 								Port: intstr.IntOrString{
 									Type:   intstr.Int,
-									IntVal: 8080,
+									IntVal: 8443,
 								},
+								Scheme: corev1.URISchemeHTTPS,
 							},
 						},
 						InitialDelaySeconds: 2,

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -47,6 +47,7 @@ import (
 
 func newServer() *uploadServerApp {
 	config := &Config{
+		Insecure:           true,
 		BindAddress:        "127.0.0.1",
 		BindPort:           0,
 		Destination:        "disk.img",
@@ -233,9 +234,8 @@ var _ = Describe("Upload server tests", func() {
 
 		rr := httptest.NewRecorder()
 
-		app := uploadServerApp{}
-		server, _ := app.createHealthzServer()
-		server.Handler.ServeHTTP(rr, req)
+		server := newServer()
+		server.ServeHTTP(rr, req)
 
 		status := rr.Code
 		Expect(status).To(Equal(http.StatusOK))


### PR DESCRIPTION
healthcheck used to be on a dedicated port for "reasons" and by that I mean I was too lazy to properly set up the tls configuration and check authz in upload handlers

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This one is for @akalenyu and @0xFelix: I know I told you this wasn't possible but here you go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3450

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cdi-uploadserver reporting readiness more honestly resulting in concurrent image uploads failing less
```

