### PR TITLE
Add recording rules with new naming

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -10,10 +10,14 @@
 | kubevirt_cdi_openstack_populator_progress_total | Metric | Counter | Progress of volume population |
 | kubevirt_cdi_ovirt_progress_total | Metric | Counter | Progress of volume population |
 | kubevirt_cdi_storageprofile_info | Metric | Gauge | `StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone, `degraded` indicates it is not optimal for virtualization |
-| kubevirt_cdi_clone_pods_high_restart | Recording rule | Gauge | The number of CDI clone pods with high restart count |
-| kubevirt_cdi_import_pods_high_restart | Recording rule | Gauge | The number of CDI import pods with high restart count |
-| kubevirt_cdi_operator_up | Recording rule | Gauge | CDI operator status |
-| kubevirt_cdi_upload_pods_high_restart | Recording rule | Gauge | The number of CDI upload server pods with high restart count |
+| cluster:kubevirt_cdi_clone_pods_high_restart:count | Recording rule | Gauge | The number of CDI clone pods with high restart count |
+| cluster:kubevirt_cdi_import_pods_high_restart:count | Recording rule | Gauge | The number of CDI import pods with high restart count |
+| cluster:kubevirt_cdi_operator_up:sum | Recording rule | Gauge | The number of CDI pods that are up |
+| cluster:kubevirt_cdi_upload_pods_high_restart:count | Recording rule | Gauge | The number of CDI upload server pods with high restart count |
+| kubevirt_cdi_clone_pods_high_restart | Recording rule | Gauge | [Deprecated] The number of CDI clone pods with high restart count |
+| kubevirt_cdi_import_pods_high_restart | Recording rule | Gauge | [Deprecated] The number of CDI import pods with high restart count |
+| kubevirt_cdi_operator_up | Recording rule | Gauge | [Deprecated] CDI operator status |
+| kubevirt_cdi_upload_pods_high_restart | Recording rule | Gauge | [Deprecated] The number of CDI upload server pods with high restart count |
 
 ## Developing new metrics
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -71,10 +71,10 @@ tests:
         alertname: CDIDataImportCronOutdated
         exp_alerts: []
 
-  # CDIOperatorDown should fire when kubevirt_cdi_operator_up == 0 for 10m
+  # CDIOperatorDown should fire when cluster:kubevirt_cdi_operator_up:sum == 0 for 10m
   - interval: 1m
     input_series:
-      - series: 'kubevirt_cdi_operator_up'
+      - series: 'cluster:kubevirt_cdi_operator_up:sum'
         values: "0 0 0 0 0 0 0 0 0 0 0 0"
     alert_rule_test:
       - eval_time: 11m

--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -10,7 +10,7 @@ import (
 var operatorAlerts = []promv1.Rule{
 	{
 		Alert: "CDIOperatorDown",
-		Expr:  intstr.FromString("kubevirt_cdi_operator_up == 0"),
+		Expr:  intstr.FromString("cluster:kubevirt_cdi_operator_up:sum == 0"),
 		For:   (*promv1.Duration)(ptr.To("10m")),
 		Annotations: map[string]string{
 			"summary": "CDI operator is down",
@@ -34,7 +34,7 @@ var operatorAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "CDIDataVolumeUnusualRestartCount",
-		Expr:  intstr.FromString("kubevirt_cdi_import_pods_high_restart > 0 or kubevirt_cdi_upload_pods_high_restart > 0 or kubevirt_cdi_clone_pods_high_restart > 0"),
+		Expr:  intstr.FromString("cluster:kubevirt_cdi_import_pods_high_restart:count > 0 or cluster:kubevirt_cdi_upload_pods_high_restart:count > 0 or cluster:kubevirt_cdi_clone_pods_high_restart:count > 0"),
 		For:   (*promv1.Duration)(ptr.To("5m")),
 		Annotations: map[string]string{
 			"summary": "Some CDI population workloads have an unusual restart count, meaning they are probably failing and need to be investigated",

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -14,7 +14,17 @@ func operatorRecordingRules(namespace string) []operatorrules.RecordingRule {
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
 				Name: "kubevirt_cdi_operator_up",
-				Help: "CDI operator status",
+				Help: "[Deprecated] CDI operator status",
+			},
+			MetricType: operatormetrics.GaugeType,
+			Expr: intstr.FromString(
+				fmt.Sprintf("sum(up{namespace='%s', pod=~'cdi-operator-.*'} or vector(0))", namespace),
+			),
+		},
+		{
+			MetricsOpts: operatormetrics.MetricOpts{
+				Name: "cluster:kubevirt_cdi_operator_up:sum",
+				Help: "The number of CDI pods that are up",
 			},
 			MetricType: operatormetrics.GaugeType,
 			Expr: intstr.FromString(

--- a/pkg/monitoring/rules/recordingrules/pods.go
+++ b/pkg/monitoring/rules/recordingrules/pods.go
@@ -16,6 +16,16 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_cdi_import_pods_high_restart",
+			Help: "[Deprecated] The number of CDI import pods with high restart count",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.ImporterPodName, common.ImporterPodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+		),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "cluster:kubevirt_cdi_import_pods_high_restart:count",
 			Help: "The number of CDI import pods with high restart count",
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -26,6 +36,16 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_cdi_upload_pods_high_restart",
+			Help: "[Deprecated] The number of CDI upload server pods with high restart count",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.UploadPodName, common.UploadServerPodname, strconv.Itoa(common.UnusualRestartCountThreshold)),
+		),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "cluster:kubevirt_cdi_upload_pods_high_restart:count",
 			Help: "The number of CDI upload server pods with high restart count",
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -36,6 +56,16 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_cdi_clone_pods_high_restart",
+			Help: "[Deprecated] The number of CDI clone pods with high restart count",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'.*%s', container='%s'} > %s) or on() vector(0)", common.ClonerSourcePodNameSuffix, common.ClonerSourcePodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+		),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "cluster:kubevirt_cdi_clone_pods_high_restart:count",
 			Help: "The number of CDI clone pods with high restart count",
 		},
 		MetricType: operatormetrics.GaugeType,

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -451,7 +451,7 @@ var _ = Describe("Controller", func() {
 				duration := promv1.Duration("10m")
 				cdiDownAlert := promv1.Rule{
 					Alert: "CDIOperatorDown",
-					Expr:  intstr.FromString("kubevirt_cdi_operator_up == 0"),
+					Expr:  intstr.FromString("cluster:kubevirt_cdi_operator_up:sum == 0"),
 					For:   &duration,
 					Annotations: map[string]string{
 						"summary":     "CDI operator is down",

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -483,9 +483,9 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 				return dep.Status.Replicas == 0
 			}, 20*time.Second, 1*time.Second).Should(BeTrue())
 
-			By("Waiting for kubevirt_cdi_operator_up metric to be 0")
+			By("Waiting for cluster:kubevirt_cdi_operator_up:sum metric to be 0")
 			Eventually(func() int {
-				return getMetricValue(f, "kubevirt_cdi_operator_up")
+				return getMetricValue(f, "cluster:kubevirt_cdi_operator_up:sum")
 			}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", 0))
 
 			waitForPrometheusAlert(f, "CDIOperatorDown")
@@ -531,7 +531,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 func dataVolumeUnusualRestartTest(f *framework.Framework) {
 	By("Test metric for unusual restart count")
 	Eventually(func() bool {
-		return getMetricValue(f, "kubevirt_cdi_import_pods_high_restart") == 1
+		return getMetricValue(f, "cluster:kubevirt_cdi_import_pods_high_restart:count") == 1
 	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
 
 	waitForPrometheusAlert(f, "CDIDataVolumeUnusualRestartCount")
@@ -540,7 +540,7 @@ func dataVolumeUnusualRestartTest(f *framework.Framework) {
 func dataVolumeNoUnusualRestartTest(f *framework.Framework) {
 	By("Test metric for no unusual restart count")
 	Eventually(func() bool {
-		return getMetricValue(f, "kubevirt_cdi_import_pods_high_restart") == 0
+		return getMetricValue(f, "cluster:kubevirt_cdi_import_pods_high_restart:count") == 0
 	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
 
 	waitForNoPrometheusAlert(f, "CDIDataVolumeUnusualRestartCount")


### PR DESCRIPTION
add recording rules with new naming that follow the names linter and best practices, and deprecate old names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-71478

this is a follow up for: https://github.com/kubevirt/containerized-data-importer/pull/3980

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt_cdi_clone_pods_high_restart, kubevirt_cdi_import_pods_high_restart, kubevirt_cdi_upload_pods_high_restart and kubevirt_cdi_operator_up are deprecated in favor of cluster:kubevirt_cdi_clone_pods_high_restart:count, cluster:kubevirt_cdi_import_pods_high_restart:count, cluster:kubevirt_cdi_upload_pods_high_restart:count and cluster:kubevirt_cdi_operator_up:sum, in order to comply with the recording rules naming conventions.
```

