### PR TITLE
fix: Items type in VolumeUploadSourceList should be VolumeUploadSource

### DIFF
--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -19955,7 +19955,7 @@ func schema_pkg_apis_core_v1beta1_VolumeUploadSourceList(ref common.ReferenceCal
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.VolumeImportSource"),
+										Ref:     ref("kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.VolumeUploadSource"),
 									},
 								},
 							},
@@ -19966,7 +19966,7 @@ func schema_pkg_apis_core_v1beta1_VolumeUploadSourceList(ref common.ReferenceCal
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.VolumeImportSource"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.VolumeUploadSource"},
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -164,7 +164,6 @@ type DataSourceRefSourceDataSource struct {
 	Namespace string `json:"namespace"`
 	// The name of the source DataSource
 	Name string `json:"name"`
-
 }
 
 // DataVolumeBlankImage provides the parameters to create a new raw blank image for the PVC
@@ -517,7 +516,7 @@ type DataSourceSource struct {
 	// +optional
 	Snapshot *DataVolumeSourceSnapshot `json:"snapshot,omitempty"`
 	// +optional
-	DataSource *DataSourceRefSourceDataSource `json:"dataSource,omitempty"` 
+	DataSource *DataSourceRefSourceDataSource `json:"dataSource,omitempty"`
 }
 
 // DataSourceStatus provides the most recently observed status of the DataSource
@@ -755,7 +754,7 @@ type VolumeUploadSourceList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	// Items provides a list of DataSources
-	Items []VolumeImportSource `json:"items"`
+	Items []VolumeUploadSource `json:"items"`
 }
 
 const (

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -2196,7 +2196,7 @@ func (in *VolumeUploadSourceList) DeepCopyInto(out *VolumeUploadSourceList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]VolumeImportSource, len(*in))
+		*out = make([]VolumeUploadSource, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`Items` type should be `VolumeUploadSource` instead of `VolumeImportSource` in `VolumeUploadSourceList`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3878

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix wrong Items type in VolumeUploadSourceList
```

