### PR TITLE
Tests: Fix flaky variable assignments during Update

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk:go_default_library",

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -23,6 +23,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
@@ -109,15 +111,9 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		uploadPod, err := utils.FindPodByPrefix(f.K8sClient, f.Namespace.Name, utils.UploadPodName(pvc), common.CDILabelSelector)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to get uploader pod %q", f.Namespace.Name+"/"+utils.UploadPodName(pvc)))
 
-		Eventually(func() error {
-			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			delete(pvc.Annotations, controller.AnnUploadRequest)
-			// We shouldn't make the test fail if there's a conflict with the update request.
-			// These errors are usually transient and should be fixed in subsequent retries.
-			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
-			return err
-		}, timeout, pollingInterval).Should(Succeed())
+		patchBytes := []byte(fmt.Sprintf(`[{"op":"remove","path":"/metadata/annotations/%s"}]`, openapicommon.EscapeJsonPointer(controller.AnnUploadRequest)))
+		pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(context.TODO(), pvc.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() bool {
 			_, err = f.K8sClient.CoreV1().Pods(uploadPod.Namespace).Get(context.TODO(), uploadPod.Name, metav1.GetOptions{})
@@ -255,15 +251,10 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			Eventually(func() error {
-				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				pvc.Annotations[controller.AnnContentType] = XSSAttempt
-				// We shouldn't make the test fail if there's a conflict with the update request.
-				// These errors are usually transient and should be fixed in subsequent retries.
-				pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
-				return err
-			}, timeout, pollingInterval).Should(Succeed())
+			By("Patch PVC to inject XSS attempt")
+			patchBytes := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/annotations/%s","value":"%s"}]`, openapicommon.EscapeJsonPointer(controller.AnnContentType), XSSAttempt))
+			pvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(context.TODO(), pvc.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			var token string
 			By("Get an upload token")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes a flaky variable assignment in tests during Update by using Patch. When a PVC or DV Update call fails, then the errored PVC assignment may be used in subsequent retries and fail. Patch is atomic so these operations shouldn't fail normally.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

