### PR TITLE
metrics-server: use SecureServing option

### DIFF
--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log/zap:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics/server:go_default_library",
     ],
 )
 

--- a/cmd/cdi-operator/BUILD.bazel
+++ b/cmd/cdi-operator/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log/zap:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics/server:go_default_library",
     ],
 )
 

--- a/pkg/operator/controller/prometheus.go
+++ b/pkg/operator/controller/prometheus.go
@@ -211,7 +211,7 @@ func newPrometheusServiceMonitor(namespace string) *promv1.ServiceMonitor {
 			Endpoints: []promv1.Endpoint{
 				{
 					Port:   "metrics",
-					Scheme: "http",
+					Scheme: "https",
 					TLSConfig: &promv1.TLSConfig{
 						SafeTLSConfig: promv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -187,7 +187,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 	container.Ports = []corev1.ContainerPort{
 		{
 			Name:          "metrics",
-			ContainerPort: 8080,
+			ContainerPort: 8443,
 			Protocol:      "TCP",
 		},
 	}
@@ -386,7 +386,7 @@ func createPrometheusService() *corev1.Service {
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Name: "metrics",
-			Port: 8080,
+			Port: 8443,
 			TargetPort: intstr.IntOrString{
 				Type:   intstr.String,
 				StrVal: "metrics",

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -442,7 +442,7 @@ func createPrometheusPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
 			Name:          "metrics",
-			ContainerPort: 8080,
+			ContainerPort: 8443,
 			Protocol:      "TCP",
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As part of an effort to standardize metric exposure across KubeVirt components on port 8443, we are transitioning to HTTPS with TLS encryption for the metrics-server.

To facilitate this, we leverage the controller-runtime's SecureServing option, which creates a self-signed certificate and configures it as the server certificate for the metrics endpoint when no external certificate is provided[1].

Subsequent PRs will replace this self-signed certificate with a CDI generated one to enable a fully trusted and secure connection between the Prometheus instance and the target metrics endpoints as specified by the CDI ServiceMonitor. Until that integration is complete, the ServiceMonitor will be configured with insecureSkipVerify to allow scraping despite the untrusted certificate.

[1] https://github.com/kubernetes-sigs/controller-runtime/pull/2407


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Metrics port for cdi-prometheus-metrics service changed from 8080 to 8443.
```

