### PR TITLE
[release-v1.62] added defaults to support synology csi driver storageprofile creation

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -15,6 +15,8 @@
   - [S3-compatible client setup:](#s3-compatible-client-setup)
     - [AWS S3 cli](#aws-s3-cli)
     - [Minio cli](#minio-cli)
+  - [Troubleshooting the build process](#troubleshooting-the-build-process)
+    - [Errors pushing image to private registry](#errors-pushing-image-to-private-registry)
 
 ### Download CDI
 
@@ -226,7 +228,7 @@ not supported, then you can use the following example to run Functional Tests.
    - *host-file-server* is required by the functional tests and provides an
      endpoint server for image files and s3 buckets
    - *registry-server* is required by the functional tests and provides an endpoint server for container images.
-     Note: for this server to run the follwoing setting is required in each cluster node
+     Note: for this server to run the following setting is required in each cluster node
      ``systemctl -w user.max_user_namespaces=1024``
 
    Build and Push to registry
@@ -307,3 +309,13 @@ $HOME/.mc/config.json:
         }
 }
 ```
+
+### Troubleshooting the build process
+
+#### Errors pushing image to private registry
+
+If you run into issues with pushing the container images to a private registry, you will need to ensure that you have a `~/.docker/config.json` file that contains the proper login information for your registry. If you are using `podman` for your container runtime, you can create this file and the appropriate auth information by running the following command:
+
+`podman login --authfile ~/.docker/config.json <registry server>`
+
+Once `~/.docker/config.json` exists, you can re-run the build process and the images should be pushed to your container registry.

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -133,6 +133,10 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"driver.longhorn.io/fs":         {{rwo, file}},
 	// Oracle cloud
 	"blockvolume.csi.oraclecloud.com": {{rwx, block}, {rwo, block}, {rwo, file}},
+	// Synology
+	"csi.san.synology.com/iscsi": {{rwx, block}, {rwo, block}, {rwo, file}},
+	"csi.san.synology.com/nfs":   {{rwx, file}, {rwo, file}},
+	"csi.san.synology.com/smb":   {{rwx, file}, {rwo, file}},
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format
@@ -174,6 +178,9 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"kubesan.gitlab.io":                        cdiv1.CloneStrategyCsiClone,
 	"pd.csi.storage.gke.io":                    cdiv1.CloneStrategySnapshot,
 	"pd.csi.storage.gke.io/hyperdisk":          cdiv1.CloneStrategySnapshot,
+	"csi.san.synology.com/iscsi":               cdiv1.CloneStrategyCsiClone,
+	"csi.san.synology.com/nfs":                 cdiv1.CloneStrategyCsiClone,
+	"csi.san.synology.com/smb":                 cdiv1.CloneStrategyCsiClone,
 }
 
 // MinimumSupportedPVCSizeByProvisionerKey defines the minimum supported PVC size for a provisioner
@@ -185,6 +192,10 @@ var MinimumSupportedPVCSizeByProvisionerKey = map[string]string{
 	"ebs.csi.aws.com/gp":  "1Gi",
 	// https://cloud.google.com/netapp/volumes/docs/discover/service-levels
 	"csi.trident.netapp.io/gcnv-flex": "1Gi",
+	// https://github.com/SynologyOpenSource/synology-csi/blob/e2cc8de2fa555e26ad2377b564fac841e02100ba/pkg/driver/controllerserver.go#L55
+	"csi.san.synology.com/iscsi": "1Gi",
+	"csi.san.synology.com/nfs":   "1Gi",
+	"csi.san.synology.com/smb":   "1Gi",
 }
 
 const (
@@ -411,6 +422,19 @@ var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageCl
 			return "pd.csi.storage.gke.io/hyperdisk"
 		default:
 			return "pd.csi.storage.gke.io"
+		}
+	},
+	"csi.san.synology.com": func(sc *storagev1.StorageClass) string {
+		// https://github.com/SynologyOpenSource/synology-csi/tree/e2cc8de2fa555e26ad2377b564fac841e02100ba/deploy/kubernetes/v1.20
+		switch sc.Parameters["protocol"] {
+		case "iscsi", "":
+			return "csi.san.synology.com/iscsi"
+		case "smb":
+			return "csi.san.synology.com/smb"
+		case "nfs", "nfs_treeq":
+			return "csi.san.synology.com/nfs"
+		default:
+			return "UNKNOWN"
 		}
 	},
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/containerized-data-importer/pull/3806. 

Backporting this will make other storage capabilities cherry-picks more straightforward. It's also worth having in previous versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @akalenyu 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
1. Defined storagecapabilities for the synology-csi driver, fully populating the storageprofile for related synology storage classes.
```

