### PR TITLE
Add RWO file support for GCE persistent volumes

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -87,8 +87,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"kubernetes.io/azure-file": {{rwx, file}},
 	"file.csi.azure.com":       {{rwx, file}},
 	// GCE Persistent Disk
-	"kubernetes.io/gce-pd":            {{rwo, block}},
-	"pd.csi.storage.gke.io":           {{rwo, block}},
+	"kubernetes.io/gce-pd":            {{rwo, block}, {rwo, file}},
+	"pd.csi.storage.gke.io":           {{rwo, block}, {rwo, file}},
 	"pd.csi.storage.gke.io/hyperdisk": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// Hitachi
 	"hspc.csi.hitachi.com": {{rwx, block}, {rwo, block}, {rwo, file}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As per the reference[1] with hyperdisk taking care of rwx block usecases.

[1] https://docs.cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes#access_modes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
GCE persistent disk StorageProfile now supports RWO Filesystem. 
```

