### PR TITLE
Fix Longhorn Filesystem capabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -126,6 +126,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// Longhorn
 	"driver.longhorn.io":            {{rwo, block}},
 	"driver.longhorn.io/migratable": {{rwx, block}, {rwo, block}},
+	"driver.longhorn.io/nfs":        {{rwx, file}, {rwo, file}},
+	"driver.longhorn.io/fs":         {{rwo, file}},
 	// Oracle cloud
 	"blockvolume.csi.oraclecloud.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 }
@@ -360,10 +362,16 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 		}
 	},
 	"driver.longhorn.io": func(sc *storagev1.StorageClass) string {
-		migratable := sc.Parameters["migratable"]
-		if migratable == "true" {
+		if sc.Parameters["migratable"] == "true" {
 			return "driver.longhorn.io/migratable"
 		}
+		if sc.Parameters["nfsOptions"] != "" {
+			return "driver.longhorn.io/nfs"
+		}
+		if sc.Parameters["fsType"] != "" {
+			return "driver.longhorn.io/fs"
+		}
+
 		return "driver.longhorn.io"
 	},
 	"ebs.csi.aws.com": func(sc *storagev1.StorageClass) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
When the storage class parameters specifies `migratable: "true"` it supports RWX Block but not Filesystem:
https://github.com/longhorn/longhorn/blob/master/enhancements/20241206-v2-volume-live-migration.md https://github.com/longhorn/longhorn/blob/master/enhancements/20210216-volume-live-migration.md

RWX Filesystem is preferred when `nfsOptions` are specified:
https://longhorn.io/docs/1.8.1/nodes-and-volumes/volumes/rwx-volumes/

RWO Filesystem is preferred when `fsType` is specified.

**Which issue(s) this PR fixes**:
Fixes #3680

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix Longhorn Filesystem capabilities
```

