### PR TITLE
[release-v1.61] Cherry-pick: Update alerts health impact and eval time

### DIFF
--- a/pkg/monitoring/metrics/cdi-controller/dataimportcron.go
+++ b/pkg/monitoring/metrics/cdi-controller/dataimportcron.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// PrometheusCronNsLabel labels the DataImportCron namespace
-	PrometheusCronNsLabel = "ns"
+	PrometheusCronNsLabel = "namespace"
 	// PrometheusCronNameLabel labels the DataImportCron name
 	PrometheusCronNameLabel = "cron_name"
 	// PrometheusCronPendingLabel labels whether the DataImportCron import DataVolume is pending for default storage class

--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -11,24 +11,24 @@ var operatorAlerts = []promv1.Rule{
 	{
 		Alert: "CDIOperatorDown",
 		Expr:  intstr.FromString("kubevirt_cdi_operator_up == 0"),
-		For:   (*promv1.Duration)(ptr.To("5m")),
+		For:   (*promv1.Duration)(ptr.To("10m")),
 		Annotations: map[string]string{
 			"summary": "CDI operator is down",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
+			severityAlertLabelKey:        "critical",
 			operatorHealthImpactLabelKey: "critical",
 		},
 	},
 	{
 		Alert: "CDINotReady",
 		Expr:  intstr.FromString("kubevirt_cdi_cr_ready == 0"),
-		For:   (*promv1.Duration)(ptr.To("5m")),
+		For:   (*promv1.Duration)(ptr.To("10m")),
 		Annotations: map[string]string{
 			"summary": "CDI is not available to use",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
+			severityAlertLabelKey:        "critical",
 			operatorHealthImpactLabelKey: "critical",
 		},
 	},
@@ -58,14 +58,14 @@ var operatorAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "CDIDataImportCronOutdated",
-		Expr:  intstr.FromString(`sum by(ns,cron_name) (kubevirt_cdi_dataimportcron_outdated{pending="false"}) > 0`),
+		Expr:  intstr.FromString(`sum by(namespace,cron_name) (kubevirt_cdi_dataimportcron_outdated{pending="false"}) > 0`),
 		For:   (*promv1.Duration)(ptr.To("15m")),
 		Annotations: map[string]string{
 			"summary": "DataImportCron (recurring polling of VM templates disk image sources, also known as golden images) PVCs are not being updated on the defined schedule",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "info",
-			operatorHealthImpactLabelKey: "warning",
+			severityAlertLabelKey:        "warning",
+			operatorHealthImpactLabelKey: "none",
 		},
 	},
 	{

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -371,7 +371,7 @@ var _ = Describe("Controller", func() {
 				obj, err := getObject(args.client, rule)
 				Expect(err).ToNot(HaveOccurred())
 				rule = obj.(*promv1.PrometheusRule)
-				duration := promv1.Duration("5m")
+				duration := promv1.Duration("10m")
 				cdiDownAlert := promv1.Rule{
 					Alert: "CDIOperatorDown",
 					Expr:  intstr.FromString("kubevirt_cdi_operator_up == 0"),
@@ -381,7 +381,7 @@ var _ = Describe("Controller", func() {
 						"runbook_url": fmt.Sprintf(runbookURLTemplate, "CDIOperatorDown"),
 					},
 					Labels: map[string]string{
-						"severity":                      "warning",
+						"severity":                      "critical",
 						"operator_health_impact":        "critical",
 						"kubernetes_operator_part_of":   "kubevirt",
 						"kubernetes_operator_component": "containerized-data-importer",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Cherry-pick of 4607fc7c83de7bbd96909f933d2fc073d7740b7c to release-v1.61.

Notes:
- Resolved a delete/modify conflict by keeping the deletion of hack/prom-rule-ci/prom-rules-tests.yaml.
- Other file changes applied cleanly.

Head branch: sradco:cherrypick/4607fc7-release-v1.61
Note: Used Cursor to create this cherry-pick

Signed-off-by: Shirly Radco <sradco@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://issues.redhat.com/browse/CNV-72279

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
