### PR TITLE
build: update rules_oci to v2.3.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,6 +130,16 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "tar.bzl",
+    sha256 = "a0d64064a598d7a1e58196d17de0deed6d3d2d8bfe1407ed9e68b24c31c38e8d",
+    strip_prefix = "tar.bzl-0.7.0",
+    urls = [
+        "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/a0d64064a598d7a1e58196d17de0deed6d3d2d8bfe1407ed9e68b24c31c38e8d",
+    ],
+)
+
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
 
 aspect_bazel_lib_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,11 +122,11 @@ bazeldnf_dependencies()
 # bazel-lib rules
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "9a44f457810ce64ec36a244cc7c807607541ab88f2535e07e0bf2976ef4b73fe",
-    strip_prefix = "bazel-lib-2.19.4",
+    sha256 = "f525668442e4b19ae10d77e0b5ad15de5807025f321954dfb7065c0fe2429ec1",
+    strip_prefix = "bazel-lib-2.21.1",
     urls = [
-        "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.19.4/bazel-lib-v2.19.4.tar.gz",
-        "https://storage.googleapis.com/builddeps/9a44f457810ce64ec36a244cc7c807607541ab88f2535e07e0bf2976ef4b73fe",
+        "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.21.1/bazel-lib-v2.21.1.tar.gz",
+        "https://storage.googleapis.com/builddeps/f525668442e4b19ae10d77e0b5ad15de5807025f321954dfb7065c0fe2429ec1",
     ],
 )
 
@@ -159,14 +159,24 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
+http_archive(
+    name = "package_metadata",
+    sha256 = "5bd0cc7594ea528fd28f98d82457f157827d48cc20e07bcfdbb56072f35c8f67",
+    strip_prefix = "supply-chain-0.0.6/metadata",
+    urls = [
+        "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz",
+        "https://storage.googleapis.com/builddeps/5bd0cc7594ea528fd28f98d82457f157827d48cc20e07bcfdbb56072f35c8f67",
+    ],
+)
+
 # bazel oci rules
 http_archive(
     name = "rules_oci",
-    sha256 = "5994ec0e8df92c319ef5da5e1f9b514628ceb8fc5824b4234f2fe635abb8cc2e",
-    strip_prefix = "rules_oci-2.2.6",
+    sha256 = "e987cab7a35475cb9c9060fc3f338a1fc8896c240295a3272968b217acefd0cb",
+    strip_prefix = "rules_oci-2.3.0",
     urls = [
-        "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/rules_oci-v2.2.6.tar.gz",
-        "https://storage.googleapis.com/builddeps/5994ec0e8df92c319ef5da5e1f9b514628ceb8fc5824b4234f2fe635abb8cc2e",
+        "https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/e987cab7a35475cb9c9060fc3f338a1fc8896c240295a3272968b217acefd0cb",
     ],
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
/cc @brianmcarey @dollierp 
**What this PR does / why we need it**:
Update rules_oci from v2.2.6 to v2.3.0 and add the required `package_metadata`
dependency.
This aligns CDI with the same rules_oci version adopted by KubeVirt in
[kubevirt/kubevirt#17138](https://github.com/kubevirt/kubevirt/pull/17138).
The v2.3.0 release includes a fix for multiarch image builds that use the host
architecture for jq and crane ([bazel-contrib/rules_oci#869](https://github.com/bazel-contrib/rules_oci/pull/869)),
which resolves failures seen in [a recent rehearsal job](https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/4832/rehearsal-pull-containerized-data-importer-e2e-s390x/2037602537405681664/build-log.txt) for https://github.com/kubevirt/project-infra/pull/4832

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bump rules_oci to 2.3.0
```

