### PR TITLE
Authorize DataImportCron PVC clone based on creator UserInfo

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4377,6 +4377,10 @@
      "managedDataSource"
     ],
     "properties": {
+     "createdBy": {
+      "description": "CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron. This field is set by the mutating webhook and cannot be set by users.",
+      "type": "string"
+     },
      "garbageCollect": {
       "description": "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported. Options are currently \"Outdated\" and \"Never\", defaults to \"Outdated\".",
       "type": "string"

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -17462,6 +17462,13 @@ func schema_pkg_apis_core_v1beta1_DataImportCronSpec(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"createdBy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron. This field is set by the mutating webhook and cannot be set by users.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"template", "schedule", "managedDataSource"},
 			},

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -79,6 +79,8 @@ const (
 
 	dataImportCronValidatePath = "/dataimportcron-validate"
 
+	dataImportCronMutatePath = "/dataimportcron-mutate"
+
 	populatorValidatePath = "/populator-validate"
 
 	healthzPath = "/healthz"
@@ -212,6 +214,11 @@ func NewCdiAPIServer(bindAddress string,
 	err = app.createDataImportCronValidatingWebhook()
 	if err != nil {
 		return nil, errors.Errorf("failed to create DataImportCron validating webhook: %s", err)
+	}
+
+	err = app.createDataImportCronMutatingWebhook()
+	if err != nil {
+		return nil, errors.Errorf("failed to create DataImportCron mutating webhook: %s", err)
 	}
 
 	err = app.createPopulatorValidatingWebhook()
@@ -555,6 +562,12 @@ func (app *cdiAPIApp) createDataImportCronValidatingWebhook() error {
 	app.container.ServeMux.Handle(dataImportCronValidatePath, webhooks.NewDataImportCronValidatingWebhook(app.client, app.cdiClient))
 	return nil
 }
+
+func (app *cdiAPIApp) createDataImportCronMutatingWebhook() error {
+	app.container.ServeMux.Handle(dataImportCronMutatePath, webhooks.NewDataImportCronMutatingWebhook())
+	return nil
+}
+
 func (app *cdiAPIApp) createPopulatorValidatingWebhook() error {
 	app.container.ServeMux.Handle(populatorValidatePath, webhooks.NewPopulatorValidatingWebhook(app.client, app.cdiClient))
 	return nil

--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cdi-validate.go",
+        "dataimportcron-mutate.go",
         "dataimportcron-validate.go",
         "datavolume-mutate.go",
         "datavolume-validate.go",
@@ -29,6 +30,7 @@ go_library(
         "//vendor/github.com/robfig/cron/v3:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
+        "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
@@ -51,6 +53,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "cdi-validate_test.go",
+        "dataimportcron-mutate_test.go",
         "dataimportcron-validate_test.go",
         "datavolume-mutate_test.go",
         "datavolume-validate_test.go",
@@ -70,6 +73,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
+        "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",

--- a/pkg/apiserver/webhooks/dataimportcron-mutate.go
+++ b/pkg/apiserver/webhooks/dataimportcron-mutate.go
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package webhooks
+
+import (
+	"encoding/json"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/klog/v2"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+type dataImportCronMutatingWebhook struct{}
+
+func (wh *dataImportCronMutatingWebhook) Admit(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	klog.V(3).Infof("Got AdmissionReview %+v", ar)
+
+	if ar.Request.Operation != admissionv1.Create {
+		return allowedAdmissionResponse()
+	}
+
+	cron := &cdiv1.DataImportCron{}
+	if err := json.Unmarshal(ar.Request.Object.Raw, cron); err != nil {
+		return toAdmissionResponseError(err)
+	}
+
+	modifiedCron := cron.DeepCopy()
+	userInfoStr, err := getUserInfoString(&ar.Request.UserInfo)
+	if err != nil {
+		return toAdmissionResponseError(err)
+	}
+	modifiedCron.Spec.CreatedBy = userInfoStr
+
+	return toPatchResponse(cron, modifiedCron)
+}
+
+func getUserInfoString(ui *authenticationv1.UserInfo) (*string, error) {
+	bs, err := json.Marshal(ui)
+	if err != nil {
+		return nil, err
+	}
+	userInfoStr := string(bs)
+	return &userInfoStr, nil
+}

--- a/pkg/apiserver/webhooks/dataimportcron-mutate_test.go
+++ b/pkg/apiserver/webhooks/dataimportcron-mutate_test.go
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the CDI project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package webhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/appscode/jsonpatch"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+var _ = Describe("Mutating DataImportCron Webhook", func() {
+	Context("with DataImportCron admission review", func() {
+		It("should reject review without request", func() {
+			ar := &admissionv1.AdmissionReview{}
+			resp := mutateDataImportCrons(ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).Should(Equal("AdmissionReview.Request is nil"))
+		})
+
+		It("should allow non-Create operations without mutation", func() {
+			cron := cdiv1.DataImportCron{}
+			ar := createDataImportCronAdmissionReview(cron, admissionv1.Update, nil)
+
+			resp := mutateDataImportCrons(ar)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Patch).To(BeNil())
+		})
+
+		It("should set CreatedBy field on Create operation", func() {
+			cron := cdiv1.DataImportCron{}
+			userInfo := &authenticationv1.UserInfo{
+				Username: "test-user",
+				UID:      "test-uid",
+				Groups:   []string{"test-group"},
+			}
+			ar := createDataImportCronAdmissionReview(cron, admissionv1.Create, userInfo)
+
+			resp := mutateDataImportCrons(ar)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Patch).ToNot(BeNil())
+			var patchOps []jsonpatch.Operation
+			err := json.Unmarshal(resp.Patch, &patchOps)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patchOps).To(HaveLen(1))
+			Expect(patchOps[0].Operation).To(Equal("add"))
+			Expect(patchOps[0].Path).To(Equal("/spec/createdBy"))
+			valueStr, ok := patchOps[0].Value.(string)
+			Expect(ok).To(BeTrue())
+			Expect(valueStr).To(ContainSubstring(userInfo.Username))
+			Expect(valueStr).To(ContainSubstring(userInfo.UID))
+		})
+	})
+})
+
+func mutateDataImportCrons(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	wh := NewDataImportCronMutatingWebhook()
+	return serveDataImportCron(ar, wh)
+}
+
+func serveDataImportCron(ar *admissionv1.AdmissionReview, handler http.Handler) *admissionv1.AdmissionResponse {
+	reqBytes, _ := json.Marshal(ar)
+	req, err := http.NewRequest(http.MethodPost, "/foobar", bytes.NewReader(reqBytes))
+	Expect(err).ToNot(HaveOccurred())
+
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var response admissionv1.AdmissionReview
+	err = json.NewDecoder(rr.Body).Decode(&response)
+	Expect(err).ToNot(HaveOccurred())
+
+	return response.Response
+}
+
+func createDataImportCronAdmissionReview(cron cdiv1.DataImportCron, operation admissionv1.Operation, userInfo *authenticationv1.UserInfo) *admissionv1.AdmissionReview {
+	cronBytes, _ := json.Marshal(&cron)
+
+	request := &admissionv1.AdmissionRequest{
+		Operation: operation,
+		Resource: metav1.GroupVersionResource{
+			Group:    cdiv1.CDIGroupVersionKind.Group,
+			Version:  cdiv1.CDIGroupVersionKind.Version,
+			Resource: "dataimportcrons",
+		},
+		Object: runtime.RawExtension{
+			Raw: cronBytes,
+		},
+	}
+
+	if userInfo != nil {
+		request.UserInfo = *userInfo
+	}
+
+	return &admissionv1.AdmissionReview{
+		Request: request,
+	}
+}

--- a/pkg/apiserver/webhooks/dataimportcron-validate.go
+++ b/pkg/apiserver/webhooks/dataimportcron-validate.go
@@ -161,5 +161,25 @@ func (wh *dataImportCronValidatingWebhook) validateDataImportCronSpec(request *a
 		return causes
 	}
 
+	if request.Operation == admissionv1.Create {
+		userInfoStr, err := getUserInfoString(&request.UserInfo)
+		if err != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeInternal,
+				Message: fmt.Sprintf("Cannot marshal UserInfo to string: %v", err),
+				Field:   field.Child("CreatedBy").String(),
+			})
+			return causes
+		}
+		if spec.CreatedBy != nil && *userInfoStr != *spec.CreatedBy {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeForbidden,
+				Message: "CreatedBy field is set automatically and cannot be specified by users",
+				Field:   field.Child("CreatedBy").String(),
+			})
+			return causes
+		}
+	}
+
 	return causes
 }

--- a/pkg/apiserver/webhooks/dataimportcron-validate_test.go
+++ b/pkg/apiserver/webhooks/dataimportcron-validate_test.go
@@ -148,6 +148,14 @@ var _ = Describe("Validating Webhook", func() {
 			resp := validateDataImportCronCreate(cron)
 			Expect(resp.Allowed).To(BeFalse())
 		})
+		It("should reject DataImportCron with CreatedBy field set by user on create", func() {
+			cron := newDataImportCron(cdiv1.DataVolumeSourceRegistry{URL: &testRegistryURL})
+			createdBy := `{"username":"hacker"}`
+			cron.Spec.CreatedBy = &createdBy
+			resp := validateDataImportCronCreate(cron)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring("CreatedBy field is set automatically"))
+		})
 		It("should reject invalid DataImportCron spec update", func() {
 			newCron := newDataImportCron(cdiv1.DataVolumeSourceRegistry{URL: &testRegistryURL})
 			newBytes, _ := json.Marshal(&newCron)

--- a/pkg/apiserver/webhooks/handler.go
+++ b/pkg/apiserver/webhooks/handler.go
@@ -91,6 +91,11 @@ func NewDataImportCronValidatingWebhook(k8sClient kubernetes.Interface, cdiClien
 	return newAdmissionHandler(&dataImportCronValidatingWebhook{dataVolumeValidatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient}})
 }
 
+// NewDataImportCronMutatingWebhook creates a new DataImportCron mutating webhook
+func NewDataImportCronMutatingWebhook() http.Handler {
+	return newAdmissionHandler(&dataImportCronMutatingWebhook{})
+}
+
 // NewPopulatorValidatingWebhook creates a new DataVolumeValidation webhook
 func NewPopulatorValidatingWebhook(k8sClient kubernetes.Interface, cdiClient cdiclient.Interface) http.Handler {
 	return newAdmissionHandler(&populatorValidatingWebhook{dataVolumeValidatingWebhook{k8sClient: k8sClient, cdiClient: cdiClient}})

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -40,6 +40,8 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/robfig/cron/v3:go_default_library",
+        "//vendor/k8s.io/api/authentication/v1:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",

--- a/pkg/controller/dataimportcron-conditions.go
+++ b/pkg/controller/dataimportcron-conditions.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
-	noDigest   = "NoDigest"
-	noImport   = "NoImport"
-	outdated   = "Outdated"
-	scheduled  = "ImportScheduled"
-	inProgress = "ImportProgressing"
-	upToDate   = "UpToDate"
+	noDigest      = "NoDigest"
+	noImport      = "NoImport"
+	notAuthorized = "NotAuthorized"
+	outdated      = "Outdated"
+	scheduled     = "ImportScheduled"
+	inProgress    = "ImportProgressing"
+	upToDate      = "UpToDate"
 )
 
 func updateDataImportCronCondition(cron *cdiv1.DataImportCron, conditionType cdiv1.DataImportCronConditionType, status corev1.ConditionStatus, message, reason string) {

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -33,6 +34,8 @@ import (
 	"github.com/pkg/errors"
 	cronexpr "github.com/robfig/cron/v3"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -889,13 +892,79 @@ func (r *DataImportCronReconciler) createImportDataVolume(ctx context.Context, d
 			return nil
 		}
 	}
-
 	dv := r.newSourceDataVolume(dataImportCron, dvName)
+	if allowed, err := r.authorizeCloneDataVolume(dataImportCron, dv); err != nil {
+		return err
+	} else if !allowed {
+		updateDataImportCronCondition(dataImportCron, cdiv1.DataImportCronProgressing, corev1.ConditionFalse,
+			"Not authorized to create DataVolume", notAuthorized)
+		return nil
+	}
 	if err := r.client.Create(ctx, dv); err != nil && !k8serrors.IsAlreadyExists(err) {
 		return err
 	}
 
 	return nil
+}
+
+func (r *DataImportCronReconciler) authorizeCloneDataVolume(dataImportCron *cdiv1.DataImportCron, dv *cdiv1.DataVolume) (bool, error) {
+	if !isPvcSource(dataImportCron) {
+		return true, nil
+	}
+
+	createdBy := dataImportCron.Spec.CreatedBy
+	if createdBy == nil {
+		r.log.Info("Not authorized to create DataVolume without CreatedBy", "cron", dataImportCron.Name)
+		return false, nil
+	}
+
+	var userInfo authenticationv1.UserInfo
+	if err := json.Unmarshal([]byte(*createdBy), &userInfo); err != nil {
+		return false, err
+	}
+
+	var resp cdiv1.CloneAuthResponse
+	var err error
+	if saNamespace, saName, ok := parseServiceAccount(userInfo.Username); ok {
+		r.log.Info("Using creator ServiceAccount for authorization", "namespace", saNamespace, "name", saName, "cron", dataImportCron.Name)
+		resp, err = dv.AuthorizeSA(dv.Namespace, dv.Name, r, saNamespace, saName)
+	} else {
+		r.log.Info("Using creator User for authorization", "username", userInfo.Username, "cron", dataImportCron.Name)
+		resp, err = dv.AuthorizeUser(dv.Namespace, dv.Name, r, userInfo)
+	}
+
+	if err != nil {
+		return false, err
+	}
+	if !resp.Allowed {
+		r.log.Info("Not authorized to create DataVolume", "cron", dataImportCron.Name, "reason", resp.Reason)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (r *DataImportCronReconciler) CreateSar(sar *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
+	if err := r.client.Create(context.TODO(), sar); err != nil {
+		return nil, err
+	}
+	return sar, nil
+}
+
+func (r *DataImportCronReconciler) GetNamespace(name string) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: name}, ns); err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+func (r *DataImportCronReconciler) GetDataSource(namespace, name string) (*cdiv1.DataSource, error) {
+	das := &cdiv1.DataSource{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, das); err != nil {
+		return nil, err
+	}
+	return das, nil
 }
 
 func (r *DataImportCronReconciler) handleStorageClassChange(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass string) error {
@@ -1810,4 +1879,18 @@ func getAccessModesFromDVSpec(dv *cdiv1.DataVolume) []corev1.PersistentVolumeAcc
 	}
 
 	return nil
+}
+
+// parseServiceAccount extracts namespace and service account name from username
+// Username format: "system:serviceaccount:<namespace>:<serviceaccount-name>"
+func parseServiceAccount(username string) (namespace, saName string, ok bool) {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return "", "", false
+	}
+	parts := strings.Split(strings.TrimPrefix(username, prefix), ":")
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -2102,6 +2102,7 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.ValidatingWebhookConfiguration cdi-api-populator-validate"] = false
 	match[normalCreateSuccess+" *v1.ValidatingWebhookConfiguration objecttransfer-api-validate"] = false
 	match[normalCreateSuccess+" *v1.ValidatingWebhookConfiguration cdi-api-dataimportcron-validate"] = false
+	match[normalCreateSuccess+" *v1.MutatingWebhookConfiguration cdi-api-dataimportcron-mutate"] = false
 	match[normalCreateSuccess+" *v1.Secret cdi-apiserver-signer"] = false
 	match[normalCreateSuccess+" *v1.ConfigMap cdi-apiserver-signer-bundle"] = false
 	match[normalCreateSuccess+" *v1.Secret cdi-apiserver-server-cert"] = false

--- a/pkg/operator/resources/cluster/apiserver.go
+++ b/pkg/operator/resources/cluster/apiserver.go
@@ -56,6 +56,7 @@ func createDynamicAPIServerResources(args *FactoryArgs) []client.Object {
 		createCDIValidatingWebhook(args.Namespace, args.Client, args.Logger),
 		createObjectTransferValidatingWebhook(args.Namespace, args.Client, args.Logger),
 		createDataImportCronValidatingWebhook(args.Namespace, args.Client, args.Logger),
+		createDataImportCronMutatingWebhook(args.Namespace, args.Client, args.Logger),
 		createPopulatorsValidatingWebhook(args.Namespace, args.Client, args.Logger),
 	}
 }
@@ -331,6 +332,74 @@ func createDataImportCronValidatingWebhook(namespace string, c client.Client, l 
 					"v1", "v1beta1",
 				},
 				ObjectSelector: &metav1.LabelSelector{},
+			},
+		},
+	}
+
+	if c == nil {
+		return whc
+	}
+
+	bundle := GetAPIServerCABundle(namespace, c, l)
+	if bundle != nil {
+		whc.Webhooks[0].ClientConfig.CABundle = bundle
+	}
+
+	return whc
+}
+
+func createDataImportCronMutatingWebhook(namespace string, c client.Client, l logr.Logger) *admissionregistrationv1.MutatingWebhookConfiguration {
+	path := "/dataimportcron-mutate"
+	defaultServicePort := int32(443)
+	allScopes := admissionregistrationv1.AllScopes
+	exactPolicy := admissionregistrationv1.Exact
+	failurePolicy := admissionregistrationv1.Fail
+	defaultTimeoutSeconds := int32(30)
+	reinvocationNever := admissionregistrationv1.NeverReinvocationPolicy
+	sideEffect := admissionregistrationv1.SideEffectClassNone
+	whc := &admissionregistrationv1.MutatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admissionregistration.k8s.io/v1",
+			Kind:       "MutatingWebhookConfiguration",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cdi-api-dataimportcron-mutate",
+			Labels: map[string]string{
+				utils.CDILabel: APIServerServiceName,
+			},
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "dataimportcron-mutate.cdi.kubevirt.io",
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{cdicorev1.SchemeGroupVersion.Group},
+						APIVersions: []string{cdicorev1.SchemeGroupVersion.Version},
+						Resources:   []string{"dataimportcrons"},
+						Scope:       &allScopes,
+					},
+				}},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: namespace,
+						Name:      APIServerServiceName,
+						Path:      &path,
+						Port:      &defaultServicePort,
+					},
+				},
+				FailurePolicy:     &failurePolicy,
+				SideEffects:       &sideEffect,
+				MatchPolicy:       &exactPolicy,
+				NamespaceSelector: &metav1.LabelSelector{},
+				TimeoutSeconds:    &defaultTimeoutSeconds,
+				AdmissionReviewVersions: []string{
+					"v1", "v1beta1",
+				},
+				ObjectSelector:     &metav1.LabelSelector{},
+				ReinvocationPolicy: &reinvocationNever,
 			},
 		},
 	}

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -122,6 +122,19 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"",
 			},
 			Resources: []string{
+				"namespaces",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
 				"configmaps",
 			},
 			Verbs: []string{
@@ -269,6 +282,17 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{
 				"update",
+			},
+		},
+		{
+			APIGroups: []string{
+				"authorization.k8s.io",
+			},
+			Resources: []string{
+				"subjectaccessreviews",
+			},
+			Verbs: []string{
+				"create",
 			},
 		},
 	}

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5684,6 +5684,11 @@ spec:
           spec:
             description: DataImportCronSpec defines specification for DataImportCron
             properties:
+              createdBy:
+                description: |-
+                  CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron.
+                  This field is set by the mutating webhook and cannot be set by users.
+                type: string
               garbageCollect:
                 description: |-
                   GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -152,6 +152,7 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 			},
 			ResourceNames: []string{
 				"cdi-api-datavolume-mutate",
+				"cdi-api-dataimportcron-mutate",
 				"cdi-api-pvc-mutate",
 			},
 			Verbs: []string{

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -596,6 +596,10 @@ type DataImportCronSpec struct {
 	// RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.
 	// +optional
 	RetentionPolicy *DataImportCronRetentionPolicy `json:"retentionPolicy,omitempty"`
+	// CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron.
+	// This field is set by the mutating webhook and cannot be set by users.
+	// +optional
+	CreatedBy *string `json:"createdBy,omitempty"`
 }
 
 // DataImportCronGarbageCollect represents the DataImportCron garbage collection mode

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -295,6 +295,7 @@ func (DataImportCronSpec) SwaggerDoc() map[string]string {
 		"importsToKeep":     "Number of import PVCs to keep when garbage collecting. Default is 3.\n+optional",
 		"managedDataSource": "ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.\nDataSource has to be in the same namespace.",
 		"retentionPolicy":   "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.\n+optional",
+		"createdBy":         "CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron.\nThis field is set by the mutating webhook and cannot be set by users.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -621,6 +621,11 @@ func (in *DataImportCronSpec) DeepCopyInto(out *DataImportCronSpec) {
 		*out = new(DataImportCronRetentionPolicy)
 		**out = **in
 	}
+	if in.CreatedBy != nil {
+		in, out := &in.CreatedBy, &out.CreatedBy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -12,8 +12,10 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -831,6 +833,65 @@ var _ = Describe("DataImportCron", Serial, func() {
 			Expect(dataSource.Spec.Source).To(Equal(expectedSource))
 		})
 	})
+
+	Context("DataImportCron controller authorization when cloning from PVC source", func() {
+		const serviceAccountName = "sa-test"
+		var sourceDv *cdiv1.DataVolume
+
+		BeforeEach(func() {
+			sourceNamespace, err := f.CreateNamespace("source-ns", nil)
+			Expect(err).ToNot(HaveOccurred())
+			f.AddNamespaceToDelete(sourceNamespace)
+
+			sourceDv = utils.NewDataVolumeWithHTTPImport("source-pvc", "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+			sourceDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, sourceNamespace.Name, sourceDv)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDv)
+		})
+
+		It("[test_id:12407] should create DataVolume when kubernetes-admin created the DataImportCron", func() {
+			cron := createDataImportCronWithPVCSource(cronName, sourceDv.Namespace, sourceDv.Name)
+			cron, err := f.CdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cron.Spec.CreatedBy).ToNot(BeNil())
+			waitForConditions(corev1.ConditionFalse, corev1.ConditionTrue)
+
+			time.Sleep(60 * time.Second)
+		})
+
+		It("[test_id:12408] should create DataVolume when authorized ServiceAccount created the DataImportCron", func() {
+			createServiceAccount(f.K8sClient, ns, serviceAccountName)
+			altCdiClient, err := f.GetCdiClientForServiceAccount(ns, serviceAccountName)
+			Expect(err).ToNot(HaveOccurred())
+			addDataImportCronRBAC(f.K8sClient, serviceAccountName, ns)
+			addSourcePvcRBAC(f.K8sClient, sourceDv.Namespace, serviceAccountName, ns)
+
+			cron := createDataImportCronWithPVCSource(cronName, sourceDv.Namespace, sourceDv.Name)
+			cron, err = altCdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cron.Spec.CreatedBy).ToNot(BeNil())
+			waitForConditions(corev1.ConditionFalse, corev1.ConditionTrue)
+		})
+
+		It("[test_id:12409] should not create DataVolume when unauthorized ServiceAccount created the DataImportCron", func() {
+			createServiceAccount(f.K8sClient, ns, serviceAccountName)
+			altCdiClient, err := f.GetCdiClientForServiceAccount(ns, serviceAccountName)
+			Expect(err).ToNot(HaveOccurred())
+			addDataImportCronRBAC(f.K8sClient, serviceAccountName, ns)
+
+			cron := createDataImportCronWithPVCSource(cronName, sourceDv.Namespace, sourceDv.Name)
+			cron, err = altCdiClient.CdiV1beta1().DataImportCrons(ns).Create(context.TODO(), cron, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cron.Spec.CreatedBy).ToNot(BeNil())
+			waitForConditions(corev1.ConditionFalse, corev1.ConditionFalse)
+			cron, err = altCdiClient.CdiV1beta1().DataImportCrons(ns).Get(context.TODO(), cronName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			cronCond := controller.FindDataImportCronConditionByType(cron, cdiv1.DataImportCronProgressing)
+			Expect(cronCond).ToNot(BeNil())
+			Expect(cronCond.ConditionState.Message).To(Equal("Not authorized to create DataVolume"))
+			Expect(cronCond.ConditionState.Reason).To(Equal("NotAuthorized"))
+		})
+	})
 })
 
 func getDataVolumeSourceRegistry(f *framework.Framework) (*cdiv1.DataVolumeSourceRegistry, error) {
@@ -882,6 +943,121 @@ func updateDataSource(clientSet *cdiclientset.Clientset, namespace string, dataS
 		_, err = clientSet.CdiV1beta1().DataSources(namespace).Update(context.TODO(), dataSource, metav1.UpdateOptions{})
 		return err
 	}
+}
+
+func createServiceAccount(client kubernetes.Interface, namespace, name string) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+	if !errors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return sa
+}
+
+func createDataImportCronWithPVCSource(name string, pvcNamespace, pvcName string) *cdiv1.DataImportCron {
+	return &cdiv1.DataImportCron{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cdiv1.DataImportCronSpec{
+			Template: cdiv1.DataVolume{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Namespace: pvcNamespace,
+							Name:      pvcName,
+						},
+					},
+					Storage: &cdiv1.StorageSpec{},
+				},
+			},
+			Schedule:          scheduleOnceAYear,
+			ManagedDataSource: "datasource-test",
+		},
+	}
+}
+
+func addDataImportCronRBAC(client kubernetes.Interface, saName, saNamespace string) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: saNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"cdi.kubevirt.io"},
+				Resources: []string{"dataimportcrons"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+	_, err := client.RbacV1().Roles(role.Namespace).Create(context.TODO(), role, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: saNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "test-role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: saNamespace,
+			},
+		},
+	}
+	_, err = client.RbacV1().RoleBindings(roleBinding.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func addSourcePvcRBAC(client kubernetes.Interface, sourceNamespace, saName, saNamespace string) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: sourceNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+	_, err := client.RbacV1().Roles(role.Namespace).Create(context.TODO(), role, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: sourceNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "test-role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: saNamespace,
+			},
+		},
+	}
+	_, err = client.RbacV1().RoleBindings(roleBinding.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
 }
 
 func retryOnceOnErr(f func() error) Assertion {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the `DataImportCron` spec a `CreatedBy` field with JSON-marshaled `UserInfo` of the user who created the `DataImportCron`. The field is set by the mutating webhook and cannot be set by users.

In case of `DataImportCron` with PVC source, the controller checks the creator `ServiceAccount`/`User` is authorized to clone the source PVC.

Assisted by Cursor AI.

**Release note**:
```release-note
Authorize DataImportCron PVC clone based on creator UserInfo
```

