### PR TITLE
Support DIC DV node pullMethod for update polling

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -262,15 +262,23 @@ func (r *DataImportCronReconciler) pollSourceDigest(ctx context.Context, dataImp
 	if nextTime.After(time.Now()) {
 		return r.setNextCronTime(dataImportCron)
 	}
-	if isImageStreamSource(dataImportCron) {
+	switch {
+	case isImageStreamSource(dataImportCron):
 		if err := r.updateImageStreamDesiredDigest(ctx, dataImportCron); err != nil {
 			return reconcile.Result{}, err
 		}
-	} else if isPvcSource(dataImportCron) {
+	case isPvcSource(dataImportCron):
 		if err := r.updatePvcDesiredDigest(ctx, dataImportCron); err != nil {
 			return reconcile.Result{}, err
 		}
+	case isNodePull(dataImportCron):
+		if done, err := r.updateContainerImageDesiredDigest(ctx, dataImportCron); !done {
+			return reconcile.Result{RequeueAfter: 3 * time.Second}, err
+		} else if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
+
 	return r.setNextCronTime(dataImportCron)
 }
 
@@ -282,7 +290,7 @@ func (r *DataImportCronReconciler) setNextCronTime(dataImportCron *cdiv1.DataImp
 	}
 	nextTime := expr.Next(now)
 	requeueAfter := nextTime.Sub(now)
-	res := reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}
+	res := reconcile.Result{RequeueAfter: requeueAfter}
 	cc.AddAnnotation(dataImportCron, AnnNextCronTime, nextTime.Format(time.RFC3339))
 	return res, err
 }
@@ -295,6 +303,12 @@ func isImageStreamSource(dataImportCron *cdiv1.DataImportCron) bool {
 func isURLSource(dataImportCron *cdiv1.DataImportCron) bool {
 	regSource, err := getCronRegistrySource(dataImportCron)
 	return err == nil && regSource.URL != nil
+}
+
+func isNodePull(cron *cdiv1.DataImportCron) bool {
+	regSource, err := getCronRegistrySource(cron)
+	return err == nil && regSource != nil && regSource.PullMethod != nil &&
+		*regSource.PullMethod == cdiv1.RegistryPullNode
 }
 
 func getCronRegistrySource(cron *cdiv1.DataImportCron) (*cdiv1.DataVolumeSourceRegistry, error) {
@@ -322,7 +336,7 @@ func isPvcSource(cron *cdiv1.DataImportCron) bool {
 }
 
 func isControllerPolledSource(cron *cdiv1.DataImportCron) bool {
-	return isImageStreamSource(cron) || isPvcSource(cron)
+	return isImageStreamSource(cron) || isPvcSource(cron) || isNodePull(cron)
 }
 
 func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *cdiv1.DataImportCron) (reconcile.Result, error) {
@@ -615,6 +629,126 @@ func (r *DataImportCronReconciler) updateImageStreamDesiredDigest(ctx context.Co
 		cc.AddAnnotation(dataImportCron, AnnImageStreamDockerRef, dockerRef)
 	}
 	return nil
+}
+
+func (r *DataImportCronReconciler) updateContainerImageDesiredDigest(ctx context.Context, cron *cdiv1.DataImportCron) (bool, error) {
+	log := r.log.WithValues("name", cron.Name).WithValues("uid", cron.UID)
+	podName := naming.GetResourceName("poller-"+cron.Name, string(cron.UID)[:8])
+	ns := cron.Namespace
+	nn := types.NamespacedName{Name: podName, Namespace: ns}
+	pod := &corev1.Pod{}
+
+	if err := r.client.Get(ctx, nn, pod); err == nil {
+		digest, err := r.fetchContainerImageDigest(pod)
+		if err != nil || digest == "" {
+			return false, err
+		}
+		cc.AddAnnotation(cron, AnnLastCronTime, time.Now().Format(time.RFC3339))
+		if cron.Annotations[AnnSourceDesiredDigest] != digest {
+			log.Info("Updating DataImportCron", "digest", digest)
+			cc.AddAnnotation(cron, AnnSourceDesiredDigest, digest)
+		}
+		return true, r.client.Delete(ctx, pod)
+	} else if cc.IgnoreNotFound(err) != nil {
+		return false, err
+	}
+
+	workloadNodePlacement, err := cc.GetWorkloadNodePlacement(ctx, r.client)
+	if err != nil {
+		return false, err
+	}
+
+	containerImage := strings.TrimPrefix(*cron.Spec.Template.Spec.Source.Registry.URL, "docker://")
+
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         cron.APIVersion,
+					Kind:               cron.Kind,
+					Name:               cron.Name,
+					UID:                cron.UID,
+					BlockOwnerDeletion: ptr.To[bool](true),
+					Controller:         ptr.To[bool](true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: ptr.To[int64](0),
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			NodeSelector:                  workloadNodePlacement.NodeSelector,
+			Tolerations:                   workloadNodePlacement.Tolerations,
+			Affinity:                      workloadNodePlacement.Affinity,
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-volume",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name:                     "init",
+					Image:                    r.image,
+					ImagePullPolicy:          corev1.PullPolicy(r.pullPolicy),
+					Command:                  []string{"sh", "-c", "cp /usr/bin/cdi-containerimage-server /shared/server"},
+					VolumeMounts:             []corev1.VolumeMount{{Name: "shared-volume", MountPath: "/shared"}},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:                     "image-container",
+					Image:                    containerImage,
+					ImagePullPolicy:          corev1.PullAlways,
+					Command:                  []string{"/shared/server", "-h"},
+					VolumeMounts:             []corev1.VolumeMount{{Name: "shared-volume", MountPath: "/shared"}},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				},
+			},
+		},
+	}
+
+	cc.SetRestrictedSecurityContext(&pod.Spec)
+	if pod.Spec.SecurityContext != nil {
+		pod.Spec.SecurityContext.FSGroup = nil
+	}
+
+	return false, r.client.Create(ctx, pod)
+}
+
+func (r *DataImportCronReconciler) fetchContainerImageDigest(pod *corev1.Pod) (string, error) {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return "", nil
+	}
+
+	status := pod.Status.ContainerStatuses[0]
+	if status.State.Waiting != nil {
+		reason := status.State.Waiting.Reason
+		switch reason {
+		case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
+			return "", errors.Errorf("%s %s: %s", common.ImagePullFailureText, status.Image, reason)
+		}
+		return "", nil
+	}
+
+	if status.State.Terminated == nil {
+		return "", nil
+	}
+
+	imageID := status.ImageID
+	if imageID == "" {
+		return "", errors.Errorf("Container has no imageID")
+	}
+	idx := strings.Index(imageID, digestSha256Prefix)
+	if idx < 0 {
+		return "", errors.Errorf("Container image %s ID has no digest: %s", status.Image, imageID)
+	}
+
+	return imageID[idx:], nil
 }
 
 func (r *DataImportCronReconciler) updatePvcDesiredDigest(ctx context.Context, dataImportCron *cdiv1.DataImportCron) error {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -766,7 +766,6 @@ var _ = Describe("All DataImportCron Tests", func() {
 			reconciler = createDataImportCronReconciler(cron, imageStream)
 			res, err := reconciler.Reconcile(context.TODO(), cronReq)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(res.Requeue).To(BeTrue())
 			Expect(res.RequeueAfter.Seconds()).To(And(BeNumerically(">", 0), BeNumerically("<=", 60)))
 
 			err = reconciler.client.Get(context.TODO(), cronKey, cron)
@@ -1547,7 +1546,6 @@ func newImageStream(name string) *imagev1.ImageStream {
 
 func newDataImportCron(name string) *cdiv1.DataImportCron {
 	garbageCollect := cdiv1.DataImportCronGarbageCollectOutdated
-	registryPullNodesource := cdiv1.RegistryPullNode
 	importsToKeep := int32(2)
 	url := testRegistryURL + testTag
 
@@ -1564,8 +1562,7 @@ func newDataImportCron(name string) *cdiv1.DataImportCron {
 				Spec: cdiv1.DataVolumeSpec{
 					Source: &cdiv1.DataVolumeSource{
 						Registry: &cdiv1.DataVolumeSourceRegistry{
-							URL:        &url,
-							PullMethod: &registryPullNodesource,
+							URL: &url,
 						},
 					},
 					Storage: &cdiv1.StorageSpec{},

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -107,6 +107,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			cronJobKey   = func(cron *cdiv1.DataImportCron) types.NamespacedName {
 				return types.NamespacedName{Name: GetCronJobName(cron), Namespace: reconciler.cdiNamespace}
 			}
+			pollerPodKey = func(cron *cdiv1.DataImportCron) types.NamespacedName {
+				return types.NamespacedName{Name: getPollerPodName(cron), Namespace: metav1.NamespaceDefault}
+			}
 			dataSourceKey = func(cron *cdiv1.DataImportCron) types.NamespacedName {
 				return types.NamespacedName{Name: cron.Spec.ManagedDataSource, Namespace: metav1.NamespaceDefault}
 			}
@@ -540,6 +543,47 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Entry("default schedule", defaultSchedule, "should succeed with a default schedule"),
 			Entry("empty schedule", emptySchedule, "should succeed with an empty schedule"),
 		)
+
+		It("Should create a poller Pod, and upon its termination update the DataImportCron DesiredDigest according to the container status ImageID", func() {
+			cron = newDataImportCron(cronName)
+			cron.Spec.Template.Spec.Source.Registry.PullMethod = ptr.To(cdiv1.RegistryPullNode)
+			reconciler = createDataImportCronReconciler(cron)
+
+			res, err := reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{RequeueAfter: 3 * time.Second}))
+
+			cronjob := &batchv1.CronJob{}
+			err = reconciler.client.Get(context.TODO(), cronJobKey(cron), cronjob)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			pollerPod := &corev1.Pod{}
+			err = reconciler.client.Get(context.TODO(), pollerPodKey(cron), pollerPod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pollerPod.Spec.Containers).To(HaveLen(1))
+			Expect(pollerPod.Status.ContainerStatuses).To(BeEmpty())
+
+			pollerPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+				{
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
+					ImageID: testDockerRef,
+				},
+			}
+			err = reconciler.client.Status().Update(context.TODO(), pollerPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = reconciler.Reconcile(context.TODO(), cronReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.client.Get(context.TODO(), pollerPodKey(cron), pollerPod)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			err = reconciler.client.Get(context.TODO(), cronKey, cron)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cron.Annotations[AnnSourceDesiredDigest]).To(Equal(testDigest))
+		})
 
 		It("Should recreate DataVolume if the last import was deleted", func() {
 			cron = newDataImportCron(cronName)
@@ -1545,10 +1589,6 @@ func newImageStream(name string) *imagev1.ImageStream {
 }
 
 func newDataImportCron(name string) *cdiv1.DataImportCron {
-	garbageCollect := cdiv1.DataImportCronGarbageCollectOutdated
-	importsToKeep := int32(2)
-	url := testRegistryURL + testTag
-
 	return &cdiv1.DataImportCron{
 		TypeMeta: metav1.TypeMeta{APIVersion: cdiv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1562,7 +1602,7 @@ func newDataImportCron(name string) *cdiv1.DataImportCron {
 				Spec: cdiv1.DataVolumeSpec{
 					Source: &cdiv1.DataVolumeSource{
 						Registry: &cdiv1.DataVolumeSourceRegistry{
-							URL: &url,
+							URL: ptr.To(testRegistryURL + testTag),
 						},
 					},
 					Storage: &cdiv1.StorageSpec{},
@@ -1570,8 +1610,8 @@ func newDataImportCron(name string) *cdiv1.DataImportCron {
 			},
 			Schedule:          defaultSchedule,
 			ManagedDataSource: dataSourceName,
-			GarbageCollect:    &garbageCollect,
-			ImportsToKeep:     &importsToKeep,
+			GarbageCollect:    ptr.To(cdiv1.DataImportCronGarbageCollectOutdated),
+			ImportsToKeep:     ptr.To[int32](2),
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It allows the `DataImportCron` controller to fetch a registry `containerImage` `imageID` digest by a do-nothing image-puller container, without depending on `OpenShift` `ImageStream` or `cronJobs`. k8s node caching makes it also quite cheap. If the image was not updated, it is already cached. If the image is a new one, k8s will pull and cache it, so in the following import it will be retrieved from the cache, assuming both pods are scheduled on the same node.

**Release note**:
```release-note
Support DataImportCron DataVolume node pullMethod for update polling
```