### PR TITLE
add test for registry imports with https proxy

### DIFF
--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -37,6 +37,8 @@ const (
 	containerDiskImageDir = "disk"
 )
 
+var proxyCertificateDir = common.ImporterProxyCertDir
+
 // RegistryDataSource is the struct containing the information needed to import from a registry data source.
 // Sequence of phases:
 // 1. Info -> Transfer
@@ -188,7 +190,7 @@ func CreateCertificateDir(registryCertDir string) (string, error) {
 	}
 
 	klog.Info("Copying proxy certs")
-	if err := collectCerts(common.ImporterProxyCertDir, allCerts, "proxy-"); err != nil {
+	if err := collectCerts(proxyCertificateDir, allCerts, "proxy-"); err != nil {
 		return allCerts, err
 	}
 

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -141,4 +141,14 @@ var _ = Describe("Registry data source", func() {
 		Expect(err).To(HaveOccurred())
 		Expect("image directory contains more than one file").To(Equal(err.Error()))
 	})
+
+	It("should return certDir containing proxy certs regardless of final endpoint certs", func() {
+		proxyCertDir, err := os.MkdirTemp("", "proxycerts")
+		Expect(err).ToNot(HaveOccurred())
+		// proxy dir exists but certDir is empty
+		proxyCertificateDir = proxyCertDir
+
+		ds = NewRegistryDataSource("", "", "", "", false)
+		Expect(ds.certDir).To(Equal("/tmp/all_certs"))
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
this is a test for https://github.com/kubevirt/containerized-data-importer/pull/3651
the scenario of registry imports using https proxy AND
no certs for final endpoint should now be covered

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

