### PR TITLE
multi arch script: exit in case of errors in push

### DIFF
--- a/hack/build/multi-arch.sh
+++ b/hack/build/multi-arch.sh
@@ -19,6 +19,8 @@
 
 source hack/build/common.sh
 
+set -e
+
 COMMAND=$1
 
 build_count=$(echo ${BUILD_ARCH//,/ } | wc -w)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
we've had some errors swallowed in recent release
```
Error: fetching "quay.io/kubevirt/cdi-func-test-registry-init@sha256:052987e7da992d36d33ce17f42f16078f1fac1646ae5cbe0dc04c9b3613bf514": GET https://quay.io/v2/kubevirt/cdi-func-test-registry-init/manifests/sha256:052987e7da992d36d33ce17f42f16078f1fac1646ae5cbe0dc04c9b3613bf514: unexpected status code 401 Unauthorized: {"error": "Invalid bearer token format"}
```
https://storage.googleapis.com/kubevirt-prow/logs/push-release-containerized-data-importer-images/2039060498741202944/build-log.txt


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

