### PR TITLE
add rwo,file and rook_cephfs to cephfs capabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -47,8 +47,9 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"rook-ceph.rbd.csi.ceph.com":         createRbdCapabilities(),
 	"openshift-storage.rbd.csi.ceph.com": createRbdCapabilities(),
 	// ceph-fs
-	"cephfs.csi.ceph.com":                   {{rwx, file}},
-	"openshift-storage.cephfs.csi.ceph.com": {{rwx, file}},
+	"cephfs.csi.ceph.com":                   {{rwx, file}, {rwo, file}},
+	"rook-ceph.cephfs.csi.ceph.com":         {{rwx, file}, {rwo, file}},
+	"openshift-storage.cephfs.csi.ceph.com": {{rwx, file}, {rwo, file}},
 	// LINSTOR
 	"linstor.csi.linbit.com": createAllButRWXFileCapabilities(),
 	// DELL Unity XT


### PR DESCRIPTION
add rwo,file and rook_cephfs to cephfs capabilities
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update pkg/storagecapabilities/storagecapabilities.go to include rook-ceph.cephfs.csi.ceph.com in CapabilitiesByProvisionerKey for Ceph provisioner. Add rwo file capability to address missing support, fixing incorrect storageprofile status and claimPropertySets generation that impacted functionality.


Also related to this PR: https://github.com/kubevirt/containerized-data-importer/pull/3793

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
cephfs sc deploy by rook-ceph:
```yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  labels:
    project.cpaas.io/ALL_ALL: "true"
    project.cpaas.io/name: ""
  name: cephfs
parameters:
  clusterID: rook-ceph
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
  fsName: cephfs
  pool: cephfs-data0
provisioner: rook-ceph.cephfs.csi.ceph.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

the storageprofile:
```yaml
apiVersion: cdi.kubevirt.io/v1beta1
kind: StorageProfile
metadata:
  labels:
    app: containerized-data-importer
    cdi.kubevirt.io: ""
  name: cephfs
spec: {}
status:
  cloneStrategy: copy
  dataImportCronSourceFormat: pvc
  provisioner: rook-ceph.cephfs.csi.ceph.com
  storageClass: cephfs
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
