### PR TITLE
MTV-1699 Avoid potentially exceeding memory limit in multi-stage VDDK imports.

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -957,8 +957,8 @@ func (vs *VDDKDataSource) IsDeltaCopy() bool {
 	return result
 }
 
-// Mockable stat
-var Stat = os.Stat
+// Mockable stat, so unit tests can run through TransferFile
+var MockableStat = os.Stat
 
 // TransferFile is called to transfer the data from the source to the file passed in.
 func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
@@ -968,7 +968,7 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		}
 
 		// Make sure file exists before applying deltas.
-		_, err := Stat(fileName)
+		_, err := MockableStat(fileName)
 		if os.IsNotExist(err) {
 			klog.Infof("Disk image does not exist, cannot apply deltas for warm migration: %v", err)
 			return ProcessingPhaseError, err

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -842,7 +842,6 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 		klog.Errorf("Unable to log in to VMware: %v", err)
 		return nil, err
 	}
-	defer func() { _ = vmware.Close() }()
 
 	// Find disk object for backingFile disk image path
 	backingFileObject, err := vmware.FindDiskFromName(backingFile)
@@ -962,6 +961,8 @@ var MockableStat = os.Stat
 
 // TransferFile is called to transfer the data from the source to the file passed in.
 func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error) {
+	defer func() { _ = vs.VMware.Close() }()
+
 	if !vs.IsWarm() {
 		if err := CleanAll(fileName); err != nil {
 			return ProcessingPhaseError, err

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -973,7 +973,9 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 		if err := CleanAll(fileName); err != nil {
 			return ProcessingPhaseError, err
 		}
+	}
 
+	if vs.IsDeltaCopy() {
 		// Make sure file exists before applying deltas.
 		_, err := MockableStat(fileName)
 		if os.IsNotExist(err) {

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -379,11 +379,17 @@ func (vmware *VMwareClient) FindDiskInRootSnapshotParent(snapshots []types.Virtu
 					var parent *types.VirtualDeviceFileBackingInfo
 					switch disk.Backing.(type) {
 					case *types.VirtualDiskFlatVer1BackingInfo:
-						parent = &disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo).Parent.VirtualDeviceFileBackingInfo
+						if info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo); info != nil && info.Parent != nil {
+							parent = &info.Parent.VirtualDeviceFileBackingInfo
+						}
 					case *types.VirtualDiskFlatVer2BackingInfo:
-						parent = &disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo).Parent.VirtualDeviceFileBackingInfo
+						if info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); info != nil && info.Parent != nil {
+							parent = &info.VirtualDeviceFileBackingInfo
+						}
 					case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
-						parent = &disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo).Parent.VirtualDeviceFileBackingInfo
+						if info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo); info != nil && info.Parent != nil {
+							parent = &info.VirtualDeviceFileBackingInfo
+						}
 					}
 					if parent != nil && parent.FileName == fileName {
 						return disk

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -110,6 +110,9 @@ var _ = Describe("VDDK data source", func() {
 		replaceExport.Read = func(uint64) ([]byte, error) {
 			return bytes.Repeat([]byte{0x55}, 512), nil
 		}
+		MockableStat = func(string) (fs.FileInfo, error) {
+			return nil, nil
+		}
 		currentExport = replaceExport
 		dp, err := NewVDDKDataSource("", "", "", "", "", "", "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
@@ -203,6 +206,9 @@ var _ = Describe("VDDK data source", func() {
 		}
 		currentExport = replaceExport
 
+		MockableStat = func(string) (fs.FileInfo, error) {
+			return nil, nil
+		}
 		mockSinkBuffer = bytes.Repeat([]byte{0x00}, int(dp.Size))
 
 		phase, err := dp.TransferFile("target")
@@ -232,7 +238,7 @@ var _ = Describe("VDDK data source", func() {
 
 		mockSinkBuffer = bytes.Repeat([]byte{0x00}, int(snap1.Size))
 
-		Stat = func(string) (fs.FileInfo, error) {
+		MockableStat = func(string) (fs.FileInfo, error) {
 			return nil, nil
 		}
 		phase, err := snap1.TransferFile("target")

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -301,9 +301,6 @@ var _ = Describe("VDDK data source", func() {
 		}
 		changedSourceSum := md5.Sum(sourceBytes) //nolint:gosec // This is test code
 
-		fmt.Printf("Source: %v", sourceBytes[900:1100])
-		fmt.Printf("Dest: %v", mockSinkBuffer[900:1100])
-
 		phase, err = snap2.TransferFile(".")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(phase).To(Equal(ProcessingPhaseComplete))


### PR DESCRIPTION
**What this PR does / why we need it**:
From [this conversation](https://github.com/kubevirt/containerized-data-importer/pull/3534#discussion_r1850773134), this pull request avoids storing all results from QueryChangedDiskAreas during a VDDK warm migration. A disk with a lot of small evenly-spaced changes could get the importer to create a huge list, which might exceed the pod's memory limit. This change iterates over one result from QueryChangedDiskAreas at a time, which so far seems to be limited to 2000 changed extent entries.

**Which issue(s) this PR fixes**:
Fixes [MTV-1699](https://issues.redhat.com/browse/MTV-1699)

**Release note**:
```release-note
Reduce memory usage for multi-stage VDDK imports when the source snapshot has many changes.
```

