### PR TITLE
Append Labels From DV to Importer Pod

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -880,7 +880,7 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 	util.SetRecommendedLabels(pod, installerLabels, "cdi-controller")
 
 	// add any labels from pvc to the importer pod
-	util.AppendLabels(args.pvc.Labels, pod.Labels)
+	util.MergeLabels(args.pvc.Labels, pod.Labels)
 
 	if err = client.Create(context.TODO(), pod); err != nil {
 		return nil, err

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -879,6 +879,9 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 
 	util.SetRecommendedLabels(pod, installerLabels, "cdi-controller")
 
+	// add any labels from pvc to the importer pod
+	util.AppendLabels(pod.Labels, args.pvc.Labels)
+
 	if err = client.Create(context.TODO(), pod); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -880,7 +880,7 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 	util.SetRecommendedLabels(pod, installerLabels, "cdi-controller")
 
 	// add any labels from pvc to the importer pod
-	util.AppendLabels(pod.Labels, args.pvc.Labels)
+	util.AppendLabels(args.pvc.Labels, pod.Labels)
 
 	if err = client.Create(context.TODO(), pod); err != nil {
 		return nil, err

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -209,6 +209,7 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 	}
 	cc.CopyAllowedAnnotations(pvc, pvcPrime)
 	util.SetRecommendedLabels(pvcPrime, r.installerLabels, "cdi-controller")
+	util.MergeLabels(pvc.Labels, pvcPrime.Labels)
 
 	// We use the populator-specific pvcModifierFunc to add required annotations
 	if updatePVCForPopulation != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -169,19 +169,6 @@ func MergeLabels(src, dest map[string]string) map[string]string {
 	return dest
 }
 
-// AppendLabels append source labels to destination (update if key has existed)
-func AppendLabels(src, dest map[string]string) map[string]string {
-	if dest == nil {
-		dest = map[string]string{}
-	}
-
-	for k, v := range src {
-		dest[k] = v
-	}
-
-	return dest
-}
-
 // GetRecommendedInstallerLabelsFromCr returns the recommended labels to set on CDI resources
 func GetRecommendedInstallerLabelsFromCr(cr *cdiv1.CDI) map[string]string {
 	labels := map[string]string{}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -169,17 +169,17 @@ func MergeLabels(src, dest map[string]string) map[string]string {
 	return dest
 }
 
-// AppendLabels append dest labels to source (update if key has existed)
+// AppendLabels append source labels to destination (update if key has existed)
 func AppendLabels(src, dest map[string]string) map[string]string {
-	if src == nil {
-		src = map[string]string{}
+	if dest == nil {
+		dest = map[string]string{}
 	}
 
-	for k, v := range dest {
-		src[k] = v
+	for k, v := range src {
+		dest[k] = v
 	}
 
-	return src
+	return dest
 }
 
 // GetRecommendedInstallerLabelsFromCr returns the recommended labels to set on CDI resources

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Append Labels", func() {
 			Expect(val).To(Equal(new_labels[key]))
 		}
 		// make sure we still retain any entries from the map prior to the Append
-		Expect(new_labels["label4"]).To(Equal("val4"))
-		Expect(new_labels["label5"]).To(Equal("val5"))
+		Expect(new_labels).Should(HaveKeyWithValue("label4", "val4"))
+		Expect(new_labels).Should(HaveKeyWithValue("label5", "val5"))
 	})
 })

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -183,3 +183,39 @@ var _ = Describe("Usable Space calculation", func() {
 		Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
 	)
 })
+
+var _ = Describe("Append Labels", func() {
+
+	some_labels := map[string]string{
+		"label1": "val1",
+		"label2": "val2",
+		"label3": "val3",
+	}
+
+	empty_labels := map[string]string{}
+
+	It("Should append all entries from source map to the empty destination map", func() {
+		AppendLabels(empty_labels, some_labels)
+		Expect(len(empty_labels)).To(Equal(len(some_labels)))
+		for key, val := range some_labels {
+			Expect(val).To(Equal(empty_labels[key]))
+		}
+	})
+
+	new_labels := map[string]string{
+		"label4": "val4",
+		"label5": "val5",
+	}
+	original_len := len(new_labels)
+
+	It("Should append all entries from source map to non-empty destination map", func() {
+		AppendLabels(new_labels, some_labels)
+		Expect(len(new_labels)).To(Equal(original_len + len(some_labels)))
+		for key, val := range some_labels {
+			Expect(val).To(Equal(new_labels[key]))
+		}
+		// make sure we still retain any entries from the map prior to the Append
+		Expect(new_labels["label4"]).To(Equal("val4"))
+		Expect(new_labels["label5"]).To(Equal("val5"))
+	})
+})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Append Labels", func() {
 	empty_labels := map[string]string{}
 
 	It("Should append all entries from source map to the empty destination map", func() {
-		AppendLabels(empty_labels, some_labels)
+		AppendLabels(some_labels, empty_labels)
 		Expect(len(empty_labels)).To(Equal(len(some_labels)))
 		for key, val := range some_labels {
 			Expect(val).To(Equal(empty_labels[key]))
@@ -209,7 +209,7 @@ var _ = Describe("Append Labels", func() {
 	original_len := len(new_labels)
 
 	It("Should append all entries from source map to non-empty destination map", func() {
-		AppendLabels(new_labels, some_labels)
+		AppendLabels(some_labels, new_labels)
 		Expect(len(new_labels)).To(Equal(original_len + len(some_labels)))
 		for key, val := range some_labels {
 			Expect(val).To(Equal(new_labels[key]))

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -184,38 +184,44 @@ var _ = Describe("Usable Space calculation", func() {
 	)
 })
 
-var _ = Describe("Append Labels", func() {
+var _ = Describe("Merge Labels", func() {
 
-	someLabels := map[string]string{
-		"label1": "val1",
-		"label2": "val2",
-		"label3": "val3",
-	}
+	var (
+		someLabels, emptyLabels, existingLabels, expectedMergedLabels map[string]string
+	)
 
-	emptyLabels := map[string]string{}
-
-	It("Should append all entries from source map to the empty destination map", func() {
-		MergeLabels(someLabels, emptyLabels)
-		Expect(emptyLabels).To(HaveLen(len(someLabels)))
-		for key, val := range someLabels {
-			Expect(val).To(Equal(emptyLabels[key]))
+	BeforeEach(func() {
+		someLabels = map[string]string{
+			"label1": "val1",
+			"label2": "val2",
+			"label3": "val3",
+		}
+		emptyLabels = make(map[string]string)
+		existingLabels = map[string]string{
+			"label4": "val4",
+			"label5": "val5",
+		}
+		expectedMergedLabels = map[string]string{
+			"label1": "val1",
+			"label2": "val2",
+			"label3": "val3",
+			"label4": "val4",
+			"label5": "val5",
 		}
 	})
 
-	newLabels := map[string]string{
-		"label4": "val4",
-		"label5": "val5",
-	}
-	originalLen := len(newLabels)
-
-	It("Should append all entries from source map to non-empty destination map", func() {
-		MergeLabels(someLabels, newLabels)
-		Expect(newLabels).To(HaveLen(originalLen + len(someLabels)))
-		for key, val := range someLabels {
-			Expect(val).To(Equal(newLabels[key]))
+	DescribeTable("Should properly merge labels", func(original, merged, expected map[string]string) {
+		// copies entries from original to merged
+		MergeLabels(original, merged)
+		Expect(merged).To(HaveLen(len(expected)))
+		for key, val := range merged {
+			Expect(val).To(Equal(expected[key]))
 		}
-		// make sure we still retain any entries from the map prior to the Append
-		Expect(newLabels).Should(HaveKeyWithValue("label4", "val4"))
-		Expect(newLabels).Should(HaveKeyWithValue("label5", "val5"))
-	})
+	},
+		Entry("original is empty", emptyLabels, someLabels, someLabels),
+		Entry("original has values", someLabels, existingLabels, expectedMergedLabels),
+		Entry("original empty, adding empty", emptyLabels, emptyLabels, emptyLabels),
+		Entry("original has values, adding empty", someLabels, emptyLabels, someLabels),
+	)
+
 })

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Append Labels", func() {
 
 	It("Should append all entries from source map to the empty destination map", func() {
 		MergeLabels(someLabels, emptyLabels)
-		Expect(len(emptyLabels)).To(HaveLen(len(someLabels)))
+		Expect(emptyLabels).To(HaveLen(len(someLabels)))
 		for key, val := range someLabels {
 			Expect(val).To(Equal(emptyLabels[key]))
 		}
@@ -210,7 +210,7 @@ var _ = Describe("Append Labels", func() {
 
 	It("Should append all entries from source map to non-empty destination map", func() {
 		MergeLabels(someLabels, newLabels)
-		Expect(len(newLabels)).To(HaveLen(originalLen + len(someLabels)))
+		Expect(newLabels).To(HaveLen(originalLen + len(someLabels)))
 		for key, val := range someLabels {
 			Expect(val).To(Equal(newLabels[key]))
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Append Labels", func() {
 	empty_labels := map[string]string{}
 
 	It("Should append all entries from source map to the empty destination map", func() {
-		AppendLabels(some_labels, empty_labels)
+		MergeLabels(some_labels, empty_labels)
 		Expect(len(empty_labels)).To(Equal(len(some_labels)))
 		for key, val := range some_labels {
 			Expect(val).To(Equal(empty_labels[key]))
@@ -209,7 +209,7 @@ var _ = Describe("Append Labels", func() {
 	original_len := len(new_labels)
 
 	It("Should append all entries from source map to non-empty destination map", func() {
-		AppendLabels(some_labels, new_labels)
+		MergeLabels(some_labels, new_labels)
 		Expect(len(new_labels)).To(Equal(original_len + len(some_labels)))
 		for key, val := range some_labels {
 			Expect(val).To(Equal(new_labels[key]))

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -186,36 +186,36 @@ var _ = Describe("Usable Space calculation", func() {
 
 var _ = Describe("Append Labels", func() {
 
-	some_labels := map[string]string{
+	someLabels := map[string]string{
 		"label1": "val1",
 		"label2": "val2",
 		"label3": "val3",
 	}
 
-	empty_labels := map[string]string{}
+	emptyLabels := map[string]string{}
 
 	It("Should append all entries from source map to the empty destination map", func() {
-		MergeLabels(some_labels, empty_labels)
-		Expect(len(empty_labels)).To(Equal(len(some_labels)))
-		for key, val := range some_labels {
-			Expect(val).To(Equal(empty_labels[key]))
+		MergeLabels(someLabels, emptyLabels)
+		Expect(len(emptyLabels)).To(HaveLen(len(someLabels)))
+		for key, val := range someLabels {
+			Expect(val).To(Equal(emptyLabels[key]))
 		}
 	})
 
-	new_labels := map[string]string{
+	newLabels := map[string]string{
 		"label4": "val4",
 		"label5": "val5",
 	}
-	original_len := len(new_labels)
+	originalLen := len(newLabels)
 
 	It("Should append all entries from source map to non-empty destination map", func() {
-		MergeLabels(some_labels, new_labels)
-		Expect(len(new_labels)).To(Equal(original_len + len(some_labels)))
-		for key, val := range some_labels {
-			Expect(val).To(Equal(new_labels[key]))
+		MergeLabels(someLabels, newLabels)
+		Expect(len(newLabels)).To(HaveLen(originalLen + len(someLabels)))
+		for key, val := range someLabels {
+			Expect(val).To(Equal(newLabels[key]))
 		}
 		// make sure we still retain any entries from the map prior to the Append
-		Expect(new_labels).Should(HaveKeyWithValue("label4", "val4"))
-		Expect(new_labels).Should(HaveKeyWithValue("label5", "val5"))
+		Expect(newLabels).Should(HaveKeyWithValue("label4", "val4"))
+		Expect(newLabels).Should(HaveKeyWithValue("label5", "val5"))
 	})
 })

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -2125,7 +2125,7 @@ var _ = Describe("Containerdisk envs to PVC labels", func() {
 	)
 })
 
-var _ = Describe("Propogate DV Labels to Importer Pod", func() {
+var _ = Describe("Propagate DV Labels to Importer Pod", func() {
 	f := framework.NewFramework(namespacePrefix)
 
 	const (
@@ -2163,9 +2163,9 @@ var _ = Describe("Propogate DV Labels to Importer Pod", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Check labels were appended")
-		import_labels := importer.GetLabels()
-		Expect(import_labels).Should(HaveKeyWithValue(testKubevirtKey, testKubevirtValue))
-		Expect(import_labels).Should(HaveKeyWithValue(testNonKubevirtKey, testNonKubevirtVal))
+		importLabels := importer.GetLabels()
+		Expect(importLabels).Should(HaveKeyWithValue(testKubevirtKey, testKubevirtValue))
+		Expect(importLabels).Should(HaveKeyWithValue(testNonKubevirtKey, testNonKubevirtVal))
 
 	})
 })

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -2163,8 +2163,9 @@ var _ = Describe("Propogate DV Labels to Importer Pod", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Check labels were appended")
-		Expect(importer.GetLabels()).Should(HaveKeyWithValue(testKubevirtKey, testKubevirtValue))
-		Expect(importer.GetLabels()).Should(HaveKeyWithValue(testNonKubevirtKey, testNonKubevirtVal))
+		import_labels := importer.GetLabels()
+		Expect(import_labels).Should(HaveKeyWithValue(testKubevirtKey, testKubevirtValue))
+		Expect(import_labels).Should(HaveKeyWithValue(testNonKubevirtKey, testNonKubevirtVal))
 
 	})
 })

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -2135,11 +2135,12 @@ var _ = Describe("Propagate DV Labels to Importer Pod", func() {
 		testNonKubevirtVal = "none"
 	)
 
-	It("Import pod should inherit any labels from Data Volume", func() {
+	DescribeTable("Import pod should inherit any labels from Data Volume", func(usePopulator string) {
 
 		dataVolume := utils.NewDataVolumeWithHTTPImport("label-test", "100Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
+		dataVolume.Annotations[controller.AnnUsePopulator] = usePopulator
 
 		dataVolume.Labels = map[string]string{
 			testKubevirtKey:    testKubevirtValue,
@@ -2167,7 +2168,10 @@ var _ = Describe("Propagate DV Labels to Importer Pod", func() {
 		Expect(importLabels).Should(HaveKeyWithValue(testKubevirtKey, testKubevirtValue))
 		Expect(importLabels).Should(HaveKeyWithValue(testNonKubevirtKey, testNonKubevirtVal))
 
-	})
+	},
+		Entry("With Populators", "true"),
+		Entry("Without Populators", "false"),
+	)
 })
 
 var _ = Describe("pull image failure", func() {

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -2135,19 +2135,18 @@ var _ = Describe("Propogate DV Labels to Importer Pod", func() {
 		testNonKubevirtVal = "none"
 	)
 
-	It("Import pod should inherit non KUBEVIRT_IO_ labels from Data Volume", func() {
+	It("Import pod should inherit any labels from Data Volume", func() {
 
 		dataVolume := utils.NewDataVolumeWithHTTPImport("label-test", "100Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
-		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
 
-		// The existing key should not be overwritten
 		dataVolume.ObjectMeta.Labels = map[string]string{
 			testKubevirtKey:    testKubevirtValue,
 			testNonKubevirtKey: testNonKubevirtVal,
 		}
 
+		By(fmt.Sprintf("Create new datavolume %s", dataVolume.Name))
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -2141,7 +2141,7 @@ var _ = Describe("Propagate DV Labels to Importer Pod", func() {
 		dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 		dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
 
-		dataVolume.ObjectMeta.Labels = map[string]string{
+		dataVolume.Labels = map[string]string{
 			testKubevirtKey:    testKubevirtValue,
 			testNonKubevirtKey: testNonKubevirtVal,
 		}


### PR DESCRIPTION
Fixes #3674 

During the creation of the Importer Pod, append any labels from the PVC. This allows for labels to be passed from a Data Volume.

```release-note
Labels on DataVolumes are now copied to the importer pod
```