### PR TITLE
Update HPP-wffc manifest URL

### DIFF
--- a/cluster-sync/external/provider.sh
+++ b/cluster-sync/external/provider.sh
@@ -28,7 +28,7 @@ function configure_storage() {
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/namespace.yaml
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/operator.yaml -n hostpath-provisioner
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner
-    _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc.yaml
+    _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc-csi.yaml
     _kubectl patch storageclass hostpath-provisioner -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
   else
     echo "Local storage not needed for external provider..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When running `cluster-sync `on with external provider I was getting:
```
KUBEVIRT_PROVIDER=external KUBEVIRT_STORAGE=hpp make cluster-sync
+ _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/v0.24.0/storageclass-wffc.yaml
+ kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/v0.24.0/storageclass-wffc.yaml
error: unable to read URL "https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/v0.24.0/storageclass-wffc.yaml", server reported 404 Not Found, status code=404
make: *** [Makefile:177: cluster-sync-test-infra] Error 1
```
They just changed `storageclass-wffc.yaml` to `storageclass-wffc-legacy.yaml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

