### PR TITLE
Move applyStorageProfile constant to API package

### DIFF
--- a/pkg/apiserver/webhooks/BUILD.bazel
+++ b/pkg/apiserver/webhooks/BUILD.bazel
@@ -65,7 +65,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/client/clientset/versioned/fake:go_default_library",
-        "//pkg/common:go_default_library",
         "//pkg/controller/common:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/appscode/jsonpatch:go_default_library",

--- a/pkg/apiserver/webhooks/pvc-mutate.go
+++ b/pkg/apiserver/webhooks/pvc-mutate.go
@@ -29,7 +29,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"kubevirt.io/containerized-data-importer/pkg/common"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
 )
 
@@ -52,7 +52,7 @@ func (wh *pvcMutatingWebhook) Admit(ar admissionv1.AdmissionReview) *admissionv1
 	}
 
 	// Note the webhook LabelSelector should not pass us such pvcs
-	if pvc.Labels[common.PvcApplyStorageProfileLabel] != "true" {
+	if pvc.Labels[cdiv1.LabelApplyStorageProfile] != "true" {
 		klog.Warningf("Got PVC %s/%s which was not labeled for rendering", pvc.Namespace, pvc.Name)
 		return allowedAdmissionResponse()
 	}

--- a/pkg/apiserver/webhooks/pvc-mutate_test.go
+++ b/pkg/apiserver/webhooks/pvc-mutate_test.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 var _ = Describe("Mutating PVC Webhook", func() {
@@ -158,7 +157,7 @@ func newPvc() *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "testPvc",
-			Labels: map[string]string{common.PvcApplyStorageProfileLabel: "true"},
+			Labels: map[string]string{cdiv1.LabelApplyStorageProfile: "true"},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			Resources: corev1.VolumeResourceRequirements{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -67,9 +67,6 @@ const (
 	// DataImportCronCleanupLabel tells whether to delete the resource when its DataImportCron is deleted
 	DataImportCronCleanupLabel = DataImportCronLabel + ".cleanup"
 
-	// PvcApplyStorageProfileLabel tells whether the PVC should be rendered by the mutating webhook based on StorageProfiles
-	PvcApplyStorageProfileLabel = CDIComponentLabel + "/applyStorageProfile"
-
 	// ImporterVolumePath provides a constant for the directory where the PV is mounted.
 	ImporterVolumePath = "/data"
 	// DiskImageName provides a constant for our importer/datastream_ginkgo_test and to build ImporterWritePath

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1155,13 +1155,13 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 	annotations[cc.AnnPreallocationRequested] = strconv.FormatBool(cc.GetPreallocation(context.TODO(), r.client, dataVolume.Spec.Preallocation))
 	annotations[cc.AnnCreatedForDataVolume] = string(dataVolume.UID)
 
-	if dataVolume.Spec.Storage != nil && labels[common.PvcApplyStorageProfileLabel] == "true" {
+	if dataVolume.Spec.Storage != nil && labels[cdiv1.LabelApplyStorageProfile] == "true" {
 		isWebhookPvcRenderingEnabled, err := featuregates.IsWebhookPvcRenderingEnabled(r.client)
 		if err != nil {
 			return nil, err
 		}
 		if isWebhookPvcRenderingEnabled {
-			labels[common.PvcApplyStorageProfileLabel] = "true"
+			labels[cdiv1.LabelApplyStorageProfile] = "true"
 			if targetPvcSpec.VolumeMode == nil {
 				targetPvcSpec.VolumeMode = ptr.To[corev1.PersistentVolumeMode](cdiv1.PersistentVolumeFromStorageProfile)
 			}

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -99,7 +98,7 @@ func pvcFromStorage(client client.Client, recorder record.EventRecorder, log log
 		return nil, err
 	}
 
-	shouldRender := !isWebhookRenderingEnabled || dv.Labels[common.PvcApplyStorageProfileLabel] != "true"
+	shouldRender := !isWebhookRenderingEnabled || dv.Labels[cdiv1.LabelApplyStorageProfile] != "true"
 
 	if pvc == nil {
 		pvcSpec = copyStorageAsPvc(dv.Spec.Storage)

--- a/pkg/operator/controller/callbacks.go
+++ b/pkg/operator/controller/callbacks.go
@@ -537,7 +537,7 @@ func initPvcMutatingWebhook(whc *admissionregistrationv1.MutatingWebhookConfigur
 			},
 			ObjectSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					common.PvcApplyStorageProfileLabel: "true",
+					cdiv1.LabelApplyStorageProfile: "true",
 				},
 			},
 			ReinvocationPolicy: &reinvocationNever,

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -20,6 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 )
 
 // DataVolume is an abstraction on top of PersistentVolumeClaims to allow easy population of those PersistentVolumeClaims with relation to VirtualMachines
@@ -107,6 +109,11 @@ type StorageSpec struct {
 
 // PersistentVolumeFromStorageProfile means the volume mode will be auto selected by CDI according to a matching StorageProfile
 const PersistentVolumeFromStorageProfile corev1.PersistentVolumeMode = "FromStorageProfile"
+
+// LabelApplyStorageProfile is a PVC label that tells the CDI mutating webhook to modify the PVC
+// according to the storage profile. When set to "true", the webhook will process the PVC based on
+// its associated StorageProfile (e.g., minimumSupportedPvcSize).
+const LabelApplyStorageProfile = core.GroupName + "/applyStorageProfile"
 
 // DataVolumeCheckpoint defines a stage in a warm migration.
 type DataVolumeCheckpoint struct {

--- a/tests/clone-populator_test.go
+++ b/tests/clone-populator_test.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller/clone"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/tests/framework"
@@ -189,7 +188,7 @@ var _ = Describe("Clone Populator tests", func() {
 		}
 		pvc := generateTargetPVCWithStrategy(size, vm, strategy, scName)
 		pvc.Spec.AccessModes = nil
-		cc.AddLabel(pvc, common.PvcApplyStorageProfileLabel, "true")
+		cc.AddLabel(pvc, cdiv1.LabelApplyStorageProfile, "true")
 		Eventually(func() error {
 			err := f.CrClient.Create(context.Background(), pvc)
 			if err != nil {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2067,7 +2067,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				},
 			}
 			dataVolume := createLabeledDataVolumeForImport(f, spec,
-				map[string]string{common.PvcApplyStorageProfileLabel: webhookRenderingLabel})
+				map[string]string{cdiv1.LabelApplyStorageProfile: webhookRenderingLabel})
 
 			By("verifying event occurred")
 			Eventually(func() bool {
@@ -2113,7 +2113,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				},
 			}
 			dataVolume := createLabeledDataVolumeForImport(f, spec,
-				map[string]string{common.PvcApplyStorageProfileLabel: webhookRenderingLabel})
+				map[string]string{cdiv1.LabelApplyStorageProfile: webhookRenderingLabel})
 
 			By("verifying pvc not created")
 			_, err := utils.FindPVC(f.K8sClient, dataVolume.Namespace, dataVolume.Name)
@@ -2548,7 +2548,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			By(fmt.Sprintf("creating new datavolume %s with StorageClassName %s", dataVolumeName, scName))
 			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
 				dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
-			dataVolume.Labels = map[string]string{common.PvcApplyStorageProfileLabel: webhookRenderingLabel}
+			dataVolume.Labels = map[string]string{cdiv1.LabelApplyStorageProfile: webhookRenderingLabel}
 			dataVolume.Spec.Storage.StorageClassName = ptr.To[string](scName)
 			dataVolume.Spec.Storage.AccessModes = nil
 

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1527,7 +1527,7 @@ var _ = Describe("Import populator", func() {
 		pvc = importPopulationPVCDefinition()
 
 		if webhookRendering {
-			controller.AddLabel(pvc, common.PvcApplyStorageProfileLabel, "true")
+			controller.AddLabel(pvc, cdiv1.LabelApplyStorageProfile, "true")
 			// Unset AccessModes which will be set by the webhook rendering
 			pvc.Spec.AccessModes = nil
 		}


### PR DESCRIPTION
Moving `cdi.kubevirt.io/applyStorageProfile` to the API package.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This enables external projects (e.g., KubeVirt) to import the constant from the API package instead of duplicating it.

- Add LabelApplyStorageProfile to containerized-data-importer-api package for external consumer access
- Update CDI code to use cdiv1.LabelApplyStorageProfile


**Which issue(s) this PR fixes**:
Part of a fix for # https://issues.redhat.com/browse/CNV-73408

This https://github.com/kubevirt/kubevirt/pull/16229 PR in kubevirt relies on this change.

**Special notes for your reviewer**:
@arnongilboa 
@ShellyKa13 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

