### PR TITLE
VDDK: wrap errors from TransferFile instead of just logging them

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request wraps TransferFile errors with existing helpful debug text, so that they are returned as part of the error instead of just printed to the log. Recently I was debugging MTV bugs where this would have been useful, because the initial importer pod logs were lost and subsequent importer pods were failing with a different error. The error surfaced to the MTV plan looked something like this:

> Unable to process data: Unable to transfer source data to target file: ServerFaultCode: Error caused by file /vmfs/volumes/68f01711-8b903912-e212-002590a1ca1d/fedora/fedora_1.vmdk

This pull request will change it to:

> Unable to process data: Unable to transfer source data to target file: Failed to query changed areas: ServerFaultCode: Error caused by file /vmfs/volumes/68f01711-8b903912-e212-002590a1ca1d/fedora/fedora_1.vmdk

...which points to a much smaller range of TransferFile code to consider.

**Which issue(s) this PR fixes**:
None, this is just debug assistance resulting from [MTV-4437](https://issues.redhat.com/browse/MTV-4437) efforts

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

