### PR TITLE
report failure earlier for node pull imports

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -315,8 +315,14 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *corev1.Pod, te
 		anno[cc.AnnPodRestarts] = strconv.Itoa(podRestarts)
 	}
 
-	containerState := pod.Status.ContainerStatuses[0].State
-	if containerState.Running != nil {
+	running := true
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running == nil {
+			running = false
+			break
+		}
+	}
+	if running {
 		anno[prefix] = "true"
 		anno[prefix+".message"] = ""
 		anno[prefix+".reason"] = PodRunningReason
@@ -336,6 +342,7 @@ func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *corev1.Pod, te
 		}
 	}
 
+	containerState := pod.Status.ContainerStatuses[0].State
 	if containerState.Waiting != nil && containerState.Waiting.Reason != "CrashLoopBackOff" {
 		anno[prefix+".message"] = simplifyKnownMessage(containerState.Waiting.Message)
 		anno[prefix+".reason"] = containerState.Waiting.Reason


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
previously the imagepullerr reporting would get delayed
until the main container stopped, which was wasteful.

don't report running unless all containers in the pod are running

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

