### PR TITLE
Inherit Storage Class for Scratch Space PVCs

### DIFF
--- a/pkg/controller/config-controller.go
+++ b/pkg/controller/config-controller.go
@@ -413,18 +413,8 @@ func (r *CDIConfigReconciler) reconcileStorageClass(config *cdiv1.CDIConfig) err
 			}
 		}
 	}
-	// Check for default storage class.
-	for _, storageClass := range storageClassList.Items {
-		if defaultClassValue, ok := storageClass.Annotations[cc.AnnDefaultStorageClass]; ok {
-			if defaultClassValue == "true" {
-				log.Info("Setting scratch space to default", "storageClass.Name", storageClass.Name)
-				config.Status.ScratchSpaceStorageClass = storageClass.Name
-				return nil
-			}
-		}
-	}
-	log.Info("No default storage class found, setting scratch space to blank")
-	// No storage class found, blank it out.
+
+	// If config not set, scratch space will default to using the storage class of target resource
 	config.Status.ScratchSpaceStorageClass = ""
 	return nil
 }

--- a/pkg/controller/config-controller_test.go
+++ b/pkg/controller/config-controller_test.go
@@ -357,29 +357,28 @@ var _ = Describe("Controller storage class reconcile loop", func() {
 		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal(""))
 	})
 
-	It("Should set the scratchspaceStorageClass to the default without override", func() {
+	It("Should set the scratchspaceStorageClass to blank if there is default sc", func() {
 		reconciler, cdiConfig := createConfigReconciler(createStorageClassList(
-			*CreateStorageClass("test-default-sc", map[string]string{
-				AnnDefaultStorageClass: "true",
-			},
-			)))
-		err := reconciler.reconcileStorageClass(cdiConfig)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal("test-default-sc"))
-	})
-
-	It("Should set the scratchspaceStorageClass to the default without override and multiple sc", func() {
-		reconciler, cdiConfig := createConfigReconciler(createStorageClassList(
-			*CreateStorageClass("test-sc3", nil),
 			*CreateStorageClass("test-default-sc", map[string]string{
 				AnnDefaultStorageClass: "true",
 			}),
-			*CreateStorageClass("test-sc", nil),
-			*CreateStorageClass("test-sc2", nil),
 		))
 		err := reconciler.reconcileStorageClass(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal("test-default-sc"))
+		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal(""))
+	})
+
+	It("Should clear the scratchspaceStorageClass when only the CDIConfig status was previously set", func() {
+		reconciler, cdiConfig := createConfigReconciler(createStorageClassList(
+			*CreateStorageClass("test-default-sc", map[string]string{
+				AnnDefaultStorageClass: "true",
+			}),
+		))
+		// status was leftover, but spec is not set
+		cdiConfig.Status.ScratchSpaceStorageClass = "test"
+		err := reconciler.reconcileStorageClass(cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal(""))
 	})
 
 	It("Should set the scratchspaceStorageClass to the override even with default", func() {
@@ -398,7 +397,7 @@ var _ = Describe("Controller storage class reconcile loop", func() {
 		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal(override))
 	})
 
-	It("Should set the scratchspaceStorageClass to the default with invalid override", func() {
+	It("Should set the scratchspaceStorageClass to empty with invalid override", func() {
 		reconciler, cdiConfig := createConfigReconciler(createStorageClassList(
 			*CreateStorageClass("test-sc3", nil),
 			*CreateStorageClass("test-default-sc", map[string]string{
@@ -411,7 +410,7 @@ var _ = Describe("Controller storage class reconcile loop", func() {
 		cdiConfig.Spec.ScratchSpaceStorageClass = &override
 		err := reconciler.reconcileStorageClass(cdiConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal("test-default-sc"))
+		Expect(cdiConfig.Status.ScratchSpaceStorageClass).To(Equal(""))
 	})
 })
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -70,7 +70,7 @@ var _ = Describe("GetScratchPVCStorageClass", func() {
 		Expect(GetScratchPvcStorageClass(client, pvc)).To(Equal(storageClassName))
 	})
 
-	It("Should return default storage class from status in CDIConfig", func() {
+	It("Should return default storage class from spec in CDIConfig", func() {
 		storageClassName := "test1"
 		config := createCDIConfigWithStorageClass(common.ConfigName, storageClassName)
 		config.Spec.ScratchSpaceStorageClass = &storageClassName

--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -65,12 +65,12 @@ var _ = Describe("CDI storage class config tests", Serial, func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Waiting for default SC to be the default scratch space storage class")
+		By("Waiting for the default scratch space storage class to be blank")
 		Eventually(func() string {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return config.Status.ScratchSpaceStorageClass
-		}, time.Second*30, time.Second).Should(Equal(defaultSc.Name))
+		}, time.Second*30, time.Second).Should(BeEmpty())
 	})
 
 	AfterEach(func() {
@@ -105,36 +105,17 @@ var _ = Describe("CDI storage class config tests", Serial, func() {
 		}, timeout, pollingInterval).Should(BeTrue(), "CDIConfig status not restored by config controller")
 	})
 
-	It("[test_id:3962]should have the default storage class as its scratchSpaceStorageClass", func() {
+	It("[test_id:3962]should have scratchSpaceStorageClass set to blank", func() {
 		if defaultSc == nil {
 			Skip("No default storage class found, skipping test")
 		}
 		By("Expecting default storage class to be: " + defaultSc.Name)
 		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(config.Status.ScratchSpaceStorageClass).To(Equal(defaultSc.Name))
+		Expect(config.Status.ScratchSpaceStorageClass).To(BeEmpty())
 	})
 
-	It("[test_id:3964]should set the scratch space to blank if no default exists", func() {
-		if defaultSc == nil {
-			Skip("No default storage class found, skipping test")
-		}
-		By("Expecting default storage class to be " + defaultSc.Name)
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(defaultSc.Name).To(Equal(config.Status.ScratchSpaceStorageClass))
-
-		err = SetStorageClassDefault(f, defaultSc.Name, false)
-		Expect(err).ToNot(HaveOccurred())
-		By("Expecting default storage class to be blank")
-		Eventually(func() string {
-			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return config.Status.ScratchSpaceStorageClass
-		}, time.Second*30, time.Second).Should(Equal(""))
-	})
-
-	It("[test_id:3965]should keep the default if you specify an invalid override", func() {
+	It("[test_id:3965]should have scratchSpaceStorageClass set to blank if you specify an invalid override", func() {
 		if defaultSc == nil {
 			Skip("No default storage class found, skipping test")
 		}
@@ -154,37 +135,7 @@ var _ = Describe("CDI storage class config tests", Serial, func() {
 		}, time.Second*30, time.Second).Should(Equal(invalid))
 		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(defaultSc.Name).To(Equal(config.Status.ScratchSpaceStorageClass))
-	})
-
-	It("[test_id:3966]Should react to switching the default storage class", func() {
-		storageClasses, err := f.K8sClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		if len(storageClasses.Items) < 2 {
-			Skip("Not enough storage classes to switch default")
-		}
-		By("Expecting default storage class to be " + defaultSc.Name)
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(defaultSc.Name).To(Equal(config.Status.ScratchSpaceStorageClass))
-		By("Switching default sc")
-		err = SetStorageClassDefault(f, defaultSc.Name, false)
-		Expect(err).ToNot(HaveOccurred())
-		for _, sc := range storageClasses.Items {
-			if sc.Name != defaultSc.Name {
-				// Found other class, now set it to default.
-				secondSc = &sc
-				err = SetStorageClassDefault(f, sc.Name, true)
-				Expect(err).ToNot(HaveOccurred())
-				break
-			}
-		}
-		By("Expecting default storage class to be " + secondSc.Name)
-		Eventually(func() string {
-			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return config.Status.ScratchSpaceStorageClass
-		}, time.Second*30, time.Second).Should(Equal(secondSc.Name))
+		Expect(config.Status.ScratchSpaceStorageClass).To(BeEmpty())
 	})
 
 	It("[test_id:3967]Should use the override even if a different default is set", func() {
@@ -195,8 +146,7 @@ var _ = Describe("CDI storage class config tests", Serial, func() {
 		}
 		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		// Make sure default is current value.
-		Expect(defaultSc.Name).To(Equal(config.Status.ScratchSpaceStorageClass))
+		Expect(config.Status.ScratchSpaceStorageClass).To(BeEmpty())
 		var override string
 		for _, sc := range storageClasses.Items {
 			if sc.Name != defaultSc.Name {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -2381,6 +2381,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		BeforeEach(func() {
 			testScName = fmt.Sprintf("%s-%s", testScNamePrefix, strings.ToLower(util.RandAlphaNum(8)))
 			By(fmt.Sprintf("init test storage class name: %s", testScName))
+
+			By("Setting scratch space storage class to default storage class")
+			err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+				config.ScratchSpaceStorageClass = &utils.DefaultStorageClass.Name
+			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -2400,6 +2406,12 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				})
 				pvName = ""
 			}
+
+			By("Unsetting scratch space storage class")
+			err := utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+				config.ScratchSpaceStorageClass = nil
+			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		verifyControllerRenderingEventAndConditions := func(dv *cdiv1.DataVolume) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There are some scenarios where we would like scratch space PVCs to use the same storage class as the associated target PVC instead of falling back to the default storage class. This PR allows scratch space PVCs to inherit the storage class from the target PVC if the `config.Spec.ScratchSpaceStorageClass` is not set. 

All this requires is to set the ScratchSpaceStorageClass to be an empty string and the existing code for `GetScratchPvcStorageClass()` will already inherit the storage class from the owner PVC

https://github.com/kubevirt/containerized-data-importer/blob/c3097623efebbbd1ff3248996359126e0471b86d/pkg/controller/util.go#L237-L243

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3848 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Inherit Storage Class for Scratch Space PVCs instead of using default sc 
```

