### PR TITLE
Fix wrong error variable checked in cleanupTransfer closures

### DIFF
--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -666,8 +666,8 @@ func cleanupTransfer(conn ConnectionInterface, it *ovirtsdk4.ImageTransfer) erro
 	for retries := 10; retries > 0; retries-- {
 		cancelTransfer := func() error {
 			klog.Info("Cancelling image transfer.")
-			if _, cancelError := transferService.Cancel().Send(); err != nil {
-				klog.Errorf("Unable to cancel transfer request: %v", err)
+			if _, cancelError := transferService.Cancel().Send(); cancelError != nil {
+				klog.Errorf("Unable to cancel transfer request: %v", cancelError)
 				return cancelError
 			}
 			return nil
@@ -675,8 +675,8 @@ func cleanupTransfer(conn ConnectionInterface, it *ovirtsdk4.ImageTransfer) erro
 
 		finalizeTransfer := func() error {
 			klog.Info("Finalizing image transfer.")
-			if _, finalizeError := transferService.Finalize().Send(); err != nil {
-				klog.Errorf("Unable to finalize transfer request: %v", err)
+			if _, finalizeError := transferService.Finalize().Send(); finalizeError != nil {
+				klog.Errorf("Unable to finalize transfer request: %v", finalizeError)
 				return finalizeError
 			}
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `cancelTransfer` and `finalizeTransfer` closures in `cleanupTransfer` each assigned their error to a local variable (`cancelError`/`finalizeError`) but checked the outer scope `err` (from `transferService.Get().Send()`) instead. This caused actual Cancel/Finalize errors to be silently ignored when `Get` succeeded (`err == nil`), and could produce spurious error logs when `Get` failed (`err != nil`) even if Cancel/Finalize succeeded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

