### PR TITLE
Expose advised restore size on cron snapshots

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -235,6 +235,8 @@ const (
 
 	// AnnSourceVolumeMode is the volume mode of the source PVC specified as an annotation on snapshots
 	AnnSourceVolumeMode = AnnAPIGroup + "/storage.import.sourceVolumeMode"
+	// AnnAdvisedRestoreSize is the advised restore size for disks restored from the snapshot
+	AnnAdvisedRestoreSize = AnnAPIGroup + "/storage.import.advisedRestoreSize"
 
 	// AnnOpenShiftImageLookup is the annotation for OpenShift image stream lookup
 	AnnOpenShiftImageLookup = "alpha.image.policy.openshift.io/resolve-names"

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -39,6 +39,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1391,6 +1392,7 @@ var _ = Describe("All DataImportCron Tests", func() {
 				err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(snap.Annotations[cc.AnnSourceVolumeMode]).To(Equal("dummy"))
+				Expect(snap.Annotations[cc.AnnAdvisedRestoreSize]).To(Equal("1G"))
 				snap.Status = &snapshotv1.VolumeSnapshotStatus{
 					ReadyToUse: ptr.To[bool](true),
 				}
@@ -1567,65 +1569,110 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
 
-			It("Should set snapshot source volume mode annotation on carried-over-upgrade snapshot", func() {
-				cron = newDataImportCron(cronName)
-				dataSource = nil
-				retentionPolicy := cdiv1.DataImportCronRetainNone
-				cron.Spec.RetentionPolicy = &retentionPolicy
-				err := reconciler.client.Create(context.TODO(), cron)
-				Expect(err).ToNot(HaveOccurred())
-				verifyConditions("Before DesiredDigest is set", false, false, false, noImport, noDigest, "", &snapshotv1.VolumeSnapshot{})
+			Context("Convenience snapshot annotations", func() {
+				var dvName string
+				var pvc *corev1.PersistentVolumeClaim
 
-				cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
-				err = reconciler.client.Update(context.TODO(), cron)
-				Expect(err).ToNot(HaveOccurred())
-				dataSource = &cdiv1.DataSource{}
-				verifyConditions("After DesiredDigest is set", false, false, false, noImport, outdated, noSource, &snapshotv1.VolumeSnapshot{})
-
-				imports := cron.Status.CurrentImports
-				Expect(imports).ToNot(BeNil())
-				Expect(imports).ToNot(BeEmpty())
-				dvName := imports[0].DataVolumeName
-				Expect(dvName).ToNot(BeEmpty())
-				digest := imports[0].Digest
-				Expect(digest).To(Equal(testDigest))
-
-				dv := &cdiv1.DataVolume{}
-				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(*dv.Spec.Source.Registry.URL).To(Equal(testRegistryURL + "@" + testDigest))
-				Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
-
-				// DV GCed after hitting succeeded
-				err = reconciler.client.Delete(context.TODO(), dv)
-				Expect(err).ToNot(HaveOccurred())
-				pvc := cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
-				// Snap already exists, without the source volume mode annotation
-				snap := &snapshotv1.VolumeSnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      pvc.Name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: snapshotv1.VolumeSnapshotSpec{
-						Source: snapshotv1.VolumeSnapshotSource{
-							PersistentVolumeClaimName: &pvc.Name,
+				BeforeEach(func() {
+					cron = newDataImportCron(cronName)
+					cron.Spec.Template.Spec.Storage = &cdiv1.StorageSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
 						},
-					},
-					Status: &snapshotv1.VolumeSnapshotStatus{
-						ReadyToUse: ptr.To[bool](true),
-					},
-				}
-				err = reconciler.client.Create(context.TODO(), snap)
-				Expect(err).ToNot(HaveOccurred())
+					}
+					dataSource = nil
+					retentionPolicy := cdiv1.DataImportCronRetainNone
+					cron.Spec.RetentionPolicy = &retentionPolicy
+					err := reconciler.client.Create(context.TODO(), cron)
+					Expect(err).ToNot(HaveOccurred())
+					verifyConditions("Before DesiredDigest is set", false, false, false, noImport, noDigest, "", &snapshotv1.VolumeSnapshot{})
 
-				verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+					cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
+					err = reconciler.client.Update(context.TODO(), cron)
+					Expect(err).ToNot(HaveOccurred())
+					dataSource = &cdiv1.DataSource{}
+					verifyConditions("After DesiredDigest is set", false, false, false, noImport, outdated, noSource, &snapshotv1.VolumeSnapshot{})
 
-				snap = &snapshotv1.VolumeSnapshot{}
-				err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(*snap.Status.ReadyToUse).To(BeTrue())
-				Expect(*snap.Spec.Source.PersistentVolumeClaimName).To(Equal(dvName))
-				Expect(snap.Annotations[cc.AnnSourceVolumeMode]).To(Equal("dummyfromsp"))
+					imports := cron.Status.CurrentImports
+					Expect(imports).ToNot(BeNil())
+					Expect(imports).ToNot(BeEmpty())
+					dvName = imports[0].DataVolumeName
+					Expect(dvName).ToNot(BeEmpty())
+					digest := imports[0].Digest
+					Expect(digest).To(Equal(testDigest))
+
+					dv := &cdiv1.DataVolume{}
+					err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(*dv.Spec.Source.Registry.URL).To(Equal(testRegistryURL + "@" + testDigest))
+					Expect(dv.Annotations[cc.AnnImmediateBinding]).To(Equal("true"))
+
+					// DV GCed after hitting succeeded
+					err = reconciler.client.Delete(context.TODO(), dv)
+					Expect(err).ToNot(HaveOccurred())
+					pvc = cc.CreatePvc(dv.Name, dv.Namespace, nil, nil)
+				})
+
+				It("Should set snapshot source volume mode annotation on carried-over-upgrade snapshot", func() {
+					// Snap already exists, without the source volume mode annotation
+					snap := &snapshotv1.VolumeSnapshot{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pvc.Name,
+							Namespace: metav1.NamespaceDefault,
+						},
+						Spec: snapshotv1.VolumeSnapshotSpec{
+							Source: snapshotv1.VolumeSnapshotSource{
+								PersistentVolumeClaimName: &pvc.Name,
+							},
+						},
+						Status: &snapshotv1.VolumeSnapshotStatus{
+							ReadyToUse: ptr.To[bool](true),
+						},
+					}
+					err := reconciler.client.Create(context.TODO(), snap)
+					Expect(err).ToNot(HaveOccurred())
+
+					verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+
+					snap = &snapshotv1.VolumeSnapshot{}
+					err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(*snap.Status.ReadyToUse).To(BeTrue())
+					Expect(*snap.Spec.Source.PersistentVolumeClaimName).To(Equal(dvName))
+					Expect(snap.Annotations[cc.AnnSourceVolumeMode]).To(Equal("dummyfromsp"))
+				})
+
+				It("Should set snapshot advised restore size annotation on carried-over-upgrade snapshot", func() {
+					// Snap already exists, without the advised restore size annotation
+					snap := &snapshotv1.VolumeSnapshot{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pvc.Name,
+							Namespace: metav1.NamespaceDefault,
+						},
+						Spec: snapshotv1.VolumeSnapshotSpec{
+							Source: snapshotv1.VolumeSnapshotSource{
+								PersistentVolumeClaimName: &pvc.Name,
+							},
+						},
+						Status: &snapshotv1.VolumeSnapshotStatus{
+							ReadyToUse:  ptr.To[bool](true),
+							RestoreSize: ptr.To[resource.Quantity](resource.MustParse("100Mi")),
+						},
+					}
+					err := reconciler.client.Create(context.TODO(), snap)
+					Expect(err).ToNot(HaveOccurred())
+
+					verifyConditions("Import succeeded", false, true, true, noImport, upToDate, ready, &snapshotv1.VolumeSnapshot{})
+
+					snap = &snapshotv1.VolumeSnapshot{}
+					err = reconciler.client.Get(context.TODO(), dvKey(dvName), snap)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(*snap.Status.ReadyToUse).To(BeTrue())
+					Expect(*snap.Spec.Source.PersistentVolumeClaimName).To(Equal(dvName))
+					Expect(snap.Annotations[cc.AnnAdvisedRestoreSize]).To(Equal("1Gi"), "advised restore size should be set to the size of the source PVC")
+				})
 			})
 		})
 	})
@@ -1637,6 +1684,78 @@ var _ = Describe("untagURL", func() {
 		Expect(untagDigestedDockerURL(testRegistryURL + testTag + "@" + testDigest)).To(Equal(testDigestedURL))
 		Expect(untagDigestedDockerURL(testDigestedURL)).To(Equal(testDigestedURL))
 		Expect(untagDigestedDockerURL(testRegistryURL)).To(Equal(testRegistryURL))
+	})
+})
+
+var _ = Describe("inferAdvisedRestoreSizeForSnapshot", func() {
+	var (
+		dv       *cdiv1.DataVolume
+		snapshot *snapshotv1.VolumeSnapshot
+	)
+
+	BeforeEach(func() {
+		dv = &cdiv1.DataVolume{
+			Spec: cdiv1.DataVolumeSpec{
+				Storage: &cdiv1.StorageSpec{},
+			},
+		}
+		snapshot = &snapshotv1.VolumeSnapshot{}
+	})
+
+	DescribeTable("should return the correct size", func(dvSize, snapshotRestoreSize, fallbackSize, expectedSize string) {
+		if dvSize != "" {
+			dv.Spec.Storage = &cdiv1.StorageSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(dvSize),
+					},
+				},
+			}
+		}
+
+		if snapshotRestoreSize != "" {
+			restoreSize := resource.MustParse(snapshotRestoreSize)
+			snapshot.Status = &snapshotv1.VolumeSnapshotStatus{
+				RestoreSize: &restoreSize,
+			}
+		}
+
+		var fallback *resource.Quantity
+		if fallbackSize != "" {
+			fb := resource.MustParse(fallbackSize)
+			fallback = &fb
+		}
+
+		result := inferAdvisedRestoreSizeForSnapshot(dv, snapshot, fallback)
+
+		if expectedSize == "" {
+			Expect(result.IsZero()).To(BeTrue())
+		} else {
+			Expect(result).NotTo(BeNil())
+			Expect(result.String()).To(Equal(expectedSize))
+		}
+	},
+		Entry("should return dvSize when snapshot restoreSize is nil", "1Gi", "", "", "1Gi"),
+		Entry("should return dvSize when dvSize is larger than snapshot restoreSize", "2Gi", "1Gi", "", "2Gi"),
+		Entry("should return snapshot restoreSize when it is larger than dvSize", "1Gi", "2Gi", "", "2Gi"),
+		Entry("should return snapshot restoreSize when dvSize equals snapshot restoreSize", "1Gi", "1Gi", "", "1Gi"),
+		Entry("should return fallback when dvSize is zero and fallback is provided", "", "", "500Mi", "500Mi"),
+		Entry("should return zero when dvSize is zero, no snapshot restoreSize, and no fallback", "", "", "", ""),
+		Entry("should return dvSize when dvSize is set even if fallback is provided", "1Gi", "", "500Mi", "1Gi"),
+	)
+
+	It("should handle nil snapshot status", func() {
+		dv.Spec.Storage = &cdiv1.StorageSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		snapshot.Status = nil
+
+		result := inferAdvisedRestoreSizeForSnapshot(dv, snapshot, nil)
+		Expect(result.String()).To(Equal("1Gi"))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some provisioners (trident nfs) have a weird status.restoresize
which may direct users towards using a wrong disk restore size.

Expose our own advised size in the annotations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Expose advised restore size for cron snapshot sources cdi.kubevirt.io/storage.import.advisedRestoreSize
```

