### PR TITLE
Set nosniff header on API calls to CDI API server

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -84,6 +84,9 @@ const (
 	populatorValidatePath = "/populator-validate"
 
 	healthzPath = "/healthz"
+
+	xContentTypeOptions = "X-Content-Type-Options"
+	nosniff             = "nosniff"
 )
 
 var uploadTokenVersions = []string{"v1beta1"}
@@ -369,6 +372,7 @@ func (app *cdiAPIApp) uploadHandler(request *restful.Request, response *restful.
 	}
 
 	uploadToken.Status.Token = tkn
+	response.Header().Set(xContentTypeOptions, nosniff)
 	writeJSONResponse(response, uploadToken)
 }
 
@@ -447,6 +451,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 					Verbs:        []string{"create"},
 					ShortNames:   []string{"utr", "utrs"},
 				})
+				response.Header().Set(xContentTypeOptions, nosniff)
 				writeJSONResponse(response, list)
 			}).
 			Operation("getAPIResources-"+v).
@@ -469,6 +474,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 	ws.Route(ws.GET("/").
 		Produces("application/json").Writes(metav1.RootPaths{}).
 		To(func(request *restful.Request, response *restful.Response) {
+			response.Header().Set(xContentTypeOptions, nosniff)
 			writeJSONResponse(response, &metav1.RootPaths{
 				Paths: paths,
 			})
@@ -482,6 +488,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 	ws.Route(ws.GET(groupPath).
 		Produces("application/json").Writes(metav1.APIGroup{}).
 		To(func(request *restful.Request, response *restful.Response) {
+			response.Header().Set(xContentTypeOptions, nosniff)
 			writeJSONResponse(response, uploadTokenAPIGroup())
 		}).
 		Operation("getUploadAPIGroup").
@@ -497,7 +504,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 			list.Kind = "APIGroupList"
 			list.APIVersion = "v1"
 			list.Groups = append(list.Groups, uploadTokenAPIGroup())
-
+			response.Header().Set(xContentTypeOptions, nosniff)
 			writeJSONResponse(response, list)
 		}).
 		Operation("getUploadAPIs").
@@ -519,6 +526,7 @@ func (app *cdiAPIApp) composeUploadTokenAPI() {
 				}
 				openapispec.Info.Version = cdiversion.Get().String()
 			})
+			response.Header().Set(xContentTypeOptions, nosniff)
 			writeJSONResponse(response, openapispec)
 		}))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the nosniff header on responses from the API server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-42297

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

