### PR TITLE
Add filter label parameter for functional tests

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -95,14 +95,10 @@ fi
 
 (
     export TESTS_WORKDIR=${CDI_DIR}/tests
-    ginkgo_args="--trace --timeout=8h --v"
-
-    if [[ -n "$CDI_E2E_SKIP" ]]; then
-        ginkgo_args="${ginkgo_args} --skip=${CDI_E2E_SKIP}"
-    fi
+    ginkgo_args="--trace --timeout=8h --v --skip=${CDI_E2E_SKIP} --label-filter=${CDI_LABEL_FILTER}"
 
     if [[ -n "$CDI_E2E_FOCUS" || -n "$CDI_E2E_SKIP" ]]; then
-            ginkgo_args="${ginkgo_args} --nodes=6"
+        ginkgo_args="${ginkgo_args} --nodes=6"
     fi
 
     if [[ "$CDI_E2E_FOCUS" =~ /.+\.go/ ]]; then


### PR DESCRIPTION

**What this PR does / why we need it**:
This change adds a label-filter parameter to the functional test script.

This allows users to specify a label filter via the `CDI_LABEL_FILTER` environment variable, enabling better test selection without relying on hardcoded labels in the test descriptions. 
Discussed in https://github.com/kubevirt/containerized-data-importer/pull/3565 and makes the introduced label usable. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

