### PR TITLE
Allow mutating only PVC requested size to the minimum supported

### DIFF
--- a/pkg/apiserver/webhooks/pvc-mutate.go
+++ b/pkg/apiserver/webhooks/pvc-mutate.go
@@ -25,11 +25,9 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"kubevirt.io/containerized-data-importer/pkg/common"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 )
 
@@ -49,12 +47,6 @@ func (wh *pvcMutatingWebhook) Admit(ar admissionv1.AdmissionReview) *admissionv1
 	pvc := &v1.PersistentVolumeClaim{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, &pvc); err != nil {
 		return toAdmissionResponseError(err)
-	}
-
-	// Note the webhook LabelSelector should not pass us such pvcs
-	if pvc.Labels[common.PvcApplyStorageProfileLabel] != "true" {
-		klog.Warningf("Got PVC %s/%s which was not labeled for rendering", pvc.Namespace, pvc.Name)
-		return allowedAdmissionResponse()
 	}
 
 	pvcCpy := pvc.DeepCopy()

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -67,6 +67,8 @@ const (
 
 	// PvcApplyStorageProfileLabel tells whether the PVC should be rendered by the mutating webhook based on StorageProfiles
 	PvcApplyStorageProfileLabel = CDIComponentLabel + "/applyStorageProfile"
+	// PvcApplyStorageProfileMinimumSize tells whether the PVC mutating webhook rendering should apply only the StorageProfile minimum volume size if exists
+	PvcApplyStorageProfileMinimumSize = "minimumSize"
 
 	// ImporterVolumePath provides a constant for the directory where the PV is mounted.
 	ImporterVolumePath = "/data"

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -509,8 +509,12 @@ func initPvcMutatingWebhook(whc *admissionregistrationv1.MutatingWebhookConfigur
 				"v1",
 			},
 			ObjectSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					common.PvcApplyStorageProfileLabel: "true",
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.PvcApplyStorageProfileLabel,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true", common.PvcApplyStorageProfileMinimumSize},
+					},
 				},
 			},
 			ReinvocationPolicy: &reinvocationNever,


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow mutating only the PVC requested size to the minimum supported by the relevant `StorageProfile`, but without applying the `StorageProfile` `accessModes`, `volumeMode`, or `filesystemOverhead`.

**Release note**:
```release-note
Allow mutating only the PVC requested size to the minimum supported
```

