### PR TITLE
controller, util: make validLabelsMatch regex more lax

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -392,7 +392,7 @@ var (
 		AnnPodMultusDefaultNetwork:    "",
 	}
 
-	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/[\w-]+$`)
+	validLabelsMatch = regexp.MustCompile(`^([\w.]+\.kubevirt.io|kubevirt.io)/[\w.-]+$`)
 
 	ErrDataSourceMaxDepthReached = errors.New("DataSource reference chain exceeds maximum depth of 1")
 	ErrDataSourceSelfReference   = errors.New("DataSource cannot self-reference")

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -328,6 +328,8 @@ var _ = Describe("CopyAllowedLabels", func() {
 		testKubevirtIoValueExisting     = "existing"
 		testKubevirtIoNewValueExisting  = "newvalue"
 		testUndesiredKey                = "undesired.key"
+		testCdiDatasourceKey            = "cdi.kubevirt.io/storage.import.datasource-name"
+		testCdiDatasourceKeyValue       = "testdatasource"
 	)
 
 	It("Should copy desired labels", func() {
@@ -335,11 +337,13 @@ var _ = Describe("CopyAllowedLabels", func() {
 			testKubevirtIoKey:             testKubevirtIoValue,
 			testInstancetypeKubevirtIoKey: testInstancetypeKubevirtIoValue,
 			testUndesiredKey:              "undesired.key",
+			testCdiDatasourceKey:          testCdiDatasourceKeyValue,
 		}
 		ds := &cdiv1.DataSource{}
 		CopyAllowedLabels(srcLabels, ds, false)
 		Expect(ds.Labels).To(HaveKeyWithValue(testKubevirtIoKey, testKubevirtIoValue))
 		Expect(ds.Labels).To(HaveKeyWithValue(testInstancetypeKubevirtIoKey, testInstancetypeKubevirtIoValue))
+		Expect(ds.Labels).To(HaveKeyWithValue(testCdiDatasourceKey, testCdiDatasourceKeyValue))
 		Expect(ds.Labels).ToNot(HaveKey(testUndesiredKey))
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously certain allowed (kubevirt.io) labels that included dots after the / delimiter would be ignored as the expression only matched one or more letters/digits/underscore/dashes. This PR adds dots to the list of allowed symbols.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Enables certain requirements of https://github.com/kubevirt/enhancements/pull/49
Builds on top of https://github.com/kubevirt/containerized-data-importer/pull/3838

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

