### PR TITLE
Add VDDK node selector override via annotation

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -266,6 +266,8 @@ const (
 	VddkArgsVolName = "vddk-extra-args"
 	// VddkArgsKeyName is the name of the key that must be present in the VDDK arguments ConfigMap
 	VddkArgsKeyName = "vddk-config-file"
+	// VddkNodeSelectorKey is the name of the optional key in the VDDK arguments ConfigMap that holds a JSON-encoded node selector
+	VddkNodeSelectorKey = "vddk-node-selector"
 
 	// UploadContentTypeHeader is the header upload clients may use to set the content type explicitly
 	UploadContentTypeHeader = "x-cdi-content-type"

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"path"
@@ -119,6 +120,7 @@ type importerPodArgs struct {
 	workloadNodePlacement   *sdkapi.NodePlacement
 	vddkImageName           *string
 	vddkExtraArgs           *string
+	vddkNodeSelector        map[string]string
 	priorityClassName       string
 	serviceAccountName      string
 }
@@ -531,6 +533,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 	var scratchPvcName *string
 	var vddkImageName *string
 	var vddkExtraArgs *string
+	var vddkNodeSelector map[string]string
 	var err error
 
 	requiresScratch := r.requiresScratchSpace(pvc)
@@ -563,6 +566,11 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 		if extraArgs, ok := anno[cc.AnnVddkExtraArgs]; ok && extraArgs != "" {
 			r.log.V(1).Info("Mounting extra VDDK args ConfigMap to importer pod", "ConfigMap", extraArgs)
 			vddkExtraArgs = &extraArgs
+
+			vddkNodeSelector, err = r.getVddkNodeSelector(pvc.Namespace, extraArgs)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -580,6 +588,7 @@ func (r *ImportReconciler) createImporterPod(pvc *corev1.PersistentVolumeClaim) 
 		scratchPvcName:     scratchPvcName,
 		vddkImageName:      vddkImageName,
 		vddkExtraArgs:      vddkExtraArgs,
+		vddkNodeSelector:   vddkNodeSelector,
 		priorityClassName:  cc.GetPriorityClass(pvc),
 		serviceAccountName: cc.GetPodServiceAccount(pvc),
 	}
@@ -862,6 +871,28 @@ func (r *ImportReconciler) getVddkImageName() (*string, error) {
 	return nil, errors.Errorf("found %s ConfigMap in namespace %s, but it does not contain a '%s' entry", common.VddkConfigMap, namespace, common.VddkConfigDataKey)
 }
 
+// getVddkNodeSelector reads the optional node-selector key from the VDDK extra-args
+// ConfigMap and returns the parsed map, or nil if the key is absent.
+func (r *ImportReconciler) getVddkNodeSelector(namespace, cmName string) (map[string]string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.uncachedClient.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: namespace}, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	val, ok := cm.Data[common.VddkNodeSelectorKey]
+	if !ok || val == "" {
+		return nil, nil
+	}
+	nodeSelector := make(map[string]string)
+	if err := json.Unmarshal([]byte(val), &nodeSelector); err != nil {
+		return nil, fmt.Errorf("failed to parse %s key in ConfigMap %s/%s: %w",
+			common.VddkNodeSelectorKey, namespace, cmName, err)
+	}
+	return nodeSelector, nil
+}
+
 // returns the import image part of the endpoint string
 func getRegistryImportImage(pvc *corev1.PersistentVolumeClaim) (string, error) {
 	ep, err := cc.GetEndpoint(pvc)
@@ -1000,6 +1031,15 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 			// errors in namespaces with many Services (each injects ~7 env vars).
 			EnableServiceLinks: ptr.To(false),
 		},
+	}
+
+	if len(args.vddkNodeSelector) > 0 {
+		if pod.Spec.NodeSelector == nil {
+			pod.Spec.NodeSelector = make(map[string]string, len(args.vddkNodeSelector))
+		}
+		for k, v := range args.vddkNodeSelector {
+			pod.Spec.NodeSelector[k] = v
+		}
 	}
 
 	/**

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -296,6 +296,83 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		Expect(pod.Spec.Tolerations).To(Equal(workloads.Tolerations))
 	})
 
+	It("Should merge VDDK extra-args ConfigMap nodeSelector with system node selector", func() {
+		extraArgsCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "vddk-extra-args-cm", Namespace: "default"},
+			Data:       map[string]string{common.VddkNodeSelectorKey: `{"custom-node":"vddk-host"}`},
+		}
+		annotations := map[string]string{
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnImportPod:        "importer-testPvc1",
+			cc.AnnSource:           cc.SourceVDDK,
+			cc.AnnVddkInitImageURL: "test://vddk-image",
+			cc.AnnVddkExtraArgs:    "vddk-extra-args-cm",
+		}
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, annotations, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc, extraArgsCM)
+		workloads := updateCdiWithTestNodePlacement(reconciler.client)
+
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+		pod := &corev1.Pod{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "importer-testPvc1", Namespace: "default"}, pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		expected := make(map[string]string)
+		for k, v := range workloads.NodeSelector {
+			expected[k] = v
+		}
+		expected["custom-node"] = "vddk-host"
+		Expect(pod.Spec.NodeSelector).To(Equal(expected))
+		Expect(pod.Spec.Tolerations).To(Equal(workloads.Tolerations))
+		Expect(pod.Spec.Affinity).To(Equal(workloads.Affinity))
+	})
+
+	It("Should keep CDI CR node selector for VDDK when extra-args ConfigMap has no nodeSelector key", func() {
+		extraArgsCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "vddk-extra-args-cm", Namespace: "default"},
+			Data:       map[string]string{"vddk-config-file": "some-vddk-arg"},
+		}
+		annotations := map[string]string{
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnImportPod:        "importer-testPvc1",
+			cc.AnnSource:           cc.SourceVDDK,
+			cc.AnnVddkInitImageURL: "test://vddk-image",
+			cc.AnnVddkExtraArgs:    "vddk-extra-args-cm",
+		}
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, annotations, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc, extraArgsCM)
+		workloads := updateCdiWithTestNodePlacement(reconciler.client)
+
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+		pod := &corev1.Pod{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "importer-testPvc1", Namespace: "default"}, pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pod.Spec.NodeSelector).To(Equal(workloads.NodeSelector))
+	})
+
+	It("Should fail VDDK importer when extra-args ConfigMap has invalid nodeSelector JSON", func() {
+		extraArgsCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "vddk-extra-args-cm", Namespace: "default"},
+			Data:       map[string]string{common.VddkNodeSelectorKey: `not-valid-json`},
+		}
+		annotations := map[string]string{
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnImportPod:        "importer-testPvc1",
+			cc.AnnSource:           cc.SourceVDDK,
+			cc.AnnVddkInitImageURL: "test://vddk-image",
+			cc.AnnVddkExtraArgs:    "vddk-extra-args-cm",
+		}
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, annotations, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc, extraArgsCM)
+
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse"))
+	})
+
 	It("Should create a POD if a PVC with all needed annotations is passed", func() {
 		pvc := cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnImportPod: "importer-testPvc1", cc.AnnPodNetwork: "net1", "unrelatedAnnotation": "test"}, nil)
 		pvc.Status.Phase = v1.ClaimBound


### PR DESCRIPTION
Introduce a new annotation `cdi.kubevirt.io/storage.pod.nodeSelector`
that allows overriding the CDI CR workload node selector for VDDK
importer pods. This enables scheduling VDDK imports on specific nodes
(e.g. ones with network access to the VMware host).

The annotation value is a JSON-encoded map[string]string that, when
present on the PVC, replaces the default NodeSelector from the CDI CR
while preserving tolerations and affinity. The override is applied only
when the import source is VDDK; all other import types and CDI pod types
(clone, upload, populator, cron) are unaffected.

Includes unit tests for annotation override, missing annotation
fallback, non-VDDK source ignoring the annotation, and invalid JSON
error handling.

Signed-off-by: yaacov <yzamir@redhat.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Introduce a new annotation `cdi.kubevirt.io/storage.pod.nodeSelector` that allows overriding the CDI CR workload node selector on a per-PVC basis. The annotation value is a JSON-encoded map[string]string that, when present, replaces the default NodeSelector from the CDI CR while preserving tolerations and affinity.

**Which issue(s) this PR fixes**:
Fixes CNV-84587, MTV-3207

Ref:
https://redhat.atlassian.net/browse/CNV-84587
https://redhat.atlassian.net/browse/MTV-3207

Similar to #4000 

**Special notes for your reviewer**:

Read PVC annotations, DV annotation is copied into PVC so users can also anotatate the DV 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add per-PVC node selector override via annotation
```

