### PR TITLE
keystore_test: fix flaky RSA key comparison by replacing DeepEqual

### DIFF
--- a/pkg/keys/keystore_test.go
+++ b/pkg/keys/keystore_test.go
@@ -162,8 +162,6 @@ var _ = Describe("Create Private Key", func() {
 
 		checkActions(actions, client.Actions())
 
-		if !reflect.DeepEqual(privateKey, returnedPrivateKey) {
-			Fail("Keys do not match")
-		}
+		Expect(privateKey.Equal(returnedPrivateKey)).To(BeTrue(), "Keys should match")
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The previous UT relied on reflect.DeepEqual to compare rsa.PrivateKey structs which can be flaky since it compares internal memory state rather than cryptographic equality which is what the test should be doing. This PR replaces DeepEqual with the PrivateKey Equal method which checks whether a key and another key have an equivalent private exponent and primes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Related failure:  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/3993/pull-cdi-unit-test/2003749757226323968#1:build-log.txt%3A1413

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

