### PR TITLE
Add IBM VPC Block CSI storage capabilities

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -96,6 +96,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"spectrumscale.csi.ibm.com": {{rwx, file}, {rwo, file}},
 	// IBM block arrays (FlashSystem)
 	"block.csi.ibm.com": {{rwx, block}, {rwo, block}, {rwo, file}},
+	// IBM VPC Block CSI
+	"vpc.block.csi.ibm.io": {{rwo, block}, {rwo, file}},
 	// Portworx in-tree CSI
 	"kubernetes.io/portworx-volume/nfs": {{rwx, file}, {rwo, file}},
 	"kubernetes.io/portworx-volume":     {{rwx, block}, {rwx, file}, {rwo, block}, {rwo, file}},
@@ -162,6 +164,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"csi.hpe.com":                              cdiv1.CloneStrategyCsiClone,
 	"spectrumscale.csi.ibm.com":                cdiv1.CloneStrategyCsiClone,
 	"block.csi.ibm.com":                        cdiv1.CloneStrategyCsiClone,
+	"vpc.block.csi.ibm.io":                     cdiv1.CloneStrategyHostAssisted,
 	"rbd.csi.ceph.com":                         cdiv1.CloneStrategyCsiClone,
 	"rook-ceph.rbd.csi.ceph.com":               cdiv1.CloneStrategyCsiClone,
 	"openshift-storage.rbd.csi.ceph.com":       cdiv1.CloneStrategyCsiClone,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR defines the storage capabilities for the IBM VPC Block CSI so that CDI is working out of the box with this driver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- CLONE_VOLUME and MULTI_NODE_MULTI_WRITER capabilities are not supported by the controller
- Snapshots are not possible unless the source volume is attached to a running VSI

See documentation:
- https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-about
- https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/blob/master/pkg/ibmcsidriver/ibm_csi_driver.go

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add IBM VPC Block CSI storage capabilities
```

