### PR TITLE
[release-v1.60] Fix StorageProfile PVC rendering

### DIFF
--- a/pkg/controller/datavolume/BUILD.bazel
+++ b/pkg/controller/datavolume/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/feature-gates:go_default_library",
         "//pkg/token:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
+        "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -179,7 +179,7 @@ func renderPvcSpecVolumeModeAndAccessModesAndStorageClass(client client.Client, 
 		pvcSpec.AccessModes = append(pvcSpec.AccessModes, accessModes...)
 		pvcSpec.VolumeMode = volumeMode
 	} else if len(pvcSpec.AccessModes) == 0 {
-		accessModes, err := getDefaultAccessModes(client, storageClass, pvcSpec.VolumeMode)
+		accessModes, err := getDefaultAccessModes(client, storageClass, *pvcSpec.VolumeMode)
 		if err != nil {
 			logInfo("Cannot set accessMode for new pvc", "namespace", dv.Namespace, "name", dv.Name, "Error", err)
 			recordEventf(dv, v1.EventTypeWarning, cc.ErrClaimNotValid,
@@ -358,6 +358,7 @@ func renderPvcSpecFromAvailablePv(c client.Client, pvcSpec *v1.PersistentVolumeC
 	return nil
 }
 
+// Get the StorageProfile preferred VolumeMode and AccessModes based on the StorageClass
 func getDefaultVolumeAndAccessMode(c client.Client, storageClass *storagev1.StorageClass) ([]v1.PersistentVolumeAccessMode, *v1.PersistentVolumeMode, error) {
 	if storageClass == nil {
 		return nil, nil, errors.Errorf("no accessMode defined on DV and no StorageProfile")
@@ -380,6 +381,7 @@ func getDefaultVolumeAndAccessMode(c client.Client, storageClass *storagev1.Stor
 	return nil, nil, errors.Errorf("no accessMode defined DV nor on StorageProfile for %s StorageClass", storageClass.Name)
 }
 
+// Get the StorageProfile preferred VolumeMode based on the StorageClass and AccessModes
 func getDefaultVolumeMode(c client.Client, storageClass *storagev1.StorageClass, pvcAccessModes []v1.PersistentVolumeAccessMode) (*v1.PersistentVolumeMode, error) {
 	if storageClass == nil {
 		// fallback to k8s defaults
@@ -392,10 +394,6 @@ func getDefaultVolumeMode(c client.Client, storageClass *storagev1.StorageClass,
 		return nil, errors.Wrap(err, "cannot get StorageProfile")
 	}
 	if len(storageProfile.Status.ClaimPropertySets) > 0 {
-		volumeMode := storageProfile.Status.ClaimPropertySets[0].VolumeMode
-		if len(pvcAccessModes) == 0 {
-			return volumeMode, nil
-		}
 		// check for volume mode matching with given pvc access modes
 		for _, cps := range storageProfile.Status.ClaimPropertySets {
 			for _, accessMode := range cps.AccessModes {
@@ -406,15 +404,14 @@ func getDefaultVolumeMode(c client.Client, storageClass *storagev1.StorageClass,
 				}
 			}
 		}
-		// if not found return default volume mode for the storage class
-		return volumeMode, nil
 	}
 
-	// since volumeMode is optional - > gracefully fallback to k8s defaults,
+	// since volumeMode is optional, gracefully fallback to k8s default when no matching volumeMode
 	return nil, nil
 }
 
-func getDefaultAccessModes(c client.Client, storageClass *storagev1.StorageClass, pvcVolumeMode *v1.PersistentVolumeMode) ([]v1.PersistentVolumeAccessMode, error) {
+// Get the StorageProfile preferred AccessModes based on the StorageClass and VolumeMode
+func getDefaultAccessModes(c client.Client, storageClass *storagev1.StorageClass, pvcVolumeMode v1.PersistentVolumeMode) ([]v1.PersistentVolumeAccessMode, error) {
 	if storageClass == nil {
 		return nil, errors.Errorf("no accessMode defined on DV, no StorageProfile ")
 	}
@@ -427,24 +424,17 @@ func getDefaultAccessModes(c client.Client, storageClass *storagev1.StorageClass
 
 	if len(storageProfile.Status.ClaimPropertySets) > 0 {
 		// check for access modes matching with given pvc volume mode
-		defaultAccessModes := []v1.PersistentVolumeAccessMode{}
 		for _, cps := range storageProfile.Status.ClaimPropertySets {
-			if cps.VolumeMode != nil && pvcVolumeMode != nil && *cps.VolumeMode == *pvcVolumeMode {
+			if cps.VolumeMode != nil && *cps.VolumeMode == pvcVolumeMode {
 				if len(cps.AccessModes) > 0 {
 					return cps.AccessModes, nil
 				}
-			} else if len(cps.AccessModes) > 0 && len(defaultAccessModes) == 0 {
-				defaultAccessModes = cps.AccessModes
 			}
-		}
-		// if not found return default access modes for the storage profile
-		if len(defaultAccessModes) > 0 {
-			return defaultAccessModes, nil
 		}
 	}
 
-	// no accessMode configured on storageProfile
-	return nil, errors.Errorf("no accessMode defined on StorageProfile for %s StorageClass", storageClass.Name)
+	// no matching accessMode configured on storageProfile
+	return nil, errors.Errorf("no matching accessMode specified in StorageProfile %s", storageProfile.Name)
 }
 
 // storageClassCSIDriverExists returns true if the passed storage class has CSI drivers available

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2149,7 +2149,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				v1.PersistentVolumeFilesystem)
 			requestedSize := resource.MustParse("100Mi")
 
-			expectedVolumeMode := v1.PersistentVolumeBlock
+			expectedVolumeMode := v1.PersistentVolumeFilesystem
 			spec := cdiv1.StorageSpec{
 				AccessModes: nil,
 				VolumeMode:  &expectedVolumeMode,


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #3709

When rendering a `DataVolume` storage-api-defined PVC:

We should not set its missing `VolumeMode` to any value if its specified `AccessMode` has no match in the relevant `StorageProfile`. In this case, fallback to k8s default (`Filesysetem`).

Similarly, we should not set its missing `AccessModes` if its specified `VolumeMode` has no match in the relevant `StorageProfile`. In that case, return an error as the PVC spec is incomplete.

**Release note**:
```release-note
Fix StorageProfile PVC rendering when there is no AccessMode or VolumeMode match
```