### PR TITLE
Add provisioner-aware VolumeSnapshotClass selection and RWO access mode for DataImportCron

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -225,6 +225,10 @@ const (
 
 	// AnnMinimumSupportedPVCSize annotation on a StorageProfile specifies its minimum supported PVC size
 	AnnMinimumSupportedPVCSize = AnnAPIGroup + "/minimumSupportedPvcSize"
+	// AnnUseReadWriteOnceForDataImportCron annotation on a StorageProfile signals that DataImportCron should use RWO for DataImportCron PVCs
+	AnnUseReadWriteOnceForDataImportCron = AnnAPIGroup + "/useReadWriteOnceForDataImportCron"
+	// AnnSnapshotClassForDataImportCron annotation on a StorageProfile specifies the VolumeSnapshotClass to use for DataImportCron snapshots
+	AnnSnapshotClassForDataImportCron = AnnAPIGroup + "/snapshotClassForDataImportCron"
 
 	// AnnDefaultStorageClass is the annotation indicating that a storage class is the default one
 	AnnDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"

--- a/pkg/storagecapabilities/BUILD.bazel
+++ b/pkg/storagecapabilities/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
+        "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/component-helpers/storage/volume:go_default_library",


### PR DESCRIPTION
Add support for provisioner-specific requirements when creating snapshots and PVCs for DataImportCron. Some provisioners have specific needs:

- GKE Persistent Disk requires snapshot-type: images parameter in VSC for DataImportCron snapshots
- GKE Persistent Disk requires RWO access mode for DataImportCron PVCs

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

**What this PR does / why we need it**:

Standard GCP snapshots (using pd.csi.storage.gke.io) are limited to 6 restores per hour per snapshot. Using a VolumeSnapshotClass with `snapshot-type: images` enables unlimited restores, but these snapshots cannot be created from ReadWriteMany (RWX) PVCs. More details can be found [here](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/backup-pd-volume-snapshots#restore-snapshot)

This PR adds provisioner-aware DataImportCron configuration via StorageProfile annotations:

- **StorageProfile Controller**: Automatically detects provisioner requirements and sets:
  - `cdi.kubevirt.io/useReadWriteOnceForDataImportCron`: Signals RWO access mode for DataImportCron PVCs when not explicitly configured.
  Automatically populated for `pd.csi.storage.gke.io/*` driver.
  - `cdi.kubevirt.io/snapshotClassForDataImportCron`: Specifies the VolumeSnapshotClass name (auto-discovers matching VSC with required parameters)

- **DataImportCron Controller**: 
  - Applies RWO access mode to DataVolume PVCs when annotation is set and no access modes are configured (preserves existing configurations)
  - Uses the specified VolumeSnapshotClass from annotation when creating snapshots
  - **edit:** The Controller monitors these annotations for changes and triggers re-creation automatically to ensure the correct VSC is used.



This ensures snapshot creation succeeds without restore rate limits for GKE, while still allowing the final volume to be restored with the desired access mode. The approach is extensible - new provisioner requirements can be added by updating the storage capabilities configuration.

**Which issue(s) this PR fixes**:

Jira: https://issues.redhat.com/browse/CNV-73302

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add provisioner-aware VolumeSnapshotClass selection and RWO access mode for DataImportCron
```