### PR TITLE
fix: Use storage class from annotation for host-assisted PVC operation

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -225,6 +225,9 @@ const (
 
 	// AnnSourceVolumeMode is the volume mode of the source PVC specified as an annotation on snapshots
 	AnnSourceVolumeMode = AnnAPIGroup + "/storage.import.sourceVolumeMode"
+	// AnnSnapshotRestoreStorageClass indicates the storage class to use for restoring snapshots.
+	// This annotation should be added to DataVolumes for the temporary host-assisted source PVC.
+	AnnSnapshotRestoreStorageClass = AnnAPIGroup + "/snapshot.restore.storageClass"
 
 	// AnnOpenShiftImageLookup is the annotation for OpenShift image stream lookup
 	AnnOpenShiftImageLookup = "alpha.image.policy.openshift.io/resolve-names"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
modify the `getStorageClassCorrespondingToSnapClass` function to use the storage class from the annotation for host-assisted PVC operations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3530

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```