### PR TITLE
Fix clone to filesystem PVC sizing when storageProfile minimum applies

### DIFF
--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -323,12 +323,27 @@ func renderPvcSpecVolumeSize(client client.Client, pvcSpec *v1.PersistentVolumeC
 		return errors.Errorf("PVC Spec is not valid - storage size should be at least 1MiB")
 	}
 
-	requestedSize, err := cc.InflateSizeWithOverhead(context.TODO(), client, requestedSize.Value(), pvcSpec)
-	if err != nil {
-		return err
+	isFilesystem := util.ResolveVolumeMode(pvcSpec.VolumeMode) == v1.PersistentVolumeFilesystem
+	scName := pvcSpec.StorageClassName
+	var err error
+
+	// When cloning to filesystem, if the effective target size is larger than the requested size,
+	// pass an empty requested size so actual size is auto detected.
+	if isClone && isFilesystem && scName != nil {
+		effectiveSize, err := cc.GetEffectiveVolumeSize(context.TODO(), client, requestedSize, *scName, log)
+		if err != nil {
+			return err
+		}
+		if effectiveSize.Cmp(requestedSize) > 0 {
+			setRequestedVolumeSize(pvcSpec, resource.Quantity{})
+			return nil
+		}
 	}
 
-	if scName := pvcSpec.StorageClassName; scName != nil {
+	if requestedSize, err = cc.InflateSizeWithOverhead(context.TODO(), client, requestedSize.Value(), pvcSpec); err != nil {
+		return err
+	}
+	if scName != nil {
 		if requestedSize, err = cc.GetEffectiveVolumeSize(context.TODO(), client, requestedSize, *scName, log); err != nil {
 			return err
 		}

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -323,12 +323,20 @@ func renderPvcSpecVolumeSize(client client.Client, pvcSpec *v1.PersistentVolumeC
 		return errors.Errorf("PVC Spec is not valid - storage size should be at least 1MiB")
 	}
 
-	requestedSize, err := cc.InflateSizeWithOverhead(context.TODO(), client, requestedSize.Value(), pvcSpec)
-	if err != nil {
+	isCloneToFilesystem := isClone && util.ResolveVolumeMode(pvcSpec.VolumeMode) == v1.PersistentVolumeFilesystem
+	scName := pvcSpec.StorageClassName
+	var err error
+
+	// When cloning to filesystem, apply the effective volume size before inflating with overhead.
+	if isCloneToFilesystem && scName != nil {
+		if requestedSize, err = cc.GetEffectiveVolumeSize(context.TODO(), client, requestedSize, *scName, log); err != nil {
+			return err
+		}
+	}
+	if requestedSize, err = cc.InflateSizeWithOverhead(context.TODO(), client, requestedSize.Value(), pvcSpec); err != nil {
 		return err
 	}
-
-	if scName := pvcSpec.StorageClassName; scName != nil {
+	if !isCloneToFilesystem && scName != nil {
 		if requestedSize, err = cc.GetEffectiveVolumeSize(context.TODO(), client, requestedSize, *scName, log); err != nil {
 			return err
 		}

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -274,6 +274,55 @@ var _ = Describe("renderPvcSpec", func() {
 		Entry("fallback to k8s default when accessMode has no matching volumeMode", nil, &rwx, nil, &rwx, nil),
 		Entry("use the passed volumeMode and accessMode even if not in storageProfile", &filesystem, &rwx, &filesystem, &rwx, nil),
 	)
+
+	DescribeTable("Clone to filesystem with storageProfile minimum PVC size", func(requestedSize, minSize string, expectZero bool) {
+		scName := "test"
+		sc := CreateStorageClassWithProvisioner(scName, nil, nil, "csi.example.com")
+		sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, corev1.PersistentVolumeFilesystem)
+		sp.Annotations = map[string]string{
+			AnnMinimumSupportedPVCSize: minSize,
+		}
+		cdiConfig := &cdiv1.CDIConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "config"},
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: cdiv1.Percent("0.055"),
+				},
+			},
+		}
+		cl := createClient(sc, sp, cdiConfig)
+
+		dv := createDataVolumeWithStorageAPI("clone-dv", metav1.NamespaceDefault,
+			&cdiv1.DataVolumeSource{
+				PVC: &cdiv1.DataVolumeSourcePVC{
+					Name: "source-pvc",
+				},
+			},
+			&cdiv1.StorageSpec{
+				StorageClassName: &scName,
+				VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(requestedSize),
+					},
+				},
+			},
+		)
+
+		pvcSpec, err := renderPvcSpec(cl, nil, logr.Logger{}, dv, nil)
+		Expect(err).ToNot(HaveOccurred())
+		pvcRequestedSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
+		Expect(found).To(BeTrue())
+		if expectZero {
+			Expect(pvcRequestedSize.IsZero()).To(BeTrue())
+		} else {
+			origSize := resource.MustParse(requestedSize)
+			Expect(pvcRequestedSize.Value()).To(BeNumerically(">", origSize.Value()))
+		}
+	},
+		Entry("clears storage request when minimum exceeds requested size", "1Gi", "4Gi", true),
+		Entry("applies overhead when requested size exceeds minimum", "5Gi", "1Gi", false),
+	)
 })
 
 var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -274,6 +274,51 @@ var _ = Describe("renderPvcSpec", func() {
 		Entry("fallback to k8s default when accessMode has no matching volumeMode", nil, &rwx, nil, &rwx, nil),
 		Entry("use the passed volumeMode and accessMode even if not in storageProfile", &filesystem, &rwx, &filesystem, &rwx, nil),
 	)
+
+	DescribeTable("Clone to filesystem with storageProfile minimum PVC size applies overhead when requested size", func(requestedSize, minimumSize, expectedSize string) {
+		scName := "test"
+		sc := CreateStorageClassWithProvisioner(scName, nil, nil, "csi.example.com")
+		sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, corev1.PersistentVolumeFilesystem)
+		sp.Annotations = map[string]string{
+			AnnMinimumSupportedPVCSize: minimumSize,
+		}
+		cdiConfig := &cdiv1.CDIConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "config"},
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: cdiv1.Percent("0.25"),
+				},
+			},
+		}
+		cl := createClient(sc, sp, cdiConfig)
+
+		dv := createDataVolumeWithStorageAPI("clone-dv", metav1.NamespaceDefault,
+			&cdiv1.DataVolumeSource{
+				PVC: &cdiv1.DataVolumeSourcePVC{
+					Name: "source-pvc",
+				},
+			},
+			&cdiv1.StorageSpec{
+				StorageClassName: &scName,
+				VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(requestedSize),
+					},
+				},
+			},
+		)
+
+		pvcSpec, err := renderPvcSpec(cl, nil, logr.Logger{}, dv, nil)
+		Expect(err).ToNot(HaveOccurred())
+		pvcRequestedSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
+		Expect(found).To(BeTrue())
+		expSize := resource.MustParse(expectedSize)
+		Expect(pvcRequestedSize.Value()).To(Equal(expSize.Value()))
+	},
+		Entry("is below minimum", "1Gi", "4Gi", "5Gi"),
+		Entry("exceeds minimum", "8Gi", "4Gi", "10Gi"),
+	)
 })
 
 var _ = Describe("updateDataVolumeDefaultInstancetypeLabels", func() {

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2216,7 +2216,7 @@ var _ = Describe("all clone tests", func() {
 
 		})
 
-		DescribeTable("Block volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", Serial, func(minSize string, shouldSucceed bool) {
+		DescribeTable("Block volumeMode clone with target smaller than the source, using storageProfile with minPvcSize annotation", Serial, func(minSize string, shouldSucceed bool) {
 			if !f.IsBlockVolumeStorageClassAvailable() {
 				Skip("Storage Class for block volume is not available")
 			}
@@ -2249,7 +2249,7 @@ var _ = Describe("all clone tests", func() {
 			Entry("[test_id:12424] empty", "", false),
 		)
 
-		DescribeTable("Filesystem volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", func(minSize string, shouldSucceed bool) {
+		DescribeTable("Filesystem volumeMode clone with target smaller than the source, using storageProfile with minPvcSize annotation", func(minSize string, shouldSucceed bool) {
 			By(fmt.Sprintf("Create source PVC %s", sourcePVCName))
 			sc := createStorageWithMinimumSupportedPVCSize(f, minSize)
 			sourcePvc = utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
@@ -2278,6 +2278,35 @@ var _ = Describe("all clone tests", func() {
 			Entry("[test_id:12422] too small", "256Mi", false),
 			Entry("[test_id:12423] empty", "", false),
 		)
+
+		It("[test_id:XXXXX] Block volumeMode clone to filesystem, using storageProfile with minPvcSize annotation", Serial, func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			By(fmt.Sprintf("Create source block DataVolume %s", dataVolumeName))
+			sc := createStorageWithMinimumSupportedPVCSize(f, "4Gi")
+			sourceDV := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+			sourceDV.Spec.Storage.StorageClassName = &sc
+			sourceDV.Spec.Storage.VolumeMode = ptr.To(v1.PersistentVolumeBlock)
+			sourceDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDV)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDV)
+			By("Wait for source DataVolume import to finish")
+			err = utils.WaitForDataVolumePhaseWithTimeout(f, sourceDV.Namespace, cdiv1.Succeeded, sourceDV.Name, cloneCompleteTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetDvName := "target-fs-dv"
+			By(fmt.Sprintf("Create target filesystem DV %s", targetDvName))
+			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "1Gi", sourceDV.Namespace, sourceDV.Name, &sc, ptr.To(v1.PersistentVolumeFilesystem))
+			targetDV, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, sourceDV.Namespace, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for target DV succeeded")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDV)
+			err = utils.WaitForDataVolumePhase(f, targetDV.Namespace, cdiv1.Succeeded, targetDV.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		It("[test_id:4276] Clone datavolume with short name", Serial, func() {
 			shortDvName := "import-long-name-dv"

--- a/tests/cloner_test.go
+++ b/tests/cloner_test.go
@@ -2216,7 +2216,7 @@ var _ = Describe("all clone tests", func() {
 
 		})
 
-		DescribeTable("Block volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", Serial, func(minSize string, shouldSucceed bool) {
+		DescribeTable("Block volumeMode clone with target smaller than the source, using storageProfile with minPvcSize annotation", Serial, func(minSize string, shouldSucceed bool) {
 			if !f.IsBlockVolumeStorageClassAvailable() {
 				Skip("Storage Class for block volume is not available")
 			}
@@ -2249,7 +2249,7 @@ var _ = Describe("all clone tests", func() {
 			Entry("[test_id:12424] empty", "", false),
 		)
 
-		DescribeTable("Filesystem volumeMode clone with target smaller than the source, using storgeProfile with minPvcSize annotation", func(minSize string, shouldSucceed bool) {
+		DescribeTable("Filesystem volumeMode clone with target smaller than the source, using storageProfile with minPvcSize annotation", func(minSize string, shouldSucceed bool) {
 			By(fmt.Sprintf("Create source PVC %s", sourcePVCName))
 			sc := createStorageWithMinimumSupportedPVCSize(f, minSize)
 			sourcePvc = utils.NewPVCDefinition(sourcePVCName, "1Gi", nil, nil)
@@ -2278,6 +2278,35 @@ var _ = Describe("all clone tests", func() {
 			Entry("[test_id:12422] too small", "256Mi", false),
 			Entry("[test_id:12423] empty", "", false),
 		)
+
+		It("Block volumeMode clone to filesystem, using storageProfile with minPvcSize annotation", Serial, func() {
+			if !f.IsBlockVolumeStorageClassAvailable() {
+				Skip("Storage Class for block volume is not available")
+			}
+
+			By(fmt.Sprintf("Create source block DataVolume %s", dataVolumeName))
+			sc := createStorageWithMinimumSupportedPVCSize(f, "4Gi")
+			sourceDV := utils.NewDataVolumeWithHTTPImportAndStorageSpec(dataVolumeName, "1Gi", fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs))
+			sourceDV.Spec.Storage.StorageClassName = &sc
+			sourceDV.Spec.Storage.VolumeMode = ptr.To(v1.PersistentVolumeBlock)
+			sourceDV, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, sourceDV)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(sourceDV)
+			By("Wait for source DataVolume import to finish")
+			err = utils.WaitForDataVolumePhaseWithTimeout(f, sourceDV.Namespace, cdiv1.Succeeded, sourceDV.Name, cloneCompleteTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetDvName := "target-fs-dv"
+			By(fmt.Sprintf("Create target filesystem DV %s", targetDvName))
+			targetDV := utils.NewDataVolumeForImageCloningAndStorageSpec(targetDvName, "1Gi", sourceDV.Namespace, sourceDV.Name, &sc, ptr.To(v1.PersistentVolumeFilesystem))
+			targetDV, err = utils.CreateDataVolumeFromDefinition(f.CdiClient, sourceDV.Namespace, targetDV)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for target DV succeeded")
+			f.ForceBindPvcIfDvIsWaitForFirstConsumer(targetDV)
+			err = utils.WaitForDataVolumePhase(f, targetDV.Namespace, cdiv1.Succeeded, targetDV.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		It("[test_id:4276] Clone datavolume with short name", Serial, func() {
 			shortDvName := "import-long-name-dv"

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -64,7 +64,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 
-		verifyPVCRequestedSize(dataVolume, f, testMinPvcSize)
+		verifyPVCRequestedSizeExceeds(dataVolume, f, testMinPvcSize)
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, md5)
 		verifyCSIClone(dataVolume, f)
 	})

--- a/tests/csiclone_test.go
+++ b/tests/csiclone_test.go
@@ -17,11 +17,9 @@ import (
 	"kubevirt.io/containerized-data-importer/tests/utils"
 )
 
-const testMinPvcSize = "4Gi"
-
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:4219] CSI Volume cloning tests", Serial, func() {
 	var originalProfileSpec *cdiv1.StorageProfileSpec
-	var originalMinPvcSize, cloneStorageClassName string
+	var originalMinPvcSize, cloneStorageClassName, testMinPvcSize string
 
 	f := framework.NewFramework("dv-func-test")
 
@@ -37,6 +35,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component][crit:high][rfe_id:
 		Expect(err).ToNot(HaveOccurred())
 		originalMinPvcSize, err = utils.GetMinimumSupportedPVCSize(f.CrClient, cloneStorageClassName)
 		Expect(err).ToNot(HaveOccurred())
+		testMinPvcSize = getTestMinPvcSize(originalMinPvcSize)
 	})
 
 	AfterEach(func() {

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -78,7 +78,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests th
 
 var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", Serial, func() {
 	var originalProfileSpec *cdiv1.StorageProfileSpec
-	var originalMinPvcSize, cloneStorageClassName string
+	var originalMinPvcSize, cloneStorageClassName, testMinPvcSize string
 
 	f := framework.NewFramework("dv-func-test")
 
@@ -94,6 +94,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 		Expect(err).ToNot(HaveOccurred())
 		originalMinPvcSize, err = utils.GetMinimumSupportedPVCSize(f.CrClient, cloneStorageClassName)
 		Expect(err).ToNot(HaveOccurred())
+		testMinPvcSize = getTestMinPvcSize(originalMinPvcSize)
 
 		By(fmt.Sprintf("configure storage profile %s", cloneStorageClassName))
 		Expect(
@@ -297,4 +298,15 @@ func createDataVolume(dataVolumeName, testPath string, volumeMode v1.PersistentV
 	f.ForceBindIfWaitForFirstConsumer(pvc)
 
 	return dataVolume, md5
+}
+
+func getTestMinPvcSize(originalMinPvcSize string) string {
+	minSize := "4Gi"
+	if originalMinPvcSize != "" {
+		orig := resource.MustParse(originalMinPvcSize)
+		if orig.Cmp(resource.MustParse(minSize)) > 0 {
+			minSize = originalMinPvcSize
+		}
+	}
+	return minSize
 }

--- a/tests/smartclone_test.go
+++ b/tests/smartclone_test.go
@@ -124,7 +124,7 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]SmartClone tests", 
 		waitForDvPhase(cdiv1.Succeeded, dataVolume, f)
 		f.ExpectEvent(dataVolume.Namespace).Should(ContainSubstring(controller.CloneSucceeded))
 
-		verifyPVCRequestedSize(dataVolume, f, testMinPvcSize)
+		verifyPVCRequestedSizeExceeds(dataVolume, f, testMinPvcSize)
 		verifyPVC(dataVolume, f, utils.DefaultImagePath, expectedMd5)
 	})
 
@@ -227,7 +227,14 @@ func verifyPVCRequestedSize(dataVolume *cdiv1.DataVolume, f *framework.Framework
 	pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	quantity := resource.MustParse(size)
-	Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal((&quantity).Value()))
+	Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(Equal(quantity.Value()))
+}
+
+func verifyPVCRequestedSizeExceeds(dataVolume *cdiv1.DataVolume, f *framework.Framework, minSize string) {
+	pvc, err := f.K8sClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.TODO(), dataVolume.Name, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	minQuantity := resource.MustParse(minSize)
+	Expect(pvc.Spec.Resources.Requests.Storage().Value()).To(BeNumerically(">", minQuantity.Value()))
 }
 
 func waitForDvPhase(phase cdiv1.DataVolumePhase, dataVolume *cdiv1.DataVolume, f *framework.Framework) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When cloning to filesystem, apply the storageProfile effective volume size (minimum supported PVC size) before inflating with filesystem overhead. It helps on cloning from block to filesystem where both have minimum supported size but the target also needs filesystem overhead on top of that, otherwise the pre-clone checks fail.

jira-ticket: https://redhat.atlassian.net/browse/CNV-79503

**Release note**:
```release-note
Fix clone to filesystem PVC sizing when storageProfile minimum applies
```

