### PR TITLE
Clone: fallback to host-assisted when snapshot volume mode differs (#3621)

### DIFF
--- a/pkg/controller/clone/common.go
+++ b/pkg/controller/clone/common.go
@@ -10,11 +10,13 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
@@ -126,6 +128,18 @@ func GetGlobalCloneStrategyOverride(ctx context.Context, c client.Client) (*cdiv
 	}
 
 	return cr.Spec.CloneStrategyOverride, nil
+}
+
+// GetSnapshotContentFromSnapshot returns the VolumeSnapshotContent of a given VolumeSnapshot
+func GetSnapshotContentFromSnapshot(ctx context.Context, c client.Client, snapshot *snapshotv1.VolumeSnapshot) (*snapshotv1.VolumeSnapshotContent, error) {
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, fmt.Errorf("volumeSnapshotContent name not found")
+	}
+	vsc := &snapshotv1.VolumeSnapshotContent{}
+	if err := c.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+		return nil, err
+	}
+	return vsc, nil
 }
 
 // GetStorageClassForClaim returns the storageclass for a PVC
@@ -274,6 +288,20 @@ func SameVolumeMode(pvc1 *corev1.PersistentVolumeClaim, others ...*corev1.Persis
 	vm := util.ResolveVolumeMode(pvc1.Spec.VolumeMode)
 	for _, pvc := range others {
 		if util.ResolveVolumeMode(pvc.Spec.VolumeMode) != vm {
+			return false
+		}
+	}
+	return true
+}
+
+// SameVolumeModeSnapshot returns true if all pvcs have the same volume mode as the source snapshot
+func SameVolumeModeSnapshot(ctx context.Context, client client.Client, vsc *snapshotv1.VolumeSnapshotContent, others ...*corev1.PersistentVolumeClaim) bool {
+	if vsc.Spec.SourceVolumeMode == nil {
+		return false
+	}
+
+	for _, pvc := range others {
+		if *pvc.Spec.VolumeMode != *vsc.Spec.SourceVolumeMode {
 			return false
 		}
 	}

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -405,7 +405,7 @@ func (p *Planner) computeStrategyForSourceSnapshot(ctx context.Context, args *Ch
 		return res, nil
 	}
 
-	// Lastly, do size validation to determine whether to use dumb or smart cloning
+	// do size validation
 	valid, err = cc.ValidateSnapshotCloneSize(sourceSnapshot, &args.TargetClaim.Spec, targetStorageClass, args.Log)
 	if err != nil {
 		return nil, err
@@ -414,6 +414,18 @@ func (p *Planner) computeStrategyForSourceSnapshot(ctx context.Context, args *Ch
 		p.fallbackToHostAssisted(args.TargetClaim, res, NoVolumeExpansion, MessageNoVolumeExpansion)
 		return res, nil
 	}
+
+	// Lastly, do volume mode validation  to determine whether to use dumb or smart cloning
+	vsc, err := GetSnapshotContentFromSnapshot(ctx, p.Client, sourceSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	if !SameVolumeModeSnapshot(ctx, p.Client, vsc, args.TargetClaim) {
+		p.fallbackToHostAssisted(args.TargetClaim, res, IncompatibleVolumeModes, MessageIncompatibleVolumeModes)
+		args.Log.V(3).Info("Volume modes not compatible for advanced clone - Snapshot")
+		return res, nil
+	}
+
 	res.Strategy = cdiv1.CloneStrategySnapshot
 	return res, nil
 }
@@ -471,7 +483,7 @@ func (p *Planner) validateAdvancedClonePVC(ctx context.Context, args *ChooseStra
 
 	if !SameVolumeMode(sourceClaim, args.TargetClaim) {
 		p.fallbackToHostAssisted(args.TargetClaim, res, IncompatibleVolumeModes, MessageIncompatibleVolumeModes)
-		args.Log.V(3).Info("volume modes not compatible for advanced clone")
+		args.Log.V(3).Info("volume modes not compatible for advanced clone - PVC")
 		return nil
 	}
 
@@ -779,11 +791,8 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
 }
 
 func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
-	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
-		return nil, fmt.Errorf("volumeSnapshotContent name not found")
-	}
-	vsc := &snapshotv1.VolumeSnapshotContent{}
-	if err := client.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+	vsc, err := GetSnapshotContentFromSnapshot(ctx, client, snapshot)
+	if err != nil {
 		return nil, err
 	}
 	scName, err := getStorageClassNameForTempSourceClaim(ctx, vsc, client)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When creating a DataVolume from a snapshot with a specified target PVC, configuration mismatches can occur. For example, if the snapshot is configured with block mode and the target PVC is set to filesystem mode, the VolumeSnapshotContent's SourceVolumeMode will differ from the target PVC's volume mode. In this scenario, the cloning process should fall back to the host-assisted strategy. This ensures that cloning is performed by the CDI code rather than by a third-party driver, which may not correctly handle the conversion and could lead to mounting failures as seen in this bug.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/containerized-data-importer/issues/3621

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

