### PR TITLE
Fix metric names linter to handle recording rules separately

### DIFF
--- a/hack/ci/prom_metric_linter.sh
+++ b/hack/ci/prom_metric_linter.sh
@@ -20,7 +20,7 @@
 #
 set -e
 
-linter_image_tag="v0.0.1"
+linter_image_tag="v0.0.11"
 
 PROJECT_ROOT="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")"/../../)"
 

--- a/tools/prom-metrics-collector/BUILD.bazel
+++ b/tools/prom-metrics-collector/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/monitoring/metrics/ovirt-populator:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//vendor/github.com/kubevirt/monitoring/pkg/metrics/parser:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
     ],
 )

--- a/tools/prom-metrics-collector/metrics_json_generator.go
+++ b/tools/prom-metrics-collector/metrics_json_generator.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kubevirt/monitoring/pkg/metrics/parser"
+	dto "github.com/prometheus/client_model/go"
 	om "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
 	cdiClonerMetrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
@@ -21,6 +22,17 @@ import (
 // https://sdk.operatorframework.io/docs/best-practices/observability-best-practices/#metrics-guidelines
 // should be ignored.
 var excludedMetrics = map[string]struct{}{}
+
+type RecordingRule struct {
+	Record string `json:"record,omitempty"`
+	Expr   string `json:"expr,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+type Output struct {
+	MetricFamilies []*dto.MetricFamily `json:"metricFamilies,omitempty"`
+	RecordingRules []RecordingRule     `json:"recordingRules,omitempty"`
+}
 
 func main() {
 	err := operatorMetrics.SetupMetrics()
@@ -57,31 +69,50 @@ func main() {
 		panic(err)
 	}
 
-	var metricFamilies []parser.Metric
+	var metricFamilies []*dto.MetricFamily
 
 	metricsList := om.ListMetrics()
 	for _, m := range metricsList {
 		if _, isExcludedMetric := excludedMetrics[m.GetOpts().Name]; !isExcludedMetric {
-			metricFamilies = append(metricFamilies, parser.Metric{
+			pm := parser.Metric{
 				Name: m.GetOpts().Name,
 				Help: m.GetOpts().Help,
 				Type: strings.ToUpper(string(m.GetBaseType())),
-			})
+			}
+			metricFamilies = append(metricFamilies, parser.CreateMetricFamily(pm))
 		}
 	}
 
+	recNames := make(map[string]struct{})
+	var recRules []RecordingRule
 	rulesList := rules.ListRecordingRules()
 	for _, r := range rulesList {
-		if _, isExcludedMetric := excludedMetrics[r.GetOpts().Name]; !isExcludedMetric {
-			metricFamilies = append(metricFamilies, parser.Metric{
-				Name: r.GetOpts().Name,
-				Help: r.GetOpts().Help,
-				Type: strings.ToUpper(string(r.GetType())),
-			})
+		name := r.GetOpts().Name
+		if _, isExcludedMetric := excludedMetrics[name]; isExcludedMetric {
+			continue
 		}
+		recNames[name] = struct{}{}
+		recRules = append(recRules, RecordingRule{
+			Record: name,
+			Expr:   r.Expr.String(),
+			Type:   strings.ToUpper(string(r.GetType())),
+		})
 	}
 
-	jsonBytes, err := json.Marshal(metricFamilies)
+	// Filter out metric families that are also recording rules
+	var filteredFamilies []*dto.MetricFamily
+	for _, mf := range metricFamilies {
+		if mf == nil || mf.Name == nil {
+			continue
+		}
+		if _, isRec := recNames[*mf.Name]; isRec {
+			continue
+		}
+		filteredFamilies = append(filteredFamilies, mf)
+	}
+
+	out := Output{MetricFamilies: filteredFamilies, RecordingRules: recRules}
+	jsonBytes, err := json.Marshal(out)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### What this PR does
#### Before this PR:
recording rules and metrics sent as metrics to metrics name linter which handled them same
#### After this PR:
recording rules and metrics sent as 2 list (in the same file as before) to metrics name linter which handle them separately
  
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-73602


### Why we need it and why it was done in this way
The plan is to add duplicate recording rules with correct name and deprecate the old recording rules after a few versions.
This is what we were asked to do by the openshift observability team that need to be able to distinguish recording rules from metrics.
This linter updat will make sure no new wrong naming recording rules will be added. 

#### The following tradeoffs were made:
To avoid breaking existing rules, the linter (in the monitoring repo) will include an operator-scoped allowlist for current names, any new rule that isn’t on that list will fail CI. this keeps all policy and exceptions in the monitoring repo (no future kubevirt changes), and in a couple of versions, once old names are gone, we just remove the allowlist from monitoring and bump the linter version in kubevirt.
 
#### The following alternatives were considered:
keep testing the rules as metrics like we do now, and fix the linter only when wrong names is deprecated.
since the linter fails also with this solution and to enforces correct naming for all new rules immediately we decided to implement the new linter now and allowlist the existing wrong rules name that will fail the new linter. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

