### PR TITLE
Add default Istio ambient mesh label to importer pod

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -331,6 +331,11 @@ const (
 	// LabelExcludeFromVeleroBackup provides a const to indicate whether an object should be excluded from velero backup
 	LabelExcludeFromVeleroBackup = "velero.io/exclude-from-backup"
 
+	// LabelIstioAmbientDataPlaneMode is a label used to enable/disable Istio ambient mesh
+	LabelIstioAmbientDataPlaneMode = "istio.io/dataplane-mode"
+	// LabelIstioAmbientDatePlaneModeDefault is the default value for Istio ambient mesh (disabled)
+	LabelIstioAmbientDatePlaneModeDefault = "none"
+
 	// ProgressDone this means we are DONE
 	ProgressDone = "100.0%"
 
@@ -387,6 +392,12 @@ var (
 	}
 
 	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/[\w-]+$`)
+
+	// defaultLabels is a list of default labels
+	// that should be added to the pod
+	defaultLabels = map[string]string{
+		LabelIstioAmbientDataPlaneMode: LabelIstioAmbientDatePlaneModeDefault,
+	}
 )
 
 // FakeValidator is a fake token validator
@@ -2030,6 +2041,16 @@ func CopyAllowedAnnotations(srcObj, dstObj metav1.Object) {
 		if val != "" {
 			klog.V(1).Info("Applying annotation", "Name", dstObj.GetName(), ann, val)
 			AddAnnotation(dstObj, ann, val)
+		}
+	}
+}
+
+// SetDefaultLabels sets default labels on the object if they are not already set
+func SetDefaultLabels(obj metav1.Object) {
+	for l, v := range defaultLabels {
+		if val, ok := obj.GetLabels()[l]; !ok || val == "" {
+			klog.V(1).Info("Applying label", "Name", obj.GetName(), l, v)
+			AddLabel(obj, l, v)
 		}
 	}
 }

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -318,6 +318,31 @@ var _ = Describe("GetMetricsURL", func() {
 	})
 })
 
+var _ = Describe("SetDefaultLables", func() {
+	It("Should set default labels", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"test": "test",
+				},
+			},
+		}
+		SetDefaultLabels(pod)
+		Expect(pod.Labels).To(HaveKeyWithValue(LabelIstioAmbientDataPlaneMode, LabelIstioAmbientDatePlaneModeDefault))
+	})
+	It("Should not overwrite existing labels", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelIstioAmbientDataPlaneMode: "ambient",
+				},
+			},
+		}
+		SetDefaultLabels(pod)
+		Expect(pod.Labels).To(HaveKeyWithValue(LabelIstioAmbientDataPlaneMode, "ambient"))
+	})
+})
+
 var _ = Describe("CopyAllowedLabels", func() {
 	const (
 		testKubevirtIoKey               = "test.kubevirt.io/test"

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -951,6 +951,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 
 	cc.CopyAllowedAnnotations(args.pvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
+	cc.SetDefaultLabels(pod)
 	// We explicitly define a NodeName for dynamically provisioned PVCs
 	// when the PVC is being handled by a populator (PVC')
 	cc.SetNodeNameIfPopulator(args.pvc, &pod.Spec)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -296,7 +296,7 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		Expect(pod.Spec.Tolerations).To(Equal(workloads.Tolerations))
 	})
 
-	It("Should create a POD if a PVC with all needed annotations is passed", func() {
+	It("Should create a POD if a PVC with all needed annotations/labels is passed", func() {
 		pvc := cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnImportPod: "importer-testPvc1", cc.AnnPodNetwork: "net1"}, nil)
 		pvc.Status.Phase = v1.ClaimBound
 		reconciler = createImportReconciler(pvc)
@@ -318,6 +318,7 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		Expect(pod.GetAnnotations()[cc.AnnPodNetwork]).To(Equal("net1"))
 		Expect(pod.GetAnnotations()[cc.AnnPodSidecarInjectionIstio]).To(Equal(cc.AnnPodSidecarInjectionIstioDefault))
 		Expect(pod.GetAnnotations()[cc.AnnPodSidecarInjectionLinkerd]).To(Equal(cc.AnnPodSidecarInjectionLinkerdDefault))
+		Expect(pod.GetLabels()[cc.LabelIstioAmbientDataPlaneMode]).To(Equal(cc.LabelIstioAmbientDatePlaneModeDefault))
 	})
 
 	It("Should not pass non-approved PVC annotation to created POD", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a required label to disable Istio's ambient mesh mode for the importer pod. This is needed when running the CDI within Istio utilizing Ambient mesh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added default istio.io/dateplane-mode:none label to importer pod to disable Istio ambient mesh
```

