### PR TITLE
Revert "Clean up leftover snapshot sources from DataImportCron tests"

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -95,7 +95,6 @@ go_test(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -13,9 +13,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -79,23 +77,6 @@ var _ = Describe("DataImportCron", Serial, func() {
 
 		By("[AfterEach] Restore the profile")
 		Expect(utils.UpdateStorageProfile(f.CrClient, scName, *originalProfileSpec)).Should(Succeed())
-
-		// Clean up existing dataimportcrons in the environment that we might have switched
-		l, err := labels.Parse(common.DataImportCronLabel)
-		Expect(err).ToNot(HaveOccurred())
-		snapshots := &snapshotv1.VolumeSnapshotList{}
-		err = f.CrClient.List(context.TODO(), snapshots, &client.ListOptions{Namespace: metav1.NamespaceAll, LabelSelector: l})
-		Expect(err).To(Or(
-			Not(HaveOccurred()),
-			Satisfy(meta.IsNoMatchError),
-		))
-		for i := range snapshots.Items {
-			err = f.CrClient.Delete(context.TODO(), &snapshots.Items[i])
-			Expect(err).To(Or(
-				Not(HaveOccurred()),
-				Satisfy(meta.IsNoMatchError),
-			))
-		}
 
 		By("[AfterEach] Delete the DataImportCron under test")
 		// Delete the DataImportCron under test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This reverts commit 21be57add80c01e0a6dd0c618b70de84d5caca25.
Not needed since snap->pvc format switch is automated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

