### PR TITLE
chore: fix wrong comment for MergeLabels

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -156,7 +156,7 @@ func RoundUp(number, multiple int64) int64 {
 	return int64(partitions) * multiple
 }
 
-// MergeLabels adds source labels to destination (does not change existing ones)
+// MergeLabels copies source labels to destination (overwrites existing labels)
 func MergeLabels(src, dest map[string]string) map[string]string {
 	if dest == nil {
 		dest = map[string]string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`MergeLabels` doesn't preserve existing label values, change comment to emphasize that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Since we're already using Go 1.21+ we could do away with `MergeLabels` completely and move to `maps.Copy`. This option will be examined in the future as currently it could hinder backports.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

