### PR TITLE
change importsToKeep default from 3 to 1 to avoid unused PVC (#4002)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4382,7 +4382,7 @@
       "type": "string"
      },
      "importsToKeep": {
-      "description": "Number of import PVCs to keep when garbage collecting. Default is 3.",
+      "description": "Number of import PVCs to keep when garbage collecting. Default is 1.",
       "type": "integer",
       "format": "int32"
      },

--- a/doc/os-image-poll-and-update.md
+++ b/doc/os-image-poll-and-update.md
@@ -1,6 +1,6 @@
 # Automated OS image import, poll and update
 
-CDI supports automating OS image import, poll and update, keeping OS images up-to-date according to the given `schedule`. On the first time a `DataImportCron` is scheduled, the controller will import the source image. On any following scheduled poll, if the source image digest (sha256) has updated, the controller will import it to a new [*source*](#dataimportcron-source-formats) in the `DataImportCron` namespace, and update the managed `DataSource` to point to the newly created source. A garbage collector (`garbageCollect: Outdated` enabled by default) is responsible to keep the last `importsToKeep` (3 by default) imported sources per `DataImportCron`, and delete older ones.
+CDI supports automating OS image import, poll and update, keeping OS images up-to-date according to the given `schedule`. On the first time a `DataImportCron` is scheduled, the controller will import the source image. On any following scheduled poll, if the source image digest (sha256) has updated, the controller will import it to a new [*source*](#dataimportcron-source-formats) in the `DataImportCron` namespace, and update the managed `DataSource` to point to the newly created source. A garbage collector (`garbageCollect: Outdated` enabled by default) is responsible to keep the last `importsToKeep` (1 by default) imported sources per `DataImportCron`, and delete older ones.
 
 See design doc [here](https://github.com/kubevirt/community/blob/main/design-proposals/golden-image-delivery-and-update-pipeline.md)
 

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -17442,7 +17442,7 @@ func schema_pkg_apis_core_v1beta1_DataImportCronSpec(ref common.ReferenceCallbac
 					},
 					"importsToKeep": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Number of import PVCs to keep when garbage collecting. Default is 3.",
+							Description: "Number of import PVCs to keep when garbage collecting. Default is 1.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -106,7 +106,7 @@ const (
 	digestUIDPrefix             = "uid:"
 	digestDvNameSuffixLength    = 12
 	cronJobUIDSuffixLength      = 8
-	defaultImportsToKeepPerCron = 3
+	defaultImportsToKeepPerCron = 1
 )
 
 var ErrNotManagedByCron = errors.New("DataSource is not managed by this DataImportCron")

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -994,10 +994,9 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(cron.Status.CurrentImports).To(BeEmpty())
 		})
 
-		It("Should succeed garbage collecting old version DVs", func() {
+		DescribeTable("Should succeed garbage collecting old version DVs", func(importsToKeep *int32) {
 			cron = newDataImportCron(cronName)
-			importsToKeep := int32(1)
-			cron.Spec.ImportsToKeep = &importsToKeep
+			cron.Spec.ImportsToKeep = importsToKeep
 			reconciler = createDataImportCronReconciler(cron)
 
 			// Labeled DV and unlabeled PVC
@@ -1049,7 +1048,11 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = reconciler.client.Get(context.TODO(), dvKey(pvc3.Name), pvc3)
 			Expect(err).ToNot(HaveOccurred())
-		})
+
+		},
+			Entry("ImportsToKeep set to nil to use default", nil),
+			Entry("ImportsToKeep set to 1", ptr.To(int32(1))),
+		)
 
 		It("should pass through metadata to DataVolume", func() {
 			cron = newDataImportCron(cronName)

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5691,7 +5691,7 @@ spec:
                 type: string
               importsToKeep:
                 description: Number of import PVCs to keep when garbage collecting.
-                  Default is 3.
+                  Default is 1.
                 format: int32
                 type: integer
               managedDataSource:

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -587,7 +587,7 @@ type DataImportCronSpec struct {
 	// Options are currently "Outdated" and "Never", defaults to "Outdated".
 	// +optional
 	GarbageCollect *DataImportCronGarbageCollect `json:"garbageCollect,omitempty"`
-	// Number of import PVCs to keep when garbage collecting. Default is 3.
+	// Number of import PVCs to keep when garbage collecting. Default is 1.
 	// +optional
 	ImportsToKeep *int32 `json:"importsToKeep,omitempty"`
 	// ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -292,7 +292,7 @@ func (DataImportCronSpec) SwaggerDoc() map[string]string {
 		"template":           "Template specifies template for the DVs to be created",
 		"schedule":           "Schedule specifies in cron format when and how often to look for new imports",
 		"garbageCollect":     "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.\nOptions are currently \"Outdated\" and \"Never\", defaults to \"Outdated\".\n+optional",
-		"importsToKeep":      "Number of import PVCs to keep when garbage collecting. Default is 3.\n+optional",
+		"importsToKeep":      "Number of import PVCs to keep when garbage collecting. Default is 1.\n+optional",
 		"managedDataSource":  "ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.\nDataSource has to be in the same namespace.",
 		"retentionPolicy":    "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.\n+optional",
 		"serviceAccountName": "ServiceAccountName is the name of the ServiceAccount for creating DataVolumes.\n+optional\n+kubebuilder:validation:MinLength=1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Changed the default importsToKeep (in DataImportCron) from 3 to 1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4002

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue #4002
```

