### PR TITLE
Recreate DIC import DV when first default SC is set

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -359,19 +359,18 @@ func (r *DataImportCronReconciler) update(ctx context.Context, dataImportCron *c
 		return res, err
 	}
 	if desiredStorageClass != nil {
-		if deleted, err := r.deleteOutdatedPendingPvc(ctx, pvc, desiredStorageClass.Name, dataImportCron.Name); deleted || err != nil {
+		desiredSc := desiredStorageClass.Name
+		outdated, err := r.isImportOutdated(ctx, dataImportCron, dv, pvc, desiredSc)
+		if err != nil {
 			return res, err
 		}
-		currentSc, hasCurrent := dataImportCron.Annotations[AnnStorageClass]
-		desiredSc := desiredStorageClass.Name
-		if hasCurrent && currentSc != desiredSc {
-			r.log.Info("Storage class changed, delete most recent source on the old sc as it's no longer the desired", "currentSc", currentSc, "desiredSc", desiredSc)
-			if err := r.handleStorageClassChange(ctx, dataImportCron, desiredSc); err != nil {
+		if outdated {
+			if err := r.recreateImport(ctx, dataImportCron, desiredSc); err != nil {
 				return res, err
 			}
 			return reconcile.Result{RequeueAfter: time.Second}, nil
 		}
-		cc.AddAnnotation(dataImportCron, AnnStorageClass, desiredStorageClass.Name)
+		cc.AddAnnotation(dataImportCron, AnnStorageClass, desiredSc)
 	}
 	format, err := r.getSourceFormat(ctx, desiredStorageClass)
 	if err != nil {
@@ -974,7 +973,7 @@ func (p *authProxy) GetDataSource(namespace, name string) (*cdiv1.DataSource, er
 	return das, nil
 }
 
-func (r *DataImportCronReconciler) handleStorageClassChange(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass string) error {
+func (r *DataImportCronReconciler) recreateImport(ctx context.Context, dataImportCron *cdiv1.DataImportCron, desiredStorageClass string) error {
 	digest, ok := dataImportCron.Annotations[AnnSourceDesiredDigest]
 	if !ok {
 		// nothing to delete
@@ -1109,6 +1108,37 @@ func (r *DataImportCronReconciler) handleSnapshotClassChange(ctx context.Context
 		return false, client.IgnoreNotFound(err)
 	}
 	return true, nil
+}
+
+func (r *DataImportCronReconciler) isImportOutdated(ctx context.Context, cron *cdiv1.DataImportCron, currentDV *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim, desiredSCName string) (bool, error) {
+	currentSc, hasCurrent := cron.Annotations[AnnStorageClass]
+	scChanged := currentSc != desiredSCName
+	reimportRequired := hasCurrent || len(cron.Status.CurrentImports) > 0
+	if scChanged && reimportRequired {
+		r.log.Info("Storage class changed, resetting import", "currentSc", currentSc, "desiredSc", desiredSCName)
+		return true, nil
+	}
+
+	if pvc != nil && pvc.Status.Phase == corev1.ClaimPending &&
+		pvc.Labels[common.DataImportCronLabel] == cron.Name &&
+		pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != desiredSCName {
+		r.log.Info("Pending PVC has outdated storage class, resetting import", "pvc", pvc.Name, "pvcSc", *pvc.Spec.StorageClassName, "desiredSc", desiredSCName)
+		return true, nil
+	}
+
+	if currentDV != nil {
+		sp := &cdiv1.StorageProfile{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: desiredSCName}, sp); err != nil {
+			return false, err
+		}
+		desiredDV := r.newSourceDataVolume(cron, currentDV.Name, sp)
+		if !reflect.DeepEqual(currentDV.Spec, desiredDV.Spec) {
+			r.log.Info("Import DV spec changed, resetting import", "dv", currentDV.Name)
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // getSnapshotClassForDataImportCron returns the VolumeSnapshotClass name to use for DataImportCron snapshots.
@@ -1531,24 +1561,6 @@ func getReconcileRequestsForDicsWithoutExplicitStorageClass(ctx context.Context,
 	}
 
 	return reqs, nil
-}
-
-func (r *DataImportCronReconciler) deleteOutdatedPendingPvc(ctx context.Context, pvc *corev1.PersistentVolumeClaim, desiredStorageClass, cronName string) (bool, error) {
-	if pvc == nil || pvc.Status.Phase != corev1.ClaimPending || pvc.Labels[common.DataImportCronLabel] != cronName {
-		return false, nil
-	}
-
-	sc := pvc.Spec.StorageClassName
-	if sc == nil || *sc == desiredStorageClass {
-		return false, nil
-	}
-
-	r.log.Info("Delete pending pvc", "name", pvc.Name, "ns", pvc.Namespace, "sc", *sc)
-	if err := r.client.Delete(ctx, pvc); cc.IgnoreNotFound(err) != nil {
-		return false, err
-	}
-
-	return true, nil
 }
 
 func (r *DataImportCronReconciler) cronJobExistsAndUpdated(ctx context.Context, cron *cdiv1.DataImportCron) (bool, error) {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -1844,6 +1844,88 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Expect(dv.Spec.Storage.AccessModes).To(BeEmpty())
 			})
 
+			It("Should delete old DV and requeue when first default StorageClass is set", func() {
+				dvName := "test-datasource-68b44fc891f3"
+				sp := &cdiv1.StorageProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: storageClassName},
+				}
+				reconciler = createDataImportCronReconciler(sc, sp)
+
+				cron = newDataImportCron(cronName)
+				cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
+				cron.Status.CurrentImports = []cdiv1.ImportStatus{{DataVolumeName: dvName, Digest: testDigest}}
+				err := reconciler.client.Create(context.TODO(), cron)
+				Expect(err).ToNot(HaveOccurred())
+				dataSource = &cdiv1.DataSource{}
+
+				dv := &cdiv1.DataVolume{ObjectMeta: metav1.ObjectMeta{Name: dvName, Namespace: metav1.NamespaceDefault}}
+				err = reconciler.client.Create(context.TODO(), dv)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("First reconcile: detect SC change and delete old DV")
+				res, err := reconciler.Reconcile(context.TODO(), cronReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(time.Second))
+
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+				err = reconciler.client.Get(context.TODO(), cronKey, cron)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cron.Annotations[AnnStorageClass]).To(Equal(storageClassName))
+
+				By("Second reconcile: create new DV with the correct SC context")
+				_, err = reconciler.Reconcile(context.TODO(), cronReq)
+				Expect(err).ToNot(HaveOccurred())
+
+				dv = &cdiv1.DataVolume{}
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("Should delete DV and requeue when StorageProfile RWO annotation changes", func() {
+				dvName := "test-datasource-68b44fc891f3"
+				sp := &cdiv1.StorageProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        storageClassName,
+						Annotations: map[string]string{cc.AnnUseReadWriteOnceForDataImportCron: "true"},
+					},
+				}
+				reconciler = createDataImportCronReconciler(sc, sp)
+
+				cron = newDataImportCron(cronName)
+				cron.Spec.Template.Spec.Storage.AccessModes = nil
+				cc.AddAnnotation(cron, AnnSourceDesiredDigest, testDigest)
+				cc.AddAnnotation(cron, AnnStorageClass, storageClassName)
+				cron.Status.CurrentImports = []cdiv1.ImportStatus{{DataVolumeName: dvName, Digest: testDigest}}
+				err := reconciler.client.Create(context.TODO(), cron)
+				Expect(err).ToNot(HaveOccurred())
+				dataSource = &cdiv1.DataSource{}
+
+				dv := cron.Spec.Template.DeepCopy()
+				dv.Name = dvName
+				dv.Namespace = metav1.NamespaceDefault
+				err = reconciler.client.Create(context.TODO(), dv)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("First reconcile: detect DV spec drift and delete old DV")
+				res, err := reconciler.Reconcile(context.TODO(), cronReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(time.Second))
+
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+				By("Second reconcile: create new DV with RWO access mode")
+				_, err = reconciler.Reconcile(context.TODO(), cronReq)
+				Expect(err).ToNot(HaveOccurred())
+
+				dv = &cdiv1.DataVolume{}
+				err = reconciler.client.Get(context.TODO(), dvKey(dvName), dv)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dv.Spec.Storage.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}))
+			})
+
 		})
 	})
 })


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The default SC change condition only handled changes from one SC to another, but did not handle the first default SC being set.

To get the DIC-created DV with the DIC-special RWO preference, it must be deleted (as DV is immutable) and recreated with the right settings from the new default StorageClass.

**Which issue(s) this PR fixes**:
Jira: https://redhat.atlassian.net/browse/CNV-81826

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

