### PR TITLE
Adding importsToKeep to DataImportCron status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4430,6 +4430,11 @@
        "$ref": "#/definitions/v1beta1.ImportStatus"
       }
      },
+     "importsToKeep": {
+      "description": "ImportsToKeep is the effective number of imports to keep when garbage collecting",
+      "type": "integer",
+      "format": "int32"
+     },
      "lastExecutionTimestamp": {
       "description": "LastExecutionTimestamp is the time of the last polling",
       "$ref": "#/definitions/v1.Time"

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -17524,6 +17524,13 @@ func schema_pkg_apis_core_v1beta1_DataImportCronStatus(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"importsToKeep": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImportsToKeep is the effective number of imports to keep when garbage collecting",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -352,6 +352,8 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 	imports := dataImportCron.Status.CurrentImports
 	importSucceeded := false
 
+	dataImportCron.Status.ImportsToKeep = int32(GetImportsToKeep(dataImportCron))
+
 	dataVolume := dataImportCron.Spec.Template
 	explicitScName := cc.GetStorageClassFromDVSpec(&dataVolume)
 	desiredStorageClass, err := cc.GetStorageClassByNameWithVirtFallback(ctx, r.client, explicitScName, dataVolume.Spec.ContentType)
@@ -1104,11 +1106,7 @@ func (r *DataImportCronReconciler) garbageCollectOldImports(ctx context.Context,
 		return err
 	}
 
-	maxImports := defaultImportsToKeepPerCron
-
-	if cron.Spec.ImportsToKeep != nil && *cron.Spec.ImportsToKeep >= 0 {
-		maxImports = int(*cron.Spec.ImportsToKeep)
-	}
+	maxImports := GetImportsToKeep(cron)
 
 	if err := r.garbageCollectPVCs(ctx, cron.Namespace, cron.Name, selector, maxImports); err != nil {
 		return err
@@ -1118,6 +1116,14 @@ func (r *DataImportCronReconciler) garbageCollectOldImports(ctx context.Context,
 	}
 
 	return nil
+}
+
+func GetImportsToKeep(cron *cdiv1.DataImportCron) int {
+	maxImports := defaultImportsToKeepPerCron
+	if cron.Spec.ImportsToKeep != nil && *cron.Spec.ImportsToKeep >= 0 {
+		maxImports = int(*cron.Spec.ImportsToKeep)
+	}
+	return maxImports
 }
 
 func (r *DataImportCronReconciler) garbageCollectPVCs(ctx context.Context, namespace, cronName string, selector labels.Selector, maxImports int) error {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -132,6 +132,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 			cronCond = FindDataImportCronConditionByType(cron, cdiv1.DataImportCronUpToDate)
 			Expect(cronCond).ToNot(BeNil())
 			verifyConditionState(string(cdiv1.DataImportCronUpToDate), cronCond.ConditionState, isUpToDate, reasonUpToDate)
+			Expect(cron.Status.ImportsToKeep).To(Equal(int32(GetImportsToKeep(cron))))
 			if dataSource != nil {
 				imports := cron.Status.CurrentImports
 				Expect(imports).ToNot(BeNil())

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6455,6 +6455,11 @@ spec:
                   - Digest
                   type: object
                 type: array
+              importsToKeep:
+                description: ImportsToKeep is the effective number of imports to keep
+                  when garbage collecting
+                format: int32
+                type: integer
               lastExecutionTimestamp:
                 description: LastExecutionTimestamp is the time of the last polling
                 format: date-time

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -634,6 +634,8 @@ type DataImportCronStatus struct {
 	LastImportTimestamp *metav1.Time `json:"lastImportTimestamp,omitempty"`
 	// SourceFormat defines the format of the DataImportCron-created disk image sources
 	SourceFormat *DataImportCronSourceFormat `json:"sourceFormat,omitempty"`
+	// ImportsToKeep is the effective number of imports to keep when garbage collecting
+	ImportsToKeep int32 `json:"importsToKeep,omitempty"`
 	Conditions   []DataImportCronCondition   `json:"conditions,omitempty" optional:"true"`
 }
 

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -307,6 +307,7 @@ func (DataImportCronStatus) SwaggerDoc() map[string]string {
 		"lastExecutionTimestamp": "LastExecutionTimestamp is the time of the last polling",
 		"lastImportTimestamp":    "LastImportTimestamp is the time of the last import",
 		"sourceFormat":           "SourceFormat defines the format of the DataImportCron-created disk image sources",
+		"importsToKeep":          "ImportsToKeep is the effective number of imports to keep when garbage collecting",
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds a new field "importsToKeep" to the DataImportCron status
It is used to help users to get the effective importsToKeep value

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4006

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It fixes issue #4006 
```

