### PR TITLE
Copy Events from tmp PVCs during Clone

### DIFF
--- a/pkg/controller/clone/csi-clone.go
+++ b/pkg/controller/clone/csi-clone.go
@@ -73,6 +73,12 @@ func (p *CSIClonePhase) Reconcile(ctx context.Context) (*reconcile.Result, error
 		}
 	}
 
+	targetPvc, err := cc.GetAnnotatedEventSource(ctx, p.Client, pvc)
+	if err != nil {
+		return nil, err
+	}
+	cc.CopyEvents(pvc, targetPvc, p.Client, p.Recorder)
+
 	done, err := isClaimBoundOrWFFC(ctx, p.Client, pvc)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/clone/host-clone.go
+++ b/pkg/controller/clone/host-clone.go
@@ -165,6 +165,12 @@ func (p *HostClonePhase) Reconcile(ctx context.Context) (*reconcile.Result, erro
 		}
 	}
 
+	targetPvc, err := cc.GetAnnotatedEventSource(ctx, p.Client, actualClaim)
+	if err != nil {
+		return nil, err
+	}
+	cc.CopyEvents(actualClaim, targetPvc, p.Client, p.Recorder)
+
 	if !p.hostCloneComplete(actualClaim) {
 		// requeue to update status
 		return &reconcile.Result{RequeueAfter: 3 * time.Second}, nil

--- a/pkg/controller/clone/snap-clone.go
+++ b/pkg/controller/clone/snap-clone.go
@@ -69,6 +69,12 @@ func (p *SnapshotClonePhase) Reconcile(ctx context.Context) (*reconcile.Result, 
 		}
 	}
 
+	targetPvc, err := cc.GetAnnotatedEventSource(ctx, p.Client, pvc)
+	if err != nil {
+		return nil, err
+	}
+	cc.CopyEvents(pvc, targetPvc, p.Client, p.Recorder)
+
 	done, err := isClaimBoundOrWFFC(ctx, p.Client, pvc)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2219,3 +2219,53 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 
 	return nil
 }
+
+// CopyEvents gets srcPvc events and re-emits them on the target PVC with the src name prefix
+func CopyEvents(srcPVC, targetPVC client.Object, c client.Client, recorder record.EventRecorder) {
+	srcPrefixMsg := fmt.Sprintf("[%s] : ", srcPVC.GetName())
+
+	newEvents := &corev1.EventList{}
+	err := c.List(context.TODO(), newEvents,
+		client.InNamespace(srcPVC.GetNamespace()),
+		client.MatchingFields{"involvedObject.name": srcPVC.GetName(),
+			"involvedObject.uid": string(srcPVC.GetUID())},
+	)
+
+	if err != nil {
+		klog.Error(err, "Could not retrieve srcPVC list of Events")
+	}
+
+	currEvents := &corev1.EventList{}
+	err = c.List(context.TODO(), currEvents,
+		client.InNamespace(targetPVC.GetNamespace()),
+		client.MatchingFields{"involvedObject.name": targetPVC.GetName(),
+			"involvedObject.uid": string(targetPVC.GetUID())},
+	)
+
+	if err != nil {
+		klog.Error(err, "Could not retrieve targetPVC list of Events")
+	}
+
+	// use this to hash each message for quick lookup, value is unused
+	eventMap := make(map[string]bool)
+
+	for _, event := range currEvents.Items {
+		eventMap[event.Message] = true
+	}
+
+	for _, newEvent := range newEvents.Items {
+		msg := newEvent.Message
+
+		// check if target PVC already has this equivalent event
+		if _, exists := eventMap[msg]; exists {
+			continue
+		}
+
+		formattedMsg := srcPrefixMsg + msg
+		// check if we already emitted this event with the src prefix
+		if _, exists := eventMap[formattedMsg]; exists {
+			continue
+		}
+		recorder.Event(targetPVC, newEvent.Type, newEvent.Reason, formattedMsg)
+	}
+}

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -165,7 +165,7 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	}
 
 	// copy over any new events from pvcPrime to pvc
-	r.copyEvents(pvcPrime, pvcCopy)
+	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
 	err = cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
 	if err != nil {

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -18,7 +18,6 @@ package populators
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -296,56 +295,6 @@ func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolum
 		}
 	}
 	return pvcCopy, nil
-}
-
-// CopyEvents gets primePVC events and re-emits them on the target PVC with the prime name prefix
-func (r *ReconcilerBase) copyEvents(primePVC, targetPVC client.Object) {
-	primePrefixMsg := fmt.Sprintf("[%s] : ", primePVC.GetName())
-
-	newEvents := &corev1.EventList{}
-	err := r.client.List(context.TODO(), newEvents,
-		client.InNamespace(primePVC.GetNamespace()),
-		client.MatchingFields{"involvedObject.name": primePVC.GetName(),
-			"involvedObject.uid": string(primePVC.GetUID())},
-	)
-
-	if err != nil {
-		r.log.Error(err, "Could not retrieve primePVC list of Events")
-	}
-
-	currEvents := &corev1.EventList{}
-	err = r.client.List(context.TODO(), currEvents,
-		client.InNamespace(targetPVC.GetNamespace()),
-		client.MatchingFields{"involvedObject.name": targetPVC.GetName(),
-			"involvedObject.uid": string(targetPVC.GetUID())},
-	)
-
-	if err != nil {
-		r.log.Error(err, "Could not retrieve targetPVC list of Events")
-	}
-
-	// use this to hash each message for quick lookup, value is unused
-	eventMap := make(map[string]bool)
-
-	for _, event := range currEvents.Items {
-		eventMap[event.Message] = true
-	}
-
-	for _, newEvent := range newEvents.Items {
-		msg := newEvent.Message
-
-		// check if target PVC already has this equivalent event
-		if _, exists := eventMap[msg]; exists {
-			continue
-		}
-
-		formattedMsg := primePrefixMsg + msg
-		// check if we already emitted this event with the prime prefix
-		if _, exists := eventMap[formattedMsg]; exists {
-			continue
-		}
-		r.recorder.Event(targetPVC, newEvent.Type, newEvent.Reason, formattedMsg)
-	}
 }
 
 // reconcile functions

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -144,7 +144,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	}
 
 	// copy over any new events from pvcPrime to pvc
-	r.copyEvents(pvcPrime, pvcCopy)
+	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
 	err := cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Extension of #3764

If a clone gets stuck for whatever reason it is helpful to be able to see the original error from the PVC/DV that initiated the clone. 

Leveraging the functionality from the above PR to copy events from tmp-pvcs during a clone to the their owner pvc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Events from Clone PVCs
```

