### PR TITLE
Allow more restricted volume plugins in our scc

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -243,15 +243,19 @@ var _ = Describe("Controller", func() {
 				Expect(scc.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
 				Expect(scc.Priority).To(BeNil())
 
-				for _, eu := range []string{"system:serviceaccount:cdi:cdi-sa"} {
-					found := false
-					for _, au := range scc.Users {
-						if eu == au {
-							found = true
-						}
-					}
-					Expect(found).To(BeTrue())
-				}
+				Expect(scc.Users).To(ContainElement("system:serviceaccount:cdi:cdi-sa"))
+
+				Expect(scc.Volumes).To(ConsistOf(
+					secv1.FSTypeConfigMap,
+					secv1.FSTypeDownwardAPI,
+					secv1.FSTypeEmptyDir,
+					secv1.FSTypePersistentVolumeClaim,
+					secv1.FSProjected,
+					secv1.FSTypeSecret,
+					secv1.FSTypeCSI,
+					secv1.FSTypeEphemeral,
+				))
+				Expect(scc.AllowPrivilegeEscalation).To(HaveValue(BeFalse()))
 				validateEvents(args.reconciler, createReadyEventValidationMap())
 			})
 

--- a/pkg/operator/controller/scc.go
+++ b/pkg/operator/controller/scc.go
@@ -66,7 +66,11 @@ func setSCC(scc *secv1.SecurityContextConstraints) {
 		secv1.FSTypePersistentVolumeClaim,
 		secv1.FSProjected,
 		secv1.FSTypeSecret,
+		secv1.FSTypeCSI,
+		secv1.FSTypeEphemeral,
 	}
+	allowPrivilegeEscalation := false
+	scc.AllowPrivilegeEscalation = &allowPrivilegeEscalation
 }
 
 func ensureSCCExists(ctx context.Context, logger logr.Logger, c client.Client, saNamespace, saName, cronSaName string) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Our SCC is a bit tighter when it comes to volume plugins,
even compared to the restricted-v2 consensus SCC.
We should be in the clear to allow exactly the same as it does.

This also prevents CDI from breaking in an event that
something injects csi inline volumes into it's pods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: CDI pods rejected due to it's SCC not allowing some consensus volume plugins
```

