### PR TITLE
Host assisted clone should adjust requested storage when cloning from block to filesystem volume mode (#3900)

### DIFF
--- a/pkg/controller/clone/BUILD.bazel
+++ b/pkg/controller/clone/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/common:go_default_library",
         "//pkg/controller/common:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",

--- a/pkg/controller/clone/host-clone_test.go
+++ b/pkg/controller/clone/host-clone_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,17 +34,36 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 )
 
 var _ = Describe("HostClonePhase test", func() {
 	log := logf.Log.WithName("host-clone-phase-test")
 
-	creatHostClonePhase := func(objects ...runtime.Object) *HostClonePhase {
+	type ResourceModifier struct {
+		modifySourcePvc  func(pvcSpec *corev1.PersistentVolumeClaim)
+		modifyDesiredPvc func(pvc *corev1.PersistentVolumeClaim)
+	}
+
+	creatHostClonePhase := func(modifier *ResourceModifier, objects ...runtime.Object) *HostClonePhase {
 		s := scheme.Scheme
 		_ = cdiv1.AddToScheme(s)
 
 		objects = append(objects, cc.MakeEmptyCDICR())
+
+		source := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "source",
+			},
+		}
+
+		if modifier != nil && modifier.modifySourcePvc != nil {
+			modifier.modifySourcePvc(source)
+		}
+
+		objects = append(objects, source)
 
 		// Create a fake client to mock API calls.
 		builder := fake.NewClientBuilder().
@@ -67,13 +87,24 @@ var _ = Describe("HostClonePhase test", func() {
 				Namespace: "ns",
 				Name:      "desired",
 			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		if modifier != nil && modifier.modifyDesiredPvc != nil {
+			modifier.modifyDesiredPvc(desired)
 		}
 
 		return &HostClonePhase{
 			Owner:          owner,
 			OwnershipLabel: "label",
 			Namespace:      "ns",
-			SourceName:     "source",
+			SourceName:     source.Name,
 			DesiredClaim:   desired,
 			ImmediateBind:  true,
 			Preallocation:  false,
@@ -91,7 +122,7 @@ var _ = Describe("HostClonePhase test", func() {
 	}
 
 	It("should create pvc", func() {
-		p := creatHostClonePhase()
+		p := creatHostClonePhase(nil)
 
 		result, err := p.Reconcile(context.Background())
 		Expect(err).ToNot(HaveOccurred())
@@ -114,7 +145,7 @@ var _ = Describe("HostClonePhase test", func() {
 	})
 
 	It("should create pvc with priorityclass", func() {
-		p := creatHostClonePhase()
+		p := creatHostClonePhase(nil)
 		p.PriorityClassName = "priority"
 
 		result, err := p.Reconcile(context.Background())
@@ -125,6 +156,100 @@ var _ = Describe("HostClonePhase test", func() {
 
 		pvc := getDesiredClaim(p)
 		Expect(pvc.Annotations[cc.AnnPriorityClassName]).To(Equal("priority"))
+	})
+
+	It("should get error if target pvc does not have size", func() {
+		makePvcSizeMissing := func(pvc *corev1.PersistentVolumeClaim, _ corev1.PersistentVolumeMode) {
+			pvc.Spec = corev1.PersistentVolumeClaimSpec{}
+		}
+		cdiConfig := cc.MakeEmptyCDIConfigSpec(common.ConfigName)
+		cdiConfig.Status.FilesystemOverhead = &cdiv1.FilesystemOverhead{
+			Global: common.DefaultGlobalOverhead,
+		}
+
+		p := creatHostClonePhase(&ResourceModifier{
+			modifyDesiredPvc: func(pvc *corev1.PersistentVolumeClaim) {
+				makePvcSizeMissing(pvc, corev1.PersistentVolumeFilesystem)
+			},
+		}, cdiConfig)
+
+		_, err := p.Reconcile(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no target resource request specified"))
+	})
+
+	It("should adjust requested size for block to filesystem volume mode clone", func() {
+		setPvcAttributes := func(pvcSpec *corev1.PersistentVolumeClaimSpec, volumeMode corev1.PersistentVolumeMode, storage string) {
+			pvcSpec.VolumeMode = &volumeMode
+			if pvcSpec.Resources.Requests == nil {
+				pvcSpec.Resources.Requests = corev1.ResourceList{}
+			}
+			pvcSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(storage)
+		}
+		cdiConfig := cc.MakeEmptyCDIConfigSpec(common.ConfigName)
+		cdiConfig.Status.FilesystemOverhead = &cdiv1.FilesystemOverhead{
+			Global: common.DefaultGlobalOverhead,
+		}
+
+		p := creatHostClonePhase(&ResourceModifier{
+			modifySourcePvc: func(pvc *corev1.PersistentVolumeClaim) {
+				setPvcAttributes(&pvc.Spec, corev1.PersistentVolumeBlock, "8Gi")
+			},
+			modifyDesiredPvc: func(pvc *corev1.PersistentVolumeClaim) {
+				setPvcAttributes(&pvc.Spec, corev1.PersistentVolumeFilesystem, "8Gi")
+			},
+		}, cdiConfig)
+
+		result, err := p.Reconcile(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Requeue).To(BeFalse())
+		Expect(result.RequeueAfter).ToNot(BeZero())
+
+		pvc := getDesiredClaim(p)
+
+		Expect(*pvc.Spec.VolumeMode).To(Equal(corev1.PersistentVolumeFilesystem))
+		actualSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		originalRequested := resource.MustParse("8Gi")
+
+		Expect(actualSize.Cmp(originalRequested)).To(BeNumerically(">", 0), "The actual should be greater than the requested", "actual", actualSize, "requested", originalRequested)
+	})
+
+	It("should inflate the target size for filesystem to filesystem volume mode clone", func() {
+		setPvcAttributes := func(pvcSpec *corev1.PersistentVolumeClaimSpec, volumeMode corev1.PersistentVolumeMode, storage string) {
+			pvcSpec.VolumeMode = &volumeMode
+			if pvcSpec.Resources.Requests == nil {
+				pvcSpec.Resources.Requests = corev1.ResourceList{}
+			}
+			pvcSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(storage)
+		}
+		cdiConfig := cc.MakeEmptyCDIConfigSpec(common.ConfigName)
+		cdiConfig.Status.FilesystemOverhead = &cdiv1.FilesystemOverhead{
+			Global: common.DefaultGlobalOverhead,
+		}
+
+		p := creatHostClonePhase(&ResourceModifier{
+			modifySourcePvc: func(pvc *corev1.PersistentVolumeClaim) {
+				setPvcAttributes(&pvc.Spec, corev1.PersistentVolumeFilesystem, "8Gi")
+			},
+			modifyDesiredPvc: func(pvc *corev1.PersistentVolumeClaim) {
+				setPvcAttributes(&pvc.Spec, corev1.PersistentVolumeFilesystem, "8Gi")
+			},
+		}, cdiConfig)
+
+		result, err := p.Reconcile(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Requeue).To(BeFalse())
+		Expect(result.RequeueAfter).ToNot(BeZero())
+
+		pvc := getDesiredClaim(p)
+
+		Expect(*pvc.Spec.VolumeMode).To(Equal(corev1.PersistentVolumeFilesystem))
+		actualSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		originalRequested := resource.MustParse("8Gi")
+
+		Expect(actualSize.Cmp(originalRequested)).To(BeNumerically(">", 0), "The actual should be greater than the requested", "actual", actualSize, "requested", originalRequested)
 	})
 
 	Context("with desired claim created", func() {
@@ -141,7 +266,7 @@ var _ = Describe("HostClonePhase test", func() {
 		It("should wait for clone to succeed", func() {
 			desired := getCliam()
 			desired.Annotations[cc.AnnPodPhase] = "Running"
-			p := creatHostClonePhase(desired)
+			p := creatHostClonePhase(nil, desired)
 
 			result, err := p.Reconcile(context.Background())
 			Expect(err).ToNot(HaveOccurred())
@@ -153,7 +278,7 @@ var _ = Describe("HostClonePhase test", func() {
 		It("should wait for clone to succeed with preallocation", func() {
 			desired := getCliam()
 			desired.Annotations[cc.AnnPodPhase] = "Succeeded"
-			p := creatHostClonePhase(desired)
+			p := creatHostClonePhase(nil, desired)
 			p.Preallocation = true
 
 			result, err := p.Reconcile(context.Background())
@@ -166,7 +291,7 @@ var _ = Describe("HostClonePhase test", func() {
 		It("should succeed", func() {
 			desired := getCliam()
 			desired.Annotations[cc.AnnPodPhase] = "Succeeded"
-			p := creatHostClonePhase(desired)
+			p := creatHostClonePhase(nil, desired)
 
 			result, err := p.Reconcile(context.Background())
 			Expect(err).ToNot(HaveOccurred())
@@ -177,7 +302,7 @@ var _ = Describe("HostClonePhase test", func() {
 			desired := getCliam()
 			desired.Annotations[cc.AnnPodPhase] = "Succeeded"
 			desired.Annotations[cc.AnnPreallocationApplied] = "true"
-			p := creatHostClonePhase(desired)
+			p := creatHostClonePhase(nil, desired)
 			p.Preallocation = true
 
 			result, err := p.Reconcile(context.Background())


### PR DESCRIPTION
When cloning from a source, the host cloner should check the requested size for the target tmp pvc if the tmp source pvc is of block volume mode and the target pvc is of filesystem volume mode because it should take filesystem overhead into consideration and enlarge the original request size accordingly
before creating the tmp pvc.

Because currently the check is missing the cloning will fail on validation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-44140

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Host assisted clone should adjust requested storage when cloning from block to filesystem volume mode
```

