### PR TITLE
Allow increasing PVC size to the minimum supported by its storage class

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -218,6 +218,9 @@ const (
 	// AnnUsePopulator annotation indicates if the datavolume population will use populators
 	AnnUsePopulator = AnnAPIGroup + "/storage.usePopulator"
 
+	// AnnMinimumSupportedPVCSize annotation on a StorageProfile specifies its minimum supported PVC size
+	AnnMinimumSupportedPVCSize = AnnAPIGroup + "/minimumSupportedPvcSize"
+
 	// AnnDefaultStorageClass is the annotation indicating that a storage class is the default one
 	AnnDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 	// AnnDefaultVirtStorageClass is the annotation indicating that a storage class is the default one for virtualization purposes


### PR DESCRIPTION
**What this PR does / why we need it**:
Supports both `DataVolume` PVC rendering and PVC mutating webhook rendering, so it can cover the kubevirt-side created `TPM` small PVC and any other PVC created by `DataVolume` or independently. For independent PVCs they should be labeled with `cdi.kubevirt.io/applyStorageProfile: "true"` and CDI featureGate `WebhookPvcRendering` should be enabled. A `StorageProfile` can be annotated with its minimum supported volume size with e.g.:
`cdi.kubevirt.io/minimumSupportedPvcSize: 4Gi`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Allow increasing PVC size to the minimum supported by its storage class
```