### PR TITLE
Add missing RBAC to forklift volume populator CRDs.

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -2056,5 +2056,13 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.Secret cdi-uploadserver-client-cert"] = false
 	match[normalCreateSuccess+" *v1.Service cdi-prometheus-metrics"] = false
 	match[normalCreateEnsured+" SecurityContextConstraint exists"] = false
+
+	// Forklift
+	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:admin"] = false
+	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:edit"] = false
+	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:view"] = false
+	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:config-reader"] = false
+	match[normalCreateSuccess+" *v1.ClusterRoleBinding forklift.cdi.kubevirt.io:config-reader"] = false
+
 	return match
 }

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -520,14 +520,24 @@ var _ = Describe("Controller", func() {
 					}
 				}
 
+				allGroupsExcepted := func(groups []string) bool {
+					for _, group := range groups {
+						if !strings.HasSuffix(group, "cdi.kubevirt.io") {
+							return false
+						}
+					}
+					return true
+				}
+
 				verifyRule := func(rule *rbacv1.PolicyRule) {
 					Expect(rule.Verbs).ToNot(ContainElement("escalate"))
 					Expect(rule.Verbs).ToNot(ContainElement("bind"))
 					Expect(rule.Verbs).ToNot(ContainElement("impersonate"))
 					Expect(rule.APIGroups).ToNot(ContainElement("*"))
-					if len(rule.APIGroups) == 1 && strings.HasSuffix(rule.APIGroups[0], "cdi.kubevirt.io") {
+					if len(rule.APIGroups) > 0 && allGroupsExcepted(rule.APIGroups) {
 						return
 					}
+
 					Expect(rule.Resources).ToNot(ContainElement("*"))
 					Expect(rule.Verbs).ToNot(ContainElement("*"))
 

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -2067,12 +2067,5 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.Service cdi-prometheus-metrics"] = false
 	match[normalCreateEnsured+" SecurityContextConstraint exists"] = false
 
-	// Forklift
-	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:admin"] = false
-	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:edit"] = false
-	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:view"] = false
-	match[normalCreateSuccess+" *v1.ClusterRole forklift.cdi.kubevirt.io:config-reader"] = false
-	match[normalCreateSuccess+" *v1.ClusterRoleBinding forklift.cdi.kubevirt.io:config-reader"] = false
-
 	return match
 }

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -165,9 +165,11 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"get",
 			},
 		},
+		// "*" permissions are usually bad, but it makes sense for CDI to have them as it controls everything related
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
+				"forklift.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",
@@ -264,25 +266,6 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"update",
-			},
-		},
-		{
-			APIGroups: []string{
-				"forklift.cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"ovirtvolumepopulators",
-				"openstackvolumepopulators",
-			},
-			Verbs: []string{
-				"create",
-				"delete",
-				"deletecollection",
-				"get",
-				"list",
-				"patch",
-				"update",
-				"watch",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -275,9 +275,7 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"openstackvolumepopulators",
 			},
 			Verbs: []string{
-				"get",
-				"list",
-				"watch",
+				"*",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -165,11 +165,9 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"get",
 			},
 		},
-		// "*" permissions are usually bad, but it makes sense for CDI to have them as it controls everything related
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
-				"forklift.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",
@@ -266,6 +264,25 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"update",
+			},
+		},
+		{
+			APIGroups: []string{
+				"forklift.cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"ovirtvolumepopulators",
+				"openstackvolumepopulators",
+			},
+			Verbs: []string{
+				"create",
+				"delete",
+				"deletecollection",
+				"get",
+				"list",
+				"patch",
+				"update",
+				"watch",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -165,9 +165,11 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"get",
 			},
 		},
+		// "*" permissions are usually bad, but it makes sense for CDI to have them as it controls everything related
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",
+				"forklift.cdi.kubevirt.io",
 			},
 			Resources: []string{
 				"*",
@@ -264,18 +266,6 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"update",
-			},
-		},
-		{
-			APIGroups: []string{
-				"forklift.cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"ovirtvolumepopulators",
-				"openstackvolumepopulators",
-			},
-			Verbs: []string{
-				"*",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -89,14 +89,7 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 				"openstackvolumepopulators",
 			},
 			Verbs: []string{
-				"create",
-				"delete",
-				"deletecollection",
-				"get",
-				"list",
-				"patch",
-				"update",
-				"watch",
+				"*",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -168,20 +168,6 @@ func createConfigReaderClusterRole(name string) *rbacv1.ClusterRole {
 				"watch",
 			},
 		},
-		{
-			APIGroups: []string{
-				"forklift.cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"ovirtvolumepopulators",
-				"openstackvolumepopulators",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
 	}
 
 	return utils.ResourceBuilder.CreateClusterRole(name, rules)

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -30,13 +30,8 @@ func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:view", "view", getViewPolicyRules()),
-		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
-		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
-		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:view", "view", getViewPolicyRules()),
 		createConfigReaderClusterRole("cdi.kubevirt.io:config-reader"),
-		createConfigReaderClusterRole("forklift.cdi.kubevirt.io:config-reader"),
 		createConfigReaderClusterRoleBinding("cdi.kubevirt.io:config-reader"),
-		createConfigReaderClusterRoleBinding("forklift.cdi.kubevirt.io:config-reader"),
 	}
 }
 

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -89,7 +89,14 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 				"openstackvolumepopulators",
 			},
 			Verbs: []string{
-				"*",
+				"create",
+				"delete",
+				"deletecollection",
+				"get",
+				"list",
+				"patch",
+				"update",
+				"watch",
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -30,8 +30,13 @@ func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:view", "view", getViewPolicyRules()),
+		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
+		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
+		utils.ResourceBuilder.CreateAggregateClusterRole("forklift.cdi.kubevirt.io:view", "view", getViewPolicyRules()),
 		createConfigReaderClusterRole("cdi.kubevirt.io:config-reader"),
+		createConfigReaderClusterRole("forklift.cdi.kubevirt.io:config-reader"),
 		createConfigReaderClusterRoleBinding("cdi.kubevirt.io:config-reader"),
+		createConfigReaderClusterRoleBinding("forklift.cdi.kubevirt.io:config-reader"),
 	}
 }
 
@@ -75,6 +80,18 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"forklift.cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"ovirtvolumepopulators",
+				"openstackvolumepopulators",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
 	}
 }
 
@@ -109,6 +126,20 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
+				"forklift.cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"ovirtvolumepopulators",
+				"openstackvolumepopulators",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
 				"cdi.kubevirt.io",
 			},
 			Resources: []string{
@@ -130,6 +161,20 @@ func createConfigReaderClusterRole(name string) *rbacv1.ClusterRole {
 			Resources: []string{
 				"cdiconfigs",
 				"storageprofiles",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"forklift.cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"ovirtvolumepopulators",
+				"openstackvolumepopulators",
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
**What this PR does / why we need it**:
This continues pull request #3320 to address feedback on the forklift populator policy rules.

**Which issue(s) this PR fixes**:
Hopefully fixes [CNV-64424](https://issues.redhat.com/browse/CNV-64424), and a bunch of older clones

**Special notes for your reviewer**:
This passes the previously failing unit tests that check for wildcards in the verb lists, and gets `system:cluster-readers` to show up in the output of the `oc adm policy who-can get` commands shown in [CNV-64424](https://issues.redhat.com/browse/CNV-64424). I don't have a deep enough understanding of RBAC to tell if anything else is missing though.

**Release note**:
```release-note
Add missing RBAC for ovirt and openstack volume populator CRDs
```

