### PR TITLE
Enable CSI cloning functionality when CDI populators are disabled

### DIFF
--- a/pkg/controller/datavolume/BUILD.bazel
+++ b/pkg/controller/datavolume/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/monitoring/metrics/cdi-cloner:go_default_library",
         "//pkg/monitoring/metrics/cdi-controller:go_default_library",
         "//pkg/monitoring/metrics/cdi-importer:go_default_library",
+        "//pkg/storagecapabilities:go_default_library",
         "//pkg/token:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -937,6 +937,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					}
 				} else {
 					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
+					dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress(cc.ProgressDone)
 				}
 			case corev1.ClaimBound:
 				switch dataVolumeCopy.Status.Phase {
@@ -954,6 +955,7 @@ func (r *ReconcilerBase) updateStatus(req reconcile.Request, phaseSync *statusPh
 					}
 				} else {
 					dataVolumeCopy.Status.Phase = cdiv1.Succeeded
+					dataVolumeCopy.Status.Progress = cdiv1.DataVolumeProgress(cc.ProgressDone)
 				}
 
 			case corev1.ClaimLost:


### PR DESCRIPTION
This draft introduces an attempt to allow DataVolumes to use CSI volume cloning (instead of falling back to host-assisted clone strategy) even when the usePopulator feature is set to false, providing direct cloning for storage classes that support CSI clone operations.

added csi-clone support for both pvc and snapshot sources - withing the cloning process, PVC with a dataSource/dataSourceRef pointing to the pvc/volumesnapshot will be created.




<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following our discussion about Portworx’s set of the userPopulator field to false, we decided to reintroduce the ability to perform a CSI-based clone even without CDI populators. This avoids falling back to host-assisted cloning, which significantly increases clone completion time. 

**Which issue(s) this PR fixes** *
Jira Ticket: https://issues.redhat.com/browse/CNV-66958
for additional context:
The PR that removed csi-cloning after introducing CDI populators: https://github.com/kubevirt/containerized-data-importer/pull/2750/commits/2285ceb46045bc281264591b4d0497a57f9bd527#r1235350852

**Special notes for your reviewer**:
@alromeros  
@akalenyu 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

