### PR TITLE
Set EnableServiceLinks=false on importer/cloner/uploader pods

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -630,6 +631,10 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 			},
 			ImagePullSecrets: imagePullSecrets,
 			RestartPolicy:    corev1.RestartPolicyOnFailure,
+			// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+			// Disable service environment variable injection to avoid 'argument list too long'
+			// errors in namespaces with many Services (each injects ~7 env vars).
+			EnableServiceLinks: ptr.To(false),
 			Volumes: []corev1.Volume{
 				{
 					Name: cc.DataVolName,

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -886,6 +887,7 @@ func createSourcePod(pvc *corev1.PersistentVolumeClaim, pvcUID string) *corev1.P
 					},
 				},
 			},
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1375,8 +1375,9 @@ func CreateImporterTestPod(pvc *corev1.PersistentVolumeClaim, dvname string, scr
 					},
 				},
 			},
-			RestartPolicy: corev1.RestartPolicyOnFailure,
-			Volumes:       volumes,
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			Volumes:            volumes,
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -964,6 +964,10 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			PriorityClassName:  args.priorityClassName,
 			ServiceAccountName: args.serviceAccountName,
 			ImagePullSecrets:   args.imagePullSecrets,
+			// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+			// Disable service environment variable injection to avoid 'argument list too long'
+			// errors in namespaces with many Services (each injects ~7 env vars).
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 

--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -622,6 +622,10 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 			},
 		},
 		RestartPolicy: corev1.RestartPolicyOnFailure,
+		// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+		// Disable service environment variable injection to avoid 'argument list too long'
+		// errors in namespaces with many Services (each injects ~7 env vars).
+		EnableServiceLinks: ptr.To(false),
 		Volumes: []corev1.Volume{
 			{
 				Name: populatorPodVolumeName,

--- a/pkg/controller/populators/forklift-populator_test.go
+++ b/pkg/controller/populators/forklift-populator_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -140,6 +141,7 @@ var _ = Describe("Forklift populator tests", func() {
 						},
 					},
 				},
+				EnableServiceLinks: ptr.To(false),
 			},
 		}
 	}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -799,6 +799,10 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			PriorityClassName:  cc.GetPriorityClass(args.PVC),
 			ServiceAccountName: cc.GetPodServiceAccount(args.PVC),
 			ImagePullSecrets:   imagePullSecrets,
+			// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+			// Disable service environment variable injection to avoid 'argument list too long'
+			// errors in namespaces with many Services (each injects ~7 env vars).
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -832,6 +833,7 @@ func createUploadClonePod(pvc *corev1.PersistentVolumeClaim, clientName string) 
 					},
 				},
 			},
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 	return pod


### PR DESCRIPTION
## Summary

Fixes #4059. CDI pods fail with "argument list too long" in namespaces with 2000+ Services because Kubernetes injects ~7 env vars per Service by default.

- Set `EnableServiceLinks: ptr.To(false)` on importer, cloner, uploader, and forklift populator pod specs
- Updated corresponding test helpers to include the new field
- All 428 existing unit tests pass

Same fix KubeVirt applied to virt-launcher pods in 2020 (kubevirt/kubevirt#4393).

```release-note
Set EnableServiceLinks=false on CDI worker pods to prevent "argument list too long" failures in namespaces with many Services.
```