### PR TITLE
Fix flaky DataImportCron volume snapshot test

### DIFF
--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -735,11 +735,9 @@ var _ = Describe("DataImportCron", Serial, func() {
 			// Now simulate an upgrade, where a new CDI version has identified
 			// more storage types that scale better with snapshots
 			configureStorageProfileResultingFormat(cdiv1.DataImportCronSourceFormatSnapshot)
-			// Switches to not ready because the snapshot wasn't created yet
-			waitForConditions(corev1.ConditionFalse, corev1.ConditionFalse)
-			waitForConditions(corev1.ConditionFalse, corev1.ConditionTrue)
 			// Check snapshot now exists and PVC is gone
 			currentSource := verifySourceReady(cdiv1.DataImportCronSourceFormatSnapshot, currentImportDv)
+			waitForConditions(corev1.ConditionFalse, corev1.ConditionTrue)
 			// DataSource is updated to point to a snapshot
 			dataSource, err := f.CdiClient.CdiV1beta1().DataSources(ns).Get(context.TODO(), cron.Spec.ManagedDataSource, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
As commented by @akalenyu : the condition check flakes because the switch to snapshot boot sources is almost instant. The `DataImportCron` never becomes "not ready" following the switch. We also moved the DIC "ready" check after the snapshot "ready" check, otherwise we may check it before it's "not ready", which checks nothing.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-40016

**Release note**:
```release-note
NONE
```

