### PR TITLE
Remove ownerrefs from temp storage classes

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -586,6 +586,8 @@ func (f *Framework) CreateNonDefaultVariationOfStorageClass(sc *storagev1.Storag
 			"cdi.kubevirt.io/testing": "",
 		},
 		Annotations: scCopy.Annotations,
+		// Avoid other operators from taking ownership of our temporary storage class
+		OwnerReferences: nil,
 	}
 
 	return f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), scCopy, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Avoid other operators from taking ownership of our temporary storage class

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

