### PR TITLE
Set DV Bound condition to False instead of Unknown

### DIFF
--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -145,7 +145,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 			conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, "Claim Lost", cc.ClaimLost)
 			conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 		default:
-			conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionUnknown, fmt.Sprintf("PVC %s phase unknown", pvc.Name), string(corev1.ConditionUnknown))
+			conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, "", "")
 			conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 		}
 	} else {
@@ -155,7 +155,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 		if reason == "" {
 			reason = cc.NotFound
 		}
-		conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionUnknown, message, reason)
+		conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, message, reason)
 		conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 	}
 	return conditions

--- a/pkg/controller/datavolume/conditions_test.go
+++ b/pkg/controller/datavolume/conditions_test.go
@@ -141,7 +141,7 @@ var _ = Describe("updateBoundCondition", func() {
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
 		Expect(condition.Message).To(Equal("No PVC found"))
 		Expect(condition.Reason).To(Equal(NotFound))
-		Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
+		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 	})
 
 	It("should create condition with reason if it doesn't exist", func() {
@@ -153,7 +153,7 @@ var _ = Describe("updateBoundCondition", func() {
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
 		Expect(condition.Message).To(Equal("No PVC found"))
 		Expect(condition.Reason).To(Equal(reason))
-		Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
+		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 	})
 
 	It("should create condition with message if one passed", func() {
@@ -165,7 +165,20 @@ var _ = Describe("updateBoundCondition", func() {
 		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
 		Expect(condition.Message).To(Equal(message))
 		Expect(condition.Reason).To(Equal(NotFound))
-		Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
+		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+	})
+
+	It("should not be bound if PVC has no phase set", func() {
+		conditions := make([]cdiv1.DataVolumeCondition, 0)
+		pvc := CreatePvc("test", corev1.NamespaceDefault, nil, nil)
+		pvc.Status.Phase = ""
+		conditions = updateBoundCondition(conditions, pvc, "", "")
+		Expect(conditions).To(HaveLen(2))
+		condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
+		Expect(condition.Type).To(Equal(cdiv1.DataVolumeBound))
+		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+		Expect(condition.Message).To(BeEmpty())
+		Expect(condition.Reason).To(BeEmpty())
 	})
 
 	It("should be bound if PVC bound", func() {

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1117,7 +1117,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(dv.Status.Phase).To(Equal(expected))
 			Expect(dv.Status.Conditions).To(HaveLen(3))
 			boundCondition := FindConditionByType(cdiv1.DataVolumeBound, dv.Status.Conditions)
-			Expect(boundCondition.Status).To(Equal(corev1.ConditionUnknown))
+			Expect(boundCondition.Status).To(Equal(corev1.ConditionFalse))
 			Expect(boundCondition.Message).To(Equal("No PVC found"))
 
 			By("Checking events recorded")

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -125,7 +125,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(cc.ErrExceededQuota))
 		boundCondition := &cdiv1.DataVolumeCondition{
 			Type:    cdiv1.DataVolumeBound,
-			Status:  v1.ConditionUnknown,
+			Status:  v1.ConditionFalse,
 			Message: "exceeded quota",
 			Reason:  cc.ErrExceededQuota,
 		}

--- a/tests/datasource_test.go
+++ b/tests/datasource_test.go
@@ -117,7 +117,7 @@ var _ = Describe("DataSource", func() {
 
 		By("Verify DV conditions")
 		utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
-			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source pvc pvc1 doesn't exist", Reason: dvc.CloneWithoutSource},
+			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionFalse, Message: "The source pvc pvc1 doesn't exist", Reason: dvc.CloneWithoutSource},
 			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
 			&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
 		f.ExpectEvent(dv.Namespace).Should(ContainSubstring(dvc.CloneWithoutSource))
@@ -321,7 +321,7 @@ var _ = Describe("DataSource", func() {
 
 			By("Verify DV conditions")
 			utils.WaitForConditions(f, dv.Name, dv.Namespace, time.Minute, pollingInterval,
-				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionUnknown, Message: "The source snapshot snap1 doesn't exist", Reason: dvc.CloneWithoutSource},
+				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeBound, Status: corev1.ConditionFalse, Message: "The source snapshot snap1 doesn't exist", Reason: dvc.CloneWithoutSource},
 				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeReady, Status: corev1.ConditionFalse, Reason: dvc.CloneWithoutSource},
 				&cdiv1.DataVolumeCondition{Type: cdiv1.DataVolumeRunning, Status: corev1.ConditionFalse})
 			f.ExpectEvent(dv.Namespace).Should(ContainSubstring(dvc.CloneWithoutSource))

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -399,7 +399,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			expectedPhase := cdiv1.Pending
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
-				Status:  v1.ConditionUnknown,
+				Status:  v1.ConditionFalse,
 				Message: "exceeded quota",
 				Reason:  controller.ErrExceededQuota,
 			}
@@ -2660,7 +2660,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By("verifying conditions")
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
-				Status:  v1.ConditionUnknown,
+				Status:  v1.ConditionFalse,
 				Message: dvc.MessageErrStorageClassNotFound,
 				Reason:  controller.ErrClaimNotValid,
 			}
@@ -2680,7 +2680,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By("verifying conditions")
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
-				Status:  v1.ConditionUnknown,
+				Status:  v1.ConditionFalse,
 				Message: "No PVC found",
 				Reason:  controller.NotFound,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Align `DataVolume` `Bound` condition with the `Ready` condition when the `PVC` does not exist or has no phase set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Set DataVolume Bound condition to False instead of Unknown
```

