### PR TITLE
Improve filesystem cloning by skipping tar for single disk.img files

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/common:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -132,7 +132,7 @@ func pipeToSnappy(reader io.ReadCloser) io.ReadCloser {
 
 func validateContentType() {
 	switch contentType {
-	case "filesystem-clone", "blockdevice-clone":
+	case "filesystem-clone", "disk-image-clone", "blockdevice-clone":
 	default:
 		klog.Fatalf("Invalid content-type %q", contentType)
 	}
@@ -201,6 +201,14 @@ func getInputStream(preallocation bool) io.ReadCloser {
 		rc, err := newTarReader(preallocation)
 		if err != nil {
 			klog.Fatalf("Error creating tar reader for %q: %+v", mountPoint, err)
+		}
+		return rc
+	case "disk-image-clone":
+		// Direct copy of disk.img without tar
+		diskImgPath := mountPoint + "/" + common.DiskImageName
+		rc, err := os.Open(diskImgPath)
+		if err != nil {
+			klog.Fatalf("Error opening disk image %q: %+v", diskImgPath, err)
 		}
 		return rc
 	case "blockdevice-clone":

--- a/cmd/cdi-cloner/clone-source_test.go
+++ b/cmd/cdi-cloner/clone-source_test.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	prometheusutil "kubevirt.io/containerized-data-importer/pkg/util/prometheus"
 )
 
@@ -26,6 +28,61 @@ var _ = Describe("Prometheus Endpoint", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(empty).To(BeFalse())
 		defer os.RemoveAll(certsDirectory)
+	})
+})
+
+var _ = Describe("getInputStream content type handling", func() {
+	var testDir string
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = os.MkdirTemp("", "clone-test")
+		Expect(err).NotTo(HaveOccurred())
+		mountPoint = testDir
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(testDir)
+	})
+
+	Context("filesystem-clone mode", func() {
+		It("Should create tar reader for filesystem-clone", func() {
+			contentType = "filesystem-clone"
+			diskImgPath := filepath.Join(testDir, common.DiskImageName)
+			err := os.WriteFile(diskImgPath, []byte("test data"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			stream := getInputStream(false)
+			Expect(stream).NotTo(BeNil())
+			stream.Close()
+		})
+	})
+
+	Context("disk-image-clone mode", func() {
+		It("Should open disk.img directly for disk-image-clone", func() {
+			contentType = "disk-image-clone"
+			diskImgPath := filepath.Join(testDir, common.DiskImageName)
+			err := os.WriteFile(diskImgPath, []byte("test data"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			stream := getInputStream(false)
+			Expect(stream).NotTo(BeNil())
+			stream.Close()
+		})
+	})
+
+	Context("blockdevice-clone mode", func() {
+		It("Should open block device for blockdevice-clone", func() {
+			contentType = "blockdevice-clone"
+			blockDevPath := filepath.Join(testDir, "block-device")
+			err := os.WriteFile(blockDevPath, []byte("block data"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			mountPoint = blockDevPath
+
+			stream := getInputStream(false)
+			Expect(stream).NotTo(BeNil())
+			stream.Close()
+		})
 	})
 })
 

--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -47,7 +47,17 @@ else
     fi
     echo "UPLOAD_BYTES=$UPLOAD_BYTES"
 
-    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type filesystem-clone -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
+    # Check if we have only disk.img (ignoring lost+found)
+    # This allows us to skip tar entirely and avoid SEEK_HOLE performance issues
+    file_count=$(find . -maxdepth 1 -type f ! -path "./lost+found" | wc -l)
+    if [ "$file_count" -eq 1 ] && [ -f "disk.img" ]; then
+        echo "Detected single disk.img, using direct copy to avoid tar overhead"
+        CONTENT_TYPE="disk-image-clone"
+    else
+        CONTENT_TYPE="filesystem-clone"
+    fi
+
+    /usr/bin/cdi-cloner -v=3 -alsologtostderr -content-type $CONTENT_TYPE -upload-bytes $UPLOAD_BYTES -mount $MOUNT_POINT
 
     popd
 fi

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -274,6 +274,9 @@ const (
 	// BlockdeviceClone is the content type when cloning a block device
 	BlockdeviceClone = "blockdevice-clone"
 
+	// FilesystemCloneSingleDiskContentType is the content type when cloning a filesystem with a single disk.img (no tar needed)
+	FilesystemCloneSingleDiskContentType = "disk-image-clone"
+
 	// UploadPathSync is the path to POST CDI uploads
 	UploadPathSync = "/v1beta1/upload"
 

--- a/pkg/uploadserver/uploadserver.go
+++ b/pkg/uploadserver/uploadserver.go
@@ -129,7 +129,9 @@ func formReadCloser(r *http.Request) (io.ReadCloser, error) {
 }
 
 func isCloneTarget(contentType string) bool {
-	return contentType == common.BlockdeviceClone || contentType == common.FilesystemCloneContentType
+	return contentType == common.BlockdeviceClone ||
+		contentType == common.FilesystemCloneContentType ||
+		contentType == common.FilesystemCloneSingleDiskContentType
 }
 
 // NewUploadServer returns a new instance of uploadServerApp
@@ -484,6 +486,18 @@ func cloneProcessor(stream io.ReadCloser, contentType, dest string, preallocate 
 			return false, err
 		}
 		stream = tarImageReader
+	} else if contentType == common.FilesystemCloneSingleDiskContentType {
+		// Direct disk.img copy without tar extraction
+		if dest != common.WriteBlockPath {
+			// For filesystem destination, write disk.img directly
+			defer stream.Close()
+			diskImgPath := common.ImporterVolumePath + "/" + common.DiskImageName
+			_, _, err := importer.StreamDataToFile(stream, diskImgPath, preallocate)
+			if err != nil {
+				return false, err
+			}
+			return false, nil
+		}
 	}
 
 	defer stream.Close()

--- a/pkg/uploadserver/uploadserver_test.go
+++ b/pkg/uploadserver/uploadserver_test.go
@@ -456,3 +456,25 @@ func newFormRequest(path string) *http.Request {
 
 	return req
 }
+
+var _ = Describe("Content type handling", func() {
+	Context("isCloneTarget", func() {
+		It("should return true for filesystem-clone", func() {
+			Expect(isCloneTarget(common.FilesystemCloneContentType)).To(BeTrue())
+		})
+
+		It("should return true for blockdevice-clone", func() {
+			Expect(isCloneTarget(common.BlockdeviceClone)).To(BeTrue())
+		})
+
+		It("should return true for disk-image-clone", func() {
+			Expect(isCloneTarget(common.FilesystemCloneSingleDiskContentType)).To(BeTrue())
+		})
+
+		It("should return false for other content types", func() {
+			Expect(isCloneTarget("kubevirt")).To(BeFalse())
+			Expect(isCloneTarget("archive")).To(BeFalse())
+			Expect(isCloneTarget("")).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Different implementation to avoid the issues described in https://github.com/kubevirt/containerized-data-importer/pull/4043.

This PR adds disk-image-clone content type to bypass tar overhead when cloning filesystems containing only disk.img.

This avoids SEEK_HOLE performance issues that can be detrimental for filesystems that don't support it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://issues.redhat.com/browse/CNV-45701
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid using tar for single file disk.img clones 
```

