### PR TITLE
Support storageProfile minimumSupportedPVCSize in clone

### DIFF
--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -460,8 +460,13 @@ func (p *Planner) validateSourcePVC(args *ChooseStrategyArgs, sourceClaim *corev
 		args.Log.V(3).Info("permissive clone annotation found, skipping size validation")
 		return nil
 	}
+	targetResources, err := cc.GetEffectiveStorageResources(context.TODO(), p.Client, args.TargetClaim.Spec.Resources,
+		args.TargetClaim.Spec.StorageClassName, cc.GetPVCContentType(args.TargetClaim), args.Log)
+	if err != nil {
+		return err
+	}
 
-	if err := cc.ValidateRequestedCloneSize(sourceClaim.Spec.Resources, args.TargetClaim.Spec.Resources); err != nil {
+	if err := cc.ValidateRequestedCloneSize(sourceClaim.Spec.Resources, targetResources); err != nil {
 		p.Recorder.Eventf(args.TargetClaim, corev1.EventTypeWarning, cc.ErrIncompatiblePVC, err.Error())
 		return err
 	}

--- a/pkg/controller/datavolume/pvc-clone-controller_test.go
+++ b/pkg/controller/datavolume/pvc-clone-controller_test.go
@@ -493,12 +493,13 @@ var _ = Describe("All DataVolume Tests", func() {
 		sourcePvc := CreatePvc("testPVC", "default", map[string]string{}, nil)
 		blockVM := corev1.PersistentVolumeBlock
 		fsVM := corev1.PersistentVolumeFilesystem
+		r := createCloneReconciler()
 
 		It("Should reject the clone if source and target have different content types", func() {
 			sourcePvc.Annotations[AnnContentType] = string(cdiv1.DataVolumeKubeVirt)
 			dvSpec := &cdiv1.DataVolumeSpec{ContentType: cdiv1.DataVolumeArchive}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
 				fmt.Sprintf("Source contentType (%s) and target contentType (%s) do not match", cdiv1.DataVolumeKubeVirt, cdiv1.DataVolumeArchive)))
@@ -516,7 +517,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			}
 			dvSpec := &cdiv1.DataVolumeSpec{Storage: storageSpec}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("target resources requests storage size is smaller than the source"))
 		})
@@ -533,7 +534,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			}
 			dvSpec := &cdiv1.DataVolumeSpec{Storage: storageSpec}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -543,7 +544,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			storageSpec := &cdiv1.StorageSpec{}
 			dvSpec := &cdiv1.DataVolumeSpec{Storage: storageSpec}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -558,7 +559,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			}
 			dvSpec := &cdiv1.DataVolumeSpec{PVC: pvcSpec}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("target resources requests storage size is smaller than the source"))
 
@@ -575,7 +576,7 @@ var _ = Describe("All DataVolume Tests", func() {
 			}
 			dvSpec := &cdiv1.DataVolumeSpec{PVC: pvcSpec}
 
-			err := validateClone(sourcePvc, dvSpec)
+			err := r.validateClone(sourcePvc, dvSpec)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/controller/datavolume/snapshot-clone-controller_test.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller_test.go
@@ -308,6 +308,7 @@ var _ = Describe("All DataVolume Tests", func() {
 
 				var _ = Describe("validateSnapshotClone", func() {
 					type snapshotModifierFunc func(*snapshotv1.VolumeSnapshot)
+					r := createSnapshotCloneReconciler()
 
 					DescribeTable("Validation mechanism rejects or accepts the clone depending snapshot state",
 						func(expectedErr string, snapshotModifier snapshotModifierFunc) {
@@ -316,7 +317,7 @@ var _ = Describe("All DataVolume Tests", func() {
 							snapshot := createSnapshotInVolumeSnapshotClass("test-snap", dv.Namespace, &expectedSnapshotClass, nil, nil, true)
 							snapshotModifier(snapshot)
 
-							err := validateSnapshotClone(snapshot, &dv.Spec)
+							err := r.validateSnapshotClone(snapshot, &dv.Spec)
 							if expectedErr != "" {
 								Expect(err).To(HaveOccurred())
 								Expect(err.Error()).To(ContainSubstring(expectedErr))
@@ -363,7 +364,7 @@ var _ = Describe("All DataVolume Tests", func() {
 							restoreSizeParsed := resource.MustParse(restoreSize)
 							snapshot.Status.RestoreSize = &restoreSizeParsed
 
-							err := validateSnapshotClone(snapshot, &dv.Spec)
+							err := r.validateSnapshotClone(snapshot, &dv.Spec)
 							if expectedErr != "" {
 								Expect(err).To(HaveOccurred())
 								Expect(err.Error()).To(ContainSubstring(expectedErr))

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2215,6 +2215,69 @@ var _ = Describe("all clone tests", func() {
 
 		})
 
+		DescribeTable("Block volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", Serial, func(minSize string, shouldSucceed bool) {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			By(fmt.Sprintf("Create source PVC %s", sourcePVCName))
+			sc := createStorageWithMinimumSupportedPVCSize(f, minSize)
+			sourcePvc = utils.NewBlockPVCDefinition(sourcePVCName, "1Gi", nil, nil, sc)
+			sourcePvc.Namespace = f.Namespace.Name
+			sourcePvc = f.CreateAndPopulateSourcePVC(sourcePvc, "fill-source-block-pod", blockFillCommand)
+
+			targetDvName := "small-target-dv"
+			By(fmt.Sprintf("Create small target DV %s", targetDvName))
+			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+			targetDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, sourcePvc.Namespace, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+
+			if !shouldSucceed {
+				By("The clone should fail")
+				f.ExpectEvent(targetDV.Namespace).Should(ContainSubstring(dvc.CloneValidationFailed))
+				return
+			}
+
+			By("Wait for target DV succeeded")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDV)
+			err = utils.WaitForDataVolumePhase(f, targetDV.Namespace, cdiv1.Succeeded, targetDV.Name)
+			Expect(err).ToNot(HaveOccurred())
+		},
+			Entry("[test_id:XXXX] large enough", "1Gi", true),
+			Entry("[test_id:XXXX] too small", "256Mi", false),
+			Entry("[test_id:XXXX] empty", "", false),
+		)
+
+		DescribeTable("Filesystem volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", func(minSize string, shouldSucceed bool) {
+			By(fmt.Sprintf("Create source PVC %s", sourcePVCName))
+			sc := createStorageWithMinimumSupportedPVCSize(f, minSize)
+			sourcePvc = utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
+			sourcePvc.Namespace = f.Namespace.Name
+			sourcePvc.Spec.StorageClassName = &sc
+			sourcePvc = f.CreateAndPopulateSourcePVC(sourcePvc, sourcePodFillerName, fillCommand+testFile+"; chmod 660 "+testBaseDir+testFile)
+
+			targetDvName := "small-target-dv"
+			By(fmt.Sprintf("Create small target DV %s", targetDvName))
+			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+			targetDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, sourcePvc.Namespace, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDV)
+
+			if !shouldSucceed {
+				By("The clone should fail")
+				f.ExpectEvent(targetDV.Namespace).Should(ContainSubstring(controller.ErrIncompatiblePVC))
+				return
+			}
+
+			By("Wait for target DV succeeded")
+			err = utils.WaitForDataVolumePhase(f, targetDV.Namespace, cdiv1.Succeeded, targetDV.Name)
+			Expect(err).ToNot(HaveOccurred())
+		},
+			Entry("[test_id:XXXX] large enough", "1Gi", true),
+			Entry("[test_id:XXXX] too small", "256Mi", false),
+			Entry("[test_id:XXXX] empty", "", false),
+		)
+
 		It("[test_id:4276] Clone datavolume with short name", Serial, func() {
 			shortDvName := "import-long-name-dv"
 
@@ -3057,4 +3120,22 @@ func validateCloneType(f *framework.Framework, dv *cdiv1.DataVolume) {
 	}
 
 	Expect(utils.GetCloneType(f.CdiClient, dv)).To(Equal(cloneType))
+}
+
+func createStorageWithMinimumSupportedPVCSize(f *framework.Framework, minSize string) string {
+	sc, err := f.CreateNonDefaultVariationOfStorageClass(utils.DefaultStorageClass,
+		func(sc *storagev1.StorageClass) { sc.UID = "" })
+	Expect(err).ToNot(HaveOccurred())
+
+	var sp *cdiv1.StorageProfile
+	Eventually(func() error {
+		sp, err = f.CdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), sc.Name, metav1.GetOptions{})
+		return err
+	}, time.Minute, time.Second).Should(Succeed())
+
+	sp.Annotations = map[string]string{controller.AnnMinimumSupportedPVCSize: minSize}
+	_, err = f.CdiClient.CdiV1beta1().StorageProfiles().Update(context.TODO(), sp, metav1.UpdateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	return sc.Name
 }

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -153,9 +153,14 @@ func CleanupDvPvcNoWait(k8sClient *kubernetes.Clientset, cdiClient *cdiclientset
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
-// NewCloningDataVolume initializes a DataVolume struct with PVC annotations
+// NewCloningDataVolume initializes a DataVolume struct with PVC spec
 func NewCloningDataVolume(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
 	return NewDataVolumeForImageCloning(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+}
+
+// NewCloningDataVolume initializes a DataVolume struct with Storage spec
+func NewCloningDataVolumeWithStorageSpec(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
+	return NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 }
 
 // NewDataVolumeWithSourceRef initializes a DataVolume struct with DataSource SourceRef


### PR DESCRIPTION
**What this PR does / why we need it**:
When the target `DataVolume` storage requests a size smaller than the source PVC. For target without size it already worked correctly.

jira-ticket: https://issues.redhat.com/browse/CNV-64264

**Release note**:
```release-note
Support storageProfile minimumSupportedPVCSize in clone
```