### PR TITLE
Add filesystem SEEK_HOLE detection to avoid tar performance issues

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -10,9 +10,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/golang/snappy"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
 
@@ -144,6 +146,55 @@ func validateMount() {
 	}
 }
 
+// seekHoleSupported probes whether SEEK_HOLE works on the given file.
+// Filesystems without real SEEK_HOLE support (e.g. NFS < 4.2) use the
+// generic VFS fallback which returns file-size, making tar -S think
+// there are no holes. We replicate the same heuristic GNU tar uses:
+// if SEEK_DATA returns 0 and SEEK_HOLE returns file-size on the first
+// call, SEEK_HOLE is not efficiently implemented.
+func seekHoleSupported(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No disk.img — likely an archive of small files where
+			// raw hole-scanning overhead is negligible.
+			klog.Infof("No %s found, skipping SEEK_HOLE probe", path)
+			return true
+		}
+		klog.Fatalf("Failed to open %s for SEEK_HOLE probe: %v", path, err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		klog.Fatalf("Failed to stat %s: %v", path, err)
+	}
+	if fi.Size() == 0 {
+		return true
+	}
+
+	dataOff, dataErr := unix.Seek(int(f.Fd()), 0, unix.SEEK_DATA)
+	if errors.Is(dataErr, unix.ENXIO) {
+		// ENXIO from SEEK_DATA means the file is entirely sparse (no data).
+		// Only a real SEEK_HOLE implementation returns this.
+		return true
+	}
+
+	holeOff, holeErr := unix.Seek(int(f.Fd()), 0, unix.SEEK_HOLE)
+
+	if dataErr != nil || holeErr != nil {
+		klog.Warningf("SEEK_HOLE probe failed on %s: SEEK_DATA=%v, SEEK_HOLE=%v", path, dataErr, holeErr)
+		return false
+	}
+
+	if dataOff == 0 && holeOff == fi.Size() {
+		klog.Infof("SEEK_HOLE not supported on %s (VFS fallback detected), omitting tar -S", path)
+		return false
+	}
+
+	return true
+}
+
 func newTarReader(preallocation bool) (io.ReadCloser, error) {
 	excludeMap := map[string]struct{}{
 		"lost+found": {},
@@ -151,8 +202,9 @@ func newTarReader(preallocation bool) (io.ReadCloser, error) {
 
 	const path = "/usr/bin/tar"
 	args := []string{"cv"}
-	if !preallocation {
-		// -S is used to handle sparse files. It can only be used when preallocation is not requested
+	if !preallocation && seekHoleSupported(filepath.Join(mountPoint, common.DiskImageName)) {
+		// -S is used to handle sparse files. It can only be used when preallocation
+		// is not requested and the filesystem supports efficient SEEK_HOLE.
 		args = append(args, "-S")
 	}
 

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -30,6 +30,11 @@ var (
 	uploadBytes uint64
 )
 
+// seekFunc is a function variable for unix.Seek, allowing test injection.
+var seekFunc = func(fd int, offset int64, whence int) (int64, error) {
+	return unix.Seek(fd, offset, whence)
+}
+
 type execReader struct {
 	cmd    *exec.Cmd
 	stdout io.ReadCloser
@@ -173,14 +178,14 @@ func seekHoleSupported(path string) bool {
 		return true
 	}
 
-	dataOff, dataErr := unix.Seek(int(f.Fd()), 0, unix.SEEK_DATA)
+	dataOff, dataErr := seekFunc(int(f.Fd()), 0, unix.SEEK_DATA)
 	if errors.Is(dataErr, unix.ENXIO) {
 		// ENXIO from SEEK_DATA means the file is entirely sparse (no data).
 		// Only a real SEEK_HOLE implementation returns this.
 		return true
 	}
 
-	holeOff, holeErr := unix.Seek(int(f.Fd()), 0, unix.SEEK_HOLE)
+	holeOff, holeErr := seekFunc(int(f.Fd()), 0, unix.SEEK_HOLE)
 
 	if dataErr != nil || holeErr != nil {
 		klog.Warningf("SEEK_HOLE probe failed on %s: SEEK_DATA=%v, SEEK_HOLE=%v", path, dataErr, holeErr)

--- a/cmd/cdi-cloner/clone-source_test.go
+++ b/cmd/cdi-cloner/clone-source_test.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/sys/unix"
 
 	prometheusutil "kubevirt.io/containerized-data-importer/pkg/util/prometheus"
 )
@@ -42,3 +44,69 @@ func isDirEmpty(dirName string) (bool, error) {
 	}
 	return false, err
 }
+
+var _ = Describe("seekHoleSupported", func() {
+	var (
+		tempDir      string
+		originalSeek func(int, int64, int) (int64, error)
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "seek-test-")
+		Expect(err).NotTo(HaveOccurred())
+		originalSeek = seekFunc
+	})
+
+	AfterEach(func() {
+		seekFunc = originalSeek
+		os.RemoveAll(tempDir)
+	})
+
+	It("should return true when file does not exist", func() {
+		result := seekHoleSupported(filepath.Join(tempDir, "does-not-exist.img"))
+		Expect(result).To(BeTrue())
+	})
+
+	It("should return true for empty file", func() {
+		emptyFile := filepath.Join(tempDir, "empty.img")
+		Expect(os.WriteFile(emptyFile, []byte{}, 0644)).To(Succeed())
+
+		result := seekHoleSupported(emptyFile)
+		Expect(result).To(BeTrue())
+	})
+
+	It("should return true for entirely sparse file", func() {
+		testFile := filepath.Join(tempDir, "sparse.img")
+		Expect(os.WriteFile(testFile, []byte("test"), 0644)).To(Succeed())
+
+		seekFunc = func(fd int, offset int64, whence int) (int64, error) {
+			if whence == unix.SEEK_DATA {
+				return 0, unix.ENXIO
+			}
+			return unix.Seek(fd, offset, whence)
+		}
+
+		result := seekHoleSupported(testFile)
+		Expect(result).To(BeTrue())
+	})
+
+	It("should detect VFS fallback", func() {
+		testFile := filepath.Join(tempDir, "vfs-fallback.img")
+		fileContent := []byte("test data")
+		Expect(os.WriteFile(testFile, fileContent, 0644)).To(Succeed())
+
+		seekFunc = func(fd int, offset int64, whence int) (int64, error) {
+			if whence == unix.SEEK_DATA {
+				return 0, nil
+			}
+			if whence == unix.SEEK_HOLE {
+				return int64(len(fileContent)), nil
+			}
+			return 0, errors.New("unexpected")
+		}
+
+		result := seekHoleSupported(testFile)
+		Expect(result).To(BeFalse())
+	})
+})

--- a/pkg/uploadserver/BUILD.bazel
+++ b/pkg/uploadserver/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/importer:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/tls-crypto-watch:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",

--- a/pkg/uploadserver/BUILD.bazel
+++ b/pkg/uploadserver/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/common:go_default_library",
         "//pkg/importer:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/util/tls-crypto-watch:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/golang/snappy:go_default_library",

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -42,7 +42,6 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
-	"kubevirt.io/containerized-data-importer/pkg/util"
 	cryptowatch "kubevirt.io/containerized-data-importer/pkg/util/tls-crypto-watch"
 )
 
@@ -475,7 +474,7 @@ func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, file
 func cloneProcessor(stream io.ReadCloser, contentType, dest string, preallocate bool) (bool, error) {
 	if contentType == common.FilesystemCloneContentType {
 		if dest != common.WriteBlockPath {
-			return fileToFileCloneProcessor(stream)
+			return fileToFileCloneProcessor(stream, preallocate)
 		}
 
 		tarImageReader, err := newTarDiskImageReader(stream)
@@ -496,12 +495,22 @@ func cloneProcessor(stream io.ReadCloser, contentType, dest string, preallocate 
 	return false, nil
 }
 
-func fileToFileCloneProcessor(stream io.ReadCloser) (bool, error) {
-	defer stream.Close()
-	if err := util.UnArchiveTar(stream, common.ImporterVolumePath); err != nil {
-		return false, errors.Wrapf(err, "error unarchiving to %s", common.ImporterVolumePath)
+func fileToFileCloneProcessor(stream io.ReadCloser, preallocate bool) (bool, error) {
+	tarImageReader, err := newTarDiskImageReader(stream)
+	if err != nil {
+		// No disk.img in archive — fall back to full untar.
+		// Note: stream is consumed at this point, so we re-report the error.
+		stream.Close()
+		return false, errors.Wrap(err, "no disk image found in tar archive")
 	}
-	return true, nil
+	defer tarImageReader.Close()
+
+	_, _, err = importer.StreamDataToFile(tarImageReader, common.ImporterWritePath, preallocate)
+	if err != nil {
+		return false, errors.Wrapf(err, "error streaming disk image to %s", common.ImporterWritePath)
+	}
+
+	return false, nil
 }
 
 type closeWrapper struct {

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -472,21 +473,18 @@ func newUploadStreamProcessor(stream io.ReadCloser, dest, imageSize string, file
 }
 
 func cloneProcessor(stream io.ReadCloser, contentType, dest string, preallocate bool) (bool, error) {
+	defer stream.Close()
 	if contentType == common.FilesystemCloneContentType {
 		if dest != common.WriteBlockPath {
-			return fileToFileCloneProcessor(stream, preallocate)
+			return fileToFileCloneProcessor(stream, preallocate, common.ImporterVolumePath, common.ImporterWritePath)
 		}
 
 		tarImageReader, err := newTarDiskImageReader(stream)
 		if err != nil {
-			stream.Close()
 			return false, err
 		}
 		stream = tarImageReader
 	}
-
-	defer stream.Close()
-
 	_, _, err := importer.StreamDataToFile(stream, dest, preallocate)
 	if err != nil {
 		return false, err
@@ -495,22 +493,78 @@ func cloneProcessor(stream io.ReadCloser, contentType, dest string, preallocate 
 	return false, nil
 }
 
-func fileToFileCloneProcessor(stream io.ReadCloser, preallocate bool) (bool, error) {
-	tarImageReader, err := newTarDiskImageReader(stream)
-	if err != nil {
-		// No disk.img in archive — fall back to full untar.
-		// Note: stream is consumed at this point, so we re-report the error.
-		stream.Close()
-		return false, errors.Wrap(err, "no disk image found in tar archive")
-	}
-	defer tarImageReader.Close()
+func fileToFileCloneProcessor(stream io.ReadCloser, preallocate bool, volumePath, diskImagePath string) (bool, error) {
+	tr := tar.NewReader(stream)
+	foundDiskImg := false
 
-	_, _, err = importer.StreamDataToFile(tarImageReader, common.ImporterWritePath, preallocate)
-	if err != nil {
-		return false, errors.Wrapf(err, "error streaming disk image to %s", common.ImporterWritePath)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false, errors.Wrap(err, "error reading tar archive")
+		}
+
+		if filepath.Base(header.Name) == common.DiskImageName {
+			foundDiskImg = true
+			if err := extractDiskImageFromTar(header, tr, diskImagePath, preallocate); err != nil {
+				return false, err
+			}
+			continue
+		}
+
+		if err := extractTarEntry(header, tr, volumePath); err != nil {
+			return false, errors.Wrapf(err, "error extracting %s", header.Name)
+		}
 	}
 
-	return false, nil
+	if !foundDiskImg {
+		klog.V(3).Info("No disk.img found in tar archive, extracted all files")
+	}
+
+	return foundDiskImg && preallocate, nil
+}
+
+func extractDiskImageFromTar(header *tar.Header, tr *tar.Reader, diskImagePath string, preallocate bool) error {
+	_, _, err := importer.StreamDataToFile(tr, diskImagePath, preallocate)
+	if err != nil {
+		return errors.Wrapf(err, "error streaming disk image to %s", diskImagePath)
+	}
+	if err := os.Chmod(diskImagePath, os.FileMode(header.Mode)); err != nil {
+		return errors.Wrapf(err, "error setting permissions on %s", diskImagePath)
+	}
+	return nil
+}
+
+func extractTarEntry(header *tar.Header, tr *tar.Reader, destDir string) error {
+	target := filepath.Join(destDir, header.Name)
+	cleanTarget := filepath.Clean(target)
+
+	// prevent path traversal
+	if !strings.HasPrefix(cleanTarget, filepath.Clean(destDir)+string(os.PathSeparator)) {
+		return fmt.Errorf("invalid tar path: %s", header.Name)
+	}
+
+	switch header.Typeflag {
+	case tar.TypeDir:
+		return os.MkdirAll(target, os.FileMode(header.Mode))
+	case tar.TypeReg:
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(f, tr)
+		return err
+	default:
+		// Intentionally skipping symlinks and other special files, we don't need to overly complicate this
+		klog.V(3).Infof("Skipping unsupported tar entry %s of type %c", header.Name, header.Typeflag)
+	}
+	return nil
 }
 
 type closeWrapper struct {

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -20,6 +20,7 @@
 package uploadserver
 
 import (
+	"archive/tar"
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
@@ -456,3 +457,86 @@ func newFormRequest(path string) *http.Request {
 
 	return req
 }
+
+var _ = Describe("fileToFileCloneProcessor", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "clone-test-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	createTarWithFiles := func(files map[string][]byte) io.ReadCloser {
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+
+		for name, content := range files {
+			hdr := &tar.Header{
+				Name: name,
+				Mode: 0644,
+				Size: int64(len(content)),
+			}
+			Expect(tw.WriteHeader(hdr)).To(Succeed())
+			_, err := tw.Write(content)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		Expect(tw.Close()).To(Succeed())
+		return io.NopCloser(&buf)
+	}
+
+	It("should extract disk.img with other files", func() {
+		stream := createTarWithFiles(map[string][]byte{
+			common.DiskImageName: []byte("disk image data"),
+			"metadata.json":      []byte(`{"key": "value"}`),
+		})
+
+		diskImagePath := filepath.Join(tempDir, common.DiskImageName)
+		preallocationApplied, err := fileToFileCloneProcessor(stream, false, tempDir, diskImagePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(preallocationApplied).To(BeFalse())
+
+		diskImg, err := os.ReadFile(diskImagePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(diskImg)).To(Equal("disk image data"))
+
+		metadata, err := os.ReadFile(filepath.Join(tempDir, "metadata.json"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(metadata)).To(Equal(`{"key": "value"}`))
+	})
+
+	It("should extract archive without disk.img", func() {
+		stream := createTarWithFiles(map[string][]byte{
+			"file1.txt": []byte("content1"),
+			"file2.txt": []byte("content2"),
+		})
+
+		diskImagePath := filepath.Join(tempDir, common.DiskImageName)
+		preallocationApplied, err := fileToFileCloneProcessor(stream, false, tempDir, diskImagePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(preallocationApplied).To(BeFalse())
+
+		file1, err := os.ReadFile(filepath.Join(tempDir, "file1.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(file1)).To(Equal("content1"))
+
+		file2, err := os.ReadFile(filepath.Join(tempDir, "file2.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(file2)).To(Equal("content2"))
+	})
+
+	It("should return true for preallocation when disk.img exists and preallocate=true", func() {
+		stream := createTarWithFiles(map[string][]byte{
+			common.DiskImageName: []byte("disk image data"),
+		})
+
+		diskImagePath := filepath.Join(tempDir, common.DiskImageName)
+		preallocationApplied, err := fileToFileCloneProcessor(stream, true, tempDir, diskImagePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(preallocationApplied).To(BeTrue())
+	})
+})


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR detects fs support for SEEK_HOLE by creating a test file so we can avoid performance issues in filesystems that don't support it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-45701

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add filesystem SEEK_HOLE detection to avoid tar -S performance issues
```

