### PR TITLE
Add AnnPodServiceAccount to allow custom ServiceAccount for CDI pods

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5027,6 +5027,10 @@
       "description": "PVC is the PVC specification",
       "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"
      },
+     "serviceAccountName": {
+      "description": "ServiceAccountName for Importer and Uploader pod",
+      "type": "string"
+     },
      "source": {
       "description": "Source is the src of the data for the requested DataVolume",
       "$ref": "#/definitions/v1beta1.DataVolumeSource"

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -18516,6 +18516,13 @@ func schema_pkg_apis_core_v1beta1_DataVolumeSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName for Importer and Uploader pod",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"contentType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DataVolumeContentType options: \"kubevirt\", \"archive\"",

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -533,25 +533,13 @@ func (p *Planner) planHostAssistedFromPVC(ctx context.Context, args *PlanArgs) (
 		DesiredClaim:   desiredClaim,
 		ImmediateBind:  true,
 		OwnershipLabel: p.OwnershipLabel,
-		Preallocation:  cc.GetPreallocation(ctx, p.Client, args.DataSource.Spec.Preallocation),
 		Client:         p.Client,
 		Log:            args.Log,
 		Recorder:       p.Recorder,
 	}
 
-	if args.DataSource.Spec.PriorityClassName != nil {
-		hcp.PriorityClassName = *args.DataSource.Spec.PriorityClassName
-	}
-
-	rp := &RebindPhase{
-		SourceNamespace: desiredClaim.Namespace,
-		SourceName:      desiredClaim.Name,
-		TargetNamespace: args.TargetClaim.Namespace,
-		TargetName:      args.TargetClaim.Name,
-		Client:          p.Client,
-		Log:             args.Log,
-		Recorder:        p.Recorder,
-	}
+	p.applyCloneSourceSpec(ctx, args, hcp)
+	rp := p.newRebindPhase(args, desiredClaim)
 
 	return []Phase{hcp, rp}, nil
 }
@@ -607,11 +595,21 @@ func (p *Planner) planHostAssistedFromSnapshot(ctx context.Context, args *PlanAr
 		Recorder:       p.Recorder,
 	}
 
+	p.applyCloneSourceSpec(ctx, args, hcp)
+	rp := p.newRebindPhase(args, desiredClaim)
+
+	return []Phase{cfsp, pcp, hcp, rp}, nil
+}
+
+func (p *Planner) applyCloneSourceSpec(ctx context.Context, args *PlanArgs, hcp *HostClonePhase) {
+	hcp.Preallocation = cc.GetPreallocation(ctx, p.Client, args.DataSource.Spec.Preallocation)
 	if args.DataSource.Spec.PriorityClassName != nil {
 		hcp.PriorityClassName = *args.DataSource.Spec.PriorityClassName
 	}
+}
 
-	rp := &RebindPhase{
+func (p *Planner) newRebindPhase(args *PlanArgs, desiredClaim *corev1.PersistentVolumeClaim) *RebindPhase {
+	return &RebindPhase{
 		SourceNamespace: desiredClaim.Namespace,
 		SourceName:      desiredClaim.Name,
 		TargetNamespace: args.TargetClaim.Namespace,
@@ -620,8 +618,6 @@ func (p *Planner) planHostAssistedFromSnapshot(ctx context.Context, args *PlanAr
 		Log:             args.Log,
 		Recorder:        p.Recorder,
 	}
-
-	return []Phase{cfsp, pcp, hcp, rp}, nil
 }
 
 func (p *Planner) planSmartCloneFromSnapshot(ctx context.Context, args *PlanArgs) ([]Phase, error) {

--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -173,9 +173,10 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 					},
 				},
 			},
-			NodeSelector: workloadNodePlacement.NodeSelector,
-			Tolerations:  workloadNodePlacement.Tolerations,
-			Affinity:     workloadNodePlacement.Affinity,
+			NodeSelector:      workloadNodePlacement.NodeSelector,
+			Tolerations:       workloadNodePlacement.Tolerations,
+			Affinity:          workloadNodePlacement.Affinity,
+			PriorityClassName: cc.GetPriorityClass(pvc),
 		},
 	}
 	util.SetRecommendedLabels(pod, p.InstallerLabels, "cdi-controller")

--- a/pkg/controller/clone/prep-claim_test.go
+++ b/pkg/controller/clone/prep-claim_test.go
@@ -244,6 +244,24 @@ var _ = Describe("PrepClaimPhase test", func() {
 			Expect(pod.Spec.NodeName).To(Equal("node1"))
 		})
 
+		It("should create pod with priority class from PVC annotations but not service account", func() {
+			claim := getClaim()
+			cc.AddAnnotation(claim, cc.AnnPriorityClassName, "high-priority")
+			cc.AddAnnotation(claim, cc.AnnPodServiceAccount, "my-sa")
+			claim.Spec.Resources.Requests[corev1.ResourceStorage] = defaultRequestSize
+			claim.Status.Phase = corev1.ClaimPending
+
+			p := createPrepClaimPhase(claim)
+
+			result, err := p.Reconcile(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+
+			pod := getCreatedPod(p)
+			Expect(pod.Spec.PriorityClassName).To(Equal("high-priority"))
+			Expect(pod.Spec.ServiceAccountName).To(BeEmpty())
+		})
+
 		It("should create pod if desired is bigger", func() {
 			claim := getClaim()
 			claim.Spec.Resources.Requests[corev1.ResourceStorage] = defaultRequestSize

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -93,6 +93,8 @@ const (
 	AnnPrePopulated = AnnAPIGroup + "/storage.prePopulated"
 	// AnnPriorityClassName is PVC annotation to indicate the priority class name for importer, cloner and uploader pod
 	AnnPriorityClassName = AnnAPIGroup + "/storage.pod.priorityclassname"
+	// AnnPodServiceAccount is a PVC annotation to indicate the service account name for importer and uploader pod
+	AnnPodServiceAccount = AnnAPIGroup + "/storage.pod.serviceAccountName"
 	// AnnExternalPopulation annotation marks a PVC as "externally populated", allowing the import-controller to skip it
 	AnnExternalPopulation = AnnAPIGroup + "/externalPopulation"
 
@@ -397,6 +399,7 @@ var (
 		AnnPodSidecarInjectionIstio:   AnnPodSidecarInjectionIstioDefault,
 		AnnPodSidecarInjectionLinkerd: AnnPodSidecarInjectionLinkerdDefault,
 		AnnPriorityClassName:          "",
+		AnnPodServiceAccount:          "",
 		AnnPodMultusDefaultNetwork:    "",
 	}
 
@@ -862,6 +865,12 @@ func ImmediateBindingRequested(obj metav1.Object) bool {
 func GetPriorityClass(pvc *corev1.PersistentVolumeClaim) string {
 	anno := pvc.GetAnnotations()
 	return anno[AnnPriorityClassName]
+}
+
+// GetPodServiceAccount gets PVC service account name
+func GetPodServiceAccount(pvc *corev1.PersistentVolumeClaim) string {
+	anno := pvc.GetAnnotations()
+	return anno[AnnPodServiceAccount]
 }
 
 // ShouldDeletePod returns whether the PVC workload pod should be deleted

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1155,6 +1155,9 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 	if dataVolume.Spec.PriorityClassName != "" {
 		annotations[cc.AnnPriorityClassName] = dataVolume.Spec.PriorityClassName
 	}
+	if dataVolume.Spec.ServiceAccountName != "" {
+		annotations[cc.AnnPodServiceAccount] = dataVolume.Spec.ServiceAccountName
+	}
 	annotations[cc.AnnPreallocationRequested] = strconv.FormatBool(cc.GetPreallocation(context.TODO(), r.client, dataVolume.Spec.Preallocation))
 	annotations[cc.AnnCreatedForDataVolume] = string(dataVolume.UID)
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -119,6 +119,7 @@ type importerPodArgs struct {
 	vddkImageName           *string
 	vddkExtraArgs           *string
 	priorityClassName       string
+	serviceAccountName      string
 }
 
 // NewImportController creates a new instance of the import controller.
@@ -541,15 +542,16 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 	}
 	// all checks passed, let's create the importer pod!
 	podArgs := &importerPodArgs{
-		image:             r.image,
-		verbose:           r.verbose,
-		pullPolicy:        r.pullPolicy,
-		podEnvVar:         podEnvVar,
-		pvc:               pvc,
-		scratchPvcName:    scratchPvcName,
-		vddkImageName:     vddkImageName,
-		vddkExtraArgs:     vddkExtraArgs,
-		priorityClassName: cc.GetPriorityClass(pvc),
+		image:              r.image,
+		verbose:            r.verbose,
+		pullPolicy:         r.pullPolicy,
+		podEnvVar:          podEnvVar,
+		pvc:                pvc,
+		scratchPvcName:     scratchPvcName,
+		vddkImageName:      vddkImageName,
+		vddkExtraArgs:      vddkExtraArgs,
+		priorityClassName:  cc.GetPriorityClass(pvc),
+		serviceAccountName: cc.GetPodServiceAccount(pvc),
 	}
 
 	pod, err := createImporterPod(context.TODO(), r.log, r.client, podArgs, r.installerLabels)
@@ -952,15 +954,16 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers:        makeImporterContainerSpec(args),
-			InitContainers:    makeImporterInitContainersSpec(args),
-			Volumes:           makeImporterVolumeSpec(args),
-			RestartPolicy:     corev1.RestartPolicyOnFailure,
-			NodeSelector:      args.workloadNodePlacement.NodeSelector,
-			Tolerations:       args.workloadNodePlacement.Tolerations,
-			Affinity:          args.workloadNodePlacement.Affinity,
-			PriorityClassName: args.priorityClassName,
-			ImagePullSecrets:  args.imagePullSecrets,
+			Containers:         makeImporterContainerSpec(args),
+			InitContainers:     makeImporterInitContainersSpec(args),
+			Volumes:            makeImporterVolumeSpec(args),
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			NodeSelector:       args.workloadNodePlacement.NodeSelector,
+			Tolerations:        args.workloadNodePlacement.Tolerations,
+			Affinity:           args.workloadNodePlacement.Affinity,
+			PriorityClassName:  args.priorityClassName,
+			ServiceAccountName: args.serviceAccountName,
+			ImagePullSecrets:   args.imagePullSecrets,
 		},
 	}
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -859,13 +859,14 @@ var _ = Describe("Create Importer Pod", func() {
 			insecureTLS:        false,
 		}
 		podArgs := &importerPodArgs{
-			image:             testImage,
-			verbose:           "5",
-			pullPolicy:        testPullPolicy,
-			podEnvVar:         podEnvVar,
-			pvc:               pvc,
-			scratchPvcName:    scratchPvcName,
-			priorityClassName: pvc.Annotations[cc.AnnPriorityClassName],
+			image:              testImage,
+			verbose:            "5",
+			pullPolicy:         testPullPolicy,
+			podEnvVar:          podEnvVar,
+			pvc:                pvc,
+			scratchPvcName:     scratchPvcName,
+			priorityClassName:  pvc.Annotations[cc.AnnPriorityClassName],
+			serviceAccountName: pvc.Annotations[cc.AnnPodServiceAccount],
 		}
 		pod, err := createImporterPod(context.TODO(), reconciler.log, reconciler.client, podArgs, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -898,11 +899,12 @@ var _ = Describe("Create Importer Pod", func() {
 		Expect(pod.Spec.Containers[0].Args[0]).To(Equal("-v=5"))
 		Expect(pod.Spec.Containers[0].TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 		Expect(pod.Spec.PriorityClassName).To(Equal(pvc.Annotations[cc.AnnPriorityClassName]))
+		Expect(pod.Spec.ServiceAccountName).To(Equal(pvc.Annotations[cc.AnnPodServiceAccount]))
 	},
-		Entry("should create pod with file system volume mode", cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0"}, nil), nil),
-		Entry("should create pod with block volume mode", createBlockPvc("testBlockPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0"}, nil), nil),
-		Entry("should create pod with file system volume mode and scratchspace", cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0"}, nil), &scratchPvcName),
-		Entry("should create pod with block volume mode and scratchspace", createBlockPvc("testBlockPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0"}, nil), &scratchPvcName),
+		Entry("should create pod with file system volume mode", cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0", cc.AnnPodServiceAccount: "my-sa"}, nil), nil),
+		Entry("should create pod with block volume mode", createBlockPvc("testBlockPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0", cc.AnnPodServiceAccount: "my-sa"}, nil), nil),
+		Entry("should create pod with file system volume mode and scratchspace", cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0", cc.AnnPodServiceAccount: "my-sa"}, nil), &scratchPvcName),
+		Entry("should create pod with block volume mode and scratchspace", createBlockPvc("testBlockPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodPending), cc.AnnImportPod: "podName", cc.AnnPriorityClassName: "p0", cc.AnnPodServiceAccount: "my-sa"}, nil), &scratchPvcName),
 	)
 
 	DescribeTable("should append current checkpoint name to importer pod", func(pvcName, checkpointID string) {

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -277,6 +277,7 @@ var _ = Describe("Import populator tests", func() {
 			Entry("No extra annotations", "", "", ""),
 			Entry("Invalid extra annotation is not passed", "invalid", "test", ""),
 			Entry("Priority class is passed", AnnPriorityClassName, "test", "test"),
+			Entry("Service account is passed", AnnPodServiceAccount, "test", "test"),
 			Entry("pod network is passed", AnnPodNetwork, "test", "test"),
 			Entry("istio side car injection is passed", AnnPodSidecarInjectionIstio, AnnPodSidecarInjectionIstioDefault, AnnPodSidecarInjectionIstioDefault),
 			Entry("linkerd side car injection is passed", AnnPodSidecarInjectionLinkerd, AnnPodSidecarInjectionLinkerdDefault, AnnPodSidecarInjectionLinkerdDefault),

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -335,6 +335,7 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		Entry("No extra annotations", "", "", ""),
 		Entry("Invalid extra annotation is not passed", "invalid", "test", ""),
 		Entry("Priority class is passed", cc.AnnPriorityClassName, "test", "test"),
+		Entry("Service account is passed", cc.AnnPodServiceAccount, "test", "test"),
 		Entry("pod network is passed", cc.AnnPodNetwork, "test", "test"),
 		Entry("istio side car injection is passed", cc.AnnPodSidecarInjectionIstio, cc.AnnPodSidecarInjectionIstioDefault, cc.AnnPodSidecarInjectionIstioDefault),
 		Entry("linkerd side car injection is passed", cc.AnnPodSidecarInjectionLinkerd, cc.AnnPodSidecarInjectionLinkerdDefault, cc.AnnPodSidecarInjectionLinkerdDefault),

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -792,14 +792,15 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers:        r.makeUploadPodContainers(args, resourceRequirements),
-			Volumes:           r.makeUploadPodVolumes(args),
-			RestartPolicy:     corev1.RestartPolicyOnFailure,
-			NodeSelector:      workloadNodePlacement.NodeSelector,
-			Tolerations:       workloadNodePlacement.Tolerations,
-			Affinity:          workloadNodePlacement.Affinity,
-			PriorityClassName: cc.GetPriorityClass(args.PVC),
-			ImagePullSecrets:  imagePullSecrets,
+			Containers:         r.makeUploadPodContainers(args, resourceRequirements),
+			Volumes:            r.makeUploadPodVolumes(args),
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			NodeSelector:       workloadNodePlacement.NodeSelector,
+			Tolerations:        workloadNodePlacement.Tolerations,
+			Affinity:           workloadNodePlacement.Affinity,
+			PriorityClassName:  cc.GetPriorityClass(args.PVC),
+			ServiceAccountName: cc.GetPodServiceAccount(args.PVC),
+			ImagePullSecrets:   imagePullSecrets,
 		},
 	}
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -277,7 +277,7 @@ var _ = Describe("Upload controller reconcile loop", func() {
 	})
 
 	It("Should return nil and create a pod and service when a clone pvc", func() {
-		testPvc := cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnCloneRequest: "default/testPvc2", AnnUploadPod: createUploadResourceName("testPvc1"), cc.AnnPriorityClassName: "p0"}, nil)
+		testPvc := cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnCloneRequest: "default/testPvc2", AnnUploadPod: createUploadResourceName("testPvc1"), cc.AnnPriorityClassName: "p0", cc.AnnPodServiceAccount: "my-sa"}, nil)
 		testPvcSource := cc.CreatePvc("testPvc2", "default", map[string]string{}, nil)
 		reconciler := createUploadReconciler(testPvc, testPvcSource)
 		By("Verifying the pod and service do not exist")
@@ -297,6 +297,7 @@ var _ = Describe("Upload controller reconcile loop", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(uploadPod.Name).To(Equal(createUploadResourceName(testPvc.Name)))
 		Expect(uploadPod.Spec.PriorityClassName).To(Equal("p0"))
+		Expect(uploadPod.Spec.ServiceAccountName).To(Equal("my-sa"))
 		Expect(uploadPod.Labels[common.AppKubernetesPartOfLabel]).To(Equal("testing"))
 
 		uploadService = &corev1.Service{}

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5928,6 +5928,10 @@ spec:
                               PersistentVolume backing this claim.
                             type: string
                         type: object
+                      serviceAccountName:
+                        description: ServiceAccountName for Importer and Uploader
+                          pod
+                        type: string
                       source:
                         description: Source is the src of the data for the requested
                           DataVolume
@@ -6936,6 +6940,9 @@ spec:
                       backing this claim.
                     type: string
                 type: object
+              serviceAccountName:
+                description: ServiceAccountName for Importer and Uploader pod
+                type: string
               source:
                 description: Source is the src of the data for the requested DataVolume
                 properties:

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -56,6 +56,9 @@ type DataVolumeSpec struct {
 	Storage *StorageSpec `json:"storage,omitempty"`
 	//PriorityClassName for Importer, Cloner and Uploader pod
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// ServiceAccountName for Importer and Uploader pod
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	//DataVolumeContentType options: "kubevirt", "archive"
 	// +kubebuilder:validation:Enum="kubevirt";"archive"
 	ContentType DataVolumeContentType `json:"contentType,omitempty"`

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -11,16 +11,17 @@ func (DataVolume) SwaggerDoc() map[string]string {
 
 func (DataVolumeSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                  "DataVolumeSpec defines the DataVolume type specification",
-		"source":            "Source is the src of the data for the requested DataVolume\n+optional",
-		"sourceRef":         "SourceRef is an indirect reference to the source of data for the requested DataVolume\n+optional",
-		"pvc":               "PVC is the PVC specification",
-		"storage":           "Storage is the requested storage specification",
-		"priorityClassName": "PriorityClassName for Importer, Cloner and Uploader pod",
-		"contentType":       "DataVolumeContentType options: \"kubevirt\", \"archive\"\n+kubebuilder:validation:Enum=\"kubevirt\";\"archive\"",
-		"checkpoints":       "Checkpoints is a list of DataVolumeCheckpoints, representing stages in a multistage import.",
-		"finalCheckpoint":   "FinalCheckpoint indicates whether the current DataVolumeCheckpoint is the final checkpoint.",
-		"preallocation":     "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
+		"":                   "DataVolumeSpec defines the DataVolume type specification",
+		"source":             "Source is the src of the data for the requested DataVolume\n+optional",
+		"sourceRef":          "SourceRef is an indirect reference to the source of data for the requested DataVolume\n+optional",
+		"pvc":                "PVC is the PVC specification",
+		"storage":            "Storage is the requested storage specification",
+		"priorityClassName":  "PriorityClassName for Importer, Cloner and Uploader pod",
+		"serviceAccountName": "ServiceAccountName for Importer and Uploader pod\n+optional",
+		"contentType":        "DataVolumeContentType options: \"kubevirt\", \"archive\"\n+kubebuilder:validation:Enum=\"kubevirt\";\"archive\"",
+		"checkpoints":        "Checkpoints is a list of DataVolumeCheckpoints, representing stages in a multistage import.",
+		"finalCheckpoint":    "FinalCheckpoint indicates whether the current DataVolumeCheckpoint is the final checkpoint.",
+		"preallocation":      "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 	}
 }
 


### PR DESCRIPTION
Add AnnPodServiceAccount to allow custom ServiceAccount for CDI pods

**What this PR does / why we need it**:

This PR adds support for specifying a custom ServiceAccount for importer
and uploader pods via a new PVC/DV annotation. This enables organizations
with security policies that require migration workloads to run under a
specific ServiceAccount rather than the namespace default.

The feature can be used in two ways:
1. **DataVolume spec field**: Set `spec.serviceAccountName` on a DataVolume,
   which gets propagated as an annotation onto the underlying PVC.
2. **PVC annotation**: Set `cdi.kubevirt.io/storage.pod.serviceAccountName`
   directly on a PVC.

The implementation mirrors the existing AnnPriorityClassName pattern:
- Added AnnPodServiceAccount constant and GetPodServiceAccount() helper
- Added AnnPodServiceAccount to allowedAnnotations whitelist
- Set pod.Spec.ServiceAccountName in import and upload controllers
- Added ServiceAccountName field to DataVolumeSpec
- Propagate annotation from DataVolume to PVC in controller-base.go
- Updated OpenAPI and CRD generated schemas for the new spec field
- Added unit tests following the AnnPriorityClassName test pattern

Clone flows are intentionally excluded — custom ServiceAccount is only
supported for import and upload. This avoids cross-namespace security
concerns where the user may not have visibility into ServiceAccounts
in the source namespace (e.g., golden images namespace).

Note: prep-claim.go also adds the missing PriorityClassName to the pod spec.
This is a pre-existing bug — CopyAllowedAnnotations copied the annotation to
pod metadata, but PodSpec.PriorityClassName was never set, so Kubernetes
ignored it for scheduling. Fixed here since we're already touching the same
code block.

Also refactored planHostAssistedFromPVC/planHostAssistedFromSnapshot in
planner.go to extract shared helpers (applyCloneSourceSpec, newRebindPhase),
fixing a pre-existing bug where Preallocation was not set on the snapshot
clone path.

**After the fix**:

Users can set the annotation cdi.kubevirt.io/storage.pod.serviceAccountName
on a DataVolume or PVC, and CDI importer/uploader pods will run under that
ServiceAccount. Clone and source-namespace pods are not affected and continue
using the default SA. If the SA does not exist, Kubernetes rejects the pod
with a clear error message.

Example DataVolume usage:
```yaml
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  annotations:
    cdi.kubevirt.io/storage.pod.serviceAccountName: "my-custom-sa"
spec:
  source:
    http:
      url: "https://example.com/disk.img"
  storage:
    resources:
      requests:
        storage: 1Gi
```

**Which issue(s) this PR fixes**:

Jira Ticket: https://redhat.atlassian.net/browse/CNV-81806

**Release note**:
```release-note
CDI importer and uploader pods can now use a custom ServiceAccount by
setting the annotation cdi.kubevirt.io/storage.pod.serviceAccountName
on the DataVolume or PVC. Clone flows are not affected.
```

