### PR TITLE
Fix typo "RatainAll" -> "RetainAll" in DataImportCron docs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4392,7 +4392,7 @@
       "default": ""
      },
      "retentionPolicy": {
-      "description": "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.",
+      "description": "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RetainAll.",
       "type": "string"
      },
      "schedule": {

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -17458,7 +17458,7 @@ func schema_pkg_apis_core_v1beta1_DataImportCronSpec(ref common.ReferenceCallbac
 					},
 					"retentionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.",
+							Description: "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RetainAll.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -5659,7 +5659,7 @@ spec:
               retentionPolicy:
                 description: RetentionPolicy specifies whether the created DataVolumes
                   and DataSources are retained when their DataImportCron is deleted.
-                  Default is RatainAll.
+                  Default is RetainAll.
                 type: string
               schedule:
                 description: Schedule specifies in cron format when and how often

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -617,7 +617,7 @@ type DataImportCronSpec struct {
 	// ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.
 	// DataSource has to be in the same namespace.
 	ManagedDataSource string `json:"managedDataSource"`
-	// RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.
+	// RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RetainAll.
 	// +optional
 	RetentionPolicy *DataImportCronRetentionPolicy `json:"retentionPolicy,omitempty"`
 	// ServiceAccountName is the name of the ServiceAccount for creating DataVolumes.

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -303,7 +303,7 @@ func (DataImportCronSpec) SwaggerDoc() map[string]string {
 		"garbageCollect":     "GarbageCollect specifies whether old PVCs should be cleaned up after a new PVC is imported.\nOptions are currently \"Outdated\" and \"Never\", defaults to \"Outdated\".\n+optional",
 		"importsToKeep":      "Number of import PVCs to keep when garbage collecting. Default is 3.\n+optional",
 		"managedDataSource":  "ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.\nDataSource has to be in the same namespace.",
-		"retentionPolicy":    "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.\n+optional",
+		"retentionPolicy":    "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RetainAll.\n+optional",
 		"serviceAccountName": "ServiceAccountName is the name of the ServiceAccount for creating DataVolumes.\n+optional\n+kubebuilder:validation:MinLength=1",
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes a typo in the DataImportCronSpec.retentionPolicy field description where "RetainAll" was misspelled as "RatainAll". 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

