### PR TITLE
dataimportcron_test: force pullMethod node for architecture pull test

### DIFF
--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -440,7 +440,11 @@ var _ = Describe("DataImportCron", Serial, func() {
 		By("Create DataImportCron with only initial poller job")
 		cron = utils.NewDataImportCron(cronName, "1Gi", scheduleOnceAYear, dataSourceName, importsToKeep, *reg)
 		retentionPolicy := cdiv1.DataImportCronRetainNone
+		url := fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix)
+		pullMethod := cdiv1.RegistryPullNode
 		cron.Spec.RetentionPolicy = &retentionPolicy
+		cron.Spec.Template.Spec.Source.Registry.URL = &url
+		cron.Spec.Template.Spec.Source.Registry.PullMethod = &pullMethod
 		cron.Spec.Template.Spec.Source.Registry.Platform = &cdiv1.PlatformOptions{Architecture: "test"}
 
 		cron, err := f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Tests running on OpenShift would fail due to tests running with `pullMethod: Pod` on OpenShift by default.
Force architecture pull test to use `pullMethod: Node` to correctly assert the behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

