### PR TITLE
[release-v1.61] Oracle Cloud: Set default clone strategy to csi-clone

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -172,6 +172,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"kubesan.gitlab.io":                        cdiv1.CloneStrategyCsiClone,
 	"pd.csi.storage.gke.io":                    cdiv1.CloneStrategySnapshot,
 	"pd.csi.storage.gke.io/hyperdisk":          cdiv1.CloneStrategySnapshot,
+	"blockvolume.csi.oraclecloud.com":          cdiv1.CloneStrategyCsiClone,
 }
 
 // MinimumSupportedPVCSizeByProvisionerKey defines the minimum supported PVC size for a provisioner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR sets the default clone strategy for OCI to csi-clone.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

