### PR TITLE
Bugfix: dataimportcron, cdi-source-update-poller should acknowledge architecture setting

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -657,6 +657,10 @@ func (r *DataImportCronReconciler) updateContainerImageDesiredDigest(ctx context
 	if err != nil {
 		return false, err
 	}
+	platform := cron.Spec.Template.Spec.Source.Registry.Platform
+	if platform != nil && platform.Architecture != "" {
+		workloadNodePlacement.NodeSelector[corev1.LabelArchStable] = platform.Architecture
+	}
 
 	containerImage := strings.TrimPrefix(*cron.Spec.Template.Spec.Source.Registry.URL, "docker://")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
All registry DataImportCron import settings would ignore the architecture setting, resulting in scenarios where the resulting populated datasource would contain an incorrect image.

This PR introduces support for architecture support in DICs for both pull method node, which was the only mode that suffered from the issue. Other modes correctly delegate the inference logic to the importer pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-68812

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: DataImportCrons now respects the platform.architecture setting in all modes.
```

