### PR TITLE
build: use gzip compression on pkg_tar

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -251,7 +251,6 @@ oci_image(
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    os = "linux",
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_s390x": [
             "//rpm:testimage_s390x",
@@ -263,6 +262,7 @@ oci_image(
             "//rpm:testimage_x86_64",
         ],
     }),
+    os = "linux",
     visibility = ["//visibility:public"],
 )
 
@@ -273,7 +273,6 @@ oci_image(
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    os = "linux",
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_s390x": [
             "//rpm:centos_base_s390x",
@@ -285,13 +284,8 @@ oci_image(
             "//rpm:centos_base_x86_64",
         ],
     }),
+    os = "linux",
     visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "ca_anchors",
-    outs = ["tls-ca-bundle.pem"],
-    cmd = "/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $@",
 )
 
 genrule(
@@ -302,11 +296,4 @@ genrule(
     outs = ["ginkgo-copier"],
     cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
     executable = 1,
-)
-
-pkg_tar(
-    name = "ca_anchors_tar",
-    srcs = [":ca_anchors"],
-    package_dir = "/etc/pki/ca-trust/extracted/pem",
-    visibility = ["//visibility:public"],
 )

--- a/cmd/cdi-apiserver/BUILD.bazel
+++ b/cmd/cdi-apiserver/BUILD.bazel
@@ -43,6 +43,7 @@ go_binary(
 pkg_tar(
     name = "cdi-apiserver-bin",
     srcs = [":cdi-apiserver"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -26,6 +26,7 @@ go_binary(
 pkg_tar(
     name = "cdi-cloner-bin",
     srcs = [":cdi-cloner"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )
@@ -33,6 +34,7 @@ pkg_tar(
 pkg_tar(
     name = "cloner-startup",
     srcs = [":cloner_startup.sh"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -59,6 +59,7 @@ go_binary(
 pkg_tar(
     name = "cdi-controller-bin",
     srcs = [":cdi-controller"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -31,6 +31,7 @@ go_binary(
 pkg_tar(
     name = "cdi-importer-bin",
     srcs = [":cdi-importer"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )
@@ -65,16 +66,30 @@ oci_image(
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_s390x": [
             "//rpm:cdi_importer_base_s390x",
-            "//:ca_anchors_tar",
+            ":ca_anchors_tar",
         ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//rpm:cdi_importer_base_aarch64",
-            "//:ca_anchors_tar",
+            ":ca_anchors_tar",
         ],
         "//conditions:default": [
             "//rpm:cdi_importer_base_x86_64",
-            "//:ca_anchors_tar",
+            ":ca_anchors_tar",
         ],
     }),
     visibility = ["//visibility:private"],
+)
+
+genrule(
+    name = "ca_anchors",
+    outs = ["tls-ca-bundle.pem"],
+    cmd = "/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $@",
+)
+
+pkg_tar(
+    name = "ca_anchors_tar",
+    srcs = [":ca_anchors"],
+    extension = "tar.gz",
+    package_dir = "/etc/pki/ca-trust/extracted/pem",
+    visibility = ["//visibility:public"],
 )

--- a/cmd/cdi-operator/BUILD.bazel
+++ b/cmd/cdi-operator/BUILD.bazel
@@ -40,6 +40,7 @@ go_binary(
 pkg_tar(
     name = "cdi-operator-bin",
     srcs = [":cdi-operator"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/cdi-uploadproxy/BUILD.bazel
+++ b/cmd/cdi-uploadproxy/BUILD.bazel
@@ -32,6 +32,7 @@ go_binary(
 pkg_tar(
     name = "cdi-uploadproxy-bin",
     srcs = [":cdi-uploadproxy"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/cdi-uploadserver/BUILD.bazel
+++ b/cmd/cdi-uploadserver/BUILD.bazel
@@ -27,6 +27,7 @@ go_binary(
 pkg_tar(
     name = "cdi-uploadserver-bin",
     srcs = [":cdi-uploadserver"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/cmd/openstack-populator/BUILD.bazel
+++ b/cmd/openstack-populator/BUILD.bazel
@@ -26,6 +26,7 @@ go_binary(
 pkg_tar(
     name = "openstack-populator-bin",
     srcs = [":openstack-populator"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/cmd/ovirt-populator/BUILD.bazel
+++ b/cmd/ovirt-populator/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 pkg_tar(
     name = "ovirt-populator-bin",
     srcs = [":ovirt-populator"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -134,6 +134,7 @@ exports_files(
 pkg_tar(
     name = "tinycore-tar",
     srcs = [":images/tinyCore.iso"],
+    extension = "tar.gz",
     owner = "107.107",
     package_dir = "/disk",
     strip_prefix = "/tests/images",
@@ -142,6 +143,7 @@ pkg_tar(
 pkg_tar(
     name = "cirros-qcow2-tar",
     srcs = [":images/cirros-qcow2.img"],
+    extension = "tar.gz",
     owner = "107.107",
     package_dir = "/disk",
     strip_prefix = "/tests/images",

--- a/tools/cdi-containerimage-server/BUILD.bazel
+++ b/tools/cdi-containerimage-server/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 pkg_tar(
     name = "cdi-containerimage-server-bin",
     srcs = [":cdi-containerimage-server"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/tools/cdi-func-test-bad-webserver/BUILD.bazel
+++ b/tools/cdi-func-test-bad-webserver/BUILD.bazel
@@ -18,6 +18,7 @@ go_binary(
 pkg_tar(
     name = "cdi-func-test-bad-webserver-bin",
     srcs = [":cdi-func-test-bad-webserver"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/tools/cdi-func-test-file-host-init/BUILD.bazel
+++ b/tools/cdi-func-test-file-host-init/BUILD.bazel
@@ -24,6 +24,7 @@ go_binary(
 pkg_tar(
     name = "cdi-func-test-file-host-init-bin",
     srcs = [":cdi-func-test-file-host-init"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )
@@ -31,6 +32,7 @@ pkg_tar(
 pkg_tar(
     name = "test-img-tar",
     srcs = ["//:test-images"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/tmp/source",
 )
@@ -38,6 +40,7 @@ pkg_tar(
 pkg_tar(
     name = "test-invalid-img-tar",
     srcs = ["//:test-invalid-images"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/tmp/source/invalid_qcow_images",
 )
@@ -53,6 +56,7 @@ filegroup(
 pkg_tar(
     name = "nginx-conf-tar",
     srcs = [":nginx-conf"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/etc/nginx/",
 )

--- a/tools/cdi-func-test-proxy/BUILD.bazel
+++ b/tools/cdi-func-test-proxy/BUILD.bazel
@@ -24,6 +24,7 @@ go_binary(
 pkg_tar(
     name = "cdi-func-test-proxy-bin",
     srcs = [":cdi-func-test-proxy"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/tools/cdi-func-test-registry-init/BUILD.bazel
+++ b/tools/cdi-func-test-registry-init/BUILD.bazel
@@ -25,6 +25,7 @@ go_binary(
 pkg_tar(
     name = "cdi-func-test-registry-init-bin",
     srcs = [":cdi-func-test-registry-init"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )
@@ -62,6 +63,7 @@ pkg_tar(
 pkg_tar(
     name = "test-img-tar",
     srcs = ["//:test-images"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/tmp/source",
 )
@@ -76,6 +78,7 @@ filegroup(
 pkg_tar(
     name = "populate-script-tar",
     srcs = [":populate-script"],
+    extension = "tar.gz",
     mode = "755",
     package_dir = "/",
 )

--- a/tools/cdi-func-test-sample-populator/BUILD.bazel
+++ b/tools/cdi-func-test-sample-populator/BUILD.bazel
@@ -26,6 +26,7 @@ go_binary(
 pkg_tar(
     name = "cdi-func-test-sample-populator-bin",
     srcs = [":cdi-func-test-sample-populator"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/tools/cdi-image-size-detection/BUILD.bazel
+++ b/tools/cdi-image-size-detection/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 pkg_tar(
     name = "cdi-image-size-detection-bin",
     srcs = [":cdi-image-size-detection"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -27,6 +27,7 @@ go_binary(
 pkg_tar(
     name = "cdi-source-update-poller-bin",
     srcs = [":cdi-source-update-poller"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/tools/csv-generator/BUILD.bazel
+++ b/tools/csv-generator/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 pkg_tar(
     name = "csv-generator-bin",
     srcs = [":csv-generator"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:public"],
 )

--- a/tools/image-io/BUILD.bazel
+++ b/tools/image-io/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
 pkg_tar(
     name = "ovirt-imageio-conf-tar",
     srcs = [":ovirt-imageio-conf"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/etc/ovirt-imageio/conf.d",
 )
@@ -25,6 +26,7 @@ pkg_tar(
 pkg_tar(
     name = "test-img-tar",
     srcs = ["//:test-images"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/images",
 )
@@ -32,6 +34,7 @@ pkg_tar(
 pkg_tar(
     name = "test-ticket-tar",
     srcs = [":test-ticket"],
+    extension = "tar.gz",
     mode = "644",
     package_dir = "/",
 )

--- a/tools/imageio-init/BUILD.bazel
+++ b/tools/imageio-init/BUILD.bazel
@@ -24,6 +24,7 @@ go_binary(
 pkg_tar(
     name = "imageio-init-bin",
     srcs = [":imageio-init"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
     visibility = ["//visibility:private"],
 )

--- a/tools/vddk-init/BUILD.bazel
+++ b/tools/vddk-init/BUILD.bazel
@@ -9,6 +9,7 @@ filegroup(
 pkg_tar(
     name = "vmware-vix-disklib-distrib-tar",
     srcs = [":vmware-vix-disklib-distrib-files"],
+    extension = "tar.gz",
     package_dir = "/opt",
     visibility = ["//visibility:private"],
 )

--- a/tools/vddk-test/BUILD.bazel
+++ b/tools/vddk-test/BUILD.bazel
@@ -4,18 +4,21 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "vcenter-govc-tar",
     srcs = ["@vcenter-govc-tar//file"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
 )
 
 pkg_tar(
     name = "vcenter-vcsim-tar",
     srcs = ["@vcenter-vcsim-tar//file"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
 )
 
 pkg_tar(
     name = "entrypoint",
     srcs = [":entrypoint.sh"],
+    extension = "tar.gz",
     package_dir = "/usr/bin/",
 )
 
@@ -40,12 +43,14 @@ cc_library(
 pkg_tar(
     name = "vddk-test-plugin-tar",
     srcs = [":vddk-test-plugin"],
+    extension = "tar.gz",
     package_dir = "/",
 )
 
 pkg_tar(
     name = "cirros-tar",
     srcs = ["//tests:images/cirros.raw"],
+    extension = "tar.gz",
     package_dir = "/",
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Before the transition from rules_docker to rules_oci resulting container image sizes were around 1/3rd what they are now. This is because rules_docker used gzip compression implicitly[1].

This PR explicitly uses gzip compression for all pkg_tar directives in order to restore the resulting images to their original sizes.

[1] https://github.com/bazelbuild/rules_docker/blob/master/docs/container.md#container_image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

