### PR TITLE
ci: fix cluster-sync don't fresh local image cache for kind provider

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -241,9 +241,9 @@ fi
 mkdir -p ./_out/tests
 rm -f $OLD_CDI_VER_PODS $NEW_CDI_VER_PODS
 
-if [[ ! $KUBEVIRT_PROVIDER =~ kind.* ]]; then
-  seed_images
-fi
+# Seed images to all nodes to ensure latest images are pulled
+# This handles both kind and vagrant/kubevirtci providers
+seed_images
 
 # Install CDI
 install_cdi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fix cluster-sync don't fresh local image cache for kind provider
<img width="2550" height="746" alt="image" src="https://github.com/user-attachments/assets/2c20fd81-646d-4b1d-8a95-95333a95db0e" />

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3577

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

