### PR TITLE
Fix libnbd Go bindings compilation failure with GCC 15

### DIFF
--- a/vendor/libguestfs.org/libnbd/wrappers.go
+++ b/vendor/libguestfs.org/libnbd/wrappers.go
@@ -2050,7 +2050,7 @@ _nbd_chunk_callback_wrapper (void *user_data, const void *subbuf,
                              size_t count, uint64_t offset, unsigned status,
                              int *error)
 {
-  return chunk_callback ((long)user_data, subbuf, count, offset, status, error);
+  return chunk_callback ((long int *)user_data, (void *)subbuf, count, offset, status, error);
 }
 
 void
@@ -2065,7 +2065,7 @@ _nbd_chunk_callback_free (void *user_data)
 int
 _nbd_completion_callback_wrapper (void *user_data, int *error)
 {
-  return completion_callback ((long)user_data, error);
+  return completion_callback ((long int *)user_data, error);
 }
 
 void
@@ -2081,7 +2081,7 @@ int
 _nbd_debug_callback_wrapper (void *user_data, const char *context,
                              const char *msg)
 {
-  return debug_callback ((long)user_data, context, msg);
+  return debug_callback ((long int *)user_data, (char *)context, (char *)msg);
 }
 
 void
@@ -2098,7 +2098,7 @@ _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
                               uint64_t offset, uint32_t *entries,
                               size_t nr_entries, int *error)
 {
-  return extent_callback ((long)user_data, metacontext, offset, entries, nr_entries, error);
+  return extent_callback ((long int *)user_data, (char *)metacontext, offset, entries, nr_entries, error);
 }
 
 void
@@ -2114,7 +2114,7 @@ int
 _nbd_list_callback_wrapper (void *user_data, const char *name,
                             const char *description)
 {
-  return list_callback ((long)user_data, name, description);
+  return list_callback ((long int *)user_data, (char *)name, (char *)description);
 }
 
 void
@@ -2129,7 +2129,7 @@ _nbd_list_callback_free (void *user_data)
 int
 _nbd_context_callback_wrapper (void *user_data, const char *name)
 {
-  return context_callback ((long)user_data, name);
+  return context_callback ((long int *)user_data, (char *)name);
 }
 
 void

--- a/vendor/libguestfs.org/libnbd/wrappers.h
+++ b/vendor/libguestfs.org/libnbd/wrappers.h
@@ -335,38 +335,38 @@ int _nbd_supports_uri_wrapper (struct error *err,
 char * _nbd_get_uri_wrapper (struct error *err,
         struct nbd_handle *h);
 
-extern int chunk_callback ();
+extern int chunk_callback (long int *callbackid, void *subbuf, size_t count, uint64_t offset, unsigned int status, int *error);
 
 int _nbd_chunk_callback_wrapper (void *user_data, const void *subbuf,
                                  size_t count, uint64_t offset,
                                  unsigned status, int *error);
 void _nbd_chunk_callback_free (void *user_data);
 
-extern int completion_callback ();
+extern int completion_callback (long int *callbackid, int *error);
 
 int _nbd_completion_callback_wrapper (void *user_data, int *error);
 void _nbd_completion_callback_free (void *user_data);
 
-extern int debug_callback ();
+extern int debug_callback (long int *callbackid, char *context, char *msg);
 
 int _nbd_debug_callback_wrapper (void *user_data, const char *context,
                                  const char *msg);
 void _nbd_debug_callback_free (void *user_data);
 
-extern int extent_callback ();
+extern int extent_callback (long int *callbackid, char *metacontext, uint64_t offset, uint32_t *entries, size_t nr_entries, int *error);
 
 int _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
                                   uint64_t offset, uint32_t *entries,
                                   size_t nr_entries, int *error);
 void _nbd_extent_callback_free (void *user_data);
 
-extern int list_callback ();
+extern int list_callback (long int *callbackid, char *name, char *description);
 
 int _nbd_list_callback_wrapper (void *user_data, const char *name,
                                 const char *description);
 void _nbd_list_callback_free (void *user_data);
 
-extern int context_callback ();
+extern int context_callback (long int *callbackid, char *name);
 
 int _nbd_context_callback_wrapper (void *user_data, const char *name);
 void _nbd_context_callback_free (void *user_data);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

GCC 15 defaults to C23 (ISO/IEC 9899:2024), which redefines empty parentheses () in function declarations as (void) — taking zero arguments. Six extern callback declarations in vendor/libguestfs.org/libnbd/wrappers.h used K&R-style empty parentheses (e.g., extern int chunk_callback();). Under C23, these mean "takes no arguments," which conflicts with the multi-parameter definitions that cgo generates from the //export directives in closures.go, producing fatal conflicting types errors on any GCC 15 toolchain.

This PR:
wrappers.h: Replaces all 6 K&R-style declarations with full ANSI C prototypes matching the exact types cgo generates from closures.go.
wrappers.go: Fixes the 6 call sites to use correct pointer casts — (long int *) for the user_data callback ID (was incorrectly cast to integer via (long)), and explicit const-stripping casts where wrapper functions pass const-qualified arguments to the non-const callback signatures.
Affected callbacks: chunk_callback, completion_callback, debug_callback, extent_callback, list_callback, context_callback.

Verified with GCC 15.2.0 (-std=c23 -Wall -Wextra -Werror -Wstrict-prototypes), Apple clang 17 (-std=c23), and backward-compatible with GCC 15 -std=c11.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #3935

**Special notes for your reviewer**:

These are vendored files generated by generator/generator in the upstream [libnbd](https://gitlab.com/nbdkit/libnbd) project. The upstream Go bindings have the same issue this fix should be upstreamed to libnbd so it isn't overwritten on the next vendor update. Until then, this vendored patch is needed to unblock GCC 15 builds (confirmed on openSUSE Tumbleweed via #3935, and affects any distro shipping GCC 15 as default).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

