### PR TITLE
chore: remove deprecated BuildNameToCertifcate function call

### DIFF
--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -83,7 +83,6 @@ func createHTTPClient(clientKey, clientCert, serverCert []byte) *http.Client {
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
 	}
-	tlsConfig.BuildNameToCertificate() //nolint:staticcheck  // todo: BuildNameToCertificate() is deprecated - check this
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: transport}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -273,7 +273,6 @@ func (app *cdiAPIApp) getTLSConfig() (*tls.Config, error) {
 			return fmt.Errorf("no valid subject specified")
 		},
 	}
-	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // todo: BuildNameToCertificate() is deprecated - check this
 
 	return tlsConfig, nil
 }

--- a/pkg/uploadproxy/uploadproxy.go
+++ b/pkg/uploadproxy/uploadproxy.go
@@ -156,7 +156,6 @@ func (c *clientCreator) CreateClient() (*http.Client, error) {
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
 	}
-	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // todo: BuildNameToCertificate() is deprecated - check this
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: transport, Timeout: proxyRequestTimeout}, nil

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -111,7 +111,6 @@ func newHTTPClient(clientKeyPair *triple.KeyPair, serverCACert *x509.Certificate
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
 	}
-	tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO: handle this deprecation
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: transport}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove BuildNameToCertifcate function call which is deprecated since Go 1.14. Mapping is instead built automatically based on present certificates at request time.

Also, CDI doesn't make use of the `NameToCertificate` configuration field anyhow, making it safe to remove the calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://github.com/golang/go/commit/67d894ee652a3c6fd0a883a33b86686371b96a0e

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

