### PR TITLE
MTV-4577 Warm migration failed at server fault code

### DIFF
--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
             "//vendor/github.com/vmware/govmomi/vim25:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/methods:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
+            "//vendor/github.com/vmware/govmomi/vim25/soap:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
             "//vendor/k8s.io/utils/ptr:go_default_library",
             "//vendor/libguestfs.org/libnbd:go_default_library",

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -40,6 +40,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/sys/unix"
 	libnbd "libguestfs.org/libnbd"
@@ -236,6 +237,7 @@ func dumpLogs(ringEntry interface{}) {
 
 // VMwareConnectionOperations provides a mockable interface for the things needed from VMware client objects.
 type VMwareConnectionOperations interface {
+	Login(context.Context, *url.Userinfo) error
 	Logout(context.Context) error
 	IsVC() bool
 }
@@ -323,6 +325,42 @@ func (vmware *VMwareClient) Close() error {
 
 	klog.Info("Logged out of VMware.")
 	return nil
+}
+
+// isSessionNotAuthenticated reports whether err indicates the vSphere session expired or was invalidated.
+func isSessionNotAuthenticated(err error) bool {
+	for err != nil {
+		if soap.IsVimFault(err) {
+			switch soap.ToVimFault(err).(type) {
+			case *types.NotAuthenticated, *types.NotAuthenticatedFault:
+				return true
+			}
+		}
+		if strings.Contains(strings.ToLower(err.Error()), "not authenticated") {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
+// withVMwareReloginRetry runs fn once; if VMware returns a not-authenticated fault (e.g. session timeout
+// during a long warm-migration delta copy), re-logs in and runs fn a second time.
+func (vmware *VMwareClient) withVMwareReloginRetry(fn func() error) error {
+	err := fn()
+	if err == nil {
+		return nil
+	}
+	if !isSessionNotAuthenticated(err) {
+		return err
+	}
+	klog.Warningf("VMware session is not authenticated (likely timed out), re-logging in: %v", err)
+	u := url.UserPassword(vmware.username, vmware.password)
+	if loginErr := vmware.conn.Login(vmware.context, u); loginErr != nil {
+		return fmt.Errorf("failed to re-authenticate VMware session: %w", loginErr)
+	}
+	klog.Infof("Re-authenticated to VMware successfully, retrying operation.")
+	return fn()
 }
 
 // getDiskFileName returns the name of a disk's backing file
@@ -1116,7 +1154,12 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 
 	if vs.IsDeltaCopy() { // Warm migration delta copy
 		// Find disk object for backingFile disk image path
-		backingFileObject, err := vs.VMware.FindDiskFromName(vs.BackingFile)
+		var backingFileObject *types.VirtualDisk
+		err := vs.VMware.withVMwareReloginRetry(func() error {
+			var inner error
+			backingFileObject, inner = vs.VMware.FindDiskFromName(vs.BackingFile)
+			return inner
+		})
 		if err != nil {
 			err = errors.Wrapf(err, "Could not find VM disk %s", vs.BackingFile)
 			klog.Error(err)
@@ -1126,7 +1169,11 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 		// Find current snapshot object if requested
 		var currentSnapshot *types.ManagedObjectReference
 		if vs.CurrentSnapshot != "" {
-			currentSnapshot, err = vs.VMware.vm.FindSnapshot(vs.VMware.context, vs.CurrentSnapshot)
+			err = vs.VMware.withVMwareReloginRetry(func() error {
+				var inner error
+				currentSnapshot, inner = vs.VMware.vm.FindSnapshot(vs.VMware.context, vs.CurrentSnapshot)
+				return inner
+			})
 			if err != nil {
 				err = errors.Wrapf(err, "Could not find current snapshot %s", vs.CurrentSnapshot)
 				klog.Error(err)
@@ -1134,7 +1181,12 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 			}
 		}
 
-		disk, err := vs.VMware.FindSnapshotDisk(currentSnapshot, backingFileObject.DiskObjectId)
+		var disk *types.VirtualDisk
+		err = vs.VMware.withVMwareReloginRetry(func() error {
+			var inner error
+			disk, inner = vs.VMware.FindSnapshotDisk(currentSnapshot, backingFileObject.DiskObjectId)
+			return inner
+		})
 		if err != nil {
 			err = errors.Wrapf(err, "Could not find matching disk in current snapshot")
 			klog.Error(err)
@@ -1147,7 +1199,11 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 		isChangeID, _ := regexp.MatchString(changeIDPattern, vs.PreviousSnapshot)
 		var previousSnapshot *types.ManagedObjectReference
 		if !isChangeID {
-			previousSnapshot, err = vs.VMware.vm.FindSnapshot(vs.VMware.context, vs.PreviousSnapshot)
+			err = vs.VMware.withVMwareReloginRetry(func() error {
+				var inner error
+				previousSnapshot, inner = vs.VMware.vm.FindSnapshot(vs.VMware.context, vs.PreviousSnapshot)
+				return inner
+			})
 			if err != nil {
 				err = errors.Wrapf(err, "Could not find previous snapshot %s", vs.PreviousSnapshot)
 				klog.Error(err)
@@ -1174,7 +1230,12 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 					StartOffset: offset,
 					This:        vs.VMware.vm.Reference(),
 				}
-				response, err := QueryChangedDiskAreas(vs.VMware.context, vs.VMware.vm.Client(), &request)
+				var response *types.QueryChangedDiskAreasResponse
+				err := vs.VMware.withVMwareReloginRetry(func() error {
+					var inner error
+					response, inner = QueryChangedDiskAreas(vs.VMware.context, vs.VMware.vm.Client(), &request)
+					return inner
+				})
 				if err != nil {
 					err = errors.Wrapf(err, "Failed to query changed areas")
 					klog.Error(err)
@@ -1188,7 +1249,12 @@ func (vs *VDDKDataSource) TransferFile(fileName string, preallocation bool) (Pro
 				changed.StartOffset = response.Returnval.StartOffset
 				changed.Length = response.Returnval.Length
 			} else { // Previous checkpoint is a snapshot
-				changedAreas, err := vs.VMware.vm.QueryChangedDiskAreas(vs.VMware.context, previousSnapshot, currentSnapshot, backingFileObject, changed.Length)
+				var changedAreas types.DiskChangeInfo
+				err := vs.VMware.withVMwareReloginRetry(func() error {
+					var inner error
+					changedAreas, inner = vs.VMware.vm.QueryChangedDiskAreas(vs.VMware.context, previousSnapshot, currentSnapshot, backingFileObject, changed.Length)
+					return inner
+				})
 				if err != nil {
 					err = errors.Wrapf(err, "Unable to query changed areas")
 					klog.Error(err)

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -1201,7 +1201,7 @@ func createMockVMwareClient(endpoint string, accessKey string, secKey string, th
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &VMwareClient{
-		conn:       &mockVMwareConnectionOperations{endpoint},
+		conn:       &mockVMwareConnectionOperations{Endpoint: endpoint},
 		cancel:     cancel,
 		context:    ctx,
 		moref:      "vm-1",

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -699,6 +699,106 @@ var _ = Describe("VDDK log watcher", func() {
 	)
 })
 
+var _ = Describe("VMware session re-authentication", func() {
+	notAuthenticatedFault := func() error {
+		return soap.WrapVimFault(&types.NotAuthenticated{})
+	}
+
+	Describe("isSessionNotAuthenticated", func() {
+		It("returns false for nil", func() {
+			Expect(isSessionNotAuthenticated(nil)).To(BeFalse())
+		})
+
+		It("returns true for a NotAuthenticated vim fault", func() {
+			Expect(isSessionNotAuthenticated(notAuthenticatedFault())).To(BeTrue())
+		})
+
+		It("returns true for a NotAuthenticatedFault vim fault", func() {
+			Expect(isSessionNotAuthenticated(soap.WrapVimFault(&types.NotAuthenticatedFault{}))).To(BeTrue())
+		})
+
+		It("returns true when the error message mentions not authenticated", func() {
+			err := errors.New("ServerFaultCode: The session is not authenticated.")
+			Expect(isSessionNotAuthenticated(err)).To(BeTrue())
+		})
+
+		It("returns true for a wrapped NotAuthenticated error", func() {
+			err := fmt.Errorf("query failed: %w", notAuthenticatedFault())
+			Expect(isSessionNotAuthenticated(err)).To(BeTrue())
+		})
+
+		It("returns false for unrelated errors", func() {
+			Expect(isSessionNotAuthenticated(errors.New("connection reset"))).To(BeFalse())
+		})
+	})
+
+	Describe("withVMwareReloginRetry", func() {
+		var conn *mockVMwareConnectionOperations
+		var vmware *VMwareClient
+
+		BeforeEach(func() {
+			conn = &mockVMwareConnectionOperations{Endpoint: "http://vcenter.test"}
+			vmware = &VMwareClient{
+				conn:     conn,
+				context:  context.Background(),
+				username: "vcenter-user",
+				password: "vcenter-pass",
+			}
+		})
+
+		It("runs the operation once when it succeeds", func() {
+			attempts := 0
+			err := vmware.withVMwareReloginRetry(func() error {
+				attempts++
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attempts).To(Equal(1))
+			Expect(conn.loginCalls).To(Equal(0))
+		})
+
+		It("re-logins and retries after a NotAuthenticated fault", func() {
+			attempts := 0
+			err := vmware.withVMwareReloginRetry(func() error {
+				attempts++
+				if attempts == 1 {
+					return notAuthenticatedFault()
+				}
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attempts).To(Equal(2))
+			Expect(conn.loginCalls).To(Equal(1))
+			Expect(conn.lastLoginUser).ToNot(BeNil())
+			Expect(conn.lastLoginUser.Username()).To(Equal("vcenter-user"))
+			password, _ := conn.lastLoginUser.Password()
+			Expect(password).To(Equal("vcenter-pass"))
+		})
+
+		It("returns the original error when the failure is not authentication related", func() {
+			original := errors.New("disk not found")
+			err := vmware.withVMwareReloginRetry(func() error {
+				return original
+			})
+			Expect(err).To(Equal(original))
+			Expect(conn.loginCalls).To(Equal(0))
+		})
+
+		It("returns an error when re-login fails", func() {
+			conn.LoginFunc = func(context.Context, *url.Userinfo) error {
+				return errors.New("login refused")
+			}
+			err := vmware.withVMwareReloginRetry(func() error {
+				return notAuthenticatedFault()
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to re-authenticate VMware session"))
+			Expect(err.Error()).To(ContainSubstring("login refused"))
+			Expect(conn.loginCalls).To(Equal(1))
+		})
+	})
+})
+
 var _ = Describe("VDDK get block status", func() {
 	defaultMockNbd := defaultMockNbdFunctions()
 	BeforeEach(func() {
@@ -1021,7 +1121,19 @@ func createMockVddkDataSink(destinationFile string, size uint64, volumeMode v1.P
 }
 
 type mockVMwareConnectionOperations struct {
-	Endpoint string
+	Endpoint      string
+	LoginFunc     func(context.Context, *url.Userinfo) error
+	loginCalls    int
+	lastLoginUser *url.Userinfo
+}
+
+func (ops *mockVMwareConnectionOperations) Login(ctx context.Context, u *url.Userinfo) error {
+	ops.loginCalls++
+	ops.lastLoginUser = u
+	if ops.LoginFunc != nil {
+		return ops.LoginFunc(ctx, u)
+	}
+	return nil
 }
 
 func (ops *mockVMwareConnectionOperations) Logout(context.Context) error {

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -718,7 +718,7 @@ var _ = Describe("VMware session re-authentication", func() {
 		})
 
 		It("returns true when the error message mentions not authenticated", func() {
-			err := errors.New("ServerFaultCode: The session is not authenticated.")
+			err := errors.New("server fault: the session is not authenticated")
 			Expect(isSessionNotAuthenticated(err)).To(BeTrue())
 		})
 


### PR DESCRIPTION
importer: Re-login to VMware on session expiry during VDDK warm migration

Summary
Warm migration delta copy can run long enough for the vSphere session to time out. After that, VMware API calls fail with NotAuthenticated / “The session is not authenticated”, which can show up next to snapshot/disk lookups during CopyDisks.

This change detects that failure, calls SessionManager.Login again on the existing client (same credentials), and retries the failing operation once for the warm-delta path: disk/snapshot resolution and QueryChangedDiskAreas (both change-ID and snapshot modes).


```release-note
VDDK: add re-login and retry on session timeout
```
**What type of PR is this?**
/kind bug
**What this PR does / why we need it:**
**Which issue(s) this PR fixes:** 
Fixes # 4069 
**Special notes for your reviewer:**
**Does this PR introduce a user-facing change?:**
Fixed bug where VMware disconnects and stays disconnected during a migration. After this fix is applied it should automatically reconnect again so the user experiences an uninterrupted migration

