### PR TITLE
rbac: add resourceclaims/driver associated-node verbs for sriov DRA d…

### DIFF
--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -115,6 +115,10 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims/status"]
   verbs: ["get","list","update","patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  resourceNames: ["sriovnetwork.k8snetworkplumbingwg.io"]
+  verbs: ["associated-node:update", "associated-node:patch"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions


### PR DESCRIPTION
…river

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR updates the SR-IOV DRA manifest RBAC to support granular authorization
for ResourceClaim status updates introduced in Kubernetes v1.36.

Node-local DRA drivers require additional permissions on the synthetic
resourceclaims/driver subresource for associated-node access.

This change adds the required RBAC rules while keeping existing
resourceclaims/status permissions unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses https://github.com/kubernetes/kubernetes/issues/138149

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

