### PR TITLE
remove RWX for filesystem PVC capability from default profile of IBM Block Storage CSI driver

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -90,7 +90,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// IBM HCI/GPFS2 (Spectrum Scale / Spectrum Fusion)
 	"spectrumscale.csi.ibm.com": {{rwx, file}, {rwo, file}},
 	// IBM block arrays (FlashSystem)
-	"block.csi.ibm.com": {{rwx, block}, {rwo, block}, {rwo, file}, {rwx, file}},
+	"block.csi.ibm.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// Portworx in-tree CSI
 	"kubernetes.io/portworx-volume/shared": {{rwx, file}},
 	"kubernetes.io/portworx-volume":        {{rwo, file}},


### PR DESCRIPTION
remove RWX for filesystem PVC capability from default profile of IBM Block Storage CSI driver

please see discussion in PR #3546 


**Release note**:
```release-note
Remove RWX for filesystem PVC capability from default profile of IBM Block Storage CSI driver
```