### PR TITLE
metrics-server: inherit TLS options from CDI TLSSecurityProfile

### DIFF
--- a/cmd/cdi-controller/BUILD.bazel
+++ b/cmd/cdi-controller/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/cmd/cdi-controller",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/datavolume:go_default_library",
@@ -18,6 +19,7 @@ go_library(
         "//pkg/util/cert:go_default_library",
         "//pkg/util/cert/fetcher:go_default_library",
         "//pkg/util/cert/generator:go_default_library",
+        "//pkg/util/tls-crypto-watch:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1:go_default_library",
         "//vendor/github.com/kelseyhightower/envconfig:go_default_library",

--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -41,6 +41,7 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	forklift "kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1"
+	cdiclient "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
 	dvc "kubevirt.io/containerized-data-importer/pkg/controller/datavolume"
@@ -51,6 +52,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/fetcher"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/generator"
+	cryptowatch "kubevirt.io/containerized-data-importer/pkg/util/tls-crypto-watch"
 )
 
 const (
@@ -193,6 +195,8 @@ func start() {
 		klog.Fatalf("Unable to get uncached client: %v\n", errors.WithStack(err))
 	}
 
+	managedTLSWatcher := cryptowatch.NewManagedTLSWatcher(cdiclient.NewForConfigOrDie(cfg))
+
 	opts := manager.Options{
 		LeaderElection:             true,
 		LeaderElectionNamespace:    namespace,
@@ -207,6 +211,15 @@ func start() {
 			// See CVE-2023-44487, CVE-2023-39325
 			TLSOpts: []func(*tls.Config){func(c *tls.Config) {
 				c.NextProtos = []string{"http/1.1"}
+				c.GetConfigForClient = func(t *tls.ClientHelloInfo) (*tls.Config, error) {
+					config := c.Clone()
+					if w := managedTLSWatcher.Watcher(); w != nil {
+						cryptoConfig := w.GetCdiTLSConfig()
+						config.CipherSuites = cryptoConfig.CipherSuites
+						config.MinVersion = cryptoConfig.MinVersion
+					}
+					return config, nil
+				}
 			}},
 		},
 	}
@@ -319,6 +332,12 @@ func start() {
 	}
 	if _, err := populators.NewForkliftPopulator(ctx, mgr, log, importerImage, ovirtPopulatorImage, installerLabels); err != nil {
 		klog.Errorf("Unable to setup forklift populator: %v", err)
+		os.Exit(1)
+	}
+
+	managedTLSWatcher.SetCache(mgr.GetCache())
+	if err := mgr.Add(managedTLSWatcher); err != nil {
+		log.Error(err, "unable to add watcher to manager")
 		os.Exit(1)
 	}
 

--- a/cmd/cdi-operator/BUILD.bazel
+++ b/cmd/cdi-operator/BUILD.bazel
@@ -8,8 +8,10 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/cmd/cdi-operator",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/operator/controller:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/tls-crypto-watch:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1:go_default_library",
         "//vendor/github.com/kubernetes-csi/volume-data-source-validator/client/apis/volumepopulator/v1beta1:go_default_library",

--- a/pkg/util/tls-crypto-watch/BUILD.bazel
+++ b/pkg/util/tls-crypto-watch/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/cache:go_default_library",
     ],
 )

--- a/pkg/util/tls-crypto-watch/tls-crypto-watch.go
+++ b/pkg/util/tls-crypto-watch/tls-crypto-watch.go
@@ -22,6 +22,7 @@ package tlscryptowatch
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"sync"
 
 	ocpcrypto "github.com/openshift/library-go/pkg/crypto"
@@ -29,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiclient "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
@@ -123,6 +126,49 @@ func (ctw *cdiConfigTLSWatcher) updateConfig(config *cdiv1.CDIConfig) {
 	ctw.mutex.Lock()
 	defer ctw.mutex.Unlock()
 	ctw.config = newConfig
+}
+
+type ManagedTLSWatcher struct {
+	client  cdiclient.Interface
+	cache   runtimecache.Cache
+	mu      sync.RWMutex
+	watcher CdiConfigTLSWatcher
+}
+
+func NewManagedTLSWatcher(cdiClient cdiclient.Interface) *ManagedTLSWatcher {
+	return &ManagedTLSWatcher{
+		client: cdiClient,
+	}
+}
+
+func (m *ManagedTLSWatcher) Start(ctx context.Context) error {
+	if !m.cache.WaitForCacheSync(ctx) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	w, err := NewCdiConfigTLSWatcher(ctx, m.client)
+	if err != nil {
+		return fmt.Errorf("failed to create TLS watcher: %w", err)
+	}
+
+	m.mu.Lock()
+	m.watcher = w
+	m.mu.Unlock()
+
+	<-ctx.Done()
+	return nil
+}
+
+func (m *ManagedTLSWatcher) Watcher() CdiConfigTLSWatcher {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.watcher
+}
+
+func (m *ManagedTLSWatcher) SetCache(cache runtimecache.Cache) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cache = cache
 }
 
 // SelectCipherSuitesAndMinTLSVersion returns cipher names and minimal TLS version according to the input profile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously the metrics-server would be initiated with default TLS configuration. This change makes it so the TLS configuration is updated during runtime for every request according to the CDI TLSSecurityProfile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses https://issues.redhat.com/browse/CNV-78858

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: cdi-operator and cdi-deployment metrics-server now correctly inherit TLS options from the CDI TLSSecrutiyProfile. 
```

