### PR TITLE
chore(doc): wrong source used for pvc in docs

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -240,7 +240,7 @@ metadata:
   name: "example-clone-dv"
 spec:
   source:
-      storage:
+      pvc:
         name: source-pvc
         namespace: example-ns
   storage:


### PR DESCRIPTION

**What this PR does / why we need it**:

Fix documentation on DataVolumes using PVCs as a source

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

