### PR TITLE
importer, transport: report DV condition for insufficient scratch space

### DIFF
--- a/pkg/importer/transport_test.go
+++ b/pkg/importer/transport_test.go
@@ -25,6 +25,8 @@ import (
 
 var _ = Describe("Registry Importer", func() {
 	source := "oci-archive:" + imageFile
+	malformedSource := "oci-archive:" + filepath.Join(imageDir, "malformed-registry-image.tar")
+
 	var tmpDir string
 	var err error
 
@@ -38,14 +40,17 @@ var _ = Describe("Registry Importer", func() {
 		os.RemoveAll(tmpDir)
 	})
 
-	It("Should extract a single file", func() {
+	DescribeTable("Should extract a single file", func(source string) {
 		info, err := CopyRegistryImage(source, tmpDir, "disk/cirros-0.3.4-x86_64-disk.img", "", "", "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(info).ToNot(BeNil())
 
 		file := filepath.Join(tmpDir, "disk/cirros-0.3.4-x86_64-disk.img")
 		Expect(file).To(BeARegularFile())
-	})
+	},
+		Entry("when all image layers are valid", source),
+		Entry("when one of the image layers is malformed", malformedSource),
+	)
 	It("Should extract files prefixed by path", func() {
 		info, err := CopyRegistryImageAll(source, tmpDir, "etc/", "", "", "", false)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When importing a DV with a registry source to a scratch space with insufficient capacity for the image, the importer Pod correctly logs an appropriate error. However, the DV conditions report an unrelated error instead.

Fixes the issue by returning early when fatal layer processing errors occur (e.g., no space left when copying located image).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [CNV-56891](https://issues.redhat.com/browse/CNV-56891)

**Special notes for your reviewer**:
Purposefully avoiding adding a unit test for this change. As far as I could gather it would entail substantial changes to how the importer tests currently work.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

