### PR TITLE
Fix ImagePullFailed handling in DIC controller

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -543,7 +543,8 @@ func (r *DataImportCronReconciler) updateSource(ctx context.Context, cron *cdiv1
 func (r *DataImportCronReconciler) deleteErroneousDataVolume(ctx context.Context, cron *cdiv1.DataImportCron, dv *cdiv1.DataVolume) error {
 	log := r.log.WithValues("name", dv.Name).WithValues("uid", dv.UID)
 	if cond := dvc.FindConditionByType(cdiv1.DataVolumeRunning, dv.Status.Conditions); cond != nil {
-		if cond.Status == corev1.ConditionFalse && cond.Reason == common.GenericError {
+		if cond.Status == corev1.ConditionFalse &&
+			(cond.Reason == common.GenericError || cond.Reason == ImagePullFailedReason) {
 			log.Info("Delete DataVolume and reset DesiredDigest due to error", "message", cond.Message)
 			// Unlabel the DV before deleting it, to eliminate reconcile before DIC is updated
 			dv.Labels[common.DataImportCronLabel] = ""

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -318,9 +318,9 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *corev1.Pod, te
 	anno[cc.AnnRunningCondition] = "false"
 
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.Started != nil && !(*status.Started) {
-			if status.State.Waiting != nil &&
-				(status.State.Waiting.Reason == "ImagePullBackOff" || status.State.Waiting.Reason == "ErrImagePull") {
+		if status.Started != nil && !(*status.Started) && status.State.Waiting != nil {
+			switch status.State.Waiting.Reason {
+			case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
 				anno[prefix+".message"] = fmt.Sprintf("%s: %s", common.ImagePullFailureText, status.Image)
 				anno[prefix+".reason"] = ImagePullFailedReason
 				return

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -35,9 +35,10 @@ const (
 	scheduleOnceAYear     = "0 0 1 1 *"
 	importsToKeep         = 1
 	emptySchedule         = ""
-	errorDigest           = "sha256:12345678900987654321"
 	testKubevirtIoKey     = "test.kubevirt.io/test"
 	testKubevirtIoValue   = "testvalue"
+	// Digest must be 64 characters long
+	errorDigest = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
 )
 
 var _ = Describe("DataImportCron", Serial, func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `DataVolume` not-`Running` condition reason `ImagePullFailedReason` for `DataImportCron` controller deletion of erroneous DVs.

In `[test_id:8266] succeed deleting error DVs`, we exercise this flow by injecting a nonexistent digest for the registry import, which did not lead us to the `ImagePullFailed` flow but the usual `GenericError` one, as the container status got the `InvalidImageName` reason because the digest was not 64 long. Fixed that.

Added `InvalidImageName` reason as a trigger of `ImagePullFailed` as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix ImagePullFailed handling in DataImportCron controller
```

