### PR TITLE
Avoid waiting out entire tcp timeout in progress call

### DIFF
--- a/pkg/controller/clone/host-clone.go
+++ b/pkg/controller/clone/host-clone.go
@@ -137,7 +137,7 @@ func progressFromClaim(ctx context.Context, args *progressFromClaimArgs) (string
 	}
 
 	// We fetch the clone progress from the clone source pod metrics
-	progressReport, err := cc.GetProgressReportFromURL(url, args.HTTPClient, metrics.CloneProgressMetricName, args.OwnerUID)
+	progressReport, err := cc.GetProgressReportFromURL(ctx, url, args.HTTPClient, metrics.CloneProgressMetricName, args.OwnerUID)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1108,7 +1108,7 @@ func updateProgressUsingPod(dataVolumeCopy *cdiv1.DataVolume, pod *corev1.Pod) e
 	}
 
 	// Used for both import and clone, so it should match both metric names
-	progressReport, err := cc.GetProgressReportFromURL(url, httpClient,
+	progressReport, err := cc.GetProgressReportFromURL(context.TODO(), url, httpClient,
 		fmt.Sprintf("%s|%s", importMetrics.ImportProgressMetricName, cloneMetrics.CloneProgressMetricName),
 		string(dataVolumeCopy.UID))
 	if err != nil {

--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -423,7 +423,7 @@ func (r *ForkliftPopulatorReconciler) updateImportProgress(podPhase string, pvc,
 
 	// We fetch the import progress from the import pod metrics
 	httpClient = cc.BuildHTTPClient(httpClient)
-	progressReport, err := cc.GetProgressReportFromURL(url, httpClient,
+	progressReport, err := cc.GetProgressReportFromURL(context.TODO(), url, httpClient,
 		fmt.Sprintf("%s|%s", openstackMetric.OpenStackPopulatorProgressMetricName, ovirtMetric.OvirtPopulatorProgressMetricName),
 		string(pvc.UID))
 	if err != nil {

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -286,7 +286,7 @@ func (r *ImportPopulatorReconciler) updateImportProgress(podPhase string, pvc, p
 
 	// We fetch the import progress from the import pod metrics
 	httpClient = cc.BuildHTTPClient(httpClient)
-	progressReport, err := cc.GetProgressReportFromURL(url, httpClient, importMetrics.ImportProgressMetricName, string(pvc.UID))
+	progressReport, err := cc.GetProgressReportFromURL(context.TODO(), url, httpClient, importMetrics.ImportProgressMetricName, string(pvc.UID))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Pretty sure we lose a worker thread whenever the GET call to /metrics
gets issued against a completed pod. Reducing the timeout to 2 seconds
should minimize that window.

```
{"level":"error","ts":"2025-03-17T20:40:34Z","logger":"controller.import-populator","msg":"Failed to update import progress for pvc <NAME/NS>","error":"Get \"https://<IP>:8443/metrics\": dial tcp <IP>:8443: i/o timeout"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: decrease timeout trying to derive progress from a completed pod to avoid delaying progress updates
```

