### PR TITLE
RWX Capability for HPP Overlay

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -36,9 +36,10 @@ const (
 // CapabilitiesByProvisionerKey defines default capabilities for different storage classes
 var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	// hostpath-provisioner
-	"kubevirt.io.hostpath-provisioner": {{rwo, file}},
-	"kubevirt.io/hostpath-provisioner": {{rwo, file}},
-	"k8s.io/minikube-hostpath":         {{rwo, file}},
+	ProvisionerHPPCSI:          {{rwo, file}},
+	ProvisionerHPPOverlayCSI:   {{rwx, file}},
+	ProvisionerHPPLegacy:       {{rwo, file}},
+	"k8s.io/minikube-hostpath": {{rwo, file}},
 	// nfs-csi
 	"nfs.csi.k8s.io": {{rwx, file}},
 	"k8s-sigs.io/nfs-subdir-external-provisioner": {{rwx, file}},
@@ -216,6 +217,12 @@ const (
 	ProvisionerRookCephBucket = "rook-ceph.ceph.rook.io/bucket"
 	// ProvisionerStorkSnapshot is the provisioner string for the Stork snapshot provisoner which does not work with CDI
 	ProvisionerStorkSnapshot = "stork-snapshot"
+	// ProvisionerHPPCSI is the CSI variant for the hostpath-provisioner
+	ProvisionerHPPCSI = "kubevirt.io.hostpath-provisioner"
+	// ProvisionerHPPOverlayCSI is the CSI overlay variant for the hostpath-provisioner
+	ProvisionerHPPOverlayCSI = "kubevirt.io.hostpath-provisioner/overlay"
+	// ProvisionerHPPLegacy is the Legacy variant for the hostpath-provisioner
+	ProvisionerHPPLegacy = "kubevirt.io/hostpath-provisioner"
 )
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI
@@ -302,6 +309,12 @@ func storageProvisionerKey(sc *storagev1.StorageClass) string {
 }
 
 var storageClassToProvisionerKeyMapper = map[string]func(sc *storagev1.StorageClass) string{
+	ProvisionerHPPCSI: func(sc *storagev1.StorageClass) string {
+		if _, exists := sc.Parameters["overlayCSI"]; exists {
+			return ProvisionerHPPOverlayCSI
+		}
+		return ProvisionerHPPCSI
+	},
 	"kubernetes.io/portworx-volume": func(sc *storagev1.StorageClass) string {
 		opts := strings.Split(sc.Parameters["sharedv4_mount_options"], ",")
 		if slices.Contains(opts, "vers=3.0") && slices.Contains(opts, "nolock") {


### PR DESCRIPTION
To enable new HPP Overlay support for backend storage PVCs (https://github.com/kubevirt/hostpath-provisioner/pull/483 
https://github.com/kubevirt/hostpath-provisioner-operator/pull/653),  we need to allow for HPP to provision volumes with RWX access mode. When creating storageprofiles for HPP, add new check for param to determine if HPP Overlay is enabled

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
RWX Capability for HPP Overlay 
```

