### PR TITLE
bazel-builder: add skopeo

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -27,6 +27,7 @@ RUN 	dnf -y install dnf-plugins-core && \
 	unzip \
 	java-11-openjdk-devel \
 	rubygems \
+    skopeo \
 	&& dnf clean all
 
 # Necessary for generation of HTML-formatted API docs (.adoc)


### PR DESCRIPTION
Skopeo is required to generate the list of images for hack/push-container-manifest.sh as it will be used to ensure the target images exist.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds Skopeo to the bazel-builder image in order to use it instead of relying on the image digests when creating the image manifest in `hack/push-container-manifest.sh`.

Skopeo is required to generate the list of images for hack/push-container-manifest.sh as it will be used to ensure the target images exist.

Relevant scripts will be updated to utilize Skopeo in following PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Reasoning for this change: https://github.com/kubevirt/kubevirt/pull/15793

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

