### PR TITLE
Build: bump builder Bazel version to 6.5.0 and go version to 1.24.9

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -37,7 +37,7 @@ ADD https://storage.googleapis.com/builddeps/swagger2markup-cli-1.3.3.jar /opt/s
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11
 
-ENV GIMME_GO_VERSION=1.23.6 GOPATH="/go" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.24.9 GOPATH="/go" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 
@@ -50,7 +50,7 @@ RUN \
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 && \
 	rm -rf "${GOPATH}/pkg"
 
-ENV BAZEL_VERSION=5.4.1
+ENV BAZEL_VERSION=6.5.0
 
 COPY output-bazel-arch.sh /output-bazel-arch.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR bumps the builder's Bazel version to 6.5.0 and Go version to 1.24.9.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

