### PR TITLE
add HCO network-policy labels to required components

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -312,6 +312,11 @@ const (
 
 	// The restricted SCC and particularly v2 is considered best practice for workloads that can manage without extended privileges
 	RestrictedSCCName = "restricted-v2"
+
+	// Label key that is used by HCO managed network policies that allows access of matched Pods to cluster services such as DNS and API
+	HCOAllowAccessClusterServices = "hco.kubevirt.io/allow-access-cluster-services"
+	// Label key that is used by HCO managed network policies that allows Prometheus access to matched Pods
+	HCOAllowAccessPrometheus = "hco.kubevirt.io/allow-prometheus-access"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/operator/resources/namespaced/apiserver.go
+++ b/pkg/operator/resources/namespaced/apiserver.go
@@ -31,6 +31,7 @@ import (
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
@@ -100,6 +101,12 @@ func createAPIServerDeployment(image, verbosity, pullPolicy string, imagePullSec
 	if replicas > 1 {
 		deployment.Spec.Replicas = &replicas
 	}
+	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{
+		common.HCOAllowAccessClusterServices: "",
+	})
+	deployment.SetLabels(labels)
+	deployment.Spec.Template.SetLabels(labels)
+
 	container := utils.CreatePortsContainer(common.CDIApiServerResourceName, image, pullPolicy, createAPIServerPorts(common.CDIApiServerResourceName))
 	container.Args = []string{"-v=" + verbosity}
 	container.Env = []corev1.EnvVar{

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -191,7 +191,11 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 			Protocol:      "TCP",
 		},
 	}
-	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{common.PrometheusLabelKey: common.PrometheusLabelValue})
+	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{
+		common.PrometheusLabelKey:            common.PrometheusLabelValue,
+		common.HCOAllowAccessClusterServices: "",
+		common.HCOAllowAccessPrometheus:      "",
+	})
 	//Add label for pod affinity
 	deployment.SetLabels(labels)
 	deployment.Spec.Template.SetLabels(labels)

--- a/pkg/operator/resources/namespaced/uploadproxy.go
+++ b/pkg/operator/resources/namespaced/uploadproxy.go
@@ -29,6 +29,7 @@ import (
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	utils "kubevirt.io/containerized-data-importer/pkg/operator/resources/utils"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
@@ -95,6 +96,12 @@ func createUploadProxyDeployment(image, verbosity, pullPolicy string, imagePullS
 	if replicas > 1 {
 		deployment.Spec.Replicas = &replicas
 	}
+	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{
+		common.HCOAllowAccessClusterServices: "",
+	})
+	deployment.SetLabels(labels)
+	deployment.Spec.Template.SetLabels(labels)
+
 	container := utils.CreateContainer(common.CDIUploadProxyResourceName, image, verbosity, pullPolicy)
 	container.Env = []corev1.EnvVar{
 		{

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -145,7 +145,12 @@ func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAcco
 		},
 	}
 	deployment := ResourceBuilder.CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount, numReplicas, podSpec)
-	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{common.PrometheusLabelKey: common.PrometheusLabelValue, common.CDIComponentLabel: common.CDIOperatorName})
+	labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{
+		common.PrometheusLabelKey:            common.PrometheusLabelValue,
+		common.CDIComponentLabel:             common.CDIOperatorName,
+		common.HCOAllowAccessClusterServices: "",
+		common.HCOAllowAccessPrometheus:      "",
+	})
 	deployment.SetLabels(labels)
 	deployment.Spec.Template.SetLabels(labels)
 	if deployment.Spec.Template.Annotations == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
HCO includes built-in network policies to allow essential traffic for operators which it deploys. These policies permit:
1. Traffic to Cluster API and DNS
2. Traffic from Prometheus to allow metric scraping

This commit adds the necessary labels which are used as the selectors of the network policies to CDI deployments which require them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [CNV-63386](https://issues.redhat.com/browse/CNV-63386)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

