### PR TITLE
Exclude scratch pvcs from velero backup

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -190,6 +190,7 @@ func createScratchPersistentVolumeClaim(client client.Client, pvc *corev1.Persis
 	scratchPvcSpec.Spec.Resources.Requests[corev1.ResourceStorage] = *resource.NewScaledQuantity(usableSpaceRaw, 0)
 
 	util.SetRecommendedLabels(scratchPvcSpec, installerLabels, "cdi-controller")
+	cc.AddLabel(scratchPvcSpec, cc.LabelExcludeFromVeleroBackup, "true")
 	if err := client.Create(context.TODO(), scratchPvcSpec); err != nil {
 		if cc.ErrQuotaExceeded(err) {
 			recorder.Event(pvc, corev1.EventTypeWarning, cc.ErrExceededQuota, err.Error())


### PR DESCRIPTION
Add to scratch pvcs a label to be able
to exclude it from velero backups.
This pvcs are temporary and should not be
backedup.

fixes: https://github.com/kubevirt/containerized-data-importer/issues/3647
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Exclude scratch pvcs from velero backup
```

