### PR TITLE
[release-v1.58] Tests: Fix Get assignment in multi-stage import test

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1936,7 +1936,7 @@ var _ = Describe("Import populator", func() {
 
 		By("Update DataVolume checkpoints")
 		Eventually(func() bool {
-			dataVolume, err := f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+			dataVolume, err = f.CdiClient.CdiV1beta1().DataVolumes(f.Namespace.Name).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			dataVolume.Spec.Checkpoints = []cdiv1.DataVolumeCheckpoint{
 				{Current: "test", Previous: "foo"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This test has been flaky for a long time: https://issues.redhat.com/browse/CNV-40015.

The issue seems to be caused by an inline DV declaration in the Eventually block, which leads to outdated data in the final check. This PR ensures we use the updated DV when comparing with the VolumeImportSource.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

