### PR TITLE
Allow CDI_NAMESPACE to be set externally in test.sh

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -24,7 +24,7 @@
 
 set -ex
 
-export CDI_NAMESPACE="cdi-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)"
+export CDI_NAMESPACE="${CDI_NAMESPACE:-cdi-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)}"
 
 echo "cdi-namespace: ${CDI_NAMESPACE}"
 
@@ -73,8 +73,6 @@ if [[ -z "$UPGRADE_FROM" ]] && [[ -z "$RANDOM_CR" ]]; then
 fi
 
 kubectl() { cluster-up/kubectl.sh "$@"; }
-
-export CDI_NAMESPACE="${CDI_NAMESPACE:-cdi}"
 
 make cluster-down
 # Create .bazelrc to use remote cache


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `CDI_NAMESPACE` in `automation/test.sh` is unconditionally randomized, making it impossible to override from the environment. 
This can be problematic for CI jobs running on shared clusters like in https://github.com/kubevirt/project-infra/pull/4832

This change wraps the assignment with `${CDI_NAMESPACE:-...}` so that an externally set `CDI_NAMESPACE` is honored, while preserving the existing randomization as the default for all other jobs.

/cc @awels @dollierp 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

