### PR TITLE
use headless service for upload server

### DIFF
--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -592,14 +592,12 @@ func (r *UploadReconciler) makeUploadServiceSpec(name string, pvc *corev1.Persis
 			},
 		},
 		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
 			Ports: []corev1.ServicePort{
 				{
-					Protocol: "TCP",
-					Port:     443,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 8443,
-					},
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8443,
+					TargetPort: intstr.FromInt32(8443),
 				},
 			},
 			Selector: map[string]string{
@@ -765,7 +763,7 @@ func UploadPossibleForPVC(pvc *corev1.PersistentVolumeClaim) error {
 // GetUploadServerURL returns the url the proxy should post to for a particular pvc
 func GetUploadServerURL(namespace, pvc, uploadPath string) string {
 	serviceName := createUploadServiceNameFromPvcName(pvc)
-	return fmt.Sprintf("https://%s.%s.svc%s", serviceName, namespace, uploadPath)
+	return fmt.Sprintf("https://%s.%s.svc:8443%s", serviceName, namespace, uploadPath)
 }
 
 // createUploadServiceName returns the name given to upload service shortened if needed

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -867,14 +867,12 @@ func createUploadService(pvc *corev1.PersistentVolumeClaim) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
 			Ports: []corev1.ServicePort{
 				{
-					Protocol: "TCP",
-					Port:     443,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 8443,
-					},
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8443,
+					TargetPort: intstr.FromInt32(8443),
 				},
 			},
 			Selector: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
apparently, there's no k8s API that says
"kube-proxy has synced iptables rules for this service on all nodes"
so, pod readiness/healthz (even endpointslices) could all report success,
but the client would still face a `connection refused`
(this is causing unnecessary restarts in the k8s 1.35 bump [PR](https://github.com/kubevirt/containerized-data-importer/pull/4047))

we faced something similar in virtctl too
https://github.com/kubevirt/containerized-data-importer/pull/3545

arguably, a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) was the right fit for us anyway
and cuts the above overhead out of the equation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3851 

**Special notes for your reviewer**:
Not sure if there's a backwards compatibility consideration in here,
since upload pods are not usually carried over an upgrade

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: use headless service for upload server
```

