### PR TITLE
Move size detection pod deletion to cleanup

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -114,6 +114,9 @@ make cluster-sync
 
 kubectl version
 
+echo "Nil check --PRE-- test run"
+kubectl get pods -n $CDI_NAMESPACE -o'custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,RESTARTS:status.containerStatuses[*].restartCount' --no-headers
+
 ginko_params="--test-args=--ginkgo.no-color --ginkgo.junit-report=${ARTIFACTS_PATH}/junit.functest.xml"
 
 if [[ -n "$CDI_DV_GC" ]]; then
@@ -122,3 +125,7 @@ fi
 
 # Run functional tests
 TEST_ARGS=$ginko_params make test-functional
+
+echo "Nil check --POST-- test run"
+kubectl get pods -n $CDI_NAMESPACE -o'custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,RESTARTS:status.containerStatuses[*].restartCount' --no-headers
+kubectl logs -n $CDI_NAMESPACE $(kubectl get pod -n $CDI_NAMESPACE -l=cdi.kubevirt.io=cdi-deployment --output=jsonpath='{$.items[0].metadata.name}') --previous || echo "this is fine"

--- a/pkg/controller/datavolume/clone-controller-base.go
+++ b/pkg/controller/datavolume/clone-controller-base.go
@@ -583,3 +583,50 @@ func addCloneWithoutSourceWatch(mgr manager.Manager, datavolumeController contro
 
 	return nil
 }
+
+func addDataSourceWatch(mgr manager.Manager, c controller.Controller, indexingKey string, op dataVolumeOp) error {
+	getKey := func(namespace, name string) string {
+		return namespace + "/" + name
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &cdiv1.DataVolume{}, indexingKey, func(obj client.Object) []string {
+		dv := obj.(*cdiv1.DataVolume)
+		if sourceRef := dv.Spec.SourceRef; sourceRef != nil && sourceRef.Kind == cdiv1.DataVolumeDataSource {
+			ns := obj.GetNamespace()
+			if sourceRef.Namespace != nil && *sourceRef.Namespace != "" {
+				ns = *sourceRef.Namespace
+			}
+			if getDataVolumeOp(context.TODO(), mgr.GetLogger(), dv, mgr.GetClient()) == op && sourceRef.Name != "" {
+				return []string{getKey(ns, sourceRef.Name)}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	mapToDataVolume := func(ctx context.Context, obj *cdiv1.DataSource) []reconcile.Request {
+		var dvs cdiv1.DataVolumeList
+		matchingFields := client.MatchingFields{indexingKey: getKey(obj.GetNamespace(), obj.GetName())}
+		if err := mgr.GetClient().List(ctx, &dvs, matchingFields); err != nil {
+			c.GetLogger().Error(err, "Unable to list DataVolumes", "matchingFields", matchingFields)
+			return nil
+		}
+		var reqs []reconcile.Request
+		for _, dv := range dvs.Items {
+			if getDataVolumeOp(ctx, c.GetLogger(), &dv, mgr.GetClient()) != op {
+				continue
+			}
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name}})
+		}
+		return reqs
+	}
+
+	if err := c.Watch(source.Kind(mgr.GetCache(), &cdiv1.DataSource{},
+		handler.TypedEnqueueRequestsFromMapFunc[*cdiv1.DataSource](mapToDataVolume),
+	)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -632,8 +632,8 @@ func (r *PvcCloneReconciler) getSizeFromPod(targetPvc, sourcePvc *corev1.Persist
 	if err := r.updateClonePVCAnnotations(sourcePvc, termMsg); err != nil {
 		return imgSize, err
 	}
-	// Finally, detelete the pod
-	if cc.ShouldDeletePod(sourcePvc) {
+	// Finally, delete the pod
+	if targetPvc != nil && cc.ShouldDeletePod(targetPvc) {
 		err = r.client.Delete(context.TODO(), pod)
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return imgSize, err

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -132,6 +132,10 @@ func (r *SnapshotCloneReconciler) addDataVolumeSnapshotCloneControllerWatches(mg
 		return err
 	}
 
+	if err := addDataSourceWatch(mgr, datavolumeController, "snapshotdatasource", dataVolumeSnapshotClone); err != nil {
+		return err
+	}
+
 	if err := r.addVolumeCloneSourceWatch(mgr, datavolumeController); err != nil {
 		return err
 	}

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -1218,7 +1218,6 @@ var _ = Describe("all clone tests", func() {
 			It("[test_id:8498]Should only use size-detection pod when cloning a PVC for the first time", func() {
 				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
-				controller.AddAnnotation(dataVolume, controller.AnnPodRetainAfterCompletion, "true")
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -1231,6 +1230,7 @@ var _ = Describe("all clone tests", func() {
 
 				// We attempt to create the sizeless clone
 				targetDataVolume := utils.NewDataVolumeForCloningWithEmptySize("target-dv", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				controller.AddAnnotation(targetDataVolume, controller.AnnPodRetainAfterCompletion, "true")
 				targetDataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDataVolume)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1280,7 +1280,6 @@ var _ = Describe("all clone tests", func() {
 			It("[test_id:8762]Should use size-detection pod when cloning if the source PVC has changed its original capacity", func() {
 				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
-				controller.AddAnnotation(dataVolume, controller.AnnPodRetainAfterCompletion, "true")
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -1293,6 +1292,7 @@ var _ = Describe("all clone tests", func() {
 
 				// We attempt to create the sizeless clone
 				targetDV := utils.NewDataVolumeForCloningWithEmptySize("target-dv", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				controller.AddAnnotation(targetDV, controller.AnnPodRetainAfterCompletion, "true")
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1356,7 +1356,6 @@ var _ = Describe("all clone tests", func() {
 			It("Should clone using size-detection pod across namespaces", func() {
 				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
-				controller.AddAnnotation(dataVolume, controller.AnnPodRetainAfterCompletion, "true")
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -1376,6 +1375,7 @@ var _ = Describe("all clone tests", func() {
 
 				// We attempt to create the sizeless clone
 				targetDataVolume := utils.NewDataVolumeForCloningWithEmptySize("target-dv", f.Namespace.Name, sourcePvc.Name, nil, &volumeMode)
+				controller.AddAnnotation(targetDataVolume, controller.AnnPodRetainAfterCompletion, "true")
 				targetDataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDataVolume)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Apparently, it's possible that the size detection pod
sticks around even if the dv is succeeded/deleted.
I think this belongs in the cleanup loop anyway

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-52272

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: size-detection pod is not always cleaned after it completes
```

