### PR TITLE
stop opinionating webhook namespaceselector field

### DIFF
--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -114,6 +114,7 @@ go_test(
         "//vendor/github.com/openshift/custom-resource-status/conditions/v1:go_default_library",
         "//vendor/github.com/openshift/library-go/pkg/operator/certrotation:go_default_library",
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
+        "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CDI opinionates the namespace selector field
which makes it play badly in case something is mutating this field.
Since we don't care we can just leave empty and allow merging with our desired spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3810 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: unset namespace selector on webhooks to allow cloud provider mutation
```

