### PR TITLE
Adding an if statement for the case that the certDir is not configured

### DIFF
--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -191,6 +191,12 @@ func CreateCertificateDir(registryCertDir string) (string, error) {
 	if err := collectCerts(common.ImporterProxyCertDir, allCerts, "proxy-"); err != nil {
 		return allCerts, err
 	}
+
+	if registryCertDir == "" {
+		klog.Info("Registry certs directory not configured")
+		return allCerts, nil
+	}
+
 	klog.Info("Copying registry certs")
 	if err := collectCerts(registryCertDir, allCerts, ""); err != nil {
 		return allCerts, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR introduces an additional if statement to ensure that proxy certificates remain available even when the certConfigMap field is not present.

Currently, if certConfigMap is missing while pulling from a registry, the proxy certificates are not utilized, which can lead to trust issues. This change ensures that proxy certificates are always accessible when configured, regardless of if certConfigMap field is present or not in the DataVolumeSourceRegistry section.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

