### PR TITLE
Add status subresource to StorageProfile

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -605,7 +605,7 @@ func createStorageProfileReconciler(objects ...runtime.Object) *StorageProfileRe
 	_ = ocpconfigv1.Install(s)
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).WithStatusSubresource(&cdiv1.StorageProfile{}).Build()
 
 	rec := record.NewFakeRecorder(10)
 	// Create a ReconcileMemcached object with the scheme and fake client.

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -7853,6 +7853,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -164,7 +164,6 @@ type DataSourceRefSourceDataSource struct {
 	Namespace string `json:"namespace"`
 	// The name of the source DataSource
 	Name string `json:"name"`
-
 }
 
 // DataVolumeBlankImage provides the parameters to create a new raw blank image for the PVC
@@ -429,6 +428,7 @@ const DataVolumeCloneSourceSubresource = "source"
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 type StorageProfile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -517,7 +517,7 @@ type DataSourceSource struct {
 	// +optional
 	Snapshot *DataVolumeSourceSnapshot `json:"snapshot,omitempty"`
 	// +optional
-	DataSource *DataSourceRefSourceDataSource `json:"dataSource,omitempty"` 
+	DataSource *DataSourceRefSourceDataSource `json:"dataSource,omitempty"`
 }
 
 // DataSourceStatus provides the most recently observed status of the DataSource

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -190,7 +190,7 @@ func (DataVolumeCondition) SwaggerDoc() map[string]string {
 
 func (StorageProfile) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "StorageProfile provides a CDI specific recommendation for storage parameters\n+genclient\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+kubebuilder:object:root=true\n+kubebuilder:storageversion\n+kubebuilder:resource:scope=Cluster",
+		"": "StorageProfile provides a CDI specific recommendation for storage parameters\n+genclient\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+kubebuilder:object:root=true\n+kubebuilder:storageversion\n+kubebuilder:resource:scope=Cluster\n+kubebuilder:subresource:status",
 	}
 }
 


### PR DESCRIPTION
We have been observing flaky failures in the StorageProfile functional tests.

The root cause appears to be a race condition. Each test resets the spec upon completion, but the controller is likely still processing the previous state when the next test begins. Without a status field, the test has no way to confirm that the controller has finished reconciling the previous state.

This change introduces a status subresource to the StorageProfile. This allows tests and clients to observe the resource's actual state and wait for the status field to be populated - signaling that reconciliation is complete before proceeding.

The implementation includes:

1. Adding the +kubebuilder:subresource:status annotation to the StorageProfile type.
2. Updating the controller to handle status updates separately from the spec.
3. Regenerating the CRD to support the status subresource.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes** 
Fixes https://issues.redhat.com/browse/CNV-48282

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

