### PR TITLE
switch to bash array to construct ginkgo cmd

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -95,25 +95,26 @@ fi
 
 (
     export TESTS_WORKDIR=${CDI_DIR}/tests
-    ginkgo_args="--trace --timeout=8h --v"
+    declare -a ginkgo_args
+    ginkgo_args+=(--trace --timeout=8h --v)
 
     if [[ -n "$CDI_LABEL_FILTER" ]]; then
-        ginkgo_args="${ginkgo_args} --label-filter=${CDI_LABEL_FILTER}"
+        ginkgo_args+=(--label-filter="${CDI_LABEL_FILTER}")
     fi
 
     if [[ -n "$CDI_E2E_SKIP" ]]; then
-        ginkgo_args="${ginkgo_args} --skip=${CDI_E2E_SKIP}"
+        ginkgo_args+=(--skip="${CDI_E2E_SKIP}")
     fi
 
     if [[ "$CDI_E2E_FOCUS" =~ /.+\.go/ ]]; then
-        ginkgo_args="${ginkgo_args} --focus-file=${CDI_E2E_FOCUS}"
+        ginkgo_args+=(--focus-file="${CDI_E2E_FOCUS}")
     elif [[ -n "$CDI_E2E_FOCUS" ]]; then
-        ginkgo_args="${ginkgo_args} --focus=${CDI_E2E_FOCUS}"
+        ginkgo_args+=(--focus="${CDI_E2E_FOCUS}")
     fi
 
     if [[ -n "$CDI_E2E_FOCUS" || -n "$CDI_E2E_SKIP" ]]; then
-        ginkgo_args="${ginkgo_args} --nodes=6"
+        ginkgo_args+=(--nodes=6)
     fi
 
-    ${TESTS_OUT_DIR}/ginkgo ${ginkgo_args} ${TESTS_OUT_DIR}/tests.test -- ${test_args}
+    ${TESTS_OUT_DIR}/ginkgo "${ginkgo_args[@]}" ${TESTS_OUT_DIR}/tests.test -- ${test_args}
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
While using ginkgos `--label-filter` through `$CDI_LABEL_FILTER` [with operators](https://onsi.github.io/ginkgo/#spec-labels) the whitespaces and special characters result in a faulty final command.
For example in the current state when having `CDI_LABEL_FILTER='!VDDK && !ImageIO'` we get:
```shell
ginkgo '--label-filter=!VDDK' '&&' '!ImageIO' 
```
This only filters out VDDK and ignores ImageIO.

To overcome this I propose to use a bash array to construct the final command, enabling the use of operators without having to use escaping or `eval`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

