### PR TITLE
Fix CDI node-placement test for cross-architecture clusters

### DIFF
--- a/tests/framework/nodeplacement.go
+++ b/tests/framework/nodeplacement.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"runtime"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,9 +9,11 @@ import (
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
+const hostnameLabel = "kubernetes.io/hostname"
+
 var (
 	//NodeSelectorTestValue is nodeSelector value for test
-	NodeSelectorTestValue = map[string]string{"kubernetes.io/arch": runtime.GOARCH}
+	NodeSelectorTestValue = map[string]string{hostnameLabel: ""}
 	//TolerationsTestValue is tolerations value for test
 	TolerationsTestValue = []v1.Toleration{{Key: "test", Value: "123"}}
 	//AffinityTestValue is affinity value for test
@@ -32,13 +33,14 @@ func (f *Framework) TestNodePlacementValues() sdkapi.NodePlacement {
 		}
 	}
 
+	NodeSelectorTestValue[hostnameLabel] = nodeName
 	AffinityTestValue = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 				NodeSelectorTerms: []v1.NodeSelectorTerm{
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
-							{Key: "kubernetes.io/hostname", Operator: v1.NodeSelectorOpIn, Values: []string{nodeName}},
+							{Key: hostnameLabel, Operator: v1.NodeSelectorOpIn, Values: []string{nodeName}},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The node-placement test was using runtime.GOARCH to set kubernetes.io/arch in the nodeSelector. This value reflects the architecture of the machine running the test binary, not the architecture of the cluster's nodes. When the test binary ran on an amd64 host while the cluster nodes were s390x, the nodeSelector became incorrect, making CDI infra pods unschedulable. This change removes the dependency on runtime.GOARCH by deriving the nodeSelector from actual cluster nodes using kubernetes.io/hostname, mirroring the existing NodeAffinity configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

