### PR TITLE
WIP Add SupportLevel to StorageProfile status

### DIFF
--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -19234,6 +19234,13 @@ func schema_pkg_apis_core_v1beta1_StorageProfileStatus(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"supportLevel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SupportLevel indicates CDI support level for the storage class",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -7788,6 +7788,10 @@ spec:
               storageClass:
                 description: The StorageClass name for which capabilities are defined
                 type: string
+              supportLevel:
+                description: SupportLevel indicates CDI support level for the storage
+                  class
+                type: string
             type: object
         required:
         - spec

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -443,6 +443,8 @@ type StorageProfileStatus struct {
 	DataImportCronSourceFormat *DataImportCronSourceFormat `json:"dataImportCronSourceFormat,omitempty"`
 	// SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.
 	SnapshotClass *string `json:"snapshotClass,omitempty"`
+	// SupportLevel indicates CDI support level for the storage class
+	SupportLevel *CDISupportLevel `json:"supportLevel,omitempty"`
 }
 
 // ClaimPropertySet is a set of properties applicable to PVC
@@ -457,6 +459,20 @@ type ClaimPropertySet struct {
 	// +kubebuilder:validation:Enum="Block";"Filesystem"
 	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode"`
 }
+
+// CDISupportLevel defines CDI support level for the storage class
+type CDISupportLevel string
+
+const (
+	// SupportLevelSupported indicates the storage is supported by CDI
+	SupportLevelSupported CDISupportLevel = "supported"
+
+	// SupportLevelUnsupported indicates the storage is unsupported by CDI
+	SupportLevelUnsupported CDISupportLevel = "unsupported"
+
+	// SupportLevelUnknown indicates the storage is unknown to CDI, but may be used for testing purposes
+	SupportLevelUnknown CDISupportLevel = "unknown"
+)
 
 // StorageProfileList provides the needed parameters to request a list of StorageProfile from the system
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -197,6 +197,7 @@ func (StorageProfileStatus) SwaggerDoc() map[string]string {
 		"claimPropertySets":          "ClaimPropertySets computed from the spec and detected in the system\n+kubebuilder:validation:MaxItems=8",
 		"dataImportCronSourceFormat": "DataImportCronSourceFormat defines the format of the DataImportCron-created disk image sources",
 		"snapshotClass":              "SnapshotClass is optional specific VolumeSnapshotClass for CloneStrategySnapshot. If not set, a VolumeSnapshotClass is chosen according to the provisioner.",
+		"supportLevel":               "SupportLevel indicates CDI support level for the storage class",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1748,6 +1748,11 @@ func (in *StorageProfileStatus) DeepCopyInto(out *StorageProfileStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SupportLevel != nil {
+		in, out := &in.SupportLevel, &out.SupportLevel
+		*out = new(CDISupportLevel)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The field indicates CDI support level per storage class, which can be either supported, unsupported or unknown. It can be used by UI for filtering the available storage classes.

**Release note**:
```release-note
Add SupportLevel to StorageProfile status
```