### PR TITLE
chore(doc): add undocumented features in datavolumes

### DIFF
--- a/doc/datavolumes.md
+++ b/doc/datavolumes.md
@@ -267,6 +267,30 @@ spec:
 ```
 [Get example](../manifests/example/clone-datavolume.yaml)
 
+### VolumeSnapshot source
+You can use a volume snapshot as an input source to create a new DV. Set the source to be a snapshot, and specify the name and namespace of the snapshot.
+
+The DV size can be omitted, we apply the same logic as when the source [is a pvc](#pvc-source).
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "example-snapshot-dv"
+spec:
+  source:
+    snapshot:
+      namespace: default
+      name: snapshot
+  storage:
+  # Can be omitted to auto-detect the correct storage size
+  # resources:
+  #   requests:
+  #     storage: 9Gi
+```
+
+More details about using snapshots as a source are available [in this document](clone-from-volumesnapshot-source.md).
+
 ### Upload Data Volumes
 You can upload a virtual disk image directly into a data volume as well, just like with PVCs. The steps to follow are identical as [upload for PVC](upload.md) except that the yaml for a Data Volume is slightly different.
 ```yaml

--- a/doc/supported_operations.md
+++ b/doc/supported_operations.md
@@ -4,7 +4,7 @@ The Containerized Data Importer (CDI) supports importing data/disk images.
 Supported formats: qcow2, VMDK, VDI, VHD, VHDX, raw XZ-compressed, gzip-compressed, and uncompressed raw files can be imported.  
 They will all be converted to the raw format.
 
-Supported sources: http, https, http with basic auth, docker registry, S3 buckets, GCS Buckets, upload.
+Supported sources: http, https, http with basic auth, docker registry, S3 buckets, GCS Buckets, upload, pvc, snapshot.
 
 Note: Some of these operations require [scratch space](scratch-space.md), doubling the storage space requirement of the import and the writes.  
 This is done with some misbehaving servers (not supporting HEAD requests), custom CAs, and during upload.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Added snapshots as a possible source in the DataVolume documentation, as it was missing. Also added PVC/snapshots to the list of available feature. 

I missed this functionality at first because the docs had this hole.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

