### PR TITLE
Bugfix/qemu img convert lose sparseness

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -107,9 +107,11 @@ func convertToRaw(src, dest string, preallocate bool, cacheMode string) error {
 	}
 
 	args := []string{"convert", "-t", cacheMode, "-p"}
-	// We assume that the destination block is already zeroed (empty),
-	// so we include the '-n' flag with '--target-is-zero' to skip unnecessary writes.
-	args = append(args, "-n", "--target-is-zero")
+	if !preallocate {
+		// We assume that the destination block is already zeroed (empty),
+		// so we include the '-n' flag with '--target-is-zero' to skip unnecessary writes.
+		args = append(args, "-n", "--target-is-zero")
+	}
 	args = append(args, "-O", "raw", src, dest)
 
 	if preallocate {

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -105,7 +105,12 @@ func convertToRaw(src, dest string, preallocate bool, cacheMode string) error {
 	if err != nil {
 		return err
 	}
-	args := []string{"convert", "-t", cacheMode, "-p", "-O", "raw", src, dest}
+
+	args := []string{"convert", "-t", cacheMode, "-p"}
+	// We assume that the destination block is already zeroed (empty),
+	// so we include the '-n' flag with '--target-is-zero' to skip unnecessary writes.
+	args = append(args, "-n", "--target-is-zero")
+	args = append(args, "-O", "raw", src, dest)
 
 	if preallocate {
 		err = addPreallocation(args, convertPreallocationMethods, func(args []string) ([]byte, error) {

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Convert to Raw", func() {
 		})
 	})
 
-	It("should add preallocation if requested", func() {
+	It("should use preallocation flags and omit -n/--target-is-zero when preallocation is requested", func() {
 		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-o", "preallocation=falloc", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
@@ -223,7 +223,7 @@ var _ = Describe("Convert to Raw", func() {
 	})
 
 	It("should not add preallocation if not requested", func() {
-		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
+		replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")
 			Expect(err).NotTo(HaveOccurred())
 			err = ConvertToRawStream(ep, destPath, false, "")
@@ -250,7 +250,7 @@ var _ = Describe("Convert to Raw", func() {
 		})
 
 		It("should use cache=none when destination supports O_DIRECT", func() {
-			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "none", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
+			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "none", "-p", "-n", "--target-is-zero", "-O", "raw", "/somefile/somewhere", destPath), func() {
 				ep, err := url.Parse("/somefile/somewhere")
 				Expect(err).NotTo(HaveOccurred())
 				err = ConvertToRawStream(ep, destPath, false, common.CacheModeTryNone)
@@ -265,7 +265,7 @@ var _ = Describe("Convert to Raw", func() {
 			_, err := os.Create(tmpFsDestPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-O", "raw", "/somefile/somewhere", tmpFsDestPath), func() {
+			replaceExecFunction(mockExecFunctionStrict("", "", nil, "convert", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "/somefile/somewhere", tmpFsDestPath), func() {
 				ep, err := url.Parse("/somefile/somewhere")
 				Expect(err).NotTo(HaveOccurred())
 				err = ConvertToRawStream(ep, tmpFsDestPath, false, common.CacheModeTryNone)

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -185,25 +185,6 @@ var _ = Describe("Convert to Raw", func() {
 		})
 	})
 
-	It("should include -n and --target-is-zero flags when preallocation is false", func() {
-		expectedArgs := []string{"convert", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "source", destPath}
-		replaceExecFunction(mockExecFunctionStrict("", "", nil, expectedArgs...), func() {
-			err := convertToRaw("source", destPath, false, "")
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	It("should include -n and --target-is-zero flags in the initial preallocation attempt", func() {
-		replaceExecFunction(mockExecFunctionStrict("", "", nil,
-			"convert", "-n", "preallocation=falloc", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "/somefile/somewhere", destPath,
-		), func() {
-			ep, err := url.Parse("/somefile/somewhere")
-			Expect(err).NotTo(HaveOccurred())
-			err = ConvertToRawStream(ep, destPath, true, "")
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
 	It("should stream file to destination", func() {
 		replaceExecFunction(mockExecFunction("", "", nil, "convert", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -185,6 +185,25 @@ var _ = Describe("Convert to Raw", func() {
 		})
 	})
 
+	It("should include -n and --target-is-zero flags when preallocation is false", func() {
+		expectedArgs := []string{"convert", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "source", destPath}
+		replaceExecFunction(mockExecFunctionStrict("", "", nil, expectedArgs...), func() {
+			err := convertToRaw("source", destPath, false, "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("should include -n and --target-is-zero flags in the initial preallocation attempt", func() {
+		replaceExecFunction(mockExecFunctionStrict("", "", nil,
+			"convert", "-n", "preallocation=falloc", "-t", "writeback", "-p", "-n", "--target-is-zero", "-O", "raw", "/somefile/somewhere", destPath,
+		), func() {
+			ep, err := url.Parse("/somefile/somewhere")
+			Expect(err).NotTo(HaveOccurred())
+			err = ConvertToRawStream(ep, destPath, true, "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	It("should stream file to destination", func() {
 		replaceExecFunction(mockExecFunction("", "", nil, "convert", "-p", "-O", "raw", "/somefile/somewhere", destPath), func() {
 			ep, err := url.Parse("/somefile/somewhere")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR updates the `qemu-img convert` command by conditionally adding the `--target-is-zero `and `-n` flags when preallocation is not requested. Since we assume that the target block device is already zeroed, the flag allows qemu-img to skip writing zero blocks—reducing unnecessary I/O and speeding up image conversion. The `-n` flag (which is used to skip target image creation) is required together with `--target-is-zero`, so it is automatically added when preallocation is disabled.

**Which issue(s) this PR fixes**:
Fixes #3614

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

