### PR TITLE
DNM: tests: deprecate DV spec.pvc, use spec.storage instead

### DIFF
--- a/tests/clone-populator_test.go
+++ b/tests/clone-populator_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Clone Populator tests", func() {
 
 	createSource := func(sz resource.Quantity, vm corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
 		dataVolume := utils.NewDataVolumeWithHTTPImport(sourceName, sz.String(), fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
-		dataVolume.Spec.PVC.VolumeMode = &vm
+		dataVolume.Spec.Storage.VolumeMode = &vm
 		dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 		Expect(err).ToNot(HaveOccurred())
 		f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -83,8 +83,8 @@ var _ = Describe("Clone Populator tests", func() {
 
 	createVolumeSnapshotSource := func(size string, storageClassName *string, volumeMode corev1.PersistentVolumeMode) *snapshotv1.VolumeSnapshot {
 		snapSourceDv := utils.NewDataVolumeWithHTTPImport(sourceName, size, fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
-		snapSourceDv.Spec.PVC.VolumeMode = &volumeMode
-		snapSourceDv.Spec.PVC.StorageClassName = storageClassName
+		snapSourceDv.Spec.Storage.VolumeMode = &volumeMode
+		snapSourceDv.Spec.Storage.StorageClassName = storageClassName
 		By(fmt.Sprintf("Create new datavolume %s which will be the source of the volumesnapshot", snapSourceDv.Name))
 		snapSourceDv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, snapSourceDv)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/clone-populator_test.go
+++ b/tests/clone-populator_test.go
@@ -234,10 +234,11 @@ var _ = Describe("Clone Populator tests", func() {
 		DescribeTable("should do filesystem to filesystem clone", func(webhookRendering bool) {
 			source := createSource(defaultSize, corev1.PersistentVolumeFilesystem)
 			createDataSource()
+			sourceCapacity := source.Status.Capacity[corev1.ResourceStorage]
 			if webhookRendering {
 				target = createIncompleteTarget(nil, corev1.PersistentVolumeFilesystem, "", utils.DefaultStorageClass.GetName())
 			} else {
-				target = createTargetWithImmediateBinding(defaultSize, corev1.PersistentVolumeFilesystem)
+				target = createTargetWithImmediateBinding(sourceCapacity, corev1.PersistentVolumeFilesystem)
 			}
 			target = waitSucceeded(target)
 			sourceHash := getHash(source, 0)
@@ -260,7 +261,8 @@ var _ = Describe("Clone Populator tests", func() {
 
 		It("should do filesystem to filesystem clone, dataSource created after target", func() {
 			source := createSource(defaultSize, corev1.PersistentVolumeFilesystem)
-			target := createTarget(defaultSize, corev1.PersistentVolumeFilesystem)
+			sourceCapacity := source.Status.Capacity[corev1.ResourceStorage]
+			target := createTarget(sourceCapacity, corev1.PersistentVolumeFilesystem)
 			createDataSource()
 			target = waitSucceeded(target)
 			sourceHash := getHash(source, 0)
@@ -307,10 +309,11 @@ var _ = Describe("Clone Populator tests", func() {
 			}
 			source := createSource(defaultSize, corev1.PersistentVolumeFilesystem)
 			createDataSource()
+			sourceCapacity := source.Status.Capacity[corev1.ResourceStorage]
 			if webhookRendering {
 				target = createIncompleteTarget(nil, corev1.PersistentVolumeBlock, "", utils.DefaultStorageClass.GetName())
 			} else {
-				target = createTarget(defaultSize, corev1.PersistentVolumeBlock)
+				target = createTarget(sourceCapacity, corev1.PersistentVolumeBlock)
 			}
 			target = waitSucceeded(target)
 			targetSize := target.Status.Capacity[corev1.ResourceStorage]
@@ -330,10 +333,11 @@ var _ = Describe("Clone Populator tests", func() {
 			}
 			source := createSource(defaultSize, corev1.PersistentVolumeFilesystem)
 			createDataSource()
+			sourceCapacity := source.Status.Capacity[corev1.ResourceStorage]
 			if webhookRendering {
 				target = createIncompleteTarget(nil, corev1.PersistentVolumeFilesystem, cloneType, utils.DefaultStorageClass.GetName())
 			} else {
-				target = createTargetWithStrategy(defaultSize, corev1.PersistentVolumeFilesystem, cloneType, utils.DefaultStorageClass.GetName())
+				target = createTargetWithStrategy(sourceCapacity, corev1.PersistentVolumeFilesystem, cloneType, utils.DefaultStorageClass.GetName())
 			}
 			target = waitSucceeded(target)
 			Expect(target.Annotations["cdi.kubevirt.io/cloneType"]).To(Equal(cloneType))

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -114,7 +114,7 @@ var _ = Describe("all clone tests", func() {
 
 			pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", pvc)
+			targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", pvc)
 			targetDV.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
 			By(fmt.Sprintf("Create new target datavolume %s", targetDV.Name))
 			targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
@@ -166,7 +166,7 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Create targetPvc in new NS.
-				targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", pvc)
+				targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", pvc)
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDataVolume)
@@ -353,7 +353,7 @@ var _ = Describe("all clone tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sourcePVC.Spec.VolumeName).To(Equal(sourcePV.Name))
 
-				targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", sourcePVCDef)
+				targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", sourcePVCDef)
 				targetDV.Spec.Storage.StorageClassName = &storageClassName
 				targetLabelSelector := metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -497,7 +497,7 @@ var _ = Describe("all clone tests", func() {
 				if cloneType == "csi-clone" || cloneType == "snapshot" {
 					Skip("csi-clone only works for the same volumeMode")
 				}
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "2Gi", fmt.Sprintf(utils.LargeVirtualDiskQcow, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "2Gi", fmt.Sprintf(utils.LargeVirtualDiskQcow, f.CdiInstallNs))
 				filesystem := v1.PersistentVolumeFilesystem
 				dataVolume.Spec.Storage.VolumeMode = &filesystem
 
@@ -507,7 +507,7 @@ var _ = Describe("all clone tests", func() {
 				sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				targetDV := utils.NewDataVolumeCloneToBlockPVStorageAPI("target-dv", "2Gi", sourcePvc.Namespace, sourcePvc.Name, f.BlockSCName)
+				targetDV := utils.NewDataVolumeCloneToBlockPV("target-dv", "2Gi", sourcePvc.Namespace, sourcePvc.Name, f.BlockSCName)
 
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
@@ -548,7 +548,7 @@ var _ = Describe("all clone tests", func() {
 				// as the actual data is the same
 				volumeMode := v1.PersistentVolumeFilesystem
 
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -556,7 +556,7 @@ var _ = Describe("all clone tests", func() {
 				sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+				targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 				targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				targetPvc, err := utils.WaitForPVC(f.K8sClient, targetDataVolume.Namespace, targetDataVolume.Name)
@@ -605,7 +605,7 @@ var _ = Describe("all clone tests", func() {
 				).Should(Succeed())
 
 				By("Cloning from the source DataVolume to under sized target")
-				targetDv := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "100Mi",
+				targetDv := utils.NewDataVolumeForImageCloning("target-dv", "100Mi",
 					f.Namespace.Name,
 					sourceDv.Name,
 					sourceDv.Spec.Storage.StorageClassName,
@@ -688,7 +688,7 @@ var _ = Describe("all clone tests", func() {
 					}
 
 					// Create the source DV
-					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+					dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 					dataVolume.Spec.Storage.VolumeMode = &sourceVolumeMode
 					if sourceSCName != "" {
 						dataVolume.Spec.Storage.StorageClassName = &sourceSCName
@@ -789,7 +789,7 @@ var _ = Describe("all clone tests", func() {
 				It("should report correct status for smart/CSI clones", func() {
 					volumeMode := v1.PersistentVolumeFilesystem
 
-					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+					dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 					dataVolume.Spec.Storage.VolumeMode = &volumeMode
 					if wffcStorageClass != nil {
 						dataVolume.Spec.Storage.StorageClassName = &wffcStorageClass.Name
@@ -803,7 +803,7 @@ var _ = Describe("all clone tests", func() {
 					sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+					targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 					if wffcStorageClass != nil {
 						targetDV.Spec.Storage.StorageClassName = &wffcStorageClass.Name
 					}
@@ -836,7 +836,7 @@ var _ = Describe("all clone tests", func() {
 				It("should succeed smart/CSI clones with immediate bind requested", func() {
 					volumeMode := v1.PersistentVolumeFilesystem
 
-					dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+					dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 					dataVolume.Spec.Storage.VolumeMode = &volumeMode
 					if wffcStorageClass != nil {
 						dataVolume.Spec.Storage.StorageClassName = &wffcStorageClass.Name
@@ -850,7 +850,7 @@ var _ = Describe("all clone tests", func() {
 					sourcePvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
+					targetDV := utils.NewDataVolumeForImageCloning("target-dv", "1Gi", sourcePvc.Namespace, sourcePvc.Name, nil, &volumeMode)
 					if wffcStorageClass != nil {
 						targetDV.Spec.Storage.StorageClassName = &wffcStorageClass.Name
 					}
@@ -1179,7 +1179,7 @@ var _ = Describe("all clone tests", func() {
 
 			DescribeTable("Should clone with different overheads in target and source", func(sourceOverHead, targetOverHead string) {
 				SetFilesystemOverhead(f, sourceOverHead, sourceOverHead)
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -1217,7 +1217,7 @@ var _ = Describe("all clone tests", func() {
 			)
 
 			It("[test_id:8498]Should only use size-detection pod when cloning a PVC for the first time", func() {
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -1279,7 +1279,7 @@ var _ = Describe("all clone tests", func() {
 			})
 
 			It("[test_id:8762]Should use size-detection pod when cloning if the source PVC has changed its original capacity", func() {
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -1355,7 +1355,7 @@ var _ = Describe("all clone tests", func() {
 			})
 
 			It("Should clone using size-detection pod across namespaces", func() {
-				dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				dataVolume := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "200Mi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				dataVolume.Spec.Storage.VolumeMode = &volumeMode
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 				Expect(err).ToNot(HaveOccurred())
@@ -1474,7 +1474,7 @@ var _ = Describe("all clone tests", func() {
 
 				sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, fillCommand+testFile+"; chmod 660 "+testBaseDir+testFile)
 
-				targetDV := utils.NewCloningDataVolume("target-pvc", "1Gi", sourcePvc)
+				targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-pvc", "1Gi", sourcePvc)
 
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
@@ -1513,7 +1513,7 @@ var _ = Describe("all clone tests", func() {
 
 			It("Should finish the clone after creating the source PVC", func() {
 				By("Create the clone before the source PVC")
-				cloneDV := utils.NewDataVolumeForImageCloningAndStorageSpec("clone-dv", "1Gi", f.Namespace.Name, dataVolumeName, nil, &fsVM)
+				cloneDV := utils.NewDataVolumeForImageCloning("clone-dv", "1Gi", f.Namespace.Name, dataVolumeName, nil, &fsVM)
 				cloneDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
 				Expect(err).ToNot(HaveOccurred())
 				// Check if the NoSourceClone annotation exists in target PVC
@@ -1521,7 +1521,7 @@ var _ = Describe("all clone tests", func() {
 				f.ExpectEvent(f.Namespace.Name).Should(ContainSubstring(dvc.CloneWithoutSource))
 
 				By("Create source PVC")
-				sourceDV := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				sourceDV := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				sourceDV.Spec.Storage.VolumeMode = &fsVM
 				sourceDV, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDV)
 				Expect(err).ToNot(HaveOccurred())
@@ -1550,7 +1550,7 @@ var _ = Describe("all clone tests", func() {
 				}
 
 				By("Create the clone before the source PVC")
-				cloneDV := utils.NewDataVolumeForImageCloningAndStorageSpec("clone-dv", "1Mi", f.Namespace.Name, dataVolumeName, &f.BlockSCName, &blockVM)
+				cloneDV := utils.NewDataVolumeForImageCloning("clone-dv", "1Mi", f.Namespace.Name, dataVolumeName, &f.BlockSCName, &blockVM)
 				_, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
 				Expect(err).ToNot(HaveOccurred())
 				// Check if the NoSourceClone annotation exists in target PVC
@@ -1559,7 +1559,7 @@ var _ = Describe("all clone tests", func() {
 
 				By("Create source PVC")
 				// We use a larger size in the source PVC so the validation fails
-				sourceDV := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+				sourceDV := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 				sourceDV.Spec.Storage.VolumeMode = &blockVM
 				sourceDV, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDV)
 				Expect(err).ToNot(HaveOccurred())
@@ -1578,7 +1578,7 @@ var _ = Describe("all clone tests", func() {
 				By(fmt.Sprintf("Creating target pvc: %s/%s", f.Namespace.Name, targetName))
 				f.CreateBoundPVCFromDefinition(
 					utils.NewPVCDefinition(targetName, "1Gi", map[string]string{controller.AnnPopulatedFor: targetName}, nil))
-				cloneDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetName, "1Gi", f.Namespace.Name, "non-existing-source", nil, &fsVM)
+				cloneDV := utils.NewDataVolumeForImageCloning(targetName, "1Gi", f.Namespace.Name, "non-existing-source", nil, &fsVM)
 				_, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
 				Expect(err).ToNot(HaveOccurred())
 				By("Wait for clone DV Succeeded phase")
@@ -1918,7 +1918,7 @@ var _ = Describe("all clone tests", func() {
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, fillCommand+testFile+"; chmod 660 "+testBaseDir+testFile)
 			// Create targetPvc in new NS.
 			By("Creating new DV")
-			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", pvcDef)
+			targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", pvcDef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -1958,7 +1958,7 @@ var _ = Describe("all clone tests", func() {
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, fillCommand+testFile+"; chmod 660 "+testBaseDir+testFile)
 			// Create targetPvc in new NS.
 			By("Creating new DV")
-			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", pvcDef)
+			targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", pvcDef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -2162,7 +2162,7 @@ var _ = Describe("all clone tests", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			f.AddNamespaceToDelete(targetNs)
-			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", sourcePvc)
+			targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", sourcePvc)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2229,7 +2229,7 @@ var _ = Describe("all clone tests", func() {
 
 			targetDvName := "small-target-dv"
 			By(fmt.Sprintf("Create small target DV %s", targetDvName))
-			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+			targetDV := utils.NewDataVolumeForImageCloning(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 			targetDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, sourcePvc.Namespace, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2259,7 +2259,7 @@ var _ = Describe("all clone tests", func() {
 
 			targetDvName := "small-target-dv"
 			By(fmt.Sprintf("Create small target DV %s", targetDvName))
-			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+			targetDV := utils.NewDataVolumeForImageCloning(targetDvName, "512Mi", sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 			targetDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, sourcePvc.Namespace, targetDV)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDV)
@@ -2484,7 +2484,7 @@ var _ = Describe("all clone tests", func() {
 			sourcePvc, err = f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", sourcePvc)
+			targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", sourcePvc)
 			preallocation := true
 			targetDV.Spec.Preallocation = &preallocation
 			targetDataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
@@ -2591,7 +2591,7 @@ var _ = Describe("all clone tests", func() {
 			createSnapshot(size, &f.SnapshotSCName, volumeMode)
 
 			for i = 0; i < repeat; i++ {
-				dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(fmt.Sprintf("clone-from-snap-%d", i), size, snapshot.Namespace, snapshot.Name, &f.SnapshotSCName, &volumeMode)
+				dataVolume := utils.NewDataVolumeForSnapshotCloning(fmt.Sprintf("clone-from-snap-%d", i), size, snapshot.Namespace, snapshot.Name, &f.SnapshotSCName, &volumeMode)
 				dataVolume.Labels = map[string]string{"test-label-1": "test-label-value-1"}
 				dataVolume.Annotations = map[string]string{"test-annotation-1": "test-annotation-value-1"}
 				By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
@@ -2667,7 +2667,7 @@ var _ = Describe("all clone tests", func() {
 				createSnapshot(snapSourceSize, &noExpansionStorageClass.Name, volumeMode)
 
 				for i = 0; i < repeat; i++ {
-					dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(fmt.Sprintf("clone-from-snap-%d", i), targetDvSize, snapshot.Namespace, snapshot.Name, &noExpansionStorageClass.Name, &volumeMode)
+					dataVolume := utils.NewDataVolumeForSnapshotCloning(fmt.Sprintf("clone-from-snap-%d", i), targetDvSize, snapshot.Namespace, snapshot.Name, &noExpansionStorageClass.Name, &volumeMode)
 					By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
 					dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, dataVolume)
 					Expect(err).ToNot(HaveOccurred())
@@ -2742,7 +2742,7 @@ var _ = Describe("all clone tests", func() {
 				dvName := "clone-from-snap"
 				createSnapshot(size, &wffcStorageClass.Name, volumeMode)
 
-				dataVolume := utils.NewDataVolumeForSnapshotCloningAndStorageSpec(dvName, size, snapshot.Namespace, snapshot.Name, &wffcStorageClass.Name, &volumeMode)
+				dataVolume := utils.NewDataVolumeForSnapshotCloning(dvName, size, snapshot.Namespace, snapshot.Name, &wffcStorageClass.Name, &volumeMode)
 				By(fmt.Sprintf("Create new datavolume %s which will clone from volumesnapshot", dataVolume.Name))
 				dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 				dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, snapshot.Namespace, dataVolume)
@@ -2768,7 +2768,7 @@ var _ = Describe("all clone tests", func() {
 				size := "1Gi"
 				volumeMode := v1.PersistentVolumeFilesystem
 				By("Create the clone before the source snapshot")
-				cloneDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("clone-from-snap", size, f.Namespace.Name, "snap-"+dataVolumeName, &f.SnapshotSCName, &volumeMode)
+				cloneDV := utils.NewDataVolumeForSnapshotCloning("clone-from-snap", size, f.Namespace.Name, "snap-"+dataVolumeName, &f.SnapshotSCName, &volumeMode)
 				cloneDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
 				Expect(err).ToNot(HaveOccurred())
 				// Check if the NoSourceClone annotation exists in target PVC
@@ -2845,7 +2845,7 @@ func doFileBasedCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolume
 		targetSize = []string{"1Gi"}
 	}
 	// Create targetPvc in new NS.
-	targetDV := utils.NewCloningDataVolume(targetDv, targetSize[0], srcPVCDef)
+	targetDV := utils.NewCloningDataVolumeWithStorageSpec(targetDv, targetSize[0], srcPVCDef)
 	if targetDV.GetLabels() == nil {
 		targetDV.SetLabels(make(map[string]string))
 	}
@@ -2898,7 +2898,7 @@ func doInUseCloneTest(f *framework.Framework, srcPVCDef *v1.PersistentVolumeClai
 	}, 90*time.Second, 2*time.Second).Should(BeTrue())
 
 	// Create targetPvc in new NS.
-	targetDV := utils.NewCloningDataVolume(targetDv, "1Gi", srcPVCDef)
+	targetDV := utils.NewCloningDataVolumeWithStorageSpec(targetDv, "1Gi", srcPVCDef)
 	dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, targetNs.Name, targetDV)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -354,13 +354,13 @@ var _ = Describe("all clone tests", func() {
 				Expect(sourcePVC.Spec.VolumeName).To(Equal(sourcePV.Name))
 
 				targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", sourcePVCDef)
-				targetDV.Spec.PVC.StorageClassName = &storageClassName
+				targetDV.Spec.Storage.StorageClassName = &storageClassName
 				targetLabelSelector := metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"target-pv": "yes",
 					},
 				}
-				targetDV.Spec.PVC.Selector = &targetLabelSelector
+				targetDV.Spec.Storage.Selector = &targetLabelSelector
 				dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDV)
 				Expect(err).ToNot(HaveOccurred())
 				f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -593,7 +593,7 @@ var _ = Describe("all clone tests", func() {
 				By("Creating a source from a real image")
 				sourceDv := utils.NewDataVolumeWithHTTPImport("source-dv", "200Mi", tinyCoreIsoURL())
 				filesystem := v1.PersistentVolumeFilesystem
-				sourceDv.Spec.PVC.VolumeMode = &filesystem
+				sourceDv.Spec.Storage.VolumeMode = &filesystem
 				sourceDv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDv)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -608,8 +608,8 @@ var _ = Describe("all clone tests", func() {
 				targetDv := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv", "100Mi",
 					f.Namespace.Name,
 					sourceDv.Name,
-					sourceDv.Spec.PVC.StorageClassName,
-					sourceDv.Spec.PVC.VolumeMode)
+					sourceDv.Spec.Storage.StorageClassName,
+					sourceDv.Spec.Storage.VolumeMode)
 
 				targetDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 				Expect(err).ToNot(HaveOccurred())
@@ -939,7 +939,7 @@ var _ = Describe("all clone tests", func() {
 					By("Cloning #NumOfClones times in parallel")
 					for i := 1; i <= NumOfClones; i++ {
 						By("Cloning from the source DataVolume to target" + strconv.Itoa(i))
-						targetDv := utils.NewDataVolumeForImageCloning("target-dv"+strconv.Itoa(i), "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+						targetDv := utils.NewDataVolumeForImageCloning("target-dv"+strconv.Itoa(i), "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 						targetDv.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
 						targetDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 						Expect(err).ToNot(HaveOccurred())
@@ -1021,7 +1021,7 @@ var _ = Describe("all clone tests", func() {
 					By("Cloning #NumOfClones times in parallel")
 					for i := 1; i <= NumOfClones; i++ {
 						By("Cloning from the source DataVolume to target" + strconv.Itoa(i))
-						targetDv := utils.NewDataVolumeForImageCloning("target-dv"+strconv.Itoa(i), "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+						targetDv := utils.NewDataVolumeForImageCloning("target-dv"+strconv.Itoa(i), "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 						targetDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 						Expect(err).ToNot(HaveOccurred())
 						f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDv)
@@ -1635,11 +1635,11 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Cloning from the source DataVolume to target1")
-			targetDv1 = utils.NewDataVolumeForImageCloning("target-dv1", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+			targetDv1 = utils.NewDataVolumeForImageCloning("target-dv1", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 			By("Cloning from the source DataVolume to target2")
-			targetDv2 = utils.NewDataVolumeForImageCloning("target-dv2", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+			targetDv2 = utils.NewDataVolumeForImageCloning("target-dv2", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 			By("Cloning from the target1 DataVolume to target3")
-			targetDv3 = utils.NewDataVolumeForImageCloning("target-dv3", "200Mi", f.Namespace.Name, targetDv1.Name, targetDv1.Spec.PVC.StorageClassName, targetDv1.Spec.PVC.VolumeMode)
+			targetDv3 = utils.NewDataVolumeForImageCloning("target-dv3", "200Mi", f.Namespace.Name, targetDv1.Name, targetDv1.Spec.Storage.StorageClassName, targetDv1.Spec.Storage.VolumeMode)
 			dvs := []*cdiv1.DataVolume{targetDv1, targetDv2, targetDv3}
 
 			for _, dv := range dvs {
@@ -1689,11 +1689,11 @@ var _ = Describe("all clone tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Cloning from the source DataVolume to target1")
-			targetDv1 = utils.NewDataVolumeForImageCloning("target-dv1", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+			targetDv1 = utils.NewDataVolumeForImageCloning("target-dv1", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 			By("Cloning from the source DataVolume to target2")
-			targetDv2 = utils.NewDataVolumeForImageCloning("target-dv2", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+			targetDv2 = utils.NewDataVolumeForImageCloning("target-dv2", "200Mi", f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 			By("Cloning from the target1 DataVolume to target3")
-			targetDv3 = utils.NewDataVolumeForImageCloning("target-dv3", "200Mi", f.Namespace.Name, targetDv1.Name, targetDv1.Spec.PVC.StorageClassName, targetDv1.Spec.PVC.VolumeMode)
+			targetDv3 = utils.NewDataVolumeForImageCloning("target-dv3", "200Mi", f.Namespace.Name, targetDv1.Name, targetDv1.Spec.Storage.StorageClassName, targetDv1.Spec.Storage.VolumeMode)
 			dvs := []*cdiv1.DataVolume{targetDv1, targetDv2, targetDv3}
 
 			for _, dv := range dvs {
@@ -1754,7 +1754,7 @@ var _ = Describe("all clone tests", func() {
 				bigPV = pv
 			}
 
-			targetDv := utils.NewDataVolumeForImageCloning("target-dv", framework.BiggerNfsPvSize, f.Namespace.Name, sourceDv.Name, sourceDv.Spec.PVC.StorageClassName, sourceDv.Spec.PVC.VolumeMode)
+			targetDv := utils.NewDataVolumeForImageCloning("target-dv", framework.BiggerNfsPvSize, f.Namespace.Name, sourceDv.Name, sourceDv.Spec.Storage.StorageClassName, sourceDv.Spec.Storage.VolumeMode)
 			targetDv, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, targetDv)
 			Expect(err).ToNot(HaveOccurred())
 			bigDV = targetDv
@@ -2521,8 +2521,8 @@ var _ = Describe("all clone tests", func() {
 
 		createSnapshot := func(size string, storageClassName *string, volumeMode v1.PersistentVolumeMode) {
 			snapSourceDv := utils.NewDataVolumeWithHTTPImport(dataVolumeName, size, fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
-			snapSourceDv.Spec.PVC.VolumeMode = &volumeMode
-			snapSourceDv.Spec.PVC.StorageClassName = storageClassName
+			snapSourceDv.Spec.Storage.VolumeMode = &volumeMode
+			snapSourceDv.Spec.Storage.StorageClassName = storageClassName
 			By(fmt.Sprintf("Create new datavolume %s which will be the source of the volumesnapshot", snapSourceDv.Name))
 			snapSourceDv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, snapSourceDv)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -782,7 +782,7 @@ var _ = Describe("DataImportCron", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshots.Items).To(BeEmpty())
 			// Ensure existing PVC clones from this source don't mess up future ones
-			cloneDV := utils.NewDataVolumeForImageCloningAndStorageSpec("target-dv-from-pvc", size, ns, currentImportDv, nil, nil)
+			cloneDV := utils.NewDataVolumeForImageCloning("target-dv-from-pvc", size, ns, currentImportDv, nil, nil)
 			cloneDV, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, cloneDV)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(cloneDV)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1399,7 +1399,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			dataVolume.Labels = map[string]string{"test-label-1": "test-label-1", "test-label-2": "test-label-2"}
 			dataVolume.Annotations = map[string]string{"test-annotation-1": "test-annotation-1", "test-annotation-2": "test-annotation-2"}
 			// Stir things up with this non widely used access mode
-			dataVolume.Spec.PVC.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}
+			dataVolume.Spec.Storage.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}
 
 			By(fmt.Sprintf("creating new datavolume %s", dataVolume.Name))
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -1785,7 +1785,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		createDataVolumeForUpload := func(f *framework.Framework, storageSpec cdiv1.StorageSpec) *cdiv1.DataVolume {
 			dataVolume := utils.NewDataVolumeForUpload(dataVolumeName, "1Mi")
-			dataVolume.Spec.PVC = nil
 			dataVolume.Spec.Storage = &storageSpec
 
 			dv, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
@@ -1800,7 +1799,6 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
 			dataVolume := utils.NewCloningDataVolume(dataVolumeName, "10Mi", sourcePvc)
-			dataVolume.Spec.PVC = nil
 			dataVolume.Spec.Storage = &storageSpec
 			dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 
@@ -2578,7 +2576,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 
 		newDataVolumeWithPvcSpec := func(scName string) *cdiv1.DataVolume {
 			dv := utils.NewDataVolumeWithHTTPImport(dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
-			dv.Spec.PVC.StorageClassName = ptr.To[string](scName)
+			dv.Spec.Storage.StorageClassName = ptr.To[string](scName)
 			return dv
 		}
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -301,7 +301,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
 
 			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
-			return utils.NewCloningDataVolume(dataVolumeName, size, sourcePvc)
+			return utils.NewCloningDataVolumeWithStorageSpec(dataVolumeName, size, sourcePvc)
 		}
 
 		createBlankRawDataVolume := func(dataVolumeName, size, url string) *cdiv1.DataVolume {
@@ -1768,7 +1768,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		fillCommand := "echo \"" + fillData + "\" >> " + testFile
 
 		createLabeledDataVolumeForImport := func(f *framework.Framework, storageSpec cdiv1.StorageSpec, labels map[string]string) *cdiv1.DataVolume {
-			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
+			dataVolume := utils.NewDataVolumeWithHTTPImport(
 				dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 
 			dataVolume.Spec.Storage = &storageSpec
@@ -1798,7 +1798,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
 
 			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
-			dataVolume := utils.NewCloningDataVolume(dataVolumeName, "10Mi", sourcePvc)
+			dataVolume := utils.NewCloningDataVolumeWithStorageSpec(dataVolumeName, "10Mi", sourcePvc)
 			dataVolume.Spec.Storage = &storageSpec
 			dataVolume.Annotations[controller.AnnImmediateBinding] = "true"
 
@@ -2532,7 +2532,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			}
 
 			By(fmt.Sprintf("creating new datavolume %s with StorageClassName %s", dataVolumeName, scName))
-			dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
+			dataVolume := utils.NewDataVolumeWithHTTPImport(
 				dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 			dataVolume.Labels = map[string]string{common.PvcApplyStorageProfileLabel: webhookRenderingLabel}
 			dataVolume.Spec.Storage.StorageClassName = ptr.To[string](scName)
@@ -2568,7 +2568,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 		)
 
 		newDataVolumeWithStorageSpec := func(scName string) *cdiv1.DataVolume {
-			dv := utils.NewDataVolumeWithHTTPImportAndStorageSpec(
+			dv := utils.NewDataVolumeWithHTTPImport(
 				dataVolumeName, "100Mi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 			dv.Spec.Storage.StorageClassName = ptr.To[string](scName)
 			return dv
@@ -2696,7 +2696,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
 
 			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
-			return utils.NewCloningDataVolume(dataVolumeName, size, sourcePvc)
+			return utils.NewCloningDataVolumeWithStorageSpec(dataVolumeName, size, sourcePvc)
 		}
 		var original *bool
 		noSuchFileFileURL := utils.InvalidQcowImagesURL + "no-such-file.img"
@@ -2818,7 +2818,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			sourcePvc = f.CreateAndPopulateSourcePVC(pvcDef, sourcePodFillerName, command)
 
 			By(fmt.Sprintf("creating a new target PVC (datavolume) to clone %s", sourcePvc.Name))
-			return utils.NewCloningDataVolume(dataVolumeName, size, sourcePvc)
+			return utils.NewCloningDataVolumeWithStorageSpec(dataVolumeName, size, sourcePvc)
 		}
 
 		DescribeTable("WFFC Feature Gate enabled - ImmediateBinding requested", func(
@@ -3161,7 +3161,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindIfWaitForFirstConsumer(pvc)
 
-			dataVolume := utils.NewCloningDataVolume(dataVolumeName, "1Gi", pvc)
+			dataVolume := utils.NewCloningDataVolumeWithStorageSpec(dataVolumeName, "1Gi", pvc)
 			Expect(dataVolume).ToNot(BeNil())
 
 			By(fmt.Sprintf("creating new datavolume %s with priority class", dataVolume.Name))

--- a/tests/external_population_test.go
+++ b/tests/external_population_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dataSourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dataSourceRef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
 			f.ForceBindPvcIfDvIsWaitForFirstConsumer(dataVolume)
@@ -175,7 +175,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeBlock, nil, dataSourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeBlock, nil, dataSourceRef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -202,7 +202,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating new datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dummySourceRef)
+			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, "100Mi", utils.DefaultStorageClass.Name, corev1.PersistentVolumeFilesystem, nil, dummySourceRef)
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -242,7 +242,7 @@ var _ = Describe("Population tests", func() {
 			}
 
 			By(fmt.Sprintf("Creating target datavolume %s", dataVolumeName))
-			dataVolume := utils.NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeFilesystem, dataSource, nil)
+			dataVolume := utils.NewDataVolumeWithExternalPopulation(dataVolumeName, "100Mi", f.CsiCloneSCName, corev1.PersistentVolumeFilesystem, dataSource, nil)
 			dataVolume.Spec.Storage.StorageClassName = nil
 			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dataVolume)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -300,7 +300,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 
 			updateDefaultStorageClasses("false")
 
-			dv := utils.NewDataVolumeWithHTTPImportAndStorageSpec("test-dv", "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
+			dv := utils.NewDataVolumeWithHTTPImport("test-dv", "1Gi", fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs))
 			if !withAccessModes {
 				dv.Spec.Storage.AccessModes = nil
 			}

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -246,7 +246,7 @@ func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f
 func createAndPopulateSourcePVC(dataVolumeName string, volumeMode v1.PersistentVolumeMode, scName string, f *framework.Framework) *v1.PersistentVolumeClaim {
 	By(fmt.Sprintf("Storage Class name: %s", scName))
 	srcName := fmt.Sprintf("%s-src-pvc", dataVolumeName)
-	dataVolume := utils.NewDataVolumeWithHTTPImportAndStorageSpec(srcName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+	dataVolume := utils.NewDataVolumeWithHTTPImport(srcName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
 	dataVolume.Spec.Storage.VolumeMode = &volumeMode
 	if scName != "" {
 		dataVolume.Spec.Storage.StorageClassName = &scName

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -1366,7 +1366,7 @@ var _ = Describe("[rfe_id:138][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 		dvName := "upload-dv"
 		By(fmt.Sprintf("Creating new datavolume %s", dvName))
-		dv := utils.NewDataVolumeForUploadWithStorageAPI(dvName, size)
+		dv := utils.NewDataVolumeForUpload(dvName, size)
 		dv.Spec.Storage.AccessModes = accessModes
 		dv.Spec.Storage.VolumeMode = &volumeMode
 		dataVolume, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -153,13 +153,9 @@ func CleanupDvPvcNoWait(k8sClient *kubernetes.Clientset, cdiClient *cdiclientset
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
-func NewCloningDataVolume(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
-	return NewDataVolumeForImageCloning(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
-}
-
 // NewCloningDataVolumeWithStorageSpec initializes a DataVolume struct with Storage spec
 func NewCloningDataVolumeWithStorageSpec(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
-	return NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
+	return NewDataVolumeForImageCloning(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 }
 
 // NewDataVolumeWithSourceRef initializes a DataVolume struct with DataSource SourceRef
@@ -279,10 +275,6 @@ func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL str
 	}
 }
 
-func NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
-	return NewDataVolumeWithHTTPImport(dataVolumeName, size, httpURL)
-}
-
 // NewDataVolumeWithImageioImport initializes a DataVolume struct with Imageio annotations
 func NewDataVolumeWithImageioImport(dataVolumeName string, size string, httpURL string, secret string, configMap string, diskID string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
@@ -391,10 +383,6 @@ func NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName 
 	return dataVolume
 }
 
-func NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, size, storageClassName string, volumeMode k8sv1.PersistentVolumeMode, dataSource *k8sv1.TypedLocalObjectReference, dataSourceRef *k8sv1.TypedObjectReference) *cdiv1.DataVolume {
-	return NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName, volumeMode, dataSource, dataSourceRef)
-}
-
 // NewDataVolumeCloneToBlockPV initializes a DataVolume for block cloning
 func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespace, srcName, storageClassName string) *cdiv1.DataVolume {
 	volumeMode := k8sv1.PersistentVolumeBlock
@@ -424,10 +412,6 @@ func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespac
 	return dataVolume
 }
 
-func NewDataVolumeCloneToBlockPVStorageAPI(dataVolumeName string, size string, srcNamespace, srcName, storageClassName string) *cdiv1.DataVolume {
-	return NewDataVolumeCloneToBlockPV(dataVolumeName, size, srcNamespace, srcName, storageClassName)
-}
-
 // NewDataVolumeForUpload initializes a DataVolume struct with Upload annotations
 func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
@@ -449,10 +433,6 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 			},
 		},
 	}
-}
-
-func NewDataVolumeForUploadWithStorageAPI(dataVolumeName string, size string) *cdiv1.DataVolume {
-	return NewDataVolumeForUpload(dataVolumeName, size)
 }
 
 // NewDataVolumeForBlankRawImage initializes a DataVolume struct for creating blank raw image
@@ -537,10 +517,6 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 	return dv
 }
 
-func NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	return NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName, storageClassName, volumeMode)
-}
-
 // NewDataVolumeForCloningWithEmptySize initializes a DataVolume struct with empty storage size to test the size-detection mechanism when cloning
 func NewDataVolumeForCloningWithEmptySize(dataVolumeName, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
 	dv := &cdiv1.DataVolume{
@@ -600,10 +576,6 @@ func NewDataVolumeForSnapshotCloning(dataVolumeName, size, namespace, snapshot s
 		dv.Spec.Storage.StorageClassName = storageClassName
 	}
 	return dv
-}
-
-func NewDataVolumeForSnapshotCloningAndStorageSpec(dataVolumeName, size, namespace, snapshot string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	return NewDataVolumeForSnapshotCloning(dataVolumeName, size, namespace, snapshot, storageClassName, volumeMode)
 }
 
 // NewDataVolumeWithRegistryImport initializes a DataVolume struct with registry annotations
@@ -782,10 +754,6 @@ func NewDataVolumeWithArchiveContent(dataVolumeName string, size string, httpURL
 			},
 		},
 	}
-}
-
-func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
-	return NewDataVolumeWithArchiveContent(dataVolumeName, size, httpURL)
 }
 
 // PersistentVolumeClaimFromDataVolume creates a PersistentVolumeClaim definition so we can use PersistentVolumeClaim for various operations.

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -153,19 +153,18 @@ func CleanupDvPvcNoWait(k8sClient *kubernetes.Clientset, cdiClient *cdiclientset
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
-// NewCloningDataVolume initializes a DataVolume struct with PVC spec
 func NewCloningDataVolume(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
 	return NewDataVolumeForImageCloning(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 }
 
-// NewCloningDataVolume initializes a DataVolume struct with Storage spec
+// NewCloningDataVolumeWithStorageSpec initializes a DataVolume struct with Storage spec
 func NewCloningDataVolumeWithStorageSpec(dataVolumeName, size string, sourcePvc *k8sv1.PersistentVolumeClaim) *cdiv1.DataVolume {
 	return NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, sourcePvc.Namespace, sourcePvc.Name, sourcePvc.Spec.StorageClassName, sourcePvc.Spec.VolumeMode)
 }
 
 // NewDataVolumeWithSourceRef initializes a DataVolume struct with DataSource SourceRef
 func NewDataVolumeWithSourceRef(dataVolumeName string, size, sourceRefNamespace, sourceRefName string) *cdiv1.DataVolume {
-	claimSpec := &k8sv1.PersistentVolumeClaimSpec{
+	storageSpec := &cdiv1.StorageSpec{
 		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 		Resources: k8sv1.VolumeResourceRequirements{
 			Requests: k8sv1.ResourceList{
@@ -185,7 +184,7 @@ func NewDataVolumeWithSourceRef(dataVolumeName string, size, sourceRefNamespace,
 				Namespace: &sourceRefNamespace,
 				Name:      sourceRefName,
 			},
-			PVC: claimSpec,
+			Storage: storageSpec,
 		},
 	}
 }
@@ -255,33 +254,6 @@ func NewSnapshotDataSource(dataSourceName, dataSourceNamespace, snapshotName, sn
 
 // NewDataVolumeWithHTTPImport initializes a DataVolume struct with HTTP annotations
 func NewDataVolumeWithHTTPImport(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
-	claimSpec := &k8sv1.PersistentVolumeClaimSpec{
-		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-		Resources: k8sv1.VolumeResourceRequirements{
-			Requests: k8sv1.ResourceList{
-				k8sv1.ResourceStorage: resource.MustParse(size),
-			},
-		},
-	}
-
-	return &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        dataVolumeName,
-			Annotations: map[string]string{},
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				HTTP: &cdiv1.DataVolumeSourceHTTP{
-					URL: httpURL,
-				},
-			},
-			PVC: claimSpec,
-		},
-	}
-}
-
-// NewDataVolumeWithHTTPImportAndStorageSpec initializes a DataVolume struct with HTTP annotations
-func NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
 	storageSpec := &cdiv1.StorageSpec{
 		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 		Resources: k8sv1.VolumeResourceRequirements{
@@ -307,6 +279,10 @@ func NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName string, size strin
 	}
 }
 
+func NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
+	return NewDataVolumeWithHTTPImport(dataVolumeName, size, httpURL)
+}
+
 // NewDataVolumeWithImageioImport initializes a DataVolume struct with Imageio annotations
 func NewDataVolumeWithImageioImport(dataVolumeName string, size string, httpURL string, secret string, configMap string, diskID string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
@@ -322,7 +298,7 @@ func NewDataVolumeWithImageioImport(dataVolumeName string, size string, httpURL 
 					DiskID:        diskID,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -351,7 +327,7 @@ func NewDataVolumeWithImageioWarmImport(dataVolumeName string, size string, http
 			},
 			FinalCheckpoint: finalCheckpoint,
 			Checkpoints:     checkpoints,
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -376,7 +352,7 @@ func NewDataVolumeWithHTTPImportToBlockPV(dataVolumeName string, size string, ht
 					URL: httpURL,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				VolumeMode:       &volumeMode,
 				StorageClassName: &storageClassName,
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
@@ -398,7 +374,7 @@ func NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName 
 			Name: dataVolumeName,
 		},
 		Spec: cdiv1.DataVolumeSpec{
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				VolumeMode:       &volumeMode,
 				StorageClassName: &storageClassName,
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
@@ -415,28 +391,8 @@ func NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName 
 	return dataVolume
 }
 
-// NewDataVolumeWithExternalPopulationAndStorageSpec initializes a DataVolume struct meant to be externally populated (with storage spec)
 func NewDataVolumeWithExternalPopulationAndStorageSpec(dataVolumeName, size, storageClassName string, volumeMode k8sv1.PersistentVolumeMode, dataSource *k8sv1.TypedLocalObjectReference, dataSourceRef *k8sv1.TypedObjectReference) *cdiv1.DataVolume {
-	dataVolume := &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Storage: &cdiv1.StorageSpec{
-				VolumeMode:       &volumeMode,
-				StorageClassName: &storageClassName,
-				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-				DataSource:       dataSource,
-				DataSourceRef:    dataSourceRef,
-				Resources: k8sv1.VolumeResourceRequirements{
-					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceStorage: resource.MustParse(size),
-					},
-				},
-			},
-		},
-	}
-	return dataVolume
+	return NewDataVolumeWithExternalPopulation(dataVolumeName, size, storageClassName, volumeMode, dataSource, dataSourceRef)
 }
 
 // NewDataVolumeCloneToBlockPV initializes a DataVolume for block cloning
@@ -453,7 +409,7 @@ func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespac
 					Namespace: srcNamespace,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				VolumeMode:       &volumeMode,
 				StorageClassName: &storageClassName,
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
@@ -468,32 +424,8 @@ func NewDataVolumeCloneToBlockPV(dataVolumeName string, size string, srcNamespac
 	return dataVolume
 }
 
-// NewDataVolumeCloneToBlockPVStorageAPI initializes a DataVolume for block cloning with Storage API
 func NewDataVolumeCloneToBlockPVStorageAPI(dataVolumeName string, size string, srcNamespace, srcName, storageClassName string) *cdiv1.DataVolume {
-	volumeMode := k8sv1.PersistentVolumeBlock
-	dataVolume := &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				PVC: &cdiv1.DataVolumeSourcePVC{
-					Name:      srcName,
-					Namespace: srcNamespace,
-				},
-			},
-			Storage: &cdiv1.StorageSpec{
-				VolumeMode:       &volumeMode,
-				StorageClassName: &storageClassName,
-				Resources: k8sv1.VolumeResourceRequirements{
-					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceStorage: resource.MustParse(size),
-					},
-				},
-			},
-		},
-	}
-	return dataVolume
+	return NewDataVolumeCloneToBlockPV(dataVolumeName, size, srcNamespace, srcName, storageClassName)
 }
 
 // NewDataVolumeForUpload initializes a DataVolume struct with Upload annotations
@@ -507,7 +439,7 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 			Source: &cdiv1.DataVolumeSource{
 				Upload: &cdiv1.DataVolumeSourceUpload{},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -519,27 +451,8 @@ func NewDataVolumeForUpload(dataVolumeName string, size string) *cdiv1.DataVolum
 	}
 }
 
-// NewDataVolumeForUploadWithStorageAPI initializes a DataVolume struct with Upload annotations
-// and using the Storage API instead of the PVC API
 func NewDataVolumeForUploadWithStorageAPI(dataVolumeName string, size string) *cdiv1.DataVolume {
-	return &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        dataVolumeName,
-			Annotations: map[string]string{},
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				Upload: &cdiv1.DataVolumeSourceUpload{},
-			},
-			Storage: &cdiv1.StorageSpec{
-				Resources: k8sv1.VolumeResourceRequirements{
-					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceStorage: resource.MustParse(size),
-					},
-				},
-			},
-		},
-	}
+	return NewDataVolumeForUpload(dataVolumeName, size)
 }
 
 // NewDataVolumeForBlankRawImage initializes a DataVolume struct for creating blank raw image
@@ -553,7 +466,7 @@ func NewDataVolumeForBlankRawImage(dataVolumeName, size string) *cdiv1.DataVolum
 			Source: &cdiv1.DataVolumeSource{
 				Blank: &cdiv1.DataVolumeBlankImage{},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -576,7 +489,7 @@ func NewDataVolumeForBlankRawImageBlock(dataVolumeName, size string, storageClas
 			Source: &cdiv1.DataVolumeSource{
 				Blank: &cdiv1.DataVolumeBlankImage{},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				VolumeMode:       &volumeMode,
 				StorageClassName: &storageClassName,
 				AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
@@ -605,7 +518,7 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 					Name:      pvcName,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -616,47 +529,16 @@ func NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName strin
 		},
 	}
 	if volumeMode != nil {
-		dv.Spec.PVC.VolumeMode = volumeMode
-	}
-	if storageClassName != nil {
-		dv.Spec.PVC.StorageClassName = storageClassName
-	}
-	return dv
-}
-
-// NewDataVolumeForImageCloningAndStorageSpec initializes a DataVolume struct with spec.storage for cloning disk image
-func NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	storageSpec := &cdiv1.StorageSpec{
-		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-		Resources: k8sv1.VolumeResourceRequirements{
-			Requests: k8sv1.ResourceList{
-				k8sv1.ResourceStorage: resource.MustParse(size),
-			},
-		},
-	}
-
-	dv := &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        dataVolumeName,
-			Annotations: map[string]string{},
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				PVC: &cdiv1.DataVolumeSourcePVC{
-					Namespace: namespace,
-					Name:      pvcName,
-				},
-			},
-			Storage: storageSpec,
-		},
-	}
-	if volumeMode != nil {
 		dv.Spec.Storage.VolumeMode = volumeMode
 	}
 	if storageClassName != nil {
 		dv.Spec.Storage.StorageClassName = storageClassName
 	}
 	return dv
+}
+
+func NewDataVolumeForImageCloningAndStorageSpec(dataVolumeName, size, namespace, pvcName string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
+	return NewDataVolumeForImageCloning(dataVolumeName, size, namespace, pvcName, storageClassName, volumeMode)
 }
 
 // NewDataVolumeForCloningWithEmptySize initializes a DataVolume struct with empty storage size to test the size-detection mechanism when cloning
@@ -701,39 +583,6 @@ func NewDataVolumeForSnapshotCloning(dataVolumeName, size, namespace, snapshot s
 					Name:      snapshot,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
-				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-				Resources: k8sv1.VolumeResourceRequirements{
-					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceStorage: resource.MustParse(size),
-					},
-				},
-			},
-		},
-	}
-	if volumeMode != nil {
-		dv.Spec.PVC.VolumeMode = volumeMode
-	}
-	if storageClassName != nil {
-		dv.Spec.PVC.StorageClassName = storageClassName
-	}
-	return dv
-}
-
-// NewDataVolumeForSnapshotCloningAndStorageSpec initializes a DataVolume struct for cloning from a volume snapshot
-func NewDataVolumeForSnapshotCloningAndStorageSpec(dataVolumeName, size, namespace, snapshot string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	dv := &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        dataVolumeName,
-			Annotations: map[string]string{},
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				Snapshot: &cdiv1.DataVolumeSourceSnapshot{
-					Namespace: namespace,
-					Name:      snapshot,
-				},
-			},
 			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
@@ -753,6 +602,10 @@ func NewDataVolumeForSnapshotCloningAndStorageSpec(dataVolumeName, size, namespa
 	return dv
 }
 
+func NewDataVolumeForSnapshotCloningAndStorageSpec(dataVolumeName, size, namespace, snapshot string, storageClassName *string, volumeMode *k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
+	return NewDataVolumeForSnapshotCloning(dataVolumeName, size, namespace, snapshot, storageClassName, volumeMode)
+}
+
 // NewDataVolumeWithRegistryImport initializes a DataVolume struct with registry annotations
 func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registryURL string) *cdiv1.DataVolume {
 	return &cdiv1.DataVolume{
@@ -766,7 +619,7 @@ func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registr
 					URL: &registryURL,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -781,8 +634,13 @@ func NewDataVolumeWithRegistryImport(dataVolumeName string, size string, registr
 // ModifyDataVolumeWithImportToBlockPV modifies a DataVolume struct for import to a block PV
 func ModifyDataVolumeWithImportToBlockPV(dataVolume *cdiv1.DataVolume, storageClassName string) *cdiv1.DataVolume {
 	volumeMode := k8sv1.PersistentVolumeBlock
-	dataVolume.Spec.PVC.VolumeMode = &volumeMode
-	dataVolume.Spec.PVC.StorageClassName = &storageClassName
+	if dataVolume.Spec.Storage != nil {
+		dataVolume.Spec.Storage.VolumeMode = &volumeMode
+		dataVolume.Spec.Storage.StorageClassName = &storageClassName
+	} else if dataVolume.Spec.PVC != nil {
+		dataVolume.Spec.PVC.VolumeMode = &volumeMode
+		dataVolume.Spec.PVC.StorageClassName = &storageClassName
+	}
 	return dataVolume
 }
 
@@ -802,7 +660,7 @@ func NewDataVolumeWithVddkImport(dataVolumeName string, size string, backingFile
 					UUID:        uuid,
 				},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -836,7 +694,7 @@ func NewDataVolumeWithVddkWarmImport(dataVolumeName string, size string, backing
 				{Current: previousCheckpoint, Previous: ""},
 				{Current: currentCheckpoint, Previous: previousCheckpoint},
 			},
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
+			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
 					Requests: k8sv1.ResourceList{
@@ -850,7 +708,7 @@ func NewDataVolumeWithVddkWarmImport(dataVolumeName string, size string, backing
 
 // NewDataVolumeWithGCSImport initializes a DataVolume struct with GCS HTTP annotations
 func NewDataVolumeWithGCSImport(dataVolumeName string, size string, gcsURL string) *cdiv1.DataVolume {
-	claimSpec := &k8sv1.PersistentVolumeClaimSpec{
+	storageSpec := &cdiv1.StorageSpec{
 		AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 		Resources: k8sv1.VolumeResourceRequirements{
 			Requests: k8sv1.ResourceList{
@@ -870,7 +728,7 @@ func NewDataVolumeWithGCSImport(dataVolumeName string, size string, gcsURL strin
 					URL: gcsURL,
 				},
 			},
-			PVC: claimSpec,
+			Storage: storageSpec,
 		},
 	}
 }
@@ -914,31 +772,6 @@ func NewDataVolumeWithArchiveContent(dataVolumeName string, size string, httpURL
 				},
 			},
 			ContentType: cdiv1.DataVolumeArchive,
-			PVC: &k8sv1.PersistentVolumeClaimSpec{
-				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-				Resources: k8sv1.VolumeResourceRequirements{
-					Requests: k8sv1.ResourceList{
-						k8sv1.ResourceStorage: resource.MustParse(size),
-					},
-				},
-			},
-		},
-	}
-}
-
-// NewDataVolumeWithArchiveContentStorage initializes a DataVolume struct with 'archive' ContentType
-func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
-	return &cdiv1.DataVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: dataVolumeName,
-		},
-		Spec: cdiv1.DataVolumeSpec{
-			Source: &cdiv1.DataVolumeSource{
-				HTTP: &cdiv1.DataVolumeSourceHTTP{
-					URL: httpURL,
-				},
-			},
-			ContentType: cdiv1.DataVolumeArchive,
 			Storage: &cdiv1.StorageSpec{
 				AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 				Resources: k8sv1.VolumeResourceRequirements{
@@ -951,11 +784,22 @@ func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, 
 	}
 }
 
+func NewDataVolumeWithArchiveContentStorage(dataVolumeName string, size string, httpURL string) *cdiv1.DataVolume {
+	return NewDataVolumeWithArchiveContent(dataVolumeName, size, httpURL)
+}
+
 // PersistentVolumeClaimFromDataVolume creates a PersistentVolumeClaim definition so we can use PersistentVolumeClaim for various operations.
 func PersistentVolumeClaimFromDataVolume(datavolume *cdiv1.DataVolume) *k8sv1.PersistentVolumeClaim {
-	// This function can work with DVs that use the 'Storage' field instead of the 'PVC' field
 	spec := k8sv1.PersistentVolumeClaimSpec{}
-	if datavolume.Spec.PVC != nil {
+	if datavolume.Spec.Storage != nil {
+		spec.AccessModes = datavolume.Spec.Storage.AccessModes
+		spec.Resources = datavolume.Spec.Storage.Resources
+		spec.StorageClassName = datavolume.Spec.Storage.StorageClassName
+		spec.VolumeMode = datavolume.Spec.Storage.VolumeMode
+		spec.Selector = datavolume.Spec.Storage.Selector
+		spec.DataSource = datavolume.Spec.Storage.DataSource
+		spec.DataSourceRef = datavolume.Spec.Storage.DataSourceRef
+	} else if datavolume.Spec.PVC != nil {
 		spec = *datavolume.Spec.PVC
 	}
 

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 				srcPVCDef.Namespace = f.Namespace.Name
 				f.CreateAndPopulateSourcePVC(srcPVCDef, "fill-source", fmt.Sprintf("echo \"hello world\" > %s/data.txt", utils.DefaultPvcMountPath))
 
-				targetDV := utils.NewCloningDataVolume("target-dv", "1Gi", srcPVCDef)
+				targetDV := utils.NewCloningDataVolumeWithStorageSpec("target-dv", "1Gi", srcPVCDef)
 
 				client, err := f.GetCdiClientForServiceAccount(targetNamespace.Name, serviceAccountName)
 				Expect(err).ToNot(HaveOccurred())
@@ -290,7 +290,7 @@ var _ = Describe("Clone Auth Webhook tests", func() {
 				err = f.CrClient.Create(context.TODO(), snapshot)
 				Expect(err).ToNot(HaveOccurred())
 				volumeMode := corev1.PersistentVolumeFilesystem
-				targetDV := utils.NewDataVolumeForSnapshotCloningAndStorageSpec("target-dv", "1Gi", snapshot.Namespace, snapshot.Name, nil, &volumeMode)
+				targetDV := utils.NewDataVolumeForSnapshotCloning("target-dv", "1Gi", snapshot.Namespace, snapshot.Name, nil, &volumeMode)
 
 				client, err := f.GetCdiClientForServiceAccount(targetNamespace.Name, serviceAccountName)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Altering volume size for DVs with an explicitly provided PVC spec is something that's only done by requesting PVC mutation using the `cdi.kubevirt.io/applyStorageProfile` annotation. In order to run tests on clusters with certain storage restrictions that are remediated via the storage profile API, use spec.storage wherever possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

