### PR TITLE
Expose scheme's GroupName and Version as GroupVersion

### DIFF
--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/register.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/register.go
@@ -8,8 +8,11 @@ import (
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 )
 
-// SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+// SchemeGroupVersion and GroupVersion is group version used to register these objects
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+	GroupVersion       = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+)
 
 // CDIGroupVersionKind group version kind
 var CDIGroupVersionKind = schema.GroupVersionKind{Group: SchemeGroupVersion.Group, Version: SchemeGroupVersion.Version, Kind: "CDI"}


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR exposes the scheme's GroupName and Version as a new gloabel variable `GroupVersion` (same as `SchemeGroupVersion` does).
This is gonna make it easier to integrate the scheme, as other providers expose their scheme's GroupVersion the same way:

- [ClusterAPI core](https://github.com/kubernetes-sigs/cluster-api/blob/main/api/core/v1beta1/groupversion_info.go#L27)
- [ClusterAPI addons](https://github.com/kubernetes-sigs/cluster-api/blob/main/api/addons/v1beta1/groupversion_info.go#L27)
- [Talos Bootstrap Provider](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/blob/main/api/v1alpha3/groupversion_info.go#L18)
- [Talos Control Plane provider](https://github.com/siderolabs/cluster-api-control-plane-provider-talos/blob/main/api/v1alpha3/groupversion_info.go#L17)
- [Kubevirt CAPI provider](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/blob/main/api/v1alpha1/groupversion_info.go#L29)
- And many more

My team is building [kommodity](https://github.com/kommodity-io/kommodity/tree/main), a Cluster API based infrastructure platform. We integrate new schemes by using their `GroupVersion` as seen [here](https://github.com/kommodity-io/kommodity/blob/main/pkg/provider/scheme.go#L45-L60).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Expose scheme's GroupName and Version as new global variable `GroupVersion` making it easier to integrate the scheme.
```

