### PR TITLE
uploadserver: wrap no capacity error

### DIFF
--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -576,7 +576,7 @@ func newSnappyReadCloser(stream io.ReadCloser) io.ReadCloser {
 func handleStreamError(w http.ResponseWriter, err error) {
 	if importer.IsNoCapacityError(err) {
 		w.WriteHeader(http.StatusBadRequest)
-		err = errors.New("effective image size is larger than the reported available storage. A larger PVC is required")
+		err = fmt.Errorf("effective image size is larger than the reported available storage: %w", err)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously a generic error was used in case of a lack of capacity error during upload.
This PR wraps the returned error instead of overwriting it to provide additional context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Removed "A larger PVC is required" as it's both an implied notion as well as an already included message as part of a possible capacity error such as `ValidationSizeError`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

