### PR TITLE
add build functest shebang

### DIFF
--- a/hack/build/build-functest.sh
+++ b/hack/build/build-functest.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #Copyright 2018 The CDI Authors.
 #
 #Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**What this PR does / why we need it**:
I've been running recently into
```bash
eval ./hack/build/build-functest.sh
./hack/build/build-functest.sh: 15: set: Illegal option -o pipefail
```
Adding a shebang solved that, so I'd include this for compatibility.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

