### PR TITLE
Populate DV with events from PVC Prime

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -163,8 +163,7 @@ func (r *CloneReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	log := r.log.WithValues("PVC", req.NamespacedName)
 	log.V(1).Info("reconciling Clone PVCs")
 
-	if checkPVC(pvc, cc.AnnCloneRequest, log) && !metav1.HasAnnotation(pvc.ObjectMeta, cc.AnnCloneOf) &&
-		!checkPVC(pvc, cc.AnnPopulatorKind, log) {
+	if checkPVC(pvc, cc.AnnCloneRequest, log) && !metav1.HasAnnotation(pvc.ObjectMeta, cc.AnnCloneOf) {
 		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -163,7 +163,7 @@ func (r *CloneReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	log := r.log.WithValues("PVC", req.NamespacedName)
 	log.V(1).Info("reconciling Clone PVCs")
 
-	if checkPVC(pvc, cc.AnnCloneRequest, log) && !metav1.HasAnnotation(pvc.ObjectMeta, cc.AnnCloneOf) {
+	if checkPVC(pvc, cc.AnnCloneRequest, log) {
 		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -351,6 +351,9 @@ const (
 
 	// AnnCreatedForDataVolume stores the UID of the datavolume that the PVC was created for
 	AnnCreatedForDataVolume = AnnAPIGroup + "/createdForDataVolume"
+
+	// AnnPVCPrimeName annotation is the name of the PVC' that is added to the target PVC
+	AnnPVCPrimeName = AnnAPIGroup + "/storage.populator.pvcPrime"
 )
 
 // Size-detection pod error codes

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2135,7 +2135,8 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 		delete(anno, AnnBoundConditionMessage)
 
 		if !reflect.DeepEqual(currentPvcCopy, pvc) {
-			if err := c.Update(context.TODO(), pvc); err != nil {
+			patch := client.MergeFrom(currentPvcCopy.(*corev1.PersistentVolumeClaim))
+			if err := c.Patch(context.TODO(), pvc, patch); err != nil {
 				return err
 			}
 		}
@@ -2214,6 +2215,11 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 	anno[AnnBoundCondition] = "false"
 	anno[AnnBoundConditionReason] = "Pending"
 	anno[AnnBoundConditionMessage] = boundMessage
+
+	patch := client.MergeFrom(currentPvcCopy.(*corev1.PersistentVolumeClaim))
+	if err := c.Patch(context.TODO(), pvc, patch); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2198,16 +2198,13 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 		// if we are using populators get the latest event from prime pvc
 		pvcPrime = fmt.Sprintf("[%s] : ", pvcPrime)
 
-		// TODO get index after pvcPrime to get message
-
-		// split so we can remove prime name prefix from event message
-		res := strings.Split(events.Items[0].Message, pvcPrime)
-		boundMessage = res[len(res)-1]
-
-		if boundMessage == "" {
-			log.V(1).Info("No bound message found, skipping bound condition update")
+		// if the first event does not contain a prime message, none will so return
+		primeIdx := strings.Index(events.Items[0].Message, pvcPrime)
+		if primeIdx == -1 {
+			log.V(1).Info("No bound message found, skipping bound condition update", "pvc", pvc.Name)
 			return nil
 		}
+		boundMessage = events.Items[0].Message[primeIdx+len(pvcPrime):]
 	} else {
 		// if not using populators just get the latest event
 		boundMessage = events.Items[0].Message

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2146,7 +2146,7 @@ func sortEvents(events *corev1.EventList, usingPopulator bool, pvcPrimeName stri
 // UpdatePVCBoundContionFromEvents updates the bound condition annotations on the PVC based on recent events
 // This function can be used by both controller and populator packages to update PVC bound condition information
 func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client.Client, log logr.Logger) error {
-	currentPvcCopy := pvc.DeepCopyObject()
+	currentPvcCopy := pvc.DeepCopy()
 
 	anno := pvc.GetAnnotations()
 	if anno == nil {
@@ -2160,7 +2160,7 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 		delete(anno, AnnBoundConditionMessage)
 
 		if !reflect.DeepEqual(currentPvcCopy, pvc) {
-			patch := client.MergeFrom(currentPvcCopy.(*corev1.PersistentVolumeClaim))
+			patch := client.MergeFrom(currentPvcCopy)
 			if err := c.Patch(context.TODO(), pvc, patch); err != nil {
 				return err
 			}
@@ -2220,7 +2220,7 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 	anno[AnnBoundConditionReason] = "Pending"
 	anno[AnnBoundConditionMessage] = boundMessage
 
-	patch := client.MergeFrom(currentPvcCopy.(*corev1.PersistentVolumeClaim))
+	patch := client.MergeFrom(currentPvcCopy)
 	if err := c.Patch(context.TODO(), pvc, patch); err != nil {
 		return err
 	}

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -130,7 +130,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 		pvcPrimeMessage := ""
 		val, exists := pvc.GetAnnotations()[cc.AnnAPIGroup+"/storage.populator.pvcPrime"]
 		if exists {
-			pvcPrimeMessage = fmt.Sprintf(" [Prime PVC %s]", val)
+			pvcPrimeMessage = fmt.Sprintf("[prime PVC %s]", val)
 		}
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:
@@ -142,7 +142,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 			}
 		case corev1.ClaimPending:
 			if pvcCondition == nil || pvcCondition.Status == corev1.ConditionTrue {
-				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s%s Pending", pvc.Name, pvcPrimeMessage), pvcPending)
+				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending %s", pvc.Name, pvcPrimeMessage), pvcPending)
 				conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcCondition.Reason)

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -140,7 +140,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending", pvc.Name), pvcPending)
 				conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
-				pvcPrimeName := getPrimeName(pvc)
+				pvcPrimeName := getFormattedPrimeName(pvc)
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s%s", pvc.Name, pvcPrimeName, pvcCondition.Message), pvcCondition.Reason)
 				conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			}
@@ -181,10 +181,10 @@ func getPVCCondition(anno map[string]string) *cdiv1.DataVolumeCondition {
 	return nil
 }
 
-func getPrimeName(pvc *corev1.PersistentVolumeClaim) string {
+func getFormattedPrimeName(pvc *corev1.PersistentVolumeClaim) string {
 	val, exists := pvc.GetAnnotations()[cc.AnnPVCPrimeName]
 	if exists {
-		primeName := fmt.Sprintf("[%s]", val)
+		primeName := fmt.Sprintf("[%s] : ", val)
 		return primeName
 	}
 	return ""

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -168,16 +168,6 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 	return conditions
 }
 
-func appendPVCEventToBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, event string) []cdiv1.DataVolumeCondition {
-	// only want to update message if we are stuck in pending phase
-	if pvc == nil || pvc.Status.Phase != corev1.ClaimPending || event == "" {
-		return conditions
-	}
-	condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
-	condition.Message += event
-	return conditions
-}
-
 func getPVCCondition(anno map[string]string) *cdiv1.DataVolumeCondition {
 	if val, ok := anno[cc.AnnBoundCondition]; ok {
 		status := corev1.ConditionUnknown

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -127,6 +127,11 @@ func UpdateReadyCondition(conditions []cdiv1.DataVolumeCondition, status corev1.
 func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, message, reason string) []cdiv1.DataVolumeCondition {
 	if pvc != nil {
 		pvcCondition := getPVCCondition(pvc.GetAnnotations())
+		pvcPrimeMessage := ""
+		val, exists := pvc.GetAnnotations()[cc.AnnAPIGroup+"/storage.populator.pvcPrime"]
+		if exists {
+			pvcPrimeMessage = fmt.Sprintf(" [Prime PVC %s]", val)
+		}
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:
 			if pvcCondition == nil || pvcCondition.Status == corev1.ConditionTrue {
@@ -137,7 +142,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 			}
 		case corev1.ClaimPending:
 			if pvcCondition == nil || pvcCondition.Status == corev1.ConditionTrue {
-				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending", pvc.Name), pvcPending)
+				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s%s Pending", pvc.Name, pvcPrimeMessage), pvcPending)
 				conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcCondition.Reason)

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -130,7 +130,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 		pvcPrimeMessage := ""
 		val, exists := pvc.GetAnnotations()[cc.AnnAPIGroup+"/storage.populator.pvcPrime"]
 		if exists {
-			pvcPrimeMessage = fmt.Sprintf("[prime PVC %s]", val)
+			pvcPrimeMessage = fmt.Sprintf(" [prime PVC %s]", val)
 		}
 		switch pvc.Status.Phase {
 		case corev1.ClaimBound:
@@ -142,7 +142,7 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 			}
 		case corev1.ClaimPending:
 			if pvcCondition == nil || pvcCondition.Status == corev1.ConditionTrue {
-				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending %s", pvc.Name, pvcPrimeMessage), pvcPending)
+				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("PVC %s Pending%s", pvc.Name, pvcPrimeMessage), pvcPending)
 				conditions = UpdateReadyCondition(conditions, corev1.ConditionFalse, "", "")
 			} else {
 				conditions = updateCondition(conditions, cdiv1.DataVolumeBound, corev1.ConditionFalse, fmt.Sprintf("target PVC %s Pending and %s", pvc.Name, pvcCondition.Message), pvcCondition.Reason)

--- a/pkg/controller/datavolume/conditions.go
+++ b/pkg/controller/datavolume/conditions.go
@@ -168,6 +168,16 @@ func updateBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.Pe
 	return conditions
 }
 
+func appendPVCEventToBoundCondition(conditions []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, event string) []cdiv1.DataVolumeCondition {
+	// only want to update message if we are stuck in pending phase
+	if pvc == nil || pvc.Status.Phase != corev1.ClaimPending || event == "" {
+		return conditions
+	}
+	condition := FindConditionByType(cdiv1.DataVolumeBound, conditions)
+	condition.Message += event
+	return conditions
+}
+
 func getPVCCondition(anno map[string]string) *cdiv1.DataVolumeCondition {
 	if val, ok := anno[cc.AnnBoundCondition]; ok {
 		status := corev1.ConditionUnknown

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -51,6 +51,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	cloneMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
@@ -889,7 +890,7 @@ func (r *ReconcilerBase) updateDataVolumeStatusPhaseWithEvent(
 		message = event.message
 	}
 	r.updateConditions(dataVolumeCopy, pvc, reason, message)
-	return r.emitEvent(dataVolume, dataVolumeCopy, curPhase, dataVolume.Status.Conditions, &event)
+	return r.emitEvent(dataVolume, dataVolumeCopy, curPhase, dataVolume.Status.Conditions, pvc, &event)
 }
 
 func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPhaseSync, dvc dvController) (reconcile.Result, error) {
@@ -979,7 +980,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 	currentCond := make([]cdiv1.DataVolumeCondition, len(dataVolumeCopy.Status.Conditions))
 	copy(currentCond, dataVolumeCopy.Status.Conditions)
 	r.updateConditions(dataVolumeCopy, pvc, "", "")
-	return result, r.emitEvent(dv, dataVolumeCopy, curPhase, currentCond, &event)
+	return result, r.emitEvent(dv, dataVolumeCopy, curPhase, currentCond, pvc, &event)
 }
 
 func (r ReconcilerBase) updateStatusPVCPending(pvc *corev1.PersistentVolumeClaim, dvc dvController, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
@@ -1075,7 +1076,7 @@ func (r *ReconcilerBase) emitFailureConditionEvent(dataVolume *cdiv1.DataVolume,
 	}
 }
 
-func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, event *Event) error {
+func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, event *Event) error {
 	if !reflect.DeepEqual(dataVolume.ObjectMeta, dataVolumeCopy.ObjectMeta) {
 		return fmt.Errorf("meta update is not allowed in updateStatus phase")
 	}
@@ -1089,6 +1090,10 @@ func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy 
 		if event.eventType != "" && curPhase != dataVolumeCopy.Status.Phase {
 			r.recorder.Event(dataVolumeCopy, event.eventType, event.reason, event.message)
 		}
+		if pvc != nil {
+			populators.CopyEvents(pvc, dataVolumeCopy, r.client, r.log, r.recorder)
+		}
+
 		r.emitConditionEvent(dataVolumeCopy, originalCond)
 	}
 	return nil

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -51,7 +51,6 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	cloneMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-controller"
@@ -890,7 +889,7 @@ func (r *ReconcilerBase) updateDataVolumeStatusPhaseWithEvent(
 		message = event.message
 	}
 	r.updateConditions(dataVolumeCopy, pvc, reason, message)
-	return r.emitEvent(dataVolume, dataVolumeCopy, curPhase, dataVolume.Status.Conditions, pvc, &event)
+	return r.emitEvent(dataVolume, dataVolumeCopy, curPhase, dataVolume.Status.Conditions, &event)
 }
 
 func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPhaseSync, dvc dvController) (reconcile.Result, error) {
@@ -980,7 +979,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 	currentCond := make([]cdiv1.DataVolumeCondition, len(dataVolumeCopy.Status.Conditions))
 	copy(currentCond, dataVolumeCopy.Status.Conditions)
 	r.updateConditions(dataVolumeCopy, pvc, "", "")
-	return result, r.emitEvent(dv, dataVolumeCopy, curPhase, currentCond, pvc, &event)
+	return result, r.emitEvent(dv, dataVolumeCopy, curPhase, currentCond, &event)
 }
 
 func (r ReconcilerBase) updateStatusPVCPending(pvc *corev1.PersistentVolumeClaim, dvc dvController, dataVolumeCopy *cdiv1.DataVolume, event *Event) error {
@@ -1076,7 +1075,7 @@ func (r *ReconcilerBase) emitFailureConditionEvent(dataVolume *cdiv1.DataVolume,
 	}
 }
 
-func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, pvc *corev1.PersistentVolumeClaim, event *Event) error {
+func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy *cdiv1.DataVolume, curPhase cdiv1.DataVolumePhase, originalCond []cdiv1.DataVolumeCondition, event *Event) error {
 	if !reflect.DeepEqual(dataVolume.ObjectMeta, dataVolumeCopy.ObjectMeta) {
 		return fmt.Errorf("meta update is not allowed in updateStatus phase")
 	}
@@ -1089,9 +1088,6 @@ func (r *ReconcilerBase) emitEvent(dataVolume *cdiv1.DataVolume, dataVolumeCopy 
 		// Emit the event only on status phase change
 		if event.eventType != "" && curPhase != dataVolumeCopy.Status.Phase {
 			r.recorder.Event(dataVolumeCopy, event.eventType, event.reason, event.message)
-		}
-		if pvc != nil {
-			populators.CopyEvents(pvc, dataVolumeCopy, r.client, r.log, r.recorder)
 		}
 
 		r.emitConditionEvent(dataVolumeCopy, originalCond)

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -23,7 +23,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -1041,6 +1043,41 @@ func (r *ReconcilerBase) updateConditions(dataVolume *cdiv1.DataVolume, pvc *cor
 	dataVolume.Status.Conditions = updateBoundCondition(dataVolume.Status.Conditions, pvc, message, reason)
 	dataVolume.Status.Conditions = UpdateReadyCondition(dataVolume.Status.Conditions, readyStatus, message, reason)
 	dataVolume.Status.Conditions = updateRunningCondition(dataVolume.Status.Conditions, anno)
+	if pvc != nil {
+		dataVolume.Status.Conditions = appendPVCEventToBoundCondition(dataVolume.Status.Conditions, pvc, r.getLatestPrimePVCEvent(pvc))
+	}
+}
+
+func (r *ReconcilerBase) getLatestPrimePVCEvent(pvc *corev1.PersistentVolumeClaim) string {
+	events := &corev1.EventList{}
+
+	err := r.client.List(context.TODO(), events,
+		client.InNamespace(pvc.GetNamespace()),
+		client.MatchingFields{"involvedObject.name": pvc.GetName(),
+			"involvedObject.uid": string(pvc.GetUID())},
+	)
+	// Sort event lists by most recent
+	sort.Slice(events.Items, func(i, j int) bool {
+		return events.Items[i].FirstTimestamp.Time.After(events.Items[j].FirstTimestamp.Time)
+	})
+
+	pvcPrime, exists := pvc.GetAnnotations()[cc.AnnAPIGroup+"/storage.populator.pvcPrime"]
+
+	// only want to return events that have come from pvcPrime
+	if err != nil || len(events.Items) == 0 || !exists {
+		return ""
+	}
+
+	pvcPrime = fmt.Sprintf("[%s] :", pvcPrime)
+
+	for _, event := range events.Items {
+		if strings.Contains(event.Message, pvcPrime) {
+			res := strings.Split(event.Message, pvcPrime)
+			r.log.V(1).Info("DANNY", "event", res[len(res)-1])
+			return res[len(res)-1]
+		}
+	}
+	return ""
 }
 
 func (r *ReconcilerBase) emitConditionEvent(dataVolume *cdiv1.DataVolume, originalCond []cdiv1.DataVolumeCondition) {

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -274,8 +274,6 @@ func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, 
 		return nil
 	}
 
-	populators.CopyEvents(pvc, dataVolumeCopy, r.client, r.log, r.recorder)
-
 	switch phase {
 	case string(corev1.PodPending):
 		// TODO: Use a more generic Scheduled, like maybe TransferScheduled.

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -274,6 +274,8 @@ func (r *ImportReconciler) updateStatusPhase(pvc *corev1.PersistentVolumeClaim, 
 		return nil
 	}
 
+	populators.CopyEvents(pvc, dataVolumeCopy, r.client, r.log, r.recorder)
+
 	switch phase {
 	case string(corev1.PodPending):
 		// TODO: Use a more generic Scheduled, like maybe TransferScheduled.

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -203,8 +203,7 @@ func (r *ImportReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 	}
 
 	// only want to update bound condition for relevant type
-	if (checkPVC(pvc, cc.AnnEndpoint, log) || checkPVC(pvc, cc.AnnSource, log)) &&
-		!checkPVC(pvc, cc.AnnPopulatorKind, log) {
+	if checkPVC(pvc, cc.AnnEndpoint, log) || checkPVC(pvc, cc.AnnSource, log) {
 		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -797,7 +796,6 @@ func (r *ImportReconciler) createScratchPvcForPod(pvc *corev1.PersistentVolumeCl
 			}
 			return fmt.Errorf("terminating scratch space found, deleting pod %s", pod.Name)
 		}
-		setBoundConditionFromPVC(anno, cc.AnnBoundCondition, scratchPvc)
 	}
 	anno[cc.AnnRequiresScratch] = "false"
 	return nil

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -202,6 +202,14 @@ func (r *ImportReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// only want to update bound condition for relevant type
+	if (checkPVC(pvc, cc.AnnEndpoint, log) || checkPVC(pvc, cc.AnnSource, log)) &&
+		!checkPVC(pvc, cc.AnnPopulatorKind, log) {
+		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	shouldReconcile, err := r.shouldReconcilePVC(pvc, log)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/populators/clone-populator.go
+++ b/pkg/controller/populators/clone-populator.go
@@ -273,7 +273,7 @@ func (r *ClonePopulatorReconciler) Reconcile(ctx context.Context, req reconcile.
 	isDeleted := !pvc.DeletionTimestamp.IsZero()
 	isSucceeded := isClonePhaseSucceeded(pvc)
 
-	log.V(1).Info("pvc state", "hasFinalizer", hasFinalizer,
+	log.V(3).Info("pvc state", "hasFinalizer", hasFinalizer,
 		"isBound", isBound, "isDeleted", isDeleted, "isSucceeded", isSucceeded)
 
 	if !isDeleted && !isSucceeded {
@@ -393,7 +393,7 @@ func (r *ClonePopulatorReconciler) planAndExecute(ctx context.Context, log logr.
 		}
 	}
 
-	log.V(1).Info("executed all phases, setting phase to Succeeded")
+	log.V(3).Info("executed all phases, setting phase to Succeeded")
 
 	return reconcile.Result{}, r.updateClonePhaseSucceeded(ctx, log, pvc, statusResults)
 }

--- a/pkg/controller/populators/clone-populator.go
+++ b/pkg/controller/populators/clone-populator.go
@@ -264,12 +264,16 @@ func (r *ClonePopulatorReconciler) Reconcile(ctx context.Context, req reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, r.log); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	hasFinalizer := cc.HasFinalizer(pvc, cloneFinalizer)
 	isBound := cc.IsBound(pvc)
 	isDeleted := !pvc.DeletionTimestamp.IsZero()
 	isSucceeded := isClonePhaseSucceeded(pvc)
 
-	log.V(3).Info("pvc state", "hasFinalizer", hasFinalizer,
+	log.V(1).Info("pvc state", "hasFinalizer", hasFinalizer,
 		"isBound", isBound, "isDeleted", isDeleted, "isSucceeded", isSucceeded)
 
 	if !isDeleted && !isSucceeded {
@@ -389,7 +393,7 @@ func (r *ClonePopulatorReconciler) planAndExecute(ctx context.Context, log logr.
 		}
 	}
 
-	log.V(3).Info("executed all phases, setting phase to Succeeded")
+	log.V(1).Info("executed all phases, setting phase to Succeeded")
 
 	return reconcile.Result{}, r.updateClonePhaseSucceeded(ctx, log, pvc, statusResults)
 }

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -112,7 +112,6 @@ func addEventWatcher(mgr manager.Manager, c controller.Controller) error {
 	if err := c.Watch(source.Kind(mgr.GetCache(), &corev1.Event{}, handler.TypedEnqueueRequestsFromMapFunc[*corev1.Event](
 		func(_ context.Context, e *corev1.Event) []reconcile.Request {
 			if e.InvolvedObject.Kind == "PersistentVolumeClaim" && strings.Contains(e.InvolvedObject.Name, "prime") {
-				mgr.GetLogger().V(1).Info("DANNY: got prime event", "name", e.InvolvedObject.Name)
 				return []reconcile.Request{{
 					NamespacedName: types.NamespacedName{Name: e.Namespace},
 				}}
@@ -155,7 +154,6 @@ func (r *ImportPopulatorReconciler) getPopulationSource(pvc *corev1.PersistentVo
 
 // Import-specific implementation of reconcileTargetPVC
 func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.PersistentVolumeClaim) (reconcile.Result, error) {
-	r.log.V(1).Info("DANNY: IN REC TARGET PVC")
 	pvcCopy := pvc.DeepCopy()
 	phase := pvcPrime.Annotations[cc.AnnPodPhase]
 	source, err := r.getPopulationSource(pvc)

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -211,7 +211,7 @@ func (r *ReconcilerBase) copyEvents(pvcPrime, pvc *corev1.PersistentVolumeClaim,
 	newEvents := &corev1.EventList{}
 	err := r.client.List(context.TODO(), newEvents,
 		client.InNamespace(pvcPrime.Namespace),
-		client.MatchingFields{"involvedObject.name": string(pvcPrime.GetName()),
+		client.MatchingFields{"involvedObject.name": pvcPrime.GetName(),
 			"involvedObject.uid": string(pvcPrime.GetUID())},
 	)
 
@@ -222,7 +222,7 @@ func (r *ReconcilerBase) copyEvents(pvcPrime, pvc *corev1.PersistentVolumeClaim,
 	oldEvents := &corev1.EventList{}
 	err = r.client.List(context.TODO(), oldEvents,
 		client.InNamespace(pvc.Namespace),
-		client.MatchingFields{"involvedObject.name": string(pvc.GetName()),
+		client.MatchingFields{"involvedObject.name": pvc.GetName(),
 			"involvedObject.uid": string(pvc.GetUID())},
 	)
 

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -163,6 +163,12 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		return reconcile.Result{}, err
 	}
 
+	updated, err := updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
+	if updated || err != nil {
+		// wait for the annotation to be updated
+		return reconcile.Result{}, err
+	}
+
 	// copy over any new events from pvcPrime to pvc
 	CopyEvents(pvcPrime, pvc, r.client, r.log, r.recorder)
 

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -241,15 +240,6 @@ func CopyEvents(srcObj, destObj client.Object, c client.Client, log logr.Logger,
 	if err != nil {
 		log.Error(err, "Could not retrieve srcObj list of Events")
 	}
-
-	// Sort event lists by most recent
-	sort.Slice(currEvents.Items, func(i, j int) bool {
-		return currEvents.Items[i].FirstTimestamp.Time.After(currEvents.Items[j].FirstTimestamp.Time)
-	})
-
-	sort.Slice(newEvents.Items, func(i, j int) bool {
-		return newEvents.Items[i].FirstTimestamp.Time.After(newEvents.Items[j].FirstTimestamp.Time)
-	})
 
 	var emitEvent bool
 	for idx, newEvent := range newEvents.Items {

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -160,7 +160,7 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		return reconcile.Result{}, err
 	}
 
-	_, err = updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
+	_, err = r.updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -267,6 +267,7 @@ func (r *ReconcilerBase) copyEvents(pvcPrime, pvc *corev1.PersistentVolumeClaim)
 					r.log.V(1).Info("DANNY: REJECTING")
 					return
 				}
+			}
 		}
 		if emitEvent {
 			r.log.V(1).Info("DANNY: EMITTING")

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -161,11 +161,7 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		return reconcile.Result{}, err
 	}
 
-	updated, err := updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
-	if updated || err != nil {
-		// wait for the annotation to be updated
-		return reconcile.Result{}, err
-	}
+	updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
 
 	// copy over any new events from pvcPrime to pvc
 	CopyEvents(pvcPrime, pvc, r.client, r.log, r.recorder)

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -161,7 +161,10 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		return reconcile.Result{}, err
 	}
 
-	updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
+	_, err = updatePVCPrimeNameAnnotation(pvcCopy, pvcPrime.Name, r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	// copy over any new events from pvcPrime to pvc
 	CopyEvents(pvcPrime, pvc, r.client, r.log, r.recorder)

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -62,7 +62,7 @@ const (
 	uidField = "metadata.uid"
 
 	involvedNameField = "involvedObject.name"
-	involvedUidField  = "involvedObject.uid"
+	involvedUIDField  = "involvedObject.uid"
 )
 
 // Interface to store populator-specific methods
@@ -109,12 +109,12 @@ func getIndexArgs() []indexArgs {
 			field: involvedNameField,
 			extractValue: func(obj client.Object) []string {
 				event := obj.(*corev1.Event)
-				return []string{string(event.InvolvedObject.Name)}
+				return []string{event.InvolvedObject.Name}
 			},
 		},
 		{
 			obj:   &corev1.Event{},
-			field: involvedUidField,
+			field: involvedUIDField,
 			extractValue: func(obj client.Object) []string {
 				event := obj.(*corev1.Event)
 				return []string{string(event.InvolvedObject.UID)}

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -62,6 +62,7 @@ const (
 	uidField = "metadata.uid"
 
 	involvedNameField = "involvedObject.name"
+	involvedUidField  = "involvedObject.uid"
 )
 
 // Interface to store populator-specific methods
@@ -109,6 +110,14 @@ func getIndexArgs() []indexArgs {
 			extractValue: func(obj client.Object) []string {
 				event := obj.(*corev1.Event)
 				return []string{string(event.InvolvedObject.Name)}
+			},
+		},
+		{
+			obj:   &corev1.Event{},
+			field: involvedUidField,
+			extractValue: func(obj client.Object) []string {
+				event := obj.(*corev1.Event)
+				return []string{string(event.InvolvedObject.UID)}
 			},
 		},
 	}

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -273,6 +273,19 @@ func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.
 	return pvcCopy, nil
 }
 
+func (r *ReconcilerBase) updatePVCPrimeNameAnnotation(pvc *corev1.PersistentVolumeClaim, pvcPrimeName string) (bool, error) {
+	if _, ok := pvc.Annotations[cc.AnnPVCPrimeName]; ok {
+		return false, nil
+	}
+
+	cc.AddAnnotation(pvc, cc.AnnPVCPrimeName, pvcPrimeName)
+	if err := r.client.Update(context.TODO(), pvc); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolumeClaim, pvcPrimeLabels map[string]string) (*corev1.PersistentVolumeClaim, error) {
 	pvcCopy := pvc.DeepCopy()
 	cc.CopyAllowedLabels(pvcPrimeLabels, pvcCopy, false)

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -288,7 +288,6 @@ func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolum
 
 func (r *ReconcilerBase) reconcile(req reconcile.Request, populator populatorController, pvcNameLogger logr.Logger) (reconcile.Result, error) {
 	// Get the target PVC
-	pvcNameLogger.V(1).Info("DANNY: IN POPULATOR REC")
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.client.Get(context.TODO(), req.NamespacedName, pvc); err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -288,6 +288,7 @@ func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolum
 
 func (r *ReconcilerBase) reconcile(req reconcile.Request, populator populatorController, pvcNameLogger logr.Logger) (reconcile.Result, error) {
 	// Get the target PVC
+	pvcNameLogger.V(1).Info("DANNY: IN POPULATOR REC")
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.client.Get(context.TODO(), req.NamespacedName, pvc); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -313,9 +314,6 @@ func (r *ReconcilerBase) reconcile(req reconcile.Request, populator populatorCon
 	if cc.IsPVCComplete(pvc) && cc.IsBound(pvc) && !cc.IsMultiStageImportInProgress(pvc) {
 		res, err = r.reconcileCleanup(pvcPrime)
 	}
-
-	// copy over any new events from pvcPrime to pvc
-	r.copyEvents(pvcPrime, pvc, pvcNameLogger)
 	return res, err
 }
 

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -144,7 +144,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	}
 
 	// copy over any new events from pvcPrime to pvc
-	CopyEvents(pvcPrime, pvcCopy, r.client, r.log, r.recorder)
+	r.copyEvents(pvcPrime, pvcCopy)
 
 	err := cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
 	if err != nil {

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -143,6 +143,14 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 	}
 
+	// copy over any new events from pvcPrime to pvc
+	CopyEvents(pvcPrime, pvcCopy, r.client, r.log, r.recorder)
+
+	err := cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Wait upload completes
 	switch phase {
 	case string(corev1.PodFailed):
@@ -157,7 +165,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 	}
 
-	_, err := r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
+	_, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: "test-pvc", Namespace: metav1.NamespaceDefault}, updatedPVC)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedPVC.GetAnnotations()).ToNot(BeNil())
-		Expect(updatedPVC.GetAnnotations()[AnnPVCPrimeName]).To(Equal(pvcPrime.Name))
+		Expect(updatedPVC.GetAnnotations()[cc.AnnPVCPrimeName]).To(Equal(pvcPrime.Name))
 	},
 		Entry("kubevirt content type", "kubevirt", false),
 		Entry("kubevirt content type with preallocation", "kubevirt", true),
@@ -97,7 +97,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 
 	It("should set event if upload pod failed", func() {
 		pvc := newUploadPopulatorPVC("test-pvc")
-		cc.AddAnnotation(pvc, AnnPVCPrimeName, PVCPrimeName(pvc))
+		cc.AddAnnotation(pvc, cc.AnnPVCPrimeName, PVCPrimeName(pvc))
 		uploadPV := uploadPV(pvc)
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)
@@ -129,7 +129,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 
 	It("should rebind PV to target PVC", func() {
 		pvc := newUploadPopulatorPVC("test-pvc")
-		cc.AddAnnotation(pvc, AnnPVCPrimeName, PVCPrimeName(pvc))
+		cc.AddAnnotation(pvc, cc.AnnPVCPrimeName, PVCPrimeName(pvc))
 		uploadPV := uploadPV(pvc)
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)
@@ -160,7 +160,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		updatedPVC := &corev1.PersistentVolumeClaim{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: "test-pvc", Namespace: metav1.NamespaceDefault}, updatedPVC)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(updatedPVC.GetAnnotations()[AnnPVCPrimeName]).To(BeEmpty())
+		Expect(updatedPVC.GetAnnotations()[cc.AnnPVCPrimeName]).To(BeEmpty())
 
 		expectEvent(r, uploadSucceeded)
 	})
@@ -197,7 +197,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		pvc.Spec.VolumeName = "test-pv"
 		pvcPrime := newUploadPopulatorPVC(PVCPrimeName(pvc))
 		cc.AddAnnotation(pvcPrime, cc.AnnPodPhase, string(corev1.PodSucceeded))
-		cc.AddAnnotation(pvcPrime, AnnPVCPrimeName, pvcPrime.Name)
+		cc.AddAnnotation(pvcPrime, cc.AnnPVCPrimeName, pvcPrime.Name)
 
 		r := createUploadPopulatorReconciler(pvc, pvcPrime)
 		pvc, err := r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateUploadAnnotations)
@@ -207,7 +207,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		updatedPVC := &corev1.PersistentVolumeClaim{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(updatedPVC.GetAnnotations()[AnnPVCPrimeName]).To(BeEmpty())
+		Expect(updatedPVC.GetAnnotations()[cc.AnnPVCPrimeName]).To(BeEmpty())
 	})
 
 	It("should wait for selected node annotation in case of wffc", func() {
@@ -248,7 +248,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 
 	DescribeTable("should update target pvc with desired annotations from pvc prime", func(podPhase string) {
 		pvc := newUploadPopulatorPVC("test-pvc")
-		cc.AddAnnotation(pvc, AnnPVCPrimeName, PVCPrimeName(pvc))
+		cc.AddAnnotation(pvc, cc.AnnPVCPrimeName, PVCPrimeName(pvc))
 		uploadPV := uploadPV(pvc)
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)
@@ -294,7 +294,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 
 	DescribeTable("Should create PVC Prime with proper upload annotations", func(key, value, expectedValue string) {
 		pvc := newUploadPopulatorPVC("test-pvc")
-		cc.AddAnnotation(pvc, AnnPVCPrimeName, PVCPrimeName(pvc))
+		cc.AddAnnotation(pvc, cc.AnnPVCPrimeName, PVCPrimeName(pvc))
 		uploadPV := uploadPV(pvc)
 
 		volumeUploadSourceCR := newUploadPopulatorCR("", false)

--- a/pkg/controller/populators/util.go
+++ b/pkg/controller/populators/util.go
@@ -46,10 +46,6 @@ const (
 	// messageRetainedPVCPrime provides a const to indicate that the PVC prime has been retained in lost state (message)
 	messageRetainedPVCPrime = "PVC Prime retained in Lost state for debugging purposes"
 
-	// AnnPVCPrimeName annotation is the name of the PVC' that is added to the target PVC
-	// used by the upload-proxy in order to get the service name
-	AnnPVCPrimeName = cc.AnnAPIGroup + "/storage.populator.pvcPrime"
-
 	// annMigratedTo annotation is added to a PVC and PV that is supposed to be
 	// dynamically provisioned/deleted by its corresponding CSI driver
 	// through the CSIMigration feature flags. When this annotation is set the

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -140,6 +140,13 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		log.V(1).Info("PVC has both clone and upload annotations")
 		return reconcile.Result{}, errors.New("PVC has both clone and upload annotations")
 	}
+
+	if (isUpload || isCloneTarget) && !checkPVC(pvc, cc.AnnExternalPopulation, log) && !checkPVC(pvc, cc.AnnPopulatorKind, log) {
+		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	shouldReconcile, err := r.shouldReconcile(isUpload, isCloneTarget, pvc, log)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -141,7 +141,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 		return reconcile.Result{}, errors.New("PVC has both clone and upload annotations")
 	}
 
-	if (isUpload || isCloneTarget) && !checkPVC(pvc, cc.AnnExternalPopulation, log) && !checkPVC(pvc, cc.AnnPopulatorKind, log) {
+	if isUpload || isCloneTarget {
 		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -485,7 +485,6 @@ func (r *UploadReconciler) getOrCreateScratchPvc(pvc *corev1.PersistentVolumeCla
 		if !metav1.IsControlledBy(scratchPvc, pod) {
 			return nil, errors.Errorf("%s scratch PVC not controlled by pod %s", scratchPvc.Name, pod.Name)
 		}
-		setBoundConditionFromPVC(anno, cc.AnnBoundCondition, scratchPvc)
 	}
 
 	return scratchPvc, nil

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -52,6 +52,9 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			Verbs: []string{
 				"create",
 				"patch",
+				"get",
+				"list",
+				"watch",
 			},
 		},
 		{

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -391,7 +391,7 @@ func (app *uploadProxyApp) startTLS() error {
 }
 
 func (app *uploadProxyApp) getPopulationPVC(ctx context.Context, pvc *v1.PersistentVolumeClaim, pvcNamespace string) (*v1.PersistentVolumeClaim, error) {
-	pvcPrimeName, ok := pvc.Annotations[populators.AnnPVCPrimeName]
+	pvcPrimeName, ok := pvc.Annotations[cc.AnnPVCPrimeName]
 	if !ok {
 		// wait for pvcPrimeName annotation on the pvc
 		return nil, nil

--- a/tests/basic_sanity_test.go
+++ b/tests/basic_sanity_test.go
@@ -59,9 +59,9 @@ var _ = Describe("[rfe_id:1347][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			sa := fmt.Sprintf("system:serviceaccount:%s:cdi-sa", f.CdiInstallNs)
 
 			eventExpectedResult := make(map[string]string)
-			eventExpectedResult["get"] = "no"
-			eventExpectedResult["list"] = "no"
-			eventExpectedResult["watch"] = "no"
+			eventExpectedResult["get"] = "yes"
+			eventExpectedResult["list"] = "yes"
+			eventExpectedResult["watch"] = "yes"
 			eventExpectedResult["delete"] = "no"
 			eventExpectedResult["create"] = "yes"
 			eventExpectedResult["update"] = "no"

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3478,60 +3478,71 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		}),
 	)
 
-	Describe("Events and Conditions from PVC Prime", func() {
+	DescribeTable("Events and Conditions from Prime PVC", func(url func() string, containsPrimeEvent bool) {
+		// create a DV that will never be able to be imported
+		dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", url())
 
-		It("should have Prime PVC events populated in target PVC", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", tinyCoreIsoURL())
+		By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
+		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
+		Expect(err).ToNot(HaveOccurred())
+		f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
 
-			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
-			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
-			Expect(err).ToNot(HaveOccurred())
-			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
+		By("verifying pvc was created")
+		pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimPending, pvc.Name)
+		Expect(err).ToNot(HaveOccurred())
 
-			// verify PVC was created
-			By("verifying pvc was created")
-			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+		usePopulator, err := dvc.CheckPVCUsingPopulators(pvc)
+		Expect(err).ToNot(HaveOccurred())
+		if !usePopulator {
+			Skip("Skipping test for non-populator PVCs")
+		}
 
-			usePopulator, err := dvc.CheckPVCUsingPopulators(pvc)
-			Expect(err).ToNot(HaveOccurred())
+		By("Verifying PVC has Prime Name annotation")
+		primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]
+		Expect(primeName).ToNot(BeEmpty())
+		primeEvent := fmt.Sprintf("[%s]", primeName)
 
-			// if we are using populators check that we get prime events in DV
-			if usePopulator {
-
-				By("Verifying event occurred")
-				Eventually(func() bool {
-					primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]
-					events, err := f.RunKubectlCommand("get", "events", "-n", pvc.Namespace, "--field-selector=involvedObject.kind=PersistentVolumeClaim")
-					primeEvent := fmt.Sprintf("[%s]", primeName)
-					if err == nil {
-						fmt.Fprintf(GinkgoWriter, "%s", events)
-						// make sure we get events from pvcPrime
-						return strings.Contains(events, primeEvent)
-					}
-					fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
-					return false
-				}, timeout, pollingInterval).Should(BeTrue())
-			} else {
-				// if we aren't using populators, just check that pvc was bound and dv was imported
-				boundCondition := &cdiv1.DataVolumeCondition{
-					Type:    cdiv1.DataVolumeBound,
-					Status:  v1.ConditionTrue,
-					Message: "PVC test-dv Bound",
-					Reason:  "Bound",
-				}
-				runningCondition := &cdiv1.DataVolumeCondition{
-					Type:    cdiv1.DataVolumeRunning,
-					Status:  v1.ConditionFalse,
-					Message: "Import Complete",
-					Reason:  "Completed",
-				}
-				utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition, runningCondition)
+		By("Verifying DV contains events from Prime PVC ")
+		Eventually(func() bool {
+			events, err := f.RunKubectlCommand("get", "events", "-n", pvc.Namespace, "--field-selector=involvedObject.kind=DataVolume")
+			if err == nil {
+				fmt.Fprintf(GinkgoWriter, "%s", events)
+				// make sure we get events from pvcPrime
+				return strings.Contains(events, primeEvent)
 			}
-		})
+			fmt.Fprintf(GinkgoWriter, "ERROR: %s\n", err.Error())
+			return false
+		}, timeout, pollingInterval).Should(BeTrue())
 
-	})
+		By("Verifying DV bound condition")
+		var boundCondition *cdiv1.DataVolumeCondition
+		if containsPrimeEvent {
+			boundMessage := fmt.Sprintf("PVC %s Pending and %s", dataVolume.Name, primeEvent)
+			boundCondition = &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeBound,
+				Status:  v1.ConditionFalse,
+				Message: boundMessage,
+				Reason:  "Pending",
+			}
+		} else {
+			boundMessage := fmt.Sprintf("PVC %s Bound", dataVolume.Name)
+			boundCondition = &cdiv1.DataVolumeCondition{
+				Type:    cdiv1.DataVolumeBound,
+				Status:  v1.ConditionTrue,
+				Message: boundMessage,
+				Reason:  "Bound",
+			}
+		}
 
+		utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition)
+	},
+		Entry("DV bound condition should be a Prime PVC event while DV is stuck in pending",
+			func() string { return "http://i-made-this-up.kube-system/tinyCore.iso" }, true),
+		Entry("DV bound condition should be correctly set without Prime PVC event when DV is bound",
+			tinyCoreIsoURL, false),
+	)
 })
 
 func SetFilesystemOverhead(f *framework.Framework, globalOverhead, scOverhead string) {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3506,7 +3506,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 				By("Verifying event occurred")
 				Eventually(func() bool {
-					events, err := f.RunKubectlCommand("get", "events", "-n", dataVolume.Namespace, "--field-selector=involvedObject.kind=PersistentVolumeClaim")
+					events, err := f.RunKubectlCommand("get", "events", "-n", dataVolume.Namespace, "--field-selector=involvedObject.kind=DataVolume")
 					primeEvent := fmt.Sprintf("[%s]", primeName)
 					if err == nil {
 						fmt.Fprintf(GinkgoWriter, "%s", events)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3481,7 +3481,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 	Describe("Events and Conditions from PVC Prime", func() {
 
 		It("should have PVC Prime events and name populated in bound condition while pending", func() {
-			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1G", tinyCoreIsoURL())
+			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", tinyCoreIsoURL())
 
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -3498,15 +3498,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				primeName = populators.PVCPrimeName(pvc)
 			}
 			Expect(primeName).ToNot(Equal(""))
-
-			By("verifying bound condition")
-			boundCondition := &cdiv1.DataVolumeCondition{
-				Type:    cdiv1.DataVolumeBound,
-				Status:  v1.ConditionFalse,
-				Message: "PVC test-dv Pending [prime PVC " + primeName + "]",
-				Reason:  "Pending",
-			}
-			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition)
 
 			By("Verifying event occurred")
 			Eventually(func() bool {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3480,7 +3480,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 	Describe("Events and Conditions from PVC Prime", func() {
 
-		It("should have PVC Prime events and name populated in bound condition while pending", func() {
+		It("should have Prime PVC events populated in target PVC", func() {
 			dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", tinyCoreIsoURL())
 
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
@@ -3499,14 +3499,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			// if we are using populators check that we get prime events in DV
 			if usePopulator {
 				By("Checking pvc prime annotation was set")
-				primeName := pvc.GetAnnotations()[controller.AnnAPIGroup+"/storage.populator.pvcPrime"]
-				if primeName == "" {
-					primeName = populators.PVCPrimeName(pvc)
-				}
+				primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]
+				Expect(primeName).ToNot(BeEmpty())
 
 				By("Verifying event occurred")
 				Eventually(func() bool {
-					events, err := f.RunKubectlCommand("get", "events", "-n", dataVolume.Namespace, "--field-selector=involvedObject.kind=DataVolume")
+					events, err := f.RunKubectlCommand("get", "events", "-n", pvc.Namespace, "--field-selector=involvedObject.kind=PersistentVolumeClaim")
 					primeEvent := fmt.Sprintf("[%s]", primeName)
 					if err == nil {
 						fmt.Fprintf(GinkgoWriter, "%s", events)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3493,8 +3493,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			By("checking pvcPrime annotation was set")
 			primeName := pvc.GetAnnotations()[controller.AnnAPIGroup+"/storage.populator.pvcPrime"]
+			if primeName == "" {
+				primeName = populators.PVCPrimeName(pvc)
+			}
 			Expect(primeName).ToNot(Equal(""))
 
 			By("verifying bound condition")

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3498,12 +3498,10 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			// if we are using populators check that we get prime events in DV
 			if usePopulator {
-				By("Checking pvc prime annotation was set")
-				primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]
-				Expect(primeName).ToNot(BeEmpty())
 
 				By("Verifying event occurred")
 				Eventually(func() bool {
+					primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]
 					events, err := f.RunKubectlCommand("get", "events", "-n", pvc.Namespace, "--field-selector=involvedObject.kind=PersistentVolumeClaim")
 					primeEvent := fmt.Sprintf("[%s]", primeName)
 					if err == nil {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3501,7 +3501,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			boundCondition := &cdiv1.DataVolumeCondition{
 				Type:    cdiv1.DataVolumeBound,
 				Status:  v1.ConditionFalse,
-				Message: "PVC test-dv [Prime PVC " + primeName + "] Pending",
+				Message: "PVC test-dv Pending [prime PVC " + primeName + "]",
 				Reason:  "Pending",
 			}
 			utils.WaitForConditions(f, dataVolume.Name, f.Namespace.Name, timeout, pollingInterval, boundCondition)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -3490,14 +3490,15 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		By("verifying pvc was created")
 		pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
-		err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimPending, pvc.Name)
-		Expect(err).ToNot(HaveOccurred())
 
 		usePopulator, err := dvc.CheckPVCUsingPopulators(pvc)
 		Expect(err).ToNot(HaveOccurred())
 		if !usePopulator {
 			Skip("Skipping test for non-populator PVCs")
 		}
+
+		err = utils.WaitForPersistentVolumeClaimPhase(f.K8sClient, pvc.Namespace, v1.ClaimPending, pvc.Name)
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying PVC has Prime Name annotation")
 		primeName := pvc.GetAnnotations()[controller.AnnPVCPrimeName]


### PR DESCRIPTION
Add new functionality to watch for any new events that come from a prime PVC, these events will be re-emitted to the regular PVC along with a prefix to indicate the prime PVC's name. Additionally while the DV's bound condition is set to pending, the prime PVC name as well as the latest event message from the prime PVC will be appended to the message which will allow for easier debugging if a provisioning problem occurs.

```release-note
DV will now contain events from PVC Prime and DV bound condition message will be updated to contain latest PVC Prime event message while bound condition is pending"
```

