### PR TITLE
dataimportcron-controller: fix nil map assignment

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -659,6 +659,9 @@ func (r *DataImportCronReconciler) updateContainerImageDesiredDigest(ctx context
 	}
 	platform := cron.Spec.Template.Spec.Source.Registry.Platform
 	if platform != nil && platform.Architecture != "" {
+		if workloadNodePlacement.NodeSelector == nil {
+			workloadNodePlacement.NodeSelector = map[string]string{}
+		}
 		workloadNodePlacement.NodeSelector[corev1.LabelArchStable] = platform.Architecture
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The code path assumed that workloadNodePlacement's NodeSelector map was already initialized. This commit ensures that it is initialized before assignment to avoid a panic when the map is nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

