### PR TITLE
tests/cloner_test: use patch instead of update to override minimumSupportedPvcSize annotation

### DIFF
--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -21,6 +21,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
@@ -3127,14 +3128,22 @@ func createStorageWithMinimumSupportedPVCSize(f *framework.Framework, minSize st
 		func(sc *storagev1.StorageClass) { sc.UID = "" })
 	Expect(err).ToNot(HaveOccurred())
 
-	var sp *cdiv1.StorageProfile
 	Eventually(func() error {
-		sp, err = f.CdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), sc.Name, metav1.GetOptions{})
+		_, err = f.CdiClient.CdiV1beta1().StorageProfiles().Get(context.TODO(), sc.Name, metav1.GetOptions{})
 		return err
 	}, time.Minute, time.Second).Should(Succeed())
 
-	sp.Annotations = map[string]string{controller.AnnMinimumSupportedPVCSize: minSize}
-	_, err = f.CdiClient.CdiV1beta1().StorageProfiles().Update(context.TODO(), sp, metav1.UpdateOptions{})
+	patch := fmt.Sprintf(
+		`{"apiVersion":"%s","kind":"%s","metadata":{"annotations":{"%s":"%s"}}}`,
+		cdiv1.SchemeGroupVersion.String(),
+		"StorageProfile",
+		controller.AnnMinimumSupportedPVCSize, minSize,
+	)
+
+	_, err = f.CdiClient.CdiV1beta1().StorageProfiles().Patch(context.TODO(),
+		sc.Name, types.ApplyPatchType, []byte(patch), metav1.PatchOptions{
+			FieldManager: "cloner-test",
+		})
 	Expect(err).ToNot(HaveOccurred())
 
 	return sc.Name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`createStorageWithMinimumSupportedPVCSize` was creating a StorageClass and sometimes failing on annotating the associated StorageProfile via an update call due to a conflict. Use merge patch instead to avoid conflicts altogether.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

