### PR TITLE
Expose ProcessingPhase in DataVolume Status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5060,6 +5060,9 @@
       "description": "Phase is the current phase of the data volume",
       "type": "string"
      },
+     "populatorPhase": {
+      "type": "string"
+     },
      "progress": {
       "type": "string"
      },

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -6,6 +6,7 @@
 | kubevirt_cdi_cr_ready | Metric | Gauge | CDI install ready |
 | kubevirt_cdi_dataimportcron_outdated | Metric | Gauge | DataImportCron has an outdated import |
 | kubevirt_cdi_datavolume_pending | Metric | Gauge | Number of DataVolumes pending for default storage class to be configured |
+| kubevirt_cdi_import_phase_info | Metric | Gauge | The current processing phase of the import |
 | kubevirt_cdi_import_progress_total | Metric | Counter | The import progress in percentage |
 | kubevirt_cdi_openstack_populator_progress_total | Metric | Counter | Progress of volume population |
 | kubevirt_cdi_ovirt_progress_total | Metric | Counter | Progress of volume population |

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -18585,6 +18585,12 @@ func schema_pkg_apis_core_v1beta1_DataVolumeStatus(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"populatorPhase": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"restartCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RestartCount is the number of times the pod populating the DataVolume has restarted",

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -327,6 +327,32 @@ const (
 	// - poller (DataImportCron poller pods that run in the CDI namespace)
 	// Copied from: https://github.com/kubevirt/kubevirt/blob/e5da5c9405d7f263ad70489a52747cc21a472489/staging/src/kubevirt.io/api/core/v1/types.go#L1369
 	AllowAccessClusterServicesNPLabel string = "np.kubevirt.io/allow-access-cluster-services"
+
+	// ProcessingPhaseInfo is the first phase, during this phase the source obtains information needed to determine which phase to go to next.
+	ProcessingPhaseInfo = "Info"
+	// ProcessingPhaseTransferScratch is the phase in which the data source writes data to the scratch space.
+	ProcessingPhaseTransferScratch = "TransferScratch"
+	// ProcessingPhaseTransferDataDir is the phase in which the data source writes data directly to the target path without conversion.
+	ProcessingPhaseTransferDataDir = "TransferDataDir"
+	// ProcessingPhaseTransferDataFile is the phase in which the data source writes data directly to the target file without conversion.
+	ProcessingPhaseTransferDataFile = "TransferDataFile"
+	// ProcessingPhaseValidatePause is the phase in which the data processor should validate and then pause.
+	ProcessingPhaseValidatePause = "ValidatePause"
+	// ProcessingPhaseValidatePreScratch is the phase in which the data processor should validate available storage before transferring to scratch space.
+	ProcessingPhaseValidatePreScratch = "ValidatePreScratch"
+	// ProcessingPhaseConvert is the phase in which the data is taken from the url provided by the source, and it is converted to the target RAW disk image format.
+	// The url can be an http end point or file system end point.
+	ProcessingPhaseConvert = "Convert"
+	// ProcessingPhaseResize the disk image, this is only needed when the target contains a file system (block device do not need a resize)
+	ProcessingPhaseResize = "Resize"
+	// ProcessingPhaseComplete is the phase where the entire process completed successfully and we can exit gracefully.
+	ProcessingPhaseComplete = "Complete"
+	// ProcessingPhasePause is the phase where we pause processing and end the loop, and expect something to call the process loop again.
+	ProcessingPhasePause = "Pause"
+	// ProcessingPhaseError is the phase in which we encountered an error and need to exit ungracefully.
+	ProcessingPhaseError = GenericError
+	// ProcessingPhaseMergeDelta is the phase in a multi-stage import where a delta image downloaded to scratch is applied to the base image
+	ProcessingPhaseMergeDelta = "MergeDelta"
 )
 
 // ProxyPaths are all supported paths
@@ -363,6 +389,22 @@ var SyncUploadFormPaths = []string{
 var AsyncUploadFormPaths = []string{
 	UploadFormAsync,
 	"/v1alpha1/upload-form-async",
+}
+
+// AllProcessingPhases contains all possible processing phases
+var AllProcessingPhases = []string{
+	ProcessingPhaseInfo,
+	ProcessingPhaseTransferScratch,
+	ProcessingPhaseTransferDataDir,
+	ProcessingPhaseTransferDataFile,
+	ProcessingPhaseValidatePause,
+	ProcessingPhaseValidatePreScratch,
+	ProcessingPhaseConvert,
+	ProcessingPhaseResize,
+	ProcessingPhaseComplete,
+	ProcessingPhasePause,
+	ProcessingPhaseError,
+	ProcessingPhaseMergeDelta,
 }
 
 // VddkInfo holds VDDK version and connection information returned by an importer pod

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -812,6 +812,10 @@ func (r *ReconcilerBase) reconcileProgressUpdate(datavolume *cdiv1.DataVolume, p
 		} else {
 			datavolume.Status.Progress = "N/A"
 		}
+
+		if populatorPhase, ok := pvc.Annotations[cc.AnnPopulatorPhase]; ok {
+			datavolume.Status.PopulatorPhase = populatorPhase
+		}
 		return nil
 	}
 

--- a/pkg/controller/datavolume/upload-controller.go
+++ b/pkg/controller/datavolume/upload-controller.go
@@ -88,7 +88,7 @@ func NewUploadController(
 			recorder:             mgr.GetEventRecorderFor(uploadControllerName),
 			featureGates:         featuregates.NewFeatureGates(client),
 			installerLabels:      installerLabels,
-			shouldUpdateProgress: false,
+			shouldUpdateProgress: true,
 		},
 	}
 

--- a/pkg/monitoring/metrics/cdi-importer/BUILD.bazel
+++ b/pkg/monitoring/metrics/cdi-importer/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-importer",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/common:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
     ],

--- a/pkg/monitoring/metrics/cdi-importer/import_metrics.go
+++ b/pkg/monitoring/metrics/cdi-importer/import_metrics.go
@@ -3,16 +3,21 @@ package cdiimporter
 import (
 	ioprometheusclient "github.com/prometheus/client_model/go"
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 const (
 	// ImportProgressMetricName is the name of the import progress metric
 	ImportProgressMetricName = "kubevirt_cdi_import_progress_total"
+	// ImportPhaseMetricName is the name of the import phase metric
+	ImportPhaseMetricName = "kubevirt_cdi_import_phase_info"
 )
 
 var (
 	importerMetrics = []operatormetrics.Metric{
 		importProgress,
+		importPhase,
 	}
 
 	importProgress = operatormetrics.NewCounterVec(
@@ -21,6 +26,14 @@ var (
 			Help: "The import progress in percentage",
 		},
 		[]string{"ownerUID"},
+	)
+
+	importPhase = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: ImportPhaseMetricName,
+			Help: "The current processing phase of the import",
+		},
+		[]string{"ownerUID", "phase"},
 	)
 )
 
@@ -49,4 +62,41 @@ func (ip *ImportProgress) Get() (float64, error) {
 // Delete removes the importProgress metric with the passed label
 func (ip *ImportProgress) Delete() {
 	importProgress.DeleteLabelValues(ip.ownerUID)
+}
+
+type ImportPhase struct {
+	ownerUID string
+}
+
+func Phase(ownerUID string) *ImportPhase {
+	return &ImportPhase{ownerUID}
+}
+
+// Set sets the current phase metric
+func (ip *ImportPhase) Set(phase string) {
+	for _, p := range common.AllProcessingPhases {
+		importPhase.WithLabelValues(ip.ownerUID, p).Set(0)
+	}
+	importPhase.WithLabelValues(ip.ownerUID, phase).Set(1)
+}
+
+// Get returns the current phase
+func (ip *ImportPhase) Get() (string, error) {
+	for _, p := range common.AllProcessingPhases {
+		dto := &ioprometheusclient.Metric{}
+		if err := importPhase.WithLabelValues(ip.ownerUID, string(p)).Write(dto); err != nil {
+			return "", err
+		}
+		if dto.Gauge.GetValue() == 1 {
+			return string(p), nil
+		}
+	}
+	return "", nil
+}
+
+// Delete removes the importPhase metric with the passed label
+func (ip *ImportPhase) Delete() {
+	for _, p := range common.AllProcessingPhases {
+		importPhase.DeleteLabelValues(ip.ownerUID, string(p))
+	}
 }

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -6388,6 +6388,8 @@ spec:
                       phase:
                         description: Phase is the current phase of the data volume
                         type: string
+                      populatorPhase:
+                        type: string
                       progress:
                         description: DataVolumeProgress is the current progress of
                           the DataVolume transfer operation. Value between 0 and 100
@@ -7388,6 +7390,8 @@ spec:
                 type: array
               phase:
                 description: Phase is the current phase of the data volume
+                type: string
+              populatorPhase:
                 type: string
               progress:
                 description: DataVolumeProgress is the current progress of the DataVolume

--- a/pkg/uploadserver/BUILD.bazel
+++ b/pkg/uploadserver/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"k8s.io/klog/v2"
 
@@ -48,6 +49,7 @@ import (
 
 const (
 	healthzPath = "/healthz"
+	metricsPath = "/metrics"
 )
 
 type Config struct {
@@ -143,6 +145,7 @@ func NewUploadServer(config *Config) UploadServer {
 		errChan:   make(chan error),
 	}
 
+	server.mux.Handle(metricsPath, promhttp.Handler())
 	server.mux.HandleFunc(healthzPath, server.healthzHandler)
 	for _, path := range common.SyncUploadPaths {
 		server.mux.HandleFunc(path, server.uploadHandler(bodyReadCloser))

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -308,8 +308,9 @@ type DataVolumeStatus struct {
 	// ClaimName is the name of the underlying PVC used by the DataVolume.
 	ClaimName string `json:"claimName,omitempty"`
 	//Phase is the current phase of the data volume
-	Phase    DataVolumePhase    `json:"phase,omitempty"`
-	Progress DataVolumeProgress `json:"progress,omitempty"`
+	Phase          DataVolumePhase    `json:"phase,omitempty"`
+	Progress       DataVolumeProgress `json:"progress,omitempty"`
+	PopulatorPhase string             `json:"populatorPhase,omitempty"`
 	// RestartCount is the number of times the pod populating the DataVolume has restarted
 	RestartCount int32                 `json:"restartCount,omitempty"`
 	Conditions   []DataVolumeCondition `json:"conditions,omitempty" optional:"true"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds the `populatorPhase` field to the DataVolume status to expose the current processing phase from importer/uploadserver pods, improving observability for users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4021

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

