### PR TITLE
rbac: add resourceclaims/driver associated-node verbs for sriov DRA

### DIFF
--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -115,6 +115,11 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims/status"]
   verbs: ["get","list","update","patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs:
+    - associated-node:update
+    - associated-node:patch
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions


### PR DESCRIPTION
Adds resourceclaims/driver permissions with associated-node scoped verbs for the SR-IOV DRA driver.

The driver runs as a DaemonSet and performs ResourceClaim status updates, which require additional authorization under the DRA granular status authorization changes introduced in Kubernetes v1.36.

This change adds:
- associated-node:update
- associated-node:patch

to the ClusterRole while keeping existing resourceclaims/status permissions intact.

```release-note
Adds resourceclaims/driver permissions with associated-node scoped verbs for the SR-IOV DRA driver to support Kubernetes v1.36 granular status authorization.
```