### PR TITLE
VDDK: search root snapshot backing file chain for target disk

### DIFF
--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -414,7 +414,6 @@ func searchDiskBackingChain(disk *types.VirtualDisk, fileName string) *types.Vir
 	return nil
 }
 
-// Further flatten indentation levels to reduce complexity rating
 func searchDiskBackingChainFlatVer1(info *types.VirtualDiskFlatVer1BackingInfo, fileName string) bool {
 	if info == nil || info.Parent == nil {
 		return false

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -370,60 +370,75 @@ func (vmware *VMwareClient) FindDiskInSnapshotTree(snapshots []types.VirtualMach
 // There are cases where the first listed disk is a delta, so other search methods can't find the right disk.
 // It also looks through backing files that haven't been consolidated yet, which show up in a chain of parent backing files.
 func (vmware *VMwareClient) FindDiskInRootSnapshotParent(snapshots []types.VirtualMachineSnapshotTree, fileName string) (*types.VirtualDisk, error) {
-	if len(snapshots) > 0 {
-		first := snapshots[0].Snapshot
-		var snapshot mo.VirtualMachineSnapshot
-		err := vmware.vm.Properties(vmware.context, first, []string{"config.hardware.device"}, &snapshot)
-		if err != nil {
-			return nil, errors.Wrap(err, "Error getting snapshot properties")
-		}
+	if len(snapshots) < 1 {
+		return nil, fmt.Errorf("No snapshots to search through on %s", fileName)
+	}
 
-		for _, device := range snapshot.Config.Hardware.Device {
-			switch disk := device.(type) {
-			case *types.VirtualDisk:
-				switch disk.Backing.(type) {
-				case *types.VirtualDiskFlatVer1BackingInfo:
-					if info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo); info != nil && info.Parent != nil {
-						for range maxParents {
-							info = info.Parent
-							if info != nil && info.FileName == fileName {
-								return disk, nil
-							}
-							if info.Parent == nil {
-								break
-							}
-						}
-					}
-				case *types.VirtualDiskFlatVer2BackingInfo:
-					if info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); info != nil && info.Parent != nil {
-						for range maxParents {
-							info = info.Parent
-							if info != nil && info.FileName == fileName {
-								return disk, nil
-							}
-							if info.Parent == nil {
-								break
-							}
-						}
-					}
-				case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
-					if info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo); info != nil && info.Parent != nil {
-						for range maxParents {
-							info = info.Parent
-							if info != nil && info.FileName == fileName {
-								return disk, nil
-							}
-							if info.Parent == nil {
-								break
-							}
-						}
-					}
-				}
+	first := snapshots[0].Snapshot
+	var snapshot mo.VirtualMachineSnapshot
+	if err := vmware.vm.Properties(vmware.context, first, []string{"config.hardware.device"}, &snapshot); err != nil {
+		return nil, errors.Wrap(err, "Error getting snapshot properties")
+	}
+
+	for _, device := range snapshot.Config.Hardware.Device {
+		switch disk := device.(type) {
+		case *types.VirtualDisk:
+			if parent := searchDiskBackingChain(disk, fileName); parent != nil {
+				return parent, nil
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("Disk %s not found within %d levels of parent disks", fileName, maxParents)
+	return nil, fmt.Errorf("Disk %s not found in any root snapshot ancestor", fileName)
+}
+
+// Helper function for FindDiskInRootSnapshotParent, split up to reduce rated complexity.
+func searchDiskBackingChain(disk *types.VirtualDisk, fileName string) *types.VirtualDisk {
+	switch disk.Backing.(type) {
+	case *types.VirtualDiskFlatVer1BackingInfo:
+		info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
+		if info == nil || info.Parent == nil {
+			break
+		}
+		for range maxParents {
+			info = info.Parent
+			if info != nil && info.FileName == fileName {
+				return disk
+			}
+			if info.Parent == nil {
+				break
+			}
+		}
+	case *types.VirtualDiskFlatVer2BackingInfo:
+		info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+		if info == nil || info.Parent == nil {
+			break
+		}
+		for range maxParents {
+			info = info.Parent
+			if info != nil && info.FileName == fileName {
+				return disk
+			}
+			if info.Parent == nil {
+				break
+			}
+		}
+	case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
+		info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
+		if info == nil || info.Parent == nil {
+			break
+		}
+		for range maxParents {
+			info = info.Parent
+			if info != nil && info.FileName == fileName {
+				return disk
+			}
+			if info.Parent == nil {
+				break
+			}
+		}
+	}
+	return nil
 }
 
 // FindDiskFromName finds a disk object with the given file name, usable by QueryChangedDiskAreas.

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -397,48 +397,70 @@ func searchDiskBackingChain(disk *types.VirtualDisk, fileName string) *types.Vir
 	switch disk.Backing.(type) {
 	case *types.VirtualDiskFlatVer1BackingInfo:
 		info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
-		if info == nil || info.Parent == nil {
-			break
-		}
-		for range maxParents {
-			info = info.Parent
-			if info != nil && info.FileName == fileName {
-				return disk
-			}
-			if info.Parent == nil {
-				break
-			}
+		if searchDiskBackingChainFlatVer1(info, fileName) {
+			return disk
 		}
 	case *types.VirtualDiskFlatVer2BackingInfo:
 		info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
-		if info == nil || info.Parent == nil {
-			break
-		}
-		for range maxParents {
-			info = info.Parent
-			if info != nil && info.FileName == fileName {
-				return disk
-			}
-			if info.Parent == nil {
-				break
-			}
+		if searchDiskBackingChainFlatVer2(info, fileName) {
+			return disk
 		}
 	case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 		info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
-		if info == nil || info.Parent == nil {
-			break
-		}
-		for range maxParents {
-			info = info.Parent
-			if info != nil && info.FileName == fileName {
-				return disk
-			}
-			if info.Parent == nil {
-				break
-			}
+		if searchDiskBackingChainRawDiskVer1(info, fileName) {
+			return disk
 		}
 	}
 	return nil
+}
+
+// Further flatten indentation levels to reduce complexity rating
+func searchDiskBackingChainFlatVer1(info *types.VirtualDiskFlatVer1BackingInfo, fileName string) bool {
+	if info == nil || info.Parent == nil {
+		return false
+	}
+	for range maxParents {
+		info = info.Parent
+		if info != nil && info.FileName == fileName {
+			return true
+		}
+		if info.Parent == nil {
+			break
+		}
+	}
+	return false
+}
+
+func searchDiskBackingChainFlatVer2(info *types.VirtualDiskFlatVer2BackingInfo, fileName string) bool {
+	if info == nil || info.Parent == nil {
+		return false
+	}
+	for range maxParents {
+		info = info.Parent
+		if info != nil && info.FileName == fileName {
+			return true
+		}
+		if info.Parent == nil {
+			break
+		}
+	}
+	return false
+}
+
+func searchDiskBackingChainRawDiskVer1(info *types.VirtualDiskRawDiskMappingVer1BackingInfo, fileName string) bool {
+	if info == nil || info.Parent == nil {
+		return false
+	}
+	for range maxParents {
+		info = info.Parent
+		if info != nil && info.FileName == fileName {
+			return true
+		}
+		if info.Parent == nil {
+			break
+		}
+	}
+	return false
 }
 
 // FindDiskFromName finds a disk object with the given file name, usable by QueryChangedDiskAreas.

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -66,6 +66,7 @@ const (
 	nbdUnixSocket = "/tmp/nbd.sock"
 	nbdPidFile    = "/tmp/nbd.pid"
 	maxLogLines   = 1000
+	maxParents    = 25
 )
 
 var vddkVersion string
@@ -367,39 +368,62 @@ func (vmware *VMwareClient) FindDiskInSnapshotTree(snapshots []types.VirtualMach
 
 // FindDiskInRootSnapshotParent checks if the parent of the very first snapshot has the target disk name.
 // There are cases where the first listed disk is a delta, so other search methods can't find the right disk.
-func (vmware *VMwareClient) FindDiskInRootSnapshotParent(snapshots []types.VirtualMachineSnapshotTree, fileName string) *types.VirtualDisk {
+// It also looks through backing files that haven't been consolidated yet, which show up in a chain of parent backing files.
+func (vmware *VMwareClient) FindDiskInRootSnapshotParent(snapshots []types.VirtualMachineSnapshotTree, fileName string) (*types.VirtualDisk, error) {
 	if len(snapshots) > 0 {
 		first := snapshots[0].Snapshot
 		var snapshot mo.VirtualMachineSnapshot
 		err := vmware.vm.Properties(vmware.context, first, []string{"config.hardware.device"}, &snapshot)
-		if err == nil {
-			for _, device := range snapshot.Config.Hardware.Device {
-				switch disk := device.(type) {
-				case *types.VirtualDisk:
-					var parent *types.VirtualDeviceFileBackingInfo
-					switch disk.Backing.(type) {
-					case *types.VirtualDiskFlatVer1BackingInfo:
-						if info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo); info != nil && info.Parent != nil {
-							parent = &info.Parent.VirtualDeviceFileBackingInfo
-						}
-					case *types.VirtualDiskFlatVer2BackingInfo:
-						if info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); info != nil && info.Parent != nil {
-							parent = &info.Parent.VirtualDeviceFileBackingInfo
-						}
-					case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
-						if info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo); info != nil && info.Parent != nil {
-							parent = &info.Parent.VirtualDeviceFileBackingInfo
+		if err != nil {
+			return nil, errors.Wrap(err, "Error getting snapshot properties")
+		}
+
+		for _, device := range snapshot.Config.Hardware.Device {
+			switch disk := device.(type) {
+			case *types.VirtualDisk:
+				switch disk.Backing.(type) {
+				case *types.VirtualDiskFlatVer1BackingInfo:
+					if info := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo); info != nil && info.Parent != nil {
+						for range maxParents {
+							info = info.Parent
+							if info != nil && info.FileName == fileName {
+								return disk, nil
+							}
+							if info.Parent == nil {
+								break
+							}
 						}
 					}
-					if parent != nil && parent.FileName == fileName {
-						return disk
+				case *types.VirtualDiskFlatVer2BackingInfo:
+					if info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); info != nil && info.Parent != nil {
+						for range maxParents {
+							info = info.Parent
+							if info != nil && info.FileName == fileName {
+								return disk, nil
+							}
+							if info.Parent == nil {
+								break
+							}
+						}
+					}
+				case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
+					if info := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo); info != nil && info.Parent != nil {
+						for range maxParents {
+							info = info.Parent
+							if info != nil && info.FileName == fileName {
+								return disk, nil
+							}
+							if info.Parent == nil {
+								break
+							}
+						}
 					}
 				}
 			}
 		}
 	}
 
-	return nil
+	return nil, fmt.Errorf("Disk %s not found within %d levels of parent disks", fileName, maxParents)
 }
 
 // FindDiskFromName finds a disk object with the given file name, usable by QueryChangedDiskAreas.
@@ -430,12 +454,14 @@ func (vmware *VMwareClient) FindDiskFromName(fileName string) (*types.VirtualDis
 	if snapshot.Snapshot == nil {
 		klog.Errorf("No snapshots on this virtual machine.")
 	} else {
-		if disk := vmware.FindDiskInSnapshotTree(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
+		var disk *types.VirtualDisk
+		if disk = vmware.FindDiskInSnapshotTree(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
 			return disk, nil
 		}
-		if disk := vmware.FindDiskInRootSnapshotParent(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
+		if disk, err = vmware.FindDiskInRootSnapshotParent(snapshot.Snapshot.RootSnapshotList, fileName); disk != nil {
 			return disk, nil
 		}
+		return nil, errors.Wrap(err, "Error finding disk in root snapshot chain")
 	}
 
 	return nil, fmt.Errorf("disk '%s' is not present in VM hardware config or snapshot list", fileName)

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -363,7 +363,7 @@ var _ = Describe("VDDK data source", func() {
 		//Expect(ds.ChangedBlocks).To(Equal(&changeInfo))
 	})
 
-	DescribeTable("disk name lookup", func(targetDiskName string, snapshotChain [][]string, backingInfoType string, expectedSuccess bool) {
+	DescribeTable("disk name lookup", func(targetDiskName string, snapshotChain [][]string, backingInfoType string, expectedSuccess bool, expectedErrorText string) {
 		// snapshotChain is a list of lists of disk file names, like this:
 		//     list 0: backing file chain for the base VM disk
 		//     list 1: backing file chain for "snapshot-1"
@@ -441,25 +441,28 @@ var _ = Describe("VDDK data source", func() {
 		} else {
 			Expect(err).To(HaveOccurred())
 			Expect(returnedDiskName).ToNot(Equal(targetDiskName))
+			if expectedErrorText != "" {
+				Expect(err.Error()).To(ContainSubstring(expectedErrorText))
+			}
 		}
 	},
-		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find base backing file in multi-level parent chain", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", false),
+		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer1BackingInfo", true, ""),
+		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true, ""),
+		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", true, ""),
+		Entry("should find base backing file in multi-level parent chain", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true, ""),
+		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", false, "Disk [teststore] testvm/testfile.vmdk not found in any root snapshot ancestor"),
 
-		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find base backing file in multi-level parent chain, FlatVer2 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", false),
+		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer2BackingInfo", true, ""),
+		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true, ""),
+		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", true, ""),
+		Entry("should find base backing file in multi-level parent chain, FlatVer2 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true, ""),
+		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", false, "Disk [teststore] testvm/testfile.vmdk not found in any root snapshot ancestor"),
 
-		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find base backing file in multi-level parent chain, RawDiskVer1 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", false),
+		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true, ""),
+		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true, ""),
+		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true, ""),
+		Entry("should find base backing file in multi-level parent chain, RawDiskVer1 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true, ""),
+		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", false, "Disk [teststore] testvm/testfile.vmdk not found in any root snapshot ancestor"),
 	)
 
 	It("should pass snapshot reference through to nbdkit", func() {

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -362,8 +362,13 @@ var _ = Describe("VDDK data source", func() {
 		//Expect(ds.ChangedBlocks).To(Equal(&changeInfo))
 	})
 
-	DescribeTable("disk name lookup", func(targetDiskName, diskName, snapshotDiskName, rootSnapshotParentName string, backingInfoType string, expectedSuccess bool) {
+	DescribeTable("disk name lookup", func(targetDiskName string, snapshotChain []string, backingInfoType string, expectedSuccess bool) {
 		var returnedDiskName string
+
+		diskName := ""
+		if len(snapshotChain) > 1 {
+			diskName = snapshotChain[0]
+		}
 
 		newVddkDataSource = createVddkDataSource
 		newNbdKitWrapper = func(vmware *VMwareClient, fileName, snapshot string) (*NbdKitWrapper, error) {
@@ -379,33 +384,43 @@ var _ = Describe("VDDK data source", func() {
 					out.Snapshot = createSnapshots("snapshot-1", "snapshot-2")
 				}
 			case *mo.VirtualMachineSnapshot:
-				out.Config = *createVirtualDiskConfig(snapshotDiskName, 123456)
+				out.Config = *createVirtualDiskConfig(diskName, 123456)
 				disk := out.Config.Hardware.Device[0].(*types.VirtualDisk)
 				switch backingInfoType {
-				case "VirtualDiskFlatVer1BackingInfo": // Default from createVirtualDiskConfig, no extra setup needed
-					parent := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo).Parent
-					parent.FileName = rootSnapshotParentName
-				case "VirtualDiskFlatVer2BackingInfo":
-					disk.Backing = &types.VirtualDiskFlatVer2BackingInfo{
-						VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-							FileName: snapshotDiskName,
-						},
-						Parent: &types.VirtualDiskFlatVer2BackingInfo{
+				case "VirtualDiskFlatVer1BackingInfo":
+					backing := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
+					for _, name := range snapshotChain {
+						*backing = types.VirtualDiskFlatVer1BackingInfo{
 							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-								FileName: rootSnapshotParentName,
+								FileName: name,
 							},
-						},
+							Parent: &types.VirtualDiskFlatVer1BackingInfo{},
+						}
+						backing = backing.Parent
+					}
+				case "VirtualDiskFlatVer2BackingInfo":
+					disk.Backing = &types.VirtualDiskFlatVer2BackingInfo{}
+					backingParent := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+					for _, name := range snapshotChain {
+						*backingParent = types.VirtualDiskFlatVer2BackingInfo{
+							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+								FileName: name,
+							},
+							Parent: &types.VirtualDiskFlatVer2BackingInfo{},
+						}
+						backingParent = backingParent.Parent
 					}
 				case "VirtualDiskRawDiskMappingVer1BackingInfo":
-					disk.Backing = &types.VirtualDiskRawDiskMappingVer1BackingInfo{
-						VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-							FileName: snapshotDiskName,
-						},
-						Parent: &types.VirtualDiskRawDiskMappingVer1BackingInfo{
+					disk.Backing = &types.VirtualDiskRawDiskMappingVer1BackingInfo{}
+					backingParent := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
+					for _, name := range snapshotChain {
+						*backingParent = types.VirtualDiskRawDiskMappingVer1BackingInfo{
 							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-								FileName: rootSnapshotParentName,
+								FileName: name,
 							},
-						},
+							Parent: &types.VirtualDiskRawDiskMappingVer1BackingInfo{},
+						}
+						backingParent = backingParent.Parent
 					}
 				}
 			}
@@ -421,18 +436,21 @@ var _ = Describe("VDDK data source", func() {
 			Expect(returnedDiskName).ToNot(Equal(targetDiskName))
 		}
 	},
-		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile.vmdk", "", "", "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", "wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", "", "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk", "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", "wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk", "VirtualDiskFlatVer1BackingInfo", false),
-		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile.vmdk", "", "", "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", "wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", "", "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk", "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", "wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk", "VirtualDiskFlatVer2BackingInfo", false),
-		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile.vmdk", "", "", "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", "wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", "", "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", "[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk", "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", "wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk", "VirtualDiskRawDiskMappingVer1BackingInfo", false),
+		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskFlatVer1BackingInfo", false),
+		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskFlatVer2BackingInfo", false),
+		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskRawDiskMappingVer1BackingInfo", false),
+		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
 	)
 
 	It("should pass snapshot reference through to nbdkit", func() {

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -362,12 +363,16 @@ var _ = Describe("VDDK data source", func() {
 		//Expect(ds.ChangedBlocks).To(Equal(&changeInfo))
 	})
 
-	DescribeTable("disk name lookup", func(targetDiskName string, snapshotChain []string, backingInfoType string, expectedSuccess bool) {
+	DescribeTable("disk name lookup", func(targetDiskName string, snapshotChain [][]string, backingInfoType string, expectedSuccess bool) {
+		// snapshotChain is a list of lists of disk file names, like this:
+		//     list 0: backing file chain for the base VM disk
+		//     list 1: backing file chain for "snapshot-1"
+		//     list 2: backing file chain for "snapshot-2"
 		var returnedDiskName string
 
 		diskName := ""
 		if len(snapshotChain) > 1 {
-			diskName = snapshotChain[0]
+			diskName = snapshotChain[0][0]
 		}
 
 		newVddkDataSource = createVddkDataSource
@@ -385,11 +390,13 @@ var _ = Describe("VDDK data source", func() {
 				}
 			case *mo.VirtualMachineSnapshot:
 				out.Config = *createVirtualDiskConfig(diskName, 123456)
+				index, err := strconv.Atoi(strings.ReplaceAll(ref.Value, "snapshot-", ""))
+				Expect(err).ToNot(HaveOccurred())
 				disk := out.Config.Hardware.Device[0].(*types.VirtualDisk)
 				switch backingInfoType {
 				case "VirtualDiskFlatVer1BackingInfo":
 					backing := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
-					for _, name := range snapshotChain {
+					for _, name := range snapshotChain[index] {
 						*backing = types.VirtualDiskFlatVer1BackingInfo{
 							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
 								FileName: name,
@@ -401,7 +408,7 @@ var _ = Describe("VDDK data source", func() {
 				case "VirtualDiskFlatVer2BackingInfo":
 					disk.Backing = &types.VirtualDiskFlatVer2BackingInfo{}
 					backingParent := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
-					for _, name := range snapshotChain {
+					for _, name := range snapshotChain[index] {
 						*backingParent = types.VirtualDiskFlatVer2BackingInfo{
 							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
 								FileName: name,
@@ -413,7 +420,7 @@ var _ = Describe("VDDK data source", func() {
 				case "VirtualDiskRawDiskMappingVer1BackingInfo":
 					disk.Backing = &types.VirtualDiskRawDiskMappingVer1BackingInfo{}
 					backingParent := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
-					for _, name := range snapshotChain {
+					for _, name := range snapshotChain[index] {
 						*backingParent = types.VirtualDiskRawDiskMappingVer1BackingInfo{
 							VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
 								FileName: name,
@@ -436,21 +443,23 @@ var _ = Describe("VDDK data source", func() {
 			Expect(returnedDiskName).ToNot(Equal(targetDiskName))
 		}
 	},
-		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskFlatVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskFlatVer1BackingInfo", false),
-		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskFlatVer2BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskFlatVer2BackingInfo", false),
-		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile.vmdk", "", ""}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk.vmdk", "[teststore] testvm/testfile.vmdk", ""}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"[teststore] testvm/testfile-000001.vmdk", "[teststore] testvm/testfile-000002.vmdk", "[teststore] testvm/testfile.vmdk"}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
-		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", []string{"wrong disk 1.vmdk", "wrong disk 2.vmdk", "wrong disk 1.vmdk"}, "VirtualDiskRawDiskMappingVer1BackingInfo", false),
-		Entry("should find base backing file in multi-level parent chain", "disk1", []string{"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find backing file on a VM", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find backing file on a snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should find base backing file in multi-level parent chain", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer1BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer1BackingInfo", false),
+
+		Entry("should find backing file on a VM, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find backing file on a snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should find base backing file in multi-level parent chain, FlatVer2 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskFlatVer2BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree, FlatVer2 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskFlatVer2BackingInfo", false),
+
+		Entry("should find backing file on a VM, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile.vmdk"}, {""}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find backing file on a snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk.vmdk"}, {"[teststore] testvm/testfile.vmdk"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find base backing file even if not listed as first snapshot, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"[teststore] testvm/testfile-000001.vmdk"}, {"[teststore] testvm/testfile-000002.vmdk"}, {"[teststore] testvm/testfile.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should find base backing file in multi-level parent chain, RawDiskVer1 backing", "disk1", [][]string{{""}, {"disk0", "disk5", "disk4", "disk3", "disk2", "disk1"}, {""}}, "VirtualDiskRawDiskMappingVer1BackingInfo", true),
+		Entry("should fail if backing file is not found in snapshot tree, RawDiskVer1 backing", "[teststore] testvm/testfile.vmdk", [][]string{{"wrong disk 1.vmdk"}, {"wrong disk 2.vmdk"}, {"wrong disk 1.vmdk"}}, "VirtualDiskRawDiskMappingVer1BackingInfo", false),
 	)
 
 	It("should pass snapshot reference through to nbdkit", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request handles VDDK snapshot backing file name lookups in the specific case where the source VM has multiple levels of unconsolidated backing files on the first snapshot. Previously this only checked for a single parent disk. I found out that unconsolidated snapshots can have longer chains of parent disks, with the expected target disk name at the very end of the chain. It is pretty rare but I did see it cause a forklift migration failure.

**Which issue(s) this PR fixes**:
Fixes [MTV-4437/CNV-81715](https://issues.redhat.com/browse/CNV-81715)

**Release note**:
```release-note
VDDK: search root snapshot backing file chain for target disk
```

