### PR TITLE
Add cdi-api-dataimportcron-mutate delete rbac

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -160,6 +160,21 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"delete",
 			},
 		},
+		// FIXME: drop after a few releases
+		{
+			APIGroups: []string{
+				"admissionregistration.k8s.io",
+			},
+			Resources: []string{
+				"mutatingwebhookconfigurations",
+			},
+			ResourceNames: []string{
+				"cdi-api-dataimportcron-mutate",
+			},
+			Verbs: []string{
+				"delete",
+			},
+		},
 		{
 			APIGroups: []string{
 				"apiregistration.k8s.io",


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow deleting the DataImportCron mutating webhook in upgrades, which are currently blocked.

**Release note**:
```release-note
Allow deleting the DataImportCron mutating webhook in upgrades
```

