### PR TITLE
[release-v1.62] Fix math in overhead size calculations and increase default overhead

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3955,7 +3955,7 @@
       }
      },
      "filesystemOverhead": {
-      "description": "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+      "description": "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
       "$ref": "#/definitions/v1beta1.FilesystemOverhead"
      },
      "imagePullSecrets": {

--- a/doc/cdi-config.md
+++ b/doc/cdi-config.md
@@ -19,7 +19,7 @@ CDI configuration in specified by administrators in the `spec.config` of the `CD
 | tlsSecurityProfile       | nil           | Used by operators to apply cluster-wide TLS security settings to operands. |
 
 filesystemOverhead configuration:
- - `global` - default value is `"0.055"` - The amount to reserve for a Filesystem volume unless a per-storageClass value is chosen.                                                                                                                                     
+ - `global` - default value is `"0.06"` - The amount to reserve for a Filesystem volume unless a per-storageClass value is chosen.                                                                                                                                     
  - `storageClass` - default value is `nil` - A value of `local: "0.6"` is understood to mean that the overhead for the local storageClass is 60%.
 
 ### Example

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -16634,7 +16634,7 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 					},
 					"filesystemOverhead": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+							Description: "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
 							Ref:         ref("kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"),
 						},
 					},

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -211,7 +211,7 @@ const (
 	// FilesystemOverheadVar provides a constant to capture our env variable "FILESYSTEM_OVERHEAD"
 	FilesystemOverheadVar = "FILESYSTEM_OVERHEAD"
 	// DefaultGlobalOverhead is the amount of space reserved on Filesystem volumes by default
-	DefaultGlobalOverhead = "0.055"
+	DefaultGlobalOverhead = "0.06"
 
 	// ConfigName is the name of default CDI Config
 	ConfigName = "config"

--- a/pkg/controller/datavolume/BUILD.bazel
+++ b/pkg/controller/datavolume/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//pkg/controller/populators:go_default_library",
         "//pkg/feature-gates:go_default_library",
         "//pkg/token:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",

--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -1694,45 +1694,6 @@ var _ = Describe("All DataVolume Tests", func() {
 		})
 	})
 
-	const (
-		Mi              = int64(1024 * 1024)
-		Gi              = 1024 * Mi
-		noOverhead      = float64(0)
-		defaultOverhead = float64(0.055)
-		largeOverhead   = float64(0.75)
-	)
-	DescribeTable("GetRequiredSpace should return properly enlarged sizes,", func(imageSize int64, overhead float64) {
-		for testedSize := imageSize - 1024; testedSize < imageSize+1024; testedSize++ {
-			alignedImageSpace := imageSize
-			if testedSize > imageSize {
-				alignedImageSpace = imageSize + Mi
-			}
-
-			// TEST
-			actualRequiredSpace := GetRequiredSpace(overhead, testedSize)
-
-			// ASSERT results
-			// check that the resulting space includes overhead over the `aligned image size`
-			overheadSpace := actualRequiredSpace - alignedImageSpace
-			actualOverhead := float64(overheadSpace) / float64(actualRequiredSpace)
-
-			Expect(actualOverhead).To(BeNumerically("~", overhead, 0.01))
-		}
-	},
-		Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
-		Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
-		Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
-		Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
-		Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
-		Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
-		Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
-		Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
-		Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
-		Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
-		Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
-		Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
-	)
-
 	var _ = Describe("shouldUseCDIPopulator", func() {
 		scName := "test"
 		sc := CreateStorageClassWithProvisioner(scName, map[string]string{

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	. "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
 var _ = Describe("renderPvcSpecVolumeSize", func() {
@@ -105,7 +105,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		fsOverheadFloat, _ := strconv.ParseFloat(string(fsOverhead), 64)
-		requiredSpace := GetRequiredSpace(fsOverheadFloat, volumeSize.Value())
+		requiredSpace := util.GetRequiredSpace(fsOverheadFloat, volumeSize.Value())
 		expectedResult := resource.NewScaledQuantity(requiredSpace, 0)
 
 		Expect(requestedVolumeSize.Value()).To(BeNumerically(">", volumeSize.Value()))
@@ -117,7 +117,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: scName,
 				Annotations: map[string]string{
-					cc.AnnMinimumSupportedPVCSize: minSupportedSize,
+					AnnMinimumSupportedPVCSize: minSupportedSize,
 				},
 			},
 		}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -853,7 +853,7 @@ var _ = Describe("Create Importer Pod", func() {
 			imageSize:          "1G",
 			certConfigMap:      "",
 			diskID:             "",
-			filesystemOverhead: "0.055",
+			filesystemOverhead: "0.06",
 			insecureTLS:        false,
 		}
 		podArgs := &importerPodArgs{
@@ -987,7 +987,7 @@ var _ = Describe("Import test env", func() {
 			doneFile:           "",
 			backingFile:        "",
 			thumbprint:         "",
-			filesystemOverhead: "0.055",
+			filesystemOverhead: "0.06",
 			insecureTLS:        false,
 			currentCheckpoint:  "",
 			previousCheckpoint: "",

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -454,8 +454,8 @@ var _ = Describe("createScratchPersistentVolumeClaim", func() {
 		Expect(scratchPVCSize.Value()).To(Equal(expectedValue * 1024 * 1024))
 	},
 		Entry("same scratch and storage class overhead", cdiv1.Percent("0.03"), cdiv1.Percent("0.03"), int64(1024)),
-		Entry("scratch  > storage class overhead", cdiv1.Percent("0.1"), cdiv1.Percent("0.03"), int64(1104)),
-		Entry("scratch  < storage class overhead", cdiv1.Percent("0.03"), cdiv1.Percent("0.1"), int64(950)),
+		Entry("scratch  > storage class overhead", cdiv1.Percent("0.1"), cdiv1.Percent("0.03"), int64(1094)),
+		Entry("scratch  < storage class overhead", cdiv1.Percent("0.03"), cdiv1.Percent("0.1"), int64(958)),
 	)
 
 	It("Should calculate the correct size for a scratch PVC from a block volume", func() {
@@ -477,7 +477,7 @@ var _ = Describe("createScratchPersistentVolumeClaim", func() {
 		Expect(res.Spec.Resources).ToNot(BeNil())
 		Expect(res.Spec.Resources.Requests.Storage()).ToNot(BeNil())
 		scratchPVCSize := *res.Spec.Resources.Requests.Storage()
-		Expect(scratchPVCSize.Value()).To(Equal(int64(1078 * 1024 * 1024)))
+		Expect(scratchPVCSize.Value()).To(Equal(int64(1076 * 1024 * 1024)))
 	})
 
 	It("Should add skip velero backup label", func() {

--- a/pkg/importer/data-processor_test.go
+++ b/pkg/importer/data-processor_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferScratch,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -167,7 +167,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataDir,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -181,7 +181,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferScratch,
 			transferResponse: ProcessingPhaseError,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(2).To(Equal(len(mdp.calledPhases)))
@@ -195,7 +195,7 @@ var _ = Describe("Data Processor", func() {
 			transferResponse: ProcessingPhaseError,
 			needsScratch:     true,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(ErrRequiresScratchSpace).To(Equal(err))
@@ -209,7 +209,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataFile,
 			transferResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			err := dp.ProcessData()
@@ -225,7 +225,7 @@ var _ = Describe("Data Processor", func() {
 			infoResponse:     ProcessingPhaseTransferDataFile,
 			transferResponse: ProcessingPhaseError,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewQEMUAllErrors()
 		replaceQEMUOperations(qemuOperations, func() {
 			err := dp.ProcessData()
@@ -240,7 +240,7 @@ var _ = Describe("Data Processor", func() {
 		mdp := &MockDataProvider{
 			infoResponse: ProcessingPhase("invalidphase"),
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 		Expect(1).To(Equal(len(mdp.calledPhases)))
@@ -259,7 +259,7 @@ var _ = Describe("Data Processor", func() {
 			transferResponse: ProcessingPhaseConvert,
 			url:              url,
 		}
-		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "", "dataDir", tmpDir, "1G", 0.06, false, "")
 		dp.availableSpace = int64(1536000)
 		usableSpace := dp.getUsableSpace()
 
@@ -282,7 +282,7 @@ var _ = Describe("Data Processor", func() {
 			},
 			fooResponse: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		dp.RegisterPhaseExecutor(ProcessingPhaseFoo, func() (ProcessingPhase, error) {
 			return mcdp.Foo()
 		})
@@ -304,7 +304,7 @@ var _ = Describe("Data Processor", func() {
 			},
 			fooResponse: ProcessingPhaseInfo,
 		}
-		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mcdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		dp.RegisterPhaseExecutor(ProcessingPhaseFoo, func() (ProcessingPhase, error) {
 			return mcdp.Foo()
 		})
@@ -316,7 +316,7 @@ var _ = Describe("Data Processor", func() {
 		mdp := &MockDataProvider{
 			infoResponse: "unknown",
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		err := dp.ProcessData()
 		Expect(err).To(HaveOccurred())
 	})
@@ -329,7 +329,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -344,7 +344,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, errors.New("Validation failure"), nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -359,7 +359,7 @@ var _ = Describe("Convert", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(errors.New("Conversion failure"), nil, fakeInfoOpRetVal{&fakeZeroImageInfo, errors.New("Scratch space required, and none found ")}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.convert(mdp.GetURL())
@@ -378,7 +378,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "", 0.055, false, "")
+		dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -400,7 +400,7 @@ var _ = Describe("Resize", func() {
 			mdp := &MockDataProvider{
 				url: url,
 			}
-			dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "1G", 0.055, false, "")
+			dp := NewDataProcessor(mdp, tempDir, "dataDir", "scratchDataDir", "1G", 0.06, false, "")
 			qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 			replaceQEMUOperations(qemuOperations, func() {
 				nextPhase, err := dp.resize()
@@ -418,7 +418,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, tmpDir, tmpDir, "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, tmpDir, tmpDir, "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewFakeQEMUOperations(nil, nil, fakeInfoOpRetVal{&fakeZeroImageInfo, nil}, nil, nil, nil)
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -435,7 +435,7 @@ var _ = Describe("Resize", func() {
 		mdp := &MockDataProvider{
 			url: url,
 		}
-		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", tmpDir, "scratchDataDir", "1G", 0.06, false, "")
 		qemuOperations := NewQEMUAllErrors()
 		replaceQEMUOperations(qemuOperations, func() {
 			nextPhase, err := dp.resize()
@@ -449,7 +449,7 @@ var _ = Describe("Resize", func() {
 			return int64(100000), nil
 		}, func() {
 			mdp := &MockDataProvider{}
-			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
+			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.06, false, "")
 			Expect(int64(100000)).To(Equal(dp.calculateTargetSize()))
 		})
 	})
@@ -459,7 +459,7 @@ var _ = Describe("Resize", func() {
 			return int64(-1), errors.New("error")
 		}, func() {
 			mdp := &MockDataProvider{}
-			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
+			dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.06, false, "")
 			// We just log the error if one happens.
 			Expect(int64(-1)).To(Equal(dp.calculateTargetSize()))
 
@@ -490,7 +490,7 @@ var _ = Describe("ResizeImage", func() {
 var _ = Describe("DataProcessorResume", func() {
 	It("Should fail with an error if the data provider cannot resume", func() {
 		mdp := &MockDataProvider{}
-		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
+		dp := NewDataProcessor(mdp, "dest", "dataDir", "scratchDataDir", "", 0.06, false, "")
 		err := dp.ProcessDataResume()
 		Expect(err).To(HaveOccurred())
 	})
@@ -499,7 +499,7 @@ var _ = Describe("DataProcessorResume", func() {
 		amdp := &MockAsyncDataProvider{
 			ResumePhase: ProcessingPhaseComplete,
 		}
-		dp := NewDataProcessor(amdp, "dest", "dataDir", "scratchDataDir", "", 0.055, false, "")
+		dp := NewDataProcessor(amdp, "dest", "dataDir", "scratchDataDir", "", 0.06, false, "")
 		err := dp.ProcessDataResume()
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -520,7 +520,7 @@ var _ = Describe("MergeDelta", func() {
 			url:              url,
 		}
 
-		dp := NewDataProcessor(mdp, expectedBackingFile, "dataDir", "scratchDataDir", "", 0.055, false, "")
+		dp := NewDataProcessor(mdp, expectedBackingFile, "dataDir", "scratchDataDir", "", 0.06, false, "")
 		err := errors.New("this operation should not be called")
 		info := &image.ImgInfo{
 			Format:      "",

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -129,7 +129,7 @@ spec:
                   filesystemOverhead:
                     description: FilesystemOverhead describes the space reserved for
                       overhead when using Filesystem volumes. A value is between 0
-                      and 1, if not defined it is 0.055 (5.5% overhead)
+                      and 1, if not defined it is 0.06 (6% overhead)
                     properties:
                       global:
                         description: Global is how much space of a Filesystem volume
@@ -2661,7 +2661,7 @@ spec:
                   filesystemOverhead:
                     description: FilesystemOverhead describes the space reserved for
                       overhead when using Filesystem volumes. A value is between 0
-                      and 1, if not defined it is 0.055 (5.5% overhead)
+                      and 1, if not defined it is 0.06 (6% overhead)
                     properties:
                       global:
                         description: Global is how much space of a Filesystem volume
@@ -5148,7 +5148,7 @@ spec:
               filesystemOverhead:
                 description: FilesystemOverhead describes the space reserved for overhead
                   when using Filesystem volumes. A value is between 0 and 1, if not
-                  defined it is 0.055 (5.5% overhead)
+                  defined it is 0.06 (6% overhead)
                 properties:
                   global:
                     description: Global is how much space of a Filesystem volume should

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -51,7 +51,7 @@ func newServer() *uploadServerApp {
 		BindAddress:        "127.0.0.1",
 		BindPort:           0,
 		Destination:        "disk.img",
-		FilesystemOverhead: 0.055,
+		FilesystemOverhead: 0.06,
 		CryptoConfig:       *cryptowatch.DefaultCryptoConfig(),
 	}
 	server := NewUploadServer(config)
@@ -87,7 +87,7 @@ func newTLSServer(clientCertName, expectedName string) (*uploadServerApp, *tripl
 		ServerCertFile:     filepath.Join(dir, "tls.crt"),
 		ClientCertFile:     filepath.Join(dir, "client.crt"),
 		ClientName:         expectedName,
-		FilesystemOverhead: 0.055,
+		FilesystemOverhead: 0.06,
 		CryptoConfig:       *cryptowatch.DefaultCryptoConfig(),
 	}
 
@@ -188,11 +188,11 @@ func (amd *AsyncMockDataSource) GetResumePhase() importer.ProcessingPhase {
 }
 
 func saveAsyncProcessorSuccess(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
-	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false, ""), nil
+	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.06, false, ""), nil
 }
 
 func saveAsyncProcessorFailure(stream io.ReadCloser, dest, imageSize string, filesystemOverhead float64, preallocation bool, contentType string) (*importer.DataProcessor, error) {
-	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.055, false, ""), fmt.Errorf("Error using datastream")
+	return importer.NewDataProcessor(&AsyncMockDataSource{}, "", "", "", "", 0.06, false, ""), fmt.Errorf("Error using datastream")
 }
 
 func withAsyncProcessorSuccess(f func()) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -249,9 +249,16 @@ func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
 	return RoundDown(spaceWithoutOverhead, DefaultAlignBlockSize)
 }
 
-func CalculateOverheadSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	spaceWithOverhead := int64(math.Ceil(float64(availableSpace) / (1 - filesystemOverhead)))
-	return RoundUp(spaceWithOverhead, DefaultAlignBlockSize)
+// GetRequiredSpace calculates space required taking file system overhead into account
+func GetRequiredSpace(filesystemOverhead float64, requestedSpace int64) int64 {
+	// the `image` has to be aligned correctly, so the space requested has to be aligned to
+	// next value that is a multiple of a block size
+	alignedSize := RoundUp(requestedSpace, DefaultAlignBlockSize)
+
+	// count overhead as a percentage of the whole/new size, including aligned image
+	// and the space required by filesystem metadata
+	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) * (1 + filesystemOverhead)))
+	return spaceWithOverhead
 }
 
 // ResolveVolumeMode returns the volume mode if set, otherwise defaults to file system mode

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -242,11 +242,11 @@ func Md5sum(filePath string) (string, error) {
 
 // GetUsableSpace calculates usable space to use taking file system overhead into account
 func GetUsableSpace(filesystemOverhead float64, availableSpace int64) int64 {
-	// +1 always rounds up.
-	spaceWithOverhead := int64(math.Ceil((1 - filesystemOverhead) * float64(availableSpace)))
+	// Reverse the overhead calculation
+	spaceWithoutOverhead := int64(math.Ceil(float64(availableSpace) / (1 + filesystemOverhead)))
 	// qemu-img will round up, making us use more than the usable space.
 	// This later conflicts with image size validation.
-	return RoundDown(spaceWithOverhead, DefaultAlignBlockSize)
+	return RoundDown(spaceWithoutOverhead, DefaultAlignBlockSize)
 }
 
 func CalculateOverheadSpace(filesystemOverhead float64, availableSpace int64) int64 {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Compare quantities", func() {
 	})
 })
 
-var _ = Describe("Usable Space calculation", func() {
+var _ = Describe("Space calculation", func() {
 
 	const (
 		Mi              = int64(1024 * 1024)
@@ -122,6 +122,38 @@ var _ = Describe("Usable Space calculation", func() {
 			} else {
 				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize + Mi))
 			}
+		}
+	},
+		Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),
+		Entry("1Mi virtual size, default overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, defaultOverhead),
+		Entry("1Mi virtual size, large overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, largeOverhead),
+		Entry("40Mi virtual size, 0 overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, noOverhead),
+		Entry("40Mi virtual size, default overhead to be 40Mi if <= 1Mi and 41Mi if > 40Mi", 40*Mi, defaultOverhead),
+		Entry("40Mi virtual size, large overhead to be 40Mi if <= 40Mi and 41Mi if > 40Mi", 40*Mi, largeOverhead),
+		Entry("1Gi virtual size, 0 overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, noOverhead),
+		Entry("1Gi virtual size, default overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, defaultOverhead),
+		Entry("1Gi virtual size, large overhead to be 1Gi if <= 1Gi and 2Gi if > 1Gi", Gi, largeOverhead),
+		Entry("40Gi virtual size, 0 overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, noOverhead),
+		Entry("40Gi virtual size, default overhead to be 40Gi if <= 1Gi and 41Gi if > 40Gi", 40*Gi, defaultOverhead),
+		Entry("40Gi virtual size, large overhead to be 40Gi if <= 40Gi and 41Gi if > 40Gi", 40*Gi, largeOverhead),
+	)
+
+	DescribeTable("GetRequiredSpace should return properly enlarged sizes,", func(imageSize int64, overhead float64) {
+		for testedSize := imageSize - 1024; testedSize < imageSize+1024; testedSize++ {
+			alignedImageSpace := imageSize
+			if testedSize > imageSize {
+				alignedImageSpace = imageSize + Mi
+			}
+
+			// TEST
+			actualRequiredSpace := GetRequiredSpace(overhead, testedSize)
+
+			// ASSERT results
+			// check that the resulting space includes overhead over the `aligned image size`
+			overheadSpace := actualRequiredSpace - alignedImageSpace
+			actualOverhead := float64(overheadSpace) / float64(alignedImageSpace)
+
+			Expect(actualOverhead).To(BeNumerically("~", overhead, 0.01))
 		}
 	},
 		Entry("1Mi virtual size, 0 overhead to be 1Mi if <= 1Mi and 2Mi if > 1Mi", Mi, noOverhead),

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -115,8 +115,8 @@ var _ = Describe("Usable Space calculation", func() {
 	)
 	DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {
 		for i := virtualSize - 1024; i < virtualSize+1024; i++ {
-			// Requested space is virtualSize rounded up to 1Mi alignment / (1 - overhead) rounded up
-			requestedSpace := int64(float64(RoundUp(i, DefaultAlignBlockSize)+1) / (1 - overhead))
+			// Requested space is virtualSize rounded up to 1Mi alignment * (1 + overhead) rounded up
+			requestedSpace := int64(float64(RoundUp(i, DefaultAlignBlockSize)+1) * (1 + overhead))
 			if i <= virtualSize {
 				Expect(GetUsableSpace(overhead, requestedSpace)).To(Equal(virtualSize))
 			} else {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Space calculation", func() {
 		Mi              = int64(1024 * 1024)
 		Gi              = 1024 * Mi
 		noOverhead      = float64(0)
-		defaultOverhead = float64(0.055)
+		defaultOverhead = float64(0.06)
 		largeOverhead   = float64(0.75)
 	)
 	DescribeTable("getusablespace should return properly aligned sizes,", func(virtualSize int64, overhead float64) {

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -1003,7 +1003,7 @@ type CDIConfigSpec struct {
 	PodResourceRequirements *corev1.ResourceRequirements `json:"podResourceRequirements,omitempty"`
 	// FeatureGates are a list of specific enabled feature gates
 	FeatureGates []string `json:"featureGates,omitempty"`
-	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -504,7 +504,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"scratchSpaceStorageClass": "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space",
 		"podResourceRequirements":  "ResourceRequirements describes the compute resource requirements.",
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
-		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
 		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.\nDeprecated: Removed in v1.62.\n+optional",

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2325,8 +2325,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		It("[test_id:6485]Import pod should have size corrected on filesystem", func() {
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
-			// given 50 percent overhead, expected size is 2x requestedSize
-			expectedSize := resource.MustParse("200Mi")
+			// given 50 percent overhead, expected size is 1.5x requestedSize
+			expectedSize := resource.MustParse("150Mi")
 
 			By("creating clone dataVolume")
 			volumeMode := v1.PersistentVolumeFilesystem
@@ -2355,8 +2355,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		It("[test_id:6099]Upload pvc should have size corrected on filesystem volume", func() {
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
-			// given 50 percent overhead, expected size is 2x requestedSize
-			expectedSize := resource.MustParse("200Mi")
+			// given 50 percent overhead, expected size is 1.5x requestedSize
+			expectedSize := resource.MustParse("150Mi")
 
 			By("creating datavolume for upload")
 			volumeMode := v1.PersistentVolumeFilesystem
@@ -2502,8 +2502,8 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		It("[test_id:6102]Clone pod should have size corrected on filesystem", func() {
 			SetFilesystemOverhead(f, "0.50", "0.50")
 			requestedSize := resource.MustParse("100Mi")
-			// given 50 percent overhead, expected size is 2x requestedSize
-			expectedSize := resource.MustParse("200Mi")
+			// given 50 percent overhead, expected size is 1.5x requestedSize
+			expectedSize := resource.MustParse("150Mi")
 
 			By("creating clone dataVolume")
 			volumeMode := v1.PersistentVolumeFilesystem

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1311,8 +1311,6 @@ var _ = Describe("Preallocation", func() {
 	)
 
 	It("Filesystem overhead is honored with blank volume", Serial, func() {
-		tests.SetFilesystemOverhead(f, "0.055", "0.055")
-
 		dv := utils.NewDataVolumeForBlankRawImage("import-dv", "100Mi")
 		preallocation := true
 		dv.Spec.Preallocation = &preallocation

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
-	"kubevirt.io/containerized-data-importer/tests"
 	"kubevirt.io/containerized-data-importer/tests/framework"
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
@@ -1366,8 +1365,6 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		// is insufficient to account for the fs overhead in small images.
 		// This issue is not seen with larger images where the overhead is sufficient.
 		size := "2147483648"
-		fsOverhead := "0.055" // The default value
-		tests.SetFilesystemOverhead(f, fsOverhead, fsOverhead)
 
 		volumeMode := v1.PersistentVolumeFilesystem
 		accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1362,10 +1362,10 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	})
 
 	It("Upload an image exactly the same size as DV request (bz#2064936)", func() {
-		// This image size and filesystem overhead combination was experimentally determined
-		// to reproduce bz#2064936 in CI when using ceph/rbd with a Filesystem mode PV since
-		// the filesystem capacity will be constrained by the PVC request size.
-		size := "858993459"
+		// Using a large image to avoid a known issue where the default overhead inflation
+		// is insufficient to account for the fs overhead in small images.
+		// This issue is not seen with larger images where the overhead is sufficient.
+		size := "2147483648"
 		fsOverhead := "0.055" // The default value
 		tests.SetFilesystemOverhead(f, fsOverhead, fsOverhead)
 
@@ -1402,7 +1402,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		By("Do upload")
 		Eventually(func() error {
-			return uploadFileNameToPath(binaryRequestFunc, utils.FsOverheadFile, uploadProxyURL, syncUploadPath, token, http.StatusOK)
+			return uploadFileNameToPath(binaryRequestFunc, utils.UploadFileLargeVirtualDiskQcow, uploadProxyURL, syncUploadPath, token, http.StatusOK)
 		}, timeout, pollingInterval).Should(BeNil(), "Upload should eventually succeed, even if initially pod is not ready")
 
 		phase = cdiv1.Succeeded


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3812 and https://github.com/kubevirt/containerized-data-importer/pull/3779. These two PRs need to be backported together to ensure consistent behavior and minimize impact on the overhead calculation results.

**Special notes for your reviewer**:

No major conflicts needed to be addressed, just some minor ones in unit tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix math in overhead size calculations:
- When using the storage API, PVC disk size is now correctly inflated to account for filesystem overhead.
- When using the PVC API, usable disk space is now calculated more accurately with "allocatedSize / (1 + overhead)". This may result in changes in usable size compared to the previous behavior.
- Increase default filesystem overhead to 6%
```

