### PR TITLE
VDDK: Add CRD field for extra configuration arguments

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4934,6 +4934,10 @@
       "description": "BackingFile is the path to the virtual hard disk to migrate from vCenter/ESXi",
       "type": "string"
      },
+     "extraArgs": {
+      "description": "ExtraArgs is a reference to a ConfigMap containing extra arguments to pass directly to the VDDK library",
+      "type": "string"
+     },
      "initImageURL": {
       "description": "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
       "type": "string"

--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -351,8 +351,9 @@ spec:
 
 #### Extra VDDK Configuration Options
 
-The VDDK library itself looks in a configuration file (such as `/etc/vmware/config`) for extra options to fine tune data transfers. To pass these options through to the VDDK, store the configuration file contents in a ConfigMap with the key `vddk-config-file` and add a `cdi.kubevirt.io/storage.pod.vddk.extraargs` annotation to the DataVolume specification. The ConfigMap will be mounted to the importer pod as a volume, and the mount directory will have a file named `vddk-config-file` with the contents of the file. This means that the ConfigMap must be placed in the same namespace as the DataVolume, and the ConfigMap should only have one file entry, `vddk-config-file`.
+The VDDK library itself looks in a configuration file (such as `/etc/vmware/config`) for extra options to fine tune data transfers. To pass these options through to the VDDK, store the configuration file contents in a ConfigMap with the key `vddk-config-file` and put the name of this ConfigMap in either the `spec.source.vddk.extraArgs` field or a `cdi.kubevirt.io/storage.pod.vddk.extraargs` annotation in the DataVolume specification. The ConfigMap will be mounted to the importer pod as a volume, and the mount directory will have a file named `vddk-config-file` with the contents of the file. This means that the ConfigMap must be placed in the same namespace as the DataVolume, and the ConfigMap should only have one file entry, `vddk-config-file`.
 
+[Example field](../manifests/example/vddk-args-field.yaml)
 [Example annotation](../manifests/example/vddk-args-annotation.yaml)
 [Example ConfigMap](../manifests/example/vddk-args-configmap.yaml)
 

--- a/manifests/example/vddk-args-field.yaml
+++ b/manifests/example/vddk-args-field.yaml
@@ -1,0 +1,20 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "vddk-dv"
+spec:
+    source:
+        vddk:
+           backingFile: "[iSCSI_Datastore] vm/vm_1.vmdk" # From 'Hard disk'/'Disk File' in vCenter/ESX VM settings
+           url: "https://vcenter.corp.com"
+           uuid: "52260566-b032-36cb-55b1-79bf29e30490"
+           thumbprint: "20:6C:8A:5D:44:40:B3:79:4B:28:EA:76:13:60:90:6E:49:D9:D9:A3" # SSL fingerprint of vCenter/ESX host
+           secretRef: "vddk-credentials"
+           initImageURL: "registry:5000/vddk-init:latest"
+           extraArgs: "vddk-arguments"
+    storage:
+       accessModes:
+         - ReadWriteOnce
+       resources:
+         requests:
+           storage: "32Gi"

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -18405,6 +18405,13 @@ func schema_pkg_apis_core_v1beta1_DataVolumeSourceVDDK(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"extraArgs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ExtraArgs is a reference to a ConfigMap containing extra arguments to pass directly to the VDDK library",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1703,6 +1703,9 @@ func UpdateVDDKAnnotations(annotations map[string]string, vddk *cdiv1.DataVolume
 	if vddk.InitImageURL != "" {
 		annotations[AnnVddkInitImageURL] = vddk.InitImageURL
 	}
+	if vddk.ExtraArgs != "" {
+		annotations[AnnVddkExtraArgs] = vddk.ExtraArgs
+	}
 }
 
 // UpdateImageIOAnnotations updates the passed annotations for proper imageIO import

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1088,6 +1088,19 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(pvc).ToNot(BeNil())
 			Expect(pvc.GetAnnotations()[AnnVddkInitImageURL]).To(Equal("test://image"))
 		})
+
+		It("Should copy extra VDDK args to PVC", func() {
+			dv := newVDDKDataVolume("test-dv")
+			dv.Spec.Source.VDDK.ExtraArgs = "vddk-extra-args"
+			reconciler = createImportReconciler(dv)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc).ToNot(BeNil())
+			Expect(pvc.GetAnnotations()[AnnVddkExtraArgs]).To(Equal("vddk-extra-args"))
+		})
 	})
 
 	var _ = Describe("Reconcile Datavolume status", func() {

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6129,6 +6129,11 @@ spec:
                                 description: BackingFile is the path to the virtual
                                   hard disk to migrate from vCenter/ESXi
                                 type: string
+                              extraArgs:
+                                description: ExtraArgs is a reference to a ConfigMap
+                                  containing extra arguments to pass directly to the
+                                  VDDK library
+                                type: string
                               initImageURL:
                                 description: InitImageURL is an optional URL to an
                                   image containing an extracted VDDK library, overrides
@@ -7083,6 +7088,10 @@ spec:
                       backingFile:
                         description: BackingFile is the path to the virtual hard disk
                           to migrate from vCenter/ESXi
+                        type: string
+                      extraArgs:
+                        description: ExtraArgs is a reference to a ConfigMap containing
+                          extra arguments to pass directly to the VDDK library
                         type: string
                       initImageURL:
                         description: InitImageURL is an optional URL to an image containing
@@ -8089,6 +8098,10 @@ spec:
                       backingFile:
                         description: BackingFile is the path to the virtual hard disk
                           to migrate from vCenter/ESXi
+                        type: string
+                      extraArgs:
+                        description: ExtraArgs is a reference to a ConfigMap containing
+                          extra arguments to pass directly to the VDDK library
                         type: string
                       initImageURL:
                         description: InitImageURL is an optional URL to an image containing

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -262,6 +262,8 @@ type DataVolumeSourceVDDK struct {
 	SecretRef string `json:"secretRef,omitempty"`
 	// InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map
 	InitImageURL string `json:"initImageURL,omitempty"`
+	// ExtraArgs is a reference to a ConfigMap containing extra arguments to pass directly to the VDDK library
+	ExtraArgs string `json:"extraArgs,omitempty"`
 }
 
 // DataVolumeSourceRef defines an indirect reference to the source of data for the DataVolume

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -138,6 +138,7 @@ func (DataVolumeSourceVDDK) SwaggerDoc() map[string]string {
 		"thumbprint":   "Thumbprint is the certificate thumbprint of the vCenter or ESXi host",
 		"secretRef":    "SecretRef provides a reference to a secret containing the username and password needed to access the vCenter or ESXi host",
 		"initImageURL": "InitImageURL is an optional URL to an image containing an extracted VDDK library, overrides v2v-vmware config map",
+		"extraArgs":    "ExtraArgs is a reference to a ConfigMap containing extra arguments to pass directly to the VDDK library",
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As requested in [3572](https://github.com/kubevirt/containerized-data-importer/pull/3572#issuecomment-2596091372), adds a CRD field for extra VDDK arguments going forward. Most of the implementation is preserved from #3572, this just needed an extra copy to the PVC annotations.


**Release note**:
```release-note
VDDK: add CRD field for extra configuration arguments.
```

