### PR TITLE
Bump libnbd version from 1.11.5 to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.7
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 	kubevirt.io/qe-tools v0.1.8
-	libguestfs.org/libnbd v1.11.5
+	libguestfs.org/libnbd v1.25.4
 	sigs.k8s.io/controller-runtime v0.19.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3396,8 +3396,8 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/qe-tools v0.1.8 h1:Ar7qicmzHdd+Ia+6rjHDg3D7GReIyq7QFXoC4F7TjhQ=
 kubevirt.io/qe-tools v0.1.8/go.mod h1:+Tr/WZGHIDQa/4pQgzM7+4J6YeVbUWAXESXtL2/zxqc=
-libguestfs.org/libnbd v1.11.5 h1:jRCRxzbeZksdj6e3sp+5/vfDfWx1s/uYyJB0qjgb8MI=
-libguestfs.org/libnbd v1.11.5/go.mod h1:Qd8vaULc6nlNgj9+6qDNm1vSD/J7/wgoIlwmCh8uxAc=
+libguestfs.org/libnbd v1.25.4 h1:RHRp6AkOi/FICrZ6aKbQaDuYbvDC/EgKc7uaS9aea2E=
+libguestfs.org/libnbd v1.25.4/go.mod h1:pSICAuDOpSGplmGmaZ8QettnBAT3IUJFcBU1bVgWgk4=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=

--- a/vendor/libguestfs.org/libnbd/README.md
+++ b/vendor/libguestfs.org/libnbd/README.md
@@ -11,6 +11,6 @@ https://gitlab.com/nbdkit/libnbd
 
 ## License
 
-The software is copyright © Red Hat Inc. and licensed under the GNU
+The software is Copyright Red Hat and licensed under the GNU
 Lesser General Public License version 2 or above (LGPLv2+).  See
 the file `LICENSE` for details.

--- a/vendor/libguestfs.org/libnbd/aio_buffer.go
+++ b/vendor/libguestfs.org/libnbd/aio_buffer.go
@@ -1,5 +1,5 @@
 /* libnbd golang AIO buffer.
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -39,27 +39,61 @@ type AioBuffer struct {
 	Size uint
 }
 
+// MakeAioBuffer makes a new buffer backed by an uninitialized C allocated
+// array.
 func MakeAioBuffer(size uint) AioBuffer {
 	return AioBuffer{C.malloc(C.ulong(size)), size}
 }
 
+// MakeAioBuffer makes a new buffer backed by a C allocated array. The
+// underlying buffer is set to zero.
+func MakeAioBufferZero(size uint) AioBuffer {
+	return AioBuffer{C.calloc(C.ulong(1), C.ulong(size)), size}
+}
+
+// FromBytes makes a new buffer backed by a C allocated array, initialized by
+// copying the given Go slice.
 func FromBytes(buf []byte) AioBuffer {
-	size := len(buf)
-	ret := MakeAioBuffer(uint(size))
-	for i := 0; i < len(buf); i++ {
-		*ret.Get(uint(i)) = buf[i]
-	}
+	ret := MakeAioBuffer(uint(len(buf)))
+	copy(ret.Slice(), buf)
 	return ret
 }
 
+// Free deallocates the underlying C allocated array. Using the buffer after
+// Free() will panic.
 func (b *AioBuffer) Free() {
-	C.free(b.P)
+	if b.P != nil {
+		C.free(b.P)
+		b.P = nil
+	}
 }
 
+// Bytes copies the underlying C array to Go allocated memory and return a
+// slice. Modifying the returned slice does not modify the underlying buffer
+// backing array.
 func (b *AioBuffer) Bytes() []byte {
+	if b.P == nil {
+		panic("Using AioBuffer after Free()")
+	}
 	return C.GoBytes(b.P, C.int(b.Size))
 }
 
+// Slice creates a slice backed by the underlying C array. The slice can be
+// used to access or modify the contents of the underlying array. The slice
+// must not be used after calling Free().
+func (b *AioBuffer) Slice() []byte {
+	if b.P == nil {
+		panic("Using AioBuffer after Free()")
+	}
+	return unsafe.Slice((*byte)(b.P), b.Size)
+}
+
+// Get returns a pointer to a byte in the underlying C array. The pointer can
+// be used to modify the underlying array. The pointer must not be used after
+// calling Free().
 func (b *AioBuffer) Get(i uint) *byte {
+	if b.P == nil {
+		panic("Using AioBuffer after Free()")
+	}
 	return (*byte)(unsafe.Pointer(uintptr(b.P) + uintptr(i)))
 }

--- a/vendor/libguestfs.org/libnbd/bindings.go
+++ b/vendor/libguestfs.org/libnbd/bindings.go
@@ -3,7 +3,7 @@
  * generator/generator
  * ANY CHANGES YOU MAKE TO THIS FILE WILL BE LOST.
  *
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -39,2743 +39,3806 @@ package libnbd
 import "C"
 
 import (
-    "runtime"
-    "unsafe"
+	"runtime"
+	"unsafe"
 )
 
 /* Enums. */
 type Tls int
+
 const (
-    TLS_DISABLE = Tls(0)
-    TLS_ALLOW = Tls(1)
-    TLS_REQUIRE = Tls(2)
+	TLS_DISABLE = Tls(0)
+	TLS_ALLOW   = Tls(1)
+	TLS_REQUIRE = Tls(2)
 )
 
 type Size int
+
 const (
-    SIZE_MINIMUM = Size(0)
-    SIZE_PREFERRED = Size(1)
-    SIZE_MAXIMUM = Size(2)
+	SIZE_MINIMUM   = Size(0)
+	SIZE_PREFERRED = Size(1)
+	SIZE_MAXIMUM   = Size(2)
+	SIZE_PAYLOAD   = Size(3)
 )
 
 /* Flags. */
 type CmdFlag uint32
+
 const (
-    CMD_FLAG_FUA = CmdFlag(0x01)
-    CMD_FLAG_NO_HOLE = CmdFlag(0x02)
-    CMD_FLAG_DF = CmdFlag(0x04)
-    CMD_FLAG_REQ_ONE = CmdFlag(0x08)
-    CMD_FLAG_FAST_ZERO = CmdFlag(0x10)
-    CMD_FLAG_MASK = CmdFlag(0x1f)
+	CMD_FLAG_FUA         = CmdFlag(0x01)
+	CMD_FLAG_NO_HOLE     = CmdFlag(0x02)
+	CMD_FLAG_DF          = CmdFlag(0x04)
+	CMD_FLAG_REQ_ONE     = CmdFlag(0x08)
+	CMD_FLAG_FAST_ZERO   = CmdFlag(0x10)
+	CMD_FLAG_PAYLOAD_LEN = CmdFlag(0x20)
+	CMD_FLAG_MASK        = CmdFlag(0x3f)
 )
 
 type HandshakeFlag uint32
+
 const (
-    HANDSHAKE_FLAG_FIXED_NEWSTYLE = HandshakeFlag(0x01)
-    HANDSHAKE_FLAG_NO_ZEROES = HandshakeFlag(0x02)
-    HANDSHAKE_FLAG_MASK = HandshakeFlag(0x03)
+	HANDSHAKE_FLAG_FIXED_NEWSTYLE = HandshakeFlag(0x01)
+	HANDSHAKE_FLAG_NO_ZEROES      = HandshakeFlag(0x02)
+	HANDSHAKE_FLAG_MASK           = HandshakeFlag(0x03)
 )
 
 type Strict uint32
+
 const (
-    STRICT_COMMANDS = Strict(0x01)
-    STRICT_FLAGS = Strict(0x02)
-    STRICT_BOUNDS = Strict(0x04)
-    STRICT_ZERO_SIZE = Strict(0x08)
-    STRICT_ALIGN = Strict(0x10)
-    STRICT_MASK = Strict(0x1f)
+	STRICT_COMMANDS  = Strict(0x01)
+	STRICT_FLAGS     = Strict(0x02)
+	STRICT_BOUNDS    = Strict(0x04)
+	STRICT_ZERO_SIZE = Strict(0x08)
+	STRICT_ALIGN     = Strict(0x10)
+	STRICT_PAYLOAD   = Strict(0x20)
+	STRICT_AUTO_FLAG = Strict(0x40)
+	STRICT_MASK      = Strict(0x7f)
 )
 
 type AllowTransport uint32
+
 const (
-    ALLOW_TRANSPORT_TCP = AllowTransport(0x01)
-    ALLOW_TRANSPORT_UNIX = AllowTransport(0x02)
-    ALLOW_TRANSPORT_VSOCK = AllowTransport(0x04)
-    ALLOW_TRANSPORT_MASK = AllowTransport(0x07)
+	ALLOW_TRANSPORT_TCP   = AllowTransport(0x01)
+	ALLOW_TRANSPORT_UNIX  = AllowTransport(0x02)
+	ALLOW_TRANSPORT_VSOCK = AllowTransport(0x04)
+	ALLOW_TRANSPORT_SSH   = AllowTransport(0x08)
+	ALLOW_TRANSPORT_MASK  = AllowTransport(0x0f)
 )
 
 type Shutdown uint32
+
 const (
-    SHUTDOWN_ABANDON_PENDING = Shutdown(0x10000)
-    SHUTDOWN_MASK = Shutdown(0x10000)
+	SHUTDOWN_ABANDON_PENDING = Shutdown(0x10000)
+	SHUTDOWN_MASK            = Shutdown(0x10000)
 )
 
 /* Constants. */
 const (
-    AIO_DIRECTION_READ uint32 = 1
-    AIO_DIRECTION_WRITE uint32 = 2
-    AIO_DIRECTION_BOTH uint32 = 3
-    READ_DATA uint32 = 1
-    READ_HOLE uint32 = 2
-    READ_ERROR uint32 = 3
-    namespace_base = "base:"
-    context_base_allocation = "base:allocation"
-    STATE_HOLE uint32 = 1
-    STATE_ZERO uint32 = 2
+	AIO_DIRECTION_READ  uint32 = 1
+	AIO_DIRECTION_WRITE uint32 = 2
+	AIO_DIRECTION_BOTH  uint32 = 3
+	READ_DATA           uint32 = 1
+	READ_HOLE           uint32 = 2
+	READ_ERROR          uint32 = 3
+	/* Meta-context namespace "base" */
+	NAMESPACE_BASE          = "base:"
+	CONTEXT_BASE_ALLOCATION = "base:allocation"
+	/* Defined bits in "base:allocation" */
+	STATE_HOLE uint32 = 1
+	STATE_ZERO uint32 = 2
+	/* Meta-context namespace "qemu" */
+	NAMESPACE_QEMU            = "qemu:"
+	CONTEXT_QEMU_DIRTY_BITMAP = "qemu:dirty-bitmap:"
+	/* Defined bits in "qemu:dirty-bitmap:" */
+	STATE_DIRTY                   uint32 = 1
+	CONTEXT_QEMU_ALLOCATION_DEPTH        = "qemu:allocation-depth"
 )
 
 /* SetDebug: set or clear the debug flag */
-func (h *Libnbd) SetDebug (debug bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_debug")
-    }
+func (h *Libnbd) SetDebug(debug bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_debug")
+	}
 
-    var c_err C.struct_error
-    c_debug := C.bool (debug)
+	var c_err C.struct_error
+	c_debug := C.bool(debug)
 
-    ret := C._nbd_set_debug_wrapper (&c_err, h.h, c_debug)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_debug", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_debug_wrapper(&c_err, h.h, c_debug)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_debug", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetDebug: return the state of the debug flag */
-func (h *Libnbd) GetDebug () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_debug")
-    }
+func (h *Libnbd) GetDebug() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_debug")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_debug_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_debug", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_debug_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_debug", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetDebugCallback: set the debug callback */
-func (h *Libnbd) SetDebugCallback (debug DebugCallback) error {
-    if h.h == nil {
-        return closed_handle_error ("set_debug_callback")
-    }
+func (h *Libnbd) SetDebugCallback(debug DebugCallback) error {
+	if h.h == nil {
+		return closed_handle_error("set_debug_callback")
+	}
 
-    var c_err C.struct_error
-    var c_debug C.nbd_debug_callback
-    c_debug.callback = (*[0]byte)(C._nbd_debug_callback_wrapper)
-    c_debug.free = (*[0]byte)(C._nbd_debug_callback_free)
-    debug_cbid := registerCallbackId(debug)
-    c_debug.user_data = C.alloc_cbid(C.long(debug_cbid))
+	var c_err C.struct_error
+	var c_debug C.nbd_debug_callback
+	c_debug.callback = (*[0]byte)(C._nbd_debug_callback_wrapper)
+	c_debug.free = (*[0]byte)(C._nbd_debug_callback_free)
+	debug_cbid := registerCallbackId(debug)
+	c_debug.user_data = C.alloc_cbid(C.long(debug_cbid))
 
-    ret := C._nbd_set_debug_callback_wrapper (&c_err, h.h, c_debug)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_debug_callback", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_debug_callback_wrapper(&c_err, h.h, c_debug)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_debug_callback", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ClearDebugCallback: clear the debug callback */
-func (h *Libnbd) ClearDebugCallback () error {
-    if h.h == nil {
-        return closed_handle_error ("clear_debug_callback")
-    }
+func (h *Libnbd) ClearDebugCallback() error {
+	if h.h == nil {
+		return closed_handle_error("clear_debug_callback")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_clear_debug_callback_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("clear_debug_callback", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_clear_debug_callback_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("clear_debug_callback", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* StatsBytesSent: statistics of bytes sent over connection so far */
+func (h *Libnbd) StatsBytesSent() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("stats_bytes_sent")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_stats_bytes_sent_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint64(ret), nil
+}
+
+/* StatsChunksSent: statistics of chunks sent over connection so far */
+func (h *Libnbd) StatsChunksSent() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("stats_chunks_sent")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_stats_chunks_sent_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint64(ret), nil
+}
+
+/* StatsBytesReceived: statistics of bytes received over connection so far */
+func (h *Libnbd) StatsBytesReceived() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("stats_bytes_received")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_stats_bytes_received_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint64(ret), nil
+}
+
+/* StatsChunksReceived: statistics of chunks received over connection so far */
+func (h *Libnbd) StatsChunksReceived() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("stats_chunks_received")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_stats_chunks_received_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint64(ret), nil
 }
 
 /* SetHandleName: set the handle name */
-func (h *Libnbd) SetHandleName (handle_name string) error {
-    if h.h == nil {
-        return closed_handle_error ("set_handle_name")
-    }
+func (h *Libnbd) SetHandleName(handle_name string) error {
+	if h.h == nil {
+		return closed_handle_error("set_handle_name")
+	}
 
-    var c_err C.struct_error
-    c_handle_name := C.CString (handle_name)
-    defer C.free (unsafe.Pointer (c_handle_name))
+	var c_err C.struct_error
+	c_handle_name := C.CString(handle_name)
+	defer C.free(unsafe.Pointer(c_handle_name))
 
-    ret := C._nbd_set_handle_name_wrapper (&c_err, h.h, c_handle_name)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_handle_name", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_handle_name_wrapper(&c_err, h.h, c_handle_name)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_handle_name", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetHandleName: get the handle name */
-func (h *Libnbd) GetHandleName () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_handle_name")
-    }
+func (h *Libnbd) GetHandleName() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_handle_name")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_handle_name_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_handle_name", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_handle_name_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_handle_name", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* SetPrivateData: set the per-handle private data */
-func (h *Libnbd) SetPrivateData (private_data uint) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("set_private_data")
-    }
+func (h *Libnbd) SetPrivateData(private_data uint) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("set_private_data")
+	}
 
-    var c_err C.struct_error
-    c_private_data := C.uintptr_t (private_data)
+	var c_err C.struct_error
+	c_private_data := C.uintptr_t(private_data)
 
-    ret := C._nbd_set_private_data_wrapper (&c_err, h.h, c_private_data)
-    runtime.KeepAlive (h.h)
-    return uint (ret), nil
+	ret := C._nbd_set_private_data_wrapper(&c_err, h.h, c_private_data)
+	runtime.KeepAlive(h.h)
+	return uint(ret), nil
 }
 
 /* GetPrivateData: get the per-handle private data */
-func (h *Libnbd) GetPrivateData () (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_private_data")
-    }
+func (h *Libnbd) GetPrivateData() (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_private_data")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_private_data_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    return uint (ret), nil
+	ret := C._nbd_get_private_data_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint(ret), nil
+}
+
+/* GetHandleSize: return an estimate of the memory allocated for the handle */
+func (h *Libnbd) GetHandleSize() (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_handle_size")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_handle_size_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_handle_size", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* SetExportName: set the export name */
-func (h *Libnbd) SetExportName (export_name string) error {
-    if h.h == nil {
-        return closed_handle_error ("set_export_name")
-    }
+func (h *Libnbd) SetExportName(export_name string) error {
+	if h.h == nil {
+		return closed_handle_error("set_export_name")
+	}
 
-    var c_err C.struct_error
-    c_export_name := C.CString (export_name)
-    defer C.free (unsafe.Pointer (c_export_name))
+	var c_err C.struct_error
+	c_export_name := C.CString(export_name)
+	defer C.free(unsafe.Pointer(c_export_name))
 
-    ret := C._nbd_set_export_name_wrapper (&c_err, h.h, c_export_name)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_export_name", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_export_name_wrapper(&c_err, h.h, c_export_name)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_export_name", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetExportName: get the export name */
-func (h *Libnbd) GetExportName () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_export_name")
-    }
+func (h *Libnbd) GetExportName() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_export_name")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_export_name_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_export_name", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_export_name_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_export_name", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
+}
+
+/* SetRequestBlockSize: control whether NBD_OPT_GO requests block size */
+func (h *Libnbd) SetRequestBlockSize(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_request_block_size")
+	}
+
+	var c_err C.struct_error
+	c_request := C.bool(request)
+
+	ret := C._nbd_set_request_block_size_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_request_block_size", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetRequestBlockSize: see if NBD_OPT_GO requests block size */
+func (h *Libnbd) GetRequestBlockSize() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_request_block_size")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_request_block_size_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_request_block_size", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetFullInfo: control whether NBD_OPT_GO requests extra details */
-func (h *Libnbd) SetFullInfo (request bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_full_info")
-    }
+func (h *Libnbd) SetFullInfo(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_full_info")
+	}
 
-    var c_err C.struct_error
-    c_request := C.bool (request)
+	var c_err C.struct_error
+	c_request := C.bool(request)
 
-    ret := C._nbd_set_full_info_wrapper (&c_err, h.h, c_request)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_full_info", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_full_info_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_full_info", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetFullInfo: see if NBD_OPT_GO requests extra details */
-func (h *Libnbd) GetFullInfo () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_full_info")
-    }
+func (h *Libnbd) GetFullInfo() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_full_info")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_full_info_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_full_info", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_full_info_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_full_info", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* GetCanonicalExportName: return the canonical export name, if the server has one */
-func (h *Libnbd) GetCanonicalExportName () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_canonical_export_name")
-    }
+func (h *Libnbd) GetCanonicalExportName() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_canonical_export_name")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_canonical_export_name_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_canonical_export_name", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_canonical_export_name_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_canonical_export_name", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* GetExportDescription: return the export description, if the server has one */
-func (h *Libnbd) GetExportDescription () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_export_description")
-    }
+func (h *Libnbd) GetExportDescription() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_export_description")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_export_description_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_export_description", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_export_description_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_export_description", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* SetTls: enable or require TLS (authentication and encryption) */
-func (h *Libnbd) SetTls (tls Tls) error {
-    if h.h == nil {
-        return closed_handle_error ("set_tls")
-    }
+func (h *Libnbd) SetTls(tls Tls) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls")
+	}
 
-    var c_err C.struct_error
-    c_tls := C.int (tls)
+	var c_err C.struct_error
+	c_tls := C.int(tls)
 
-    ret := C._nbd_set_tls_wrapper (&c_err, h.h, c_tls)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_tls", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_tls_wrapper(&c_err, h.h, c_tls)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetTls: get the TLS request setting */
-func (h *Libnbd) GetTls () (Tls, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_tls")
-    }
+func (h *Libnbd) GetTls() (Tls, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_tls")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_tls_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    return Tls (ret), nil
+	ret := C._nbd_get_tls_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return Tls(ret), nil
 }
 
 /* GetTlsNegotiated: find out if TLS was negotiated on a connection */
-func (h *Libnbd) GetTlsNegotiated () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_tls_negotiated")
-    }
+func (h *Libnbd) GetTlsNegotiated() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_tls_negotiated")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_tls_negotiated_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_tls_negotiated", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_tls_negotiated_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_tls_negotiated", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetTlsCertificates: set the path to the TLS certificates directory */
-func (h *Libnbd) SetTlsCertificates (dir string) error {
-    if h.h == nil {
-        return closed_handle_error ("set_tls_certificates")
-    }
+func (h *Libnbd) SetTlsCertificates(dir string) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_certificates")
+	}
 
-    var c_err C.struct_error
-    c_dir := C.CString (dir)
-    defer C.free (unsafe.Pointer (c_dir))
+	var c_err C.struct_error
+	c_dir := C.CString(dir)
+	defer C.free(unsafe.Pointer(c_dir))
 
-    ret := C._nbd_set_tls_certificates_wrapper (&c_err, h.h, c_dir)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_tls_certificates", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_tls_certificates_wrapper(&c_err, h.h, c_dir)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_certificates", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* SetTlsVerifyPeer: set whether we verify the identity of the server */
-func (h *Libnbd) SetTlsVerifyPeer (verify bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_tls_verify_peer")
-    }
+func (h *Libnbd) SetTlsVerifyPeer(verify bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_verify_peer")
+	}
 
-    var c_err C.struct_error
-    c_verify := C.bool (verify)
+	var c_err C.struct_error
+	c_verify := C.bool(verify)
 
-    ret := C._nbd_set_tls_verify_peer_wrapper (&c_err, h.h, c_verify)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_tls_verify_peer", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_tls_verify_peer_wrapper(&c_err, h.h, c_verify)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_verify_peer", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetTlsVerifyPeer: get whether we verify the identity of the server */
-func (h *Libnbd) GetTlsVerifyPeer () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_tls_verify_peer")
-    }
+func (h *Libnbd) GetTlsVerifyPeer() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_tls_verify_peer")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_tls_verify_peer_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_tls_verify_peer", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_tls_verify_peer_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_tls_verify_peer", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetTlsUsername: set the TLS username */
-func (h *Libnbd) SetTlsUsername (username string) error {
-    if h.h == nil {
-        return closed_handle_error ("set_tls_username")
-    }
+func (h *Libnbd) SetTlsUsername(username string) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_username")
+	}
 
-    var c_err C.struct_error
-    c_username := C.CString (username)
-    defer C.free (unsafe.Pointer (c_username))
+	var c_err C.struct_error
+	c_username := C.CString(username)
+	defer C.free(unsafe.Pointer(c_username))
 
-    ret := C._nbd_set_tls_username_wrapper (&c_err, h.h, c_username)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_tls_username", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_tls_username_wrapper(&c_err, h.h, c_username)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_username", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetTlsUsername: get the current TLS username */
-func (h *Libnbd) GetTlsUsername () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_tls_username")
-    }
+func (h *Libnbd) GetTlsUsername() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_tls_username")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_tls_username_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_tls_username", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_tls_username_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_tls_username", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
+}
+
+/* SetTlsHostname: set the TLS hostname */
+func (h *Libnbd) SetTlsHostname(hostname string) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_hostname")
+	}
+
+	var c_err C.struct_error
+	c_hostname := C.CString(hostname)
+	defer C.free(unsafe.Pointer(c_hostname))
+
+	ret := C._nbd_set_tls_hostname_wrapper(&c_err, h.h, c_hostname)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_hostname", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetTlsHostname: get the effective TLS hostname */
+func (h *Libnbd) GetTlsHostname() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_tls_hostname")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_tls_hostname_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_tls_hostname", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* SetTlsPskFile: set the TLS Pre-Shared Keys (PSK) filename */
-func (h *Libnbd) SetTlsPskFile (filename string) error {
-    if h.h == nil {
-        return closed_handle_error ("set_tls_psk_file")
-    }
+func (h *Libnbd) SetTlsPskFile(filename string) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_psk_file")
+	}
 
-    var c_err C.struct_error
-    c_filename := C.CString (filename)
-    defer C.free (unsafe.Pointer (c_filename))
+	var c_err C.struct_error
+	c_filename := C.CString(filename)
+	defer C.free(unsafe.Pointer(c_filename))
 
-    ret := C._nbd_set_tls_psk_file_wrapper (&c_err, h.h, c_filename)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_tls_psk_file", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_tls_psk_file_wrapper(&c_err, h.h, c_filename)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_psk_file", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* SetTlsPriority: set the TLS priority string */
+func (h *Libnbd) SetTlsPriority(priority string) error {
+	if h.h == nil {
+		return closed_handle_error("set_tls_priority")
+	}
+
+	var c_err C.struct_error
+	c_priority := C.CString(priority)
+	defer C.free(unsafe.Pointer(c_priority))
+
+	ret := C._nbd_set_tls_priority_wrapper(&c_err, h.h, c_priority)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tls_priority", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetTlsPriority: get the current TLS priority */
+func (h *Libnbd) GetTlsPriority() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_tls_priority")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_tls_priority_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_tls_priority", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
+}
+
+/* SetRequestExtendedHeaders: control use of extended headers */
+func (h *Libnbd) SetRequestExtendedHeaders(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_request_extended_headers")
+	}
+
+	var c_err C.struct_error
+	c_request := C.bool(request)
+
+	ret := C._nbd_set_request_extended_headers_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_request_extended_headers", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetRequestExtendedHeaders: see if extended headers are attempted */
+func (h *Libnbd) GetRequestExtendedHeaders() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_request_extended_headers")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_request_extended_headers_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_request_extended_headers", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* GetExtendedHeadersNegotiated: see if extended headers are in use */
+func (h *Libnbd) GetExtendedHeadersNegotiated() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_extended_headers_negotiated")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_extended_headers_negotiated_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_extended_headers_negotiated", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetRequestStructuredReplies: control use of structured replies */
-func (h *Libnbd) SetRequestStructuredReplies (request bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_request_structured_replies")
-    }
+func (h *Libnbd) SetRequestStructuredReplies(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_request_structured_replies")
+	}
 
-    var c_err C.struct_error
-    c_request := C.bool (request)
+	var c_err C.struct_error
+	c_request := C.bool(request)
 
-    ret := C._nbd_set_request_structured_replies_wrapper (&c_err, h.h, c_request)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_request_structured_replies", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_request_structured_replies_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_request_structured_replies", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetRequestStructuredReplies: see if structured replies are attempted */
-func (h *Libnbd) GetRequestStructuredReplies () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_request_structured_replies")
-    }
+func (h *Libnbd) GetRequestStructuredReplies() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_request_structured_replies")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_request_structured_replies_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_request_structured_replies", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_request_structured_replies_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_request_structured_replies", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* GetStructuredRepliesNegotiated: see if structured replies are in use */
-func (h *Libnbd) GetStructuredRepliesNegotiated () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_structured_replies_negotiated")
-    }
+func (h *Libnbd) GetStructuredRepliesNegotiated() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_structured_replies_negotiated")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_structured_replies_negotiated_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_structured_replies_negotiated", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_structured_replies_negotiated_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_structured_replies_negotiated", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* SetRequestMetaContext: control whether connect automatically requests meta contexts */
+func (h *Libnbd) SetRequestMetaContext(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_request_meta_context")
+	}
+
+	var c_err C.struct_error
+	c_request := C.bool(request)
+
+	ret := C._nbd_set_request_meta_context_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_request_meta_context", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetRequestMetaContext: see if connect automatically requests meta contexts */
+func (h *Libnbd) GetRequestMetaContext() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_request_meta_context")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_request_meta_context_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_request_meta_context", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetHandshakeFlags: control use of handshake flags */
-func (h *Libnbd) SetHandshakeFlags (flags HandshakeFlag) error {
-    if h.h == nil {
-        return closed_handle_error ("set_handshake_flags")
-    }
+func (h *Libnbd) SetHandshakeFlags(flags HandshakeFlag) error {
+	if h.h == nil {
+		return closed_handle_error("set_handshake_flags")
+	}
 
-    var c_err C.struct_error
-    c_flags := C.uint32_t (flags)
+	var c_err C.struct_error
+	c_flags := C.uint32_t(flags)
 
-    ret := C._nbd_set_handshake_flags_wrapper (&c_err, h.h, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_handshake_flags", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_handshake_flags_wrapper(&c_err, h.h, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_handshake_flags", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetHandshakeFlags: see which handshake flags are supported */
-func (h *Libnbd) GetHandshakeFlags () (HandshakeFlag, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_handshake_flags")
-    }
+func (h *Libnbd) GetHandshakeFlags() (HandshakeFlag, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_handshake_flags")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_handshake_flags_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    return HandshakeFlag (ret), nil
+	ret := C._nbd_get_handshake_flags_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return HandshakeFlag(ret), nil
+}
+
+/* SetPreadInitialize: control whether libnbd pre-initializes read buffers */
+func (h *Libnbd) SetPreadInitialize(request bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_pread_initialize")
+	}
+
+	var c_err C.struct_error
+	c_request := C.bool(request)
+
+	ret := C._nbd_set_pread_initialize_wrapper(&c_err, h.h, c_request)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_pread_initialize", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetPreadInitialize: see whether libnbd pre-initializes read buffers */
+func (h *Libnbd) GetPreadInitialize() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_pread_initialize")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_pread_initialize_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_pread_initialize", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SetStrictMode: control how strictly to follow NBD protocol */
-func (h *Libnbd) SetStrictMode (flags Strict) error {
-    if h.h == nil {
-        return closed_handle_error ("set_strict_mode")
-    }
+func (h *Libnbd) SetStrictMode(flags Strict) error {
+	if h.h == nil {
+		return closed_handle_error("set_strict_mode")
+	}
 
-    var c_err C.struct_error
-    c_flags := C.uint32_t (flags)
+	var c_err C.struct_error
+	c_flags := C.uint32_t(flags)
 
-    ret := C._nbd_set_strict_mode_wrapper (&c_err, h.h, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_strict_mode", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_strict_mode_wrapper(&c_err, h.h, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_strict_mode", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetStrictMode: see which strictness flags are in effect */
-func (h *Libnbd) GetStrictMode () (Strict, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_strict_mode")
-    }
+func (h *Libnbd) GetStrictMode() (Strict, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_strict_mode")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_strict_mode_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    return Strict (ret), nil
+	ret := C._nbd_get_strict_mode_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return Strict(ret), nil
 }
 
 /* SetOptMode: control option mode, for pausing during option negotiation */
-func (h *Libnbd) SetOptMode (enable bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_opt_mode")
-    }
+func (h *Libnbd) SetOptMode(enable bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_opt_mode")
+	}
 
-    var c_err C.struct_error
-    c_enable := C.bool (enable)
+	var c_err C.struct_error
+	c_enable := C.bool(enable)
 
-    ret := C._nbd_set_opt_mode_wrapper (&c_err, h.h, c_enable)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_opt_mode", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_opt_mode_wrapper(&c_err, h.h, c_enable)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_opt_mode", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetOptMode: return whether option mode was enabled */
-func (h *Libnbd) GetOptMode () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("get_opt_mode")
-    }
+func (h *Libnbd) GetOptMode() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_opt_mode")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_opt_mode_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_opt_mode", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_get_opt_mode_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_opt_mode", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* OptGo: end negotiation and move on to using an export */
-func (h *Libnbd) OptGo () error {
-    if h.h == nil {
-        return closed_handle_error ("opt_go")
-    }
+func (h *Libnbd) OptGo() error {
+	if h.h == nil {
+		return closed_handle_error("opt_go")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_opt_go_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_go", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_opt_go_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_go", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* OptAbort: end negotiation and close the connection */
-func (h *Libnbd) OptAbort () error {
-    if h.h == nil {
-        return closed_handle_error ("opt_abort")
-    }
+func (h *Libnbd) OptAbort() error {
+	if h.h == nil {
+		return closed_handle_error("opt_abort")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_opt_abort_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_abort", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_opt_abort_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_abort", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* OptStarttls: request the server to initiate TLS */
+func (h *Libnbd) OptStarttls() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("opt_starttls")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_opt_starttls_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_starttls", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* OptExtendedHeaders: request the server to enable extended headers */
+func (h *Libnbd) OptExtendedHeaders() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("opt_extended_headers")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_opt_extended_headers_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_extended_headers", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* OptStructuredReply: request the server to enable structured replies */
+func (h *Libnbd) OptStructuredReply() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("opt_structured_reply")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_opt_structured_reply_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_structured_reply", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* OptList: request the server to list all exports during negotiation */
-func (h *Libnbd) OptList (list ListCallback) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("opt_list")
-    }
+func (h *Libnbd) OptList(list ListCallback) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("opt_list")
+	}
 
-    var c_err C.struct_error
-    var c_list C.nbd_list_callback
-    c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
-    c_list.free = (*[0]byte)(C._nbd_list_callback_free)
-    list_cbid := registerCallbackId(list)
-    c_list.user_data = C.alloc_cbid(C.long(list_cbid))
+	var c_err C.struct_error
+	var c_list C.nbd_list_callback
+	c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
+	c_list.free = (*[0]byte)(C._nbd_list_callback_free)
+	list_cbid := registerCallbackId(list)
+	c_list.user_data = C.alloc_cbid(C.long(list_cbid))
 
-    ret := C._nbd_opt_list_wrapper (&c_err, h.h, c_list)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_list", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_opt_list_wrapper(&c_err, h.h, c_list)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_list", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* OptInfo: request the server for information about an export */
-func (h *Libnbd) OptInfo () error {
-    if h.h == nil {
-        return closed_handle_error ("opt_info")
-    }
+func (h *Libnbd) OptInfo() error {
+	if h.h == nil {
+		return closed_handle_error("opt_info")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_opt_info_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_info", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_opt_info_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_info", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
-/* OptListMetaContext: request the server to list available meta contexts */
-func (h *Libnbd) OptListMetaContext (context ContextCallback) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("opt_list_meta_context")
-    }
+/* OptListMetaContext: list available meta contexts, using implicit query list */
+func (h *Libnbd) OptListMetaContext(context ContextCallback) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("opt_list_meta_context")
+	}
 
-    var c_err C.struct_error
-    var c_context C.nbd_context_callback
-    c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
-    c_context.free = (*[0]byte)(C._nbd_context_callback_free)
-    context_cbid := registerCallbackId(context)
-    c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+	var c_err C.struct_error
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
 
-    ret := C._nbd_opt_list_meta_context_wrapper (&c_err, h.h, c_context)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("opt_list_meta_context", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_opt_list_meta_context_wrapper(&c_err, h.h, c_context)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_list_meta_context", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* OptListMetaContextQueries: list available meta contexts, using explicit query list */
+func (h *Libnbd) OptListMetaContextQueries(queries []string, context ContextCallback) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("opt_list_meta_context_queries")
+	}
+
+	var c_err C.struct_error
+	c_queries := arg_string_list(queries)
+	defer free_string_list(c_queries)
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+
+	ret := C._nbd_opt_list_meta_context_queries_wrapper(&c_err, h.h, &c_queries[0], c_context)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_list_meta_context_queries", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* OptSetMetaContext: select specific meta contexts, using implicit query list */
+func (h *Libnbd) OptSetMetaContext(context ContextCallback) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("opt_set_meta_context")
+	}
+
+	var c_err C.struct_error
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+
+	ret := C._nbd_opt_set_meta_context_wrapper(&c_err, h.h, c_context)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_set_meta_context", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* OptSetMetaContextQueries: select specific meta contexts, using explicit query list */
+func (h *Libnbd) OptSetMetaContextQueries(queries []string, context ContextCallback) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("opt_set_meta_context_queries")
+	}
+
+	var c_err C.struct_error
+	c_queries := arg_string_list(queries)
+	defer free_string_list(c_queries)
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+
+	ret := C._nbd_opt_set_meta_context_queries_wrapper(&c_err, h.h, &c_queries[0], c_context)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("opt_set_meta_context_queries", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* AddMetaContext: ask server to negotiate metadata context */
-func (h *Libnbd) AddMetaContext (name string) error {
-    if h.h == nil {
-        return closed_handle_error ("add_meta_context")
-    }
+func (h *Libnbd) AddMetaContext(name string) error {
+	if h.h == nil {
+		return closed_handle_error("add_meta_context")
+	}
 
-    var c_err C.struct_error
-    c_name := C.CString (name)
-    defer C.free (unsafe.Pointer (c_name))
+	var c_err C.struct_error
+	c_name := C.CString(name)
+	defer C.free(unsafe.Pointer(c_name))
 
-    ret := C._nbd_add_meta_context_wrapper (&c_err, h.h, c_name)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("add_meta_context", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_add_meta_context_wrapper(&c_err, h.h, c_name)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("add_meta_context", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* GetNrMetaContexts: return the current number of requested meta contexts */
-func (h *Libnbd) GetNrMetaContexts () (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_nr_meta_contexts")
-    }
+func (h *Libnbd) GetNrMetaContexts() (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_nr_meta_contexts")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_nr_meta_contexts_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_nr_meta_contexts", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_get_nr_meta_contexts_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_nr_meta_contexts", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* GetMetaContext: return the i'th meta context request */
-func (h *Libnbd) GetMetaContext (i int) (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_meta_context")
-    }
+func (h *Libnbd) GetMetaContext(i int) (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_meta_context")
+	}
 
-    var c_err C.struct_error
-    c_i := C.size_t (i)
+	var c_err C.struct_error
+	c_i := C.size_t(i)
 
-    ret := C._nbd_get_meta_context_wrapper (&c_err, h.h, c_i)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_meta_context", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_meta_context_wrapper(&c_err, h.h, c_i)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_meta_context", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* ClearMetaContexts: reset the list of requested meta contexts */
-func (h *Libnbd) ClearMetaContexts () error {
-    if h.h == nil {
-        return closed_handle_error ("clear_meta_contexts")
-    }
+func (h *Libnbd) ClearMetaContexts() error {
+	if h.h == nil {
+		return closed_handle_error("clear_meta_contexts")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_clear_meta_contexts_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("clear_meta_contexts", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_clear_meta_contexts_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("clear_meta_contexts", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* SetUriAllowTransports: set the allowed transports in NBD URIs */
-func (h *Libnbd) SetUriAllowTransports (mask AllowTransport) error {
-    if h.h == nil {
-        return closed_handle_error ("set_uri_allow_transports")
-    }
+func (h *Libnbd) SetUriAllowTransports(mask AllowTransport) error {
+	if h.h == nil {
+		return closed_handle_error("set_uri_allow_transports")
+	}
 
-    var c_err C.struct_error
-    c_mask := C.uint32_t (mask)
+	var c_err C.struct_error
+	c_mask := C.uint32_t(mask)
 
-    ret := C._nbd_set_uri_allow_transports_wrapper (&c_err, h.h, c_mask)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_uri_allow_transports", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_uri_allow_transports_wrapper(&c_err, h.h, c_mask)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_uri_allow_transports", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* SetUriAllowTls: set the allowed TLS settings in NBD URIs */
-func (h *Libnbd) SetUriAllowTls (tls Tls) error {
-    if h.h == nil {
-        return closed_handle_error ("set_uri_allow_tls")
-    }
+func (h *Libnbd) SetUriAllowTls(tls Tls) error {
+	if h.h == nil {
+		return closed_handle_error("set_uri_allow_tls")
+	}
 
-    var c_err C.struct_error
-    c_tls := C.int (tls)
+	var c_err C.struct_error
+	c_tls := C.int(tls)
 
-    ret := C._nbd_set_uri_allow_tls_wrapper (&c_err, h.h, c_tls)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_uri_allow_tls", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_uri_allow_tls_wrapper(&c_err, h.h, c_tls)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_uri_allow_tls", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* SetUriAllowTlsPriority: set if 'tls-priority' is allowed in NBD URIs */
+func (h *Libnbd) SetUriAllowTlsPriority(allow bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_uri_allow_tls_priority")
+	}
+
+	var c_err C.struct_error
+	c_allow := C.bool(allow)
+
+	ret := C._nbd_set_uri_allow_tls_priority_wrapper(&c_err, h.h, c_allow)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_uri_allow_tls_priority", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* SetUriAllowLocalFile: set the allowed transports in NBD URIs */
-func (h *Libnbd) SetUriAllowLocalFile (allow bool) error {
-    if h.h == nil {
-        return closed_handle_error ("set_uri_allow_local_file")
-    }
+func (h *Libnbd) SetUriAllowLocalFile(allow bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_uri_allow_local_file")
+	}
 
-    var c_err C.struct_error
-    c_allow := C.bool (allow)
+	var c_err C.struct_error
+	c_allow := C.bool(allow)
 
-    ret := C._nbd_set_uri_allow_local_file_wrapper (&c_err, h.h, c_allow)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("set_uri_allow_local_file", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_set_uri_allow_local_file_wrapper(&c_err, h.h, c_allow)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_uri_allow_local_file", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectUri: connect to NBD URI */
-func (h *Libnbd) ConnectUri (uri string) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_uri")
-    }
+func (h *Libnbd) ConnectUri(uri string) error {
+	if h.h == nil {
+		return closed_handle_error("connect_uri")
+	}
 
-    var c_err C.struct_error
-    c_uri := C.CString (uri)
-    defer C.free (unsafe.Pointer (c_uri))
+	var c_err C.struct_error
+	c_uri := C.CString(uri)
+	defer C.free(unsafe.Pointer(c_uri))
 
-    ret := C._nbd_connect_uri_wrapper (&c_err, h.h, c_uri)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_uri", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_uri_wrapper(&c_err, h.h, c_uri)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_uri", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectUnix: connect to NBD server over a Unix domain socket */
-func (h *Libnbd) ConnectUnix (unixsocket string) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_unix")
-    }
+func (h *Libnbd) ConnectUnix(unixsocket string) error {
+	if h.h == nil {
+		return closed_handle_error("connect_unix")
+	}
 
-    var c_err C.struct_error
-    c_unixsocket := C.CString (unixsocket)
-    defer C.free (unsafe.Pointer (c_unixsocket))
+	var c_err C.struct_error
+	c_unixsocket := C.CString(unixsocket)
+	defer C.free(unsafe.Pointer(c_unixsocket))
 
-    ret := C._nbd_connect_unix_wrapper (&c_err, h.h, c_unixsocket)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_unix", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_unix_wrapper(&c_err, h.h, c_unixsocket)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_unix", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectVsock: connect to NBD server over AF_VSOCK protocol */
-func (h *Libnbd) ConnectVsock (cid uint32, port uint32) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_vsock")
-    }
+func (h *Libnbd) ConnectVsock(cid uint32, port uint32) error {
+	if h.h == nil {
+		return closed_handle_error("connect_vsock")
+	}
 
-    var c_err C.struct_error
-    c_cid := C.uint32_t (cid)
-    c_port := C.uint32_t (port)
+	var c_err C.struct_error
+	c_cid := C.uint32_t(cid)
+	c_port := C.uint32_t(port)
 
-    ret := C._nbd_connect_vsock_wrapper (&c_err, h.h, c_cid, c_port)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_vsock", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_vsock_wrapper(&c_err, h.h, c_cid, c_port)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_vsock", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectTcp: connect to NBD server over a TCP port */
-func (h *Libnbd) ConnectTcp (hostname string, port string) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_tcp")
-    }
+func (h *Libnbd) ConnectTcp(hostname string, port string) error {
+	if h.h == nil {
+		return closed_handle_error("connect_tcp")
+	}
 
-    var c_err C.struct_error
-    c_hostname := C.CString (hostname)
-    defer C.free (unsafe.Pointer (c_hostname))
-    c_port := C.CString (port)
-    defer C.free (unsafe.Pointer (c_port))
+	var c_err C.struct_error
+	c_hostname := C.CString(hostname)
+	defer C.free(unsafe.Pointer(c_hostname))
+	c_port := C.CString(port)
+	defer C.free(unsafe.Pointer(c_port))
 
-    ret := C._nbd_connect_tcp_wrapper (&c_err, h.h, c_hostname, c_port)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_tcp", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_tcp_wrapper(&c_err, h.h, c_hostname, c_port)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_tcp", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectSocket: connect directly to a connected socket */
-func (h *Libnbd) ConnectSocket (sock int) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_socket")
-    }
+func (h *Libnbd) ConnectSocket(sock int) error {
+	if h.h == nil {
+		return closed_handle_error("connect_socket")
+	}
 
-    var c_err C.struct_error
-    c_sock := C.int (sock)
+	var c_err C.struct_error
+	c_sock := C.int(sock)
 
-    ret := C._nbd_connect_socket_wrapper (&c_err, h.h, c_sock)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_socket", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_socket_wrapper(&c_err, h.h, c_sock)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_socket", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectCommand: connect to NBD server command */
-func (h *Libnbd) ConnectCommand (argv []string) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_command")
-    }
+func (h *Libnbd) ConnectCommand(argv []string) error {
+	if h.h == nil {
+		return closed_handle_error("connect_command")
+	}
 
-    var c_err C.struct_error
-    c_argv := arg_string_list (argv)
-    defer free_string_list (c_argv)
+	var c_err C.struct_error
+	c_argv := arg_string_list(argv)
+	defer free_string_list(c_argv)
 
-    ret := C._nbd_connect_command_wrapper (&c_err, h.h, &c_argv[0])
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_command", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_command_wrapper(&c_err, h.h, &c_argv[0])
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_command", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* ConnectSystemdSocketActivation: connect using systemd socket activation */
-func (h *Libnbd) ConnectSystemdSocketActivation (argv []string) error {
-    if h.h == nil {
-        return closed_handle_error ("connect_systemd_socket_activation")
-    }
+func (h *Libnbd) ConnectSystemdSocketActivation(argv []string) error {
+	if h.h == nil {
+		return closed_handle_error("connect_systemd_socket_activation")
+	}
 
-    var c_err C.struct_error
-    c_argv := arg_string_list (argv)
-    defer free_string_list (c_argv)
+	var c_err C.struct_error
+	c_argv := arg_string_list(argv)
+	defer free_string_list(c_argv)
 
-    ret := C._nbd_connect_systemd_socket_activation_wrapper (&c_err, h.h, &c_argv[0])
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("connect_systemd_socket_activation", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_connect_systemd_socket_activation_wrapper(&c_err, h.h, &c_argv[0])
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("connect_systemd_socket_activation", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* SetSocketActivationName: set the socket activation name */
+func (h *Libnbd) SetSocketActivationName(socket_name string) error {
+	if h.h == nil {
+		return closed_handle_error("set_socket_activation_name")
+	}
+
+	var c_err C.struct_error
+	c_socket_name := C.CString(socket_name)
+	defer C.free(unsafe.Pointer(c_socket_name))
+
+	ret := C._nbd_set_socket_activation_name_wrapper(&c_err, h.h, c_socket_name)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_socket_activation_name", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetSocketActivationName: get the socket activation name */
+func (h *Libnbd) GetSocketActivationName() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_socket_activation_name")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_socket_activation_name_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_socket_activation_name", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
 /* IsReadOnly: is the NBD export read-only? */
-func (h *Libnbd) IsReadOnly () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("is_read_only")
-    }
+func (h *Libnbd) IsReadOnly() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("is_read_only")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_is_read_only_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("is_read_only", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_is_read_only_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("is_read_only", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanFlush: does the server support the flush command? */
-func (h *Libnbd) CanFlush () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_flush")
-    }
+func (h *Libnbd) CanFlush() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_flush")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_flush_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_flush", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_flush_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_flush", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanFua: does the server support the FUA flag? */
-func (h *Libnbd) CanFua () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_fua")
-    }
+func (h *Libnbd) CanFua() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_fua")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_fua_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_fua", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_fua_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_fua", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* IsRotational: is the NBD disk rotational (like a disk)? */
-func (h *Libnbd) IsRotational () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("is_rotational")
-    }
+func (h *Libnbd) IsRotational() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("is_rotational")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_is_rotational_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("is_rotational", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_is_rotational_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("is_rotational", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanTrim: does the server support the trim command? */
-func (h *Libnbd) CanTrim () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_trim")
-    }
+func (h *Libnbd) CanTrim() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_trim")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_trim_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_trim", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_trim_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_trim", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanZero: does the server support the zero command? */
-func (h *Libnbd) CanZero () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_zero")
-    }
+func (h *Libnbd) CanZero() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_zero")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_zero_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_zero", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_zero_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_zero", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanFastZero: does the server support the fast zero flag? */
-func (h *Libnbd) CanFastZero () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_fast_zero")
-    }
+func (h *Libnbd) CanFastZero() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_fast_zero")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_fast_zero_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_fast_zero", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_fast_zero_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_fast_zero", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* CanBlockStatusPayload: does the server support the block status payload flag? */
+func (h *Libnbd) CanBlockStatusPayload() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_block_status_payload")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_can_block_status_payload_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_block_status_payload", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanDf: does the server support the don't fragment flag to pread? */
-func (h *Libnbd) CanDf () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_df")
-    }
+func (h *Libnbd) CanDf() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_df")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_df_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_df", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_df_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_df", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanMultiConn: does the server support multi-conn? */
-func (h *Libnbd) CanMultiConn () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_multi_conn")
-    }
+func (h *Libnbd) CanMultiConn() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_multi_conn")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_multi_conn_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_multi_conn", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_multi_conn_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_multi_conn", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanCache: does the server support the cache command? */
-func (h *Libnbd) CanCache () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_cache")
-    }
+func (h *Libnbd) CanCache() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_cache")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_can_cache_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_cache", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_cache_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_cache", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* CanMetaContext: does the server support a specific meta context? */
-func (h *Libnbd) CanMetaContext (metacontext string) (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("can_meta_context")
-    }
+func (h *Libnbd) CanMetaContext(metacontext string) (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("can_meta_context")
+	}
 
-    var c_err C.struct_error
-    c_metacontext := C.CString (metacontext)
-    defer C.free (unsafe.Pointer (c_metacontext))
+	var c_err C.struct_error
+	c_metacontext := C.CString(metacontext)
+	defer C.free(unsafe.Pointer(c_metacontext))
 
-    ret := C._nbd_can_meta_context_wrapper (&c_err, h.h, c_metacontext)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("can_meta_context", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_can_meta_context_wrapper(&c_err, h.h, c_metacontext)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("can_meta_context", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* GetProtocol: return the NBD protocol variant */
-func (h *Libnbd) GetProtocol () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_protocol")
-    }
+func (h *Libnbd) GetProtocol() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_protocol")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_protocol_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_protocol", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    /* ret is statically allocated, do not free it. */
-    r := C.GoString (ret);
-    return &r, nil
+	ret := C._nbd_get_protocol_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_protocol", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	/* ret is statically allocated, do not free it. */
+	r := C.GoString(ret)
+	return &r, nil
 }
 
 /* GetSize: return the export size */
-func (h *Libnbd) GetSize () (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_size")
-    }
+func (h *Libnbd) GetSize() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_size")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_size_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_size", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_get_size_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_size", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* GetBlockSize: return a specific server block size constraint */
-func (h *Libnbd) GetBlockSize (size_type Size) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("get_block_size")
-    }
+func (h *Libnbd) GetBlockSize(size_type Size) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_block_size")
+	}
 
-    var c_err C.struct_error
-    c_size_type := C.int (size_type)
+	var c_err C.struct_error
+	c_size_type := C.int(size_type)
 
-    ret := C._nbd_get_block_size_wrapper (&c_err, h.h, c_size_type)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("get_block_size", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_get_block_size_wrapper(&c_err, h.h, c_size_type)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_block_size", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for Pread. */
 type PreadOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Pread: read from the NBD server */
-func (h *Libnbd) Pread (buf []byte, offset uint64, optargs *PreadOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("pread")
-    }
+func (h *Libnbd) Pread(buf []byte, offset uint64, optargs *PreadOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("pread")
+	}
 
-    var c_err C.struct_error
-    c_buf := unsafe.Pointer (&buf[0])
-    c_count := C.size_t (len (buf))
-    c_offset := C.uint64_t (offset)
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := unsafe.Pointer(&buf[0])
+	c_count := C.size_t(len(buf))
+	c_offset := C.uint64_t(offset)
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_pread_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("pread", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_pread_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("pread", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for PreadStructured. */
 type PreadStructuredOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* PreadStructured: read from the NBD server */
-func (h *Libnbd) PreadStructured (buf []byte, offset uint64, chunk ChunkCallback, optargs *PreadStructuredOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("pread_structured")
-    }
+func (h *Libnbd) PreadStructured(buf []byte, offset uint64, chunk ChunkCallback, optargs *PreadStructuredOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("pread_structured")
+	}
 
-    var c_err C.struct_error
-    c_buf := unsafe.Pointer (&buf[0])
-    c_count := C.size_t (len (buf))
-    c_offset := C.uint64_t (offset)
-    var c_chunk C.nbd_chunk_callback
-    c_chunk.callback = (*[0]byte)(C._nbd_chunk_callback_wrapper)
-    c_chunk.free = (*[0]byte)(C._nbd_chunk_callback_free)
-    chunk_cbid := registerCallbackId(chunk)
-    c_chunk.user_data = C.alloc_cbid(C.long(chunk_cbid))
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := unsafe.Pointer(&buf[0])
+	c_count := C.size_t(len(buf))
+	c_offset := C.uint64_t(offset)
+	var c_chunk C.nbd_chunk_callback
+	c_chunk.callback = (*[0]byte)(C._nbd_chunk_callback_wrapper)
+	c_chunk.free = (*[0]byte)(C._nbd_chunk_callback_free)
+	chunk_cbid := registerCallbackId(chunk)
+	c_chunk.user_data = C.alloc_cbid(C.long(chunk_cbid))
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_pread_structured_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_chunk, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("pread_structured", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_pread_structured_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_chunk, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("pread_structured", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Pwrite. */
 type PwriteOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Pwrite: write to the NBD server */
-func (h *Libnbd) Pwrite (buf []byte, offset uint64, optargs *PwriteOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("pwrite")
-    }
+func (h *Libnbd) Pwrite(buf []byte, offset uint64, optargs *PwriteOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("pwrite")
+	}
 
-    var c_err C.struct_error
-    c_buf := unsafe.Pointer (&buf[0])
-    c_count := C.size_t (len (buf))
-    c_offset := C.uint64_t (offset)
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := unsafe.Pointer(&buf[0])
+	c_count := C.size_t(len(buf))
+	c_offset := C.uint64_t(offset)
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_pwrite_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("pwrite", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_pwrite_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("pwrite", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Shutdown. */
 type ShutdownOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags Shutdown
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    Shutdown
 }
 
 /* Shutdown: disconnect from the NBD server */
-func (h *Libnbd) Shutdown (optargs *ShutdownOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("shutdown")
-    }
+func (h *Libnbd) Shutdown(optargs *ShutdownOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("shutdown")
+	}
 
-    var c_err C.struct_error
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_shutdown_wrapper (&c_err, h.h, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("shutdown", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_shutdown_wrapper(&c_err, h.h, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("shutdown", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Flush. */
 type FlushOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Flush: send flush command to the NBD server */
-func (h *Libnbd) Flush (optargs *FlushOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("flush")
-    }
+func (h *Libnbd) Flush(optargs *FlushOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("flush")
+	}
 
-    var c_err C.struct_error
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_flush_wrapper (&c_err, h.h, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("flush", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_flush_wrapper(&c_err, h.h, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("flush", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Trim. */
 type TrimOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Trim: send trim command to the NBD server */
-func (h *Libnbd) Trim (count uint64, offset uint64, optargs *TrimOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("trim")
-    }
+func (h *Libnbd) Trim(count uint64, offset uint64, optargs *TrimOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("trim")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_trim_wrapper (&c_err, h.h, c_count, c_offset, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("trim", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_trim_wrapper(&c_err, h.h, c_count, c_offset, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("trim", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Cache. */
 type CacheOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Cache: send cache (prefetch) command to the NBD server */
-func (h *Libnbd) Cache (count uint64, offset uint64, optargs *CacheOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("cache")
-    }
+func (h *Libnbd) Cache(count uint64, offset uint64, optargs *CacheOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("cache")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_cache_wrapper (&c_err, h.h, c_count, c_offset, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("cache", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_cache_wrapper(&c_err, h.h, c_count, c_offset, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("cache", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for Zero. */
 type ZeroOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* Zero: send write zeroes command to the NBD server */
-func (h *Libnbd) Zero (count uint64, offset uint64, optargs *ZeroOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("zero")
-    }
+func (h *Libnbd) Zero(count uint64, offset uint64, optargs *ZeroOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("zero")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_zero_wrapper (&c_err, h.h, c_count, c_offset, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("zero", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_zero_wrapper(&c_err, h.h, c_count, c_offset, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("zero", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for BlockStatus. */
 type BlockStatusOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
-/* BlockStatus: send block status command to the NBD server */
-func (h *Libnbd) BlockStatus (count uint64, offset uint64, extent ExtentCallback, optargs *BlockStatusOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("block_status")
-    }
+/* BlockStatus: send block status command, with 32-bit callback */
+func (h *Libnbd) BlockStatus(count uint64, offset uint64, extent ExtentCallback, optargs *BlockStatusOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("block_status")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_extent C.nbd_extent_callback
-    c_extent.callback = (*[0]byte)(C._nbd_extent_callback_wrapper)
-    c_extent.free = (*[0]byte)(C._nbd_extent_callback_free)
-    extent_cbid := registerCallbackId(extent)
-    c_extent.user_data = C.alloc_cbid(C.long(extent_cbid))
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_extent C.nbd_extent_callback
+	c_extent.callback = (*[0]byte)(C._nbd_extent_callback_wrapper)
+	c_extent.free = (*[0]byte)(C._nbd_extent_callback_free)
+	extent_cbid := registerCallbackId(extent)
+	c_extent.user_data = C.alloc_cbid(C.long(extent_cbid))
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_block_status_wrapper (&c_err, h.h, c_count, c_offset, c_extent, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("block_status", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_block_status_wrapper(&c_err, h.h, c_count, c_offset, c_extent, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("block_status", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* Struct carrying optional arguments for BlockStatus64. */
+type BlockStatus64Optargs struct {
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
+}
+
+/* BlockStatus64: send block status command, with 64-bit callback */
+func (h *Libnbd) BlockStatus64(count uint64, offset uint64, extent64 Extent64Callback, optargs *BlockStatus64Optargs) error {
+	if h.h == nil {
+		return closed_handle_error("block_status_64")
+	}
+
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_extent64 C.nbd_extent64_callback
+	c_extent64.callback = (*[0]byte)(C._nbd_extent64_callback_wrapper)
+	c_extent64.free = (*[0]byte)(C._nbd_extent64_callback_free)
+	extent64_cbid := registerCallbackId(extent64)
+	c_extent64.user_data = C.alloc_cbid(C.long(extent64_cbid))
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
+
+	ret := C._nbd_block_status_64_wrapper(&c_err, h.h, c_count, c_offset, c_extent64, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("block_status_64", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* Struct carrying optional arguments for BlockStatusFilter. */
+type BlockStatusFilterOptargs struct {
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
+}
+
+/* BlockStatusFilter: send filtered block status command, with 64-bit callback */
+func (h *Libnbd) BlockStatusFilter(count uint64, offset uint64, contexts []string, extent64 Extent64Callback, optargs *BlockStatusFilterOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("block_status_filter")
+	}
+
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	c_contexts := arg_string_list(contexts)
+	defer free_string_list(c_contexts)
+	var c_extent64 C.nbd_extent64_callback
+	c_extent64.callback = (*[0]byte)(C._nbd_extent64_callback_wrapper)
+	c_extent64.free = (*[0]byte)(C._nbd_extent64_callback_free)
+	extent64_cbid := registerCallbackId(extent64)
+	c_extent64.user_data = C.alloc_cbid(C.long(extent64_cbid))
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
+
+	ret := C._nbd_block_status_filter_wrapper(&c_err, h.h, c_count, c_offset, &c_contexts[0], c_extent64, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("block_status_filter", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Poll: poll the handle once */
-func (h *Libnbd) Poll (timeout int) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("poll")
-    }
+func (h *Libnbd) Poll(timeout int) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("poll")
+	}
 
-    var c_err C.struct_error
-    c_timeout := C.int (timeout)
+	var c_err C.struct_error
+	c_timeout := C.int(timeout)
 
-    ret := C._nbd_poll_wrapper (&c_err, h.h, c_timeout)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("poll", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_poll_wrapper(&c_err, h.h, c_timeout)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("poll", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* Poll2: poll the handle once, with fd */
+func (h *Libnbd) Poll2(fd int, timeout int) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("poll2")
+	}
+
+	var c_err C.struct_error
+	c_fd := C.int(fd)
+	c_timeout := C.int(timeout)
+
+	ret := C._nbd_poll2_wrapper(&c_err, h.h, c_fd, c_timeout)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("poll2", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* AioConnect: connect to the NBD server */
-func (h *Libnbd) AioConnect (addr string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect")
-    }
+func (h *Libnbd) AioConnect(addr string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect")
+	}
 
-    var c_err C.struct_error
-    panic ("SockAddrAndLen not supported")
-    var c_addr *C.struct_sockaddr
-    var c_addrlen C.uint
+	var c_err C.struct_error
+	panic("SockAddrAndLen not supported")
+	var c_addr *C.struct_sockaddr
+	var c_addrlen C.uint
 
-    ret := C._nbd_aio_connect_wrapper (&c_err, h.h, c_addr, c_addrlen)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_wrapper(&c_err, h.h, c_addr, c_addrlen)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectUri: connect to an NBD URI */
-func (h *Libnbd) AioConnectUri (uri string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_uri")
-    }
+func (h *Libnbd) AioConnectUri(uri string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_uri")
+	}
 
-    var c_err C.struct_error
-    c_uri := C.CString (uri)
-    defer C.free (unsafe.Pointer (c_uri))
+	var c_err C.struct_error
+	c_uri := C.CString(uri)
+	defer C.free(unsafe.Pointer(c_uri))
 
-    ret := C._nbd_aio_connect_uri_wrapper (&c_err, h.h, c_uri)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_uri", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_uri_wrapper(&c_err, h.h, c_uri)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_uri", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectUnix: connect to the NBD server over a Unix domain socket */
-func (h *Libnbd) AioConnectUnix (unixsocket string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_unix")
-    }
+func (h *Libnbd) AioConnectUnix(unixsocket string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_unix")
+	}
 
-    var c_err C.struct_error
-    c_unixsocket := C.CString (unixsocket)
-    defer C.free (unsafe.Pointer (c_unixsocket))
+	var c_err C.struct_error
+	c_unixsocket := C.CString(unixsocket)
+	defer C.free(unsafe.Pointer(c_unixsocket))
 
-    ret := C._nbd_aio_connect_unix_wrapper (&c_err, h.h, c_unixsocket)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_unix", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_unix_wrapper(&c_err, h.h, c_unixsocket)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_unix", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectVsock: connect to the NBD server over AF_VSOCK socket */
-func (h *Libnbd) AioConnectVsock (cid uint32, port uint32) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_vsock")
-    }
+func (h *Libnbd) AioConnectVsock(cid uint32, port uint32) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_vsock")
+	}
 
-    var c_err C.struct_error
-    c_cid := C.uint32_t (cid)
-    c_port := C.uint32_t (port)
+	var c_err C.struct_error
+	c_cid := C.uint32_t(cid)
+	c_port := C.uint32_t(port)
 
-    ret := C._nbd_aio_connect_vsock_wrapper (&c_err, h.h, c_cid, c_port)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_vsock", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_vsock_wrapper(&c_err, h.h, c_cid, c_port)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_vsock", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectTcp: connect to the NBD server over a TCP port */
-func (h *Libnbd) AioConnectTcp (hostname string, port string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_tcp")
-    }
+func (h *Libnbd) AioConnectTcp(hostname string, port string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_tcp")
+	}
 
-    var c_err C.struct_error
-    c_hostname := C.CString (hostname)
-    defer C.free (unsafe.Pointer (c_hostname))
-    c_port := C.CString (port)
-    defer C.free (unsafe.Pointer (c_port))
+	var c_err C.struct_error
+	c_hostname := C.CString(hostname)
+	defer C.free(unsafe.Pointer(c_hostname))
+	c_port := C.CString(port)
+	defer C.free(unsafe.Pointer(c_port))
 
-    ret := C._nbd_aio_connect_tcp_wrapper (&c_err, h.h, c_hostname, c_port)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_tcp", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_tcp_wrapper(&c_err, h.h, c_hostname, c_port)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_tcp", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectSocket: connect directly to a connected socket */
-func (h *Libnbd) AioConnectSocket (sock int) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_socket")
-    }
+func (h *Libnbd) AioConnectSocket(sock int) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_socket")
+	}
 
-    var c_err C.struct_error
-    c_sock := C.int (sock)
+	var c_err C.struct_error
+	c_sock := C.int(sock)
 
-    ret := C._nbd_aio_connect_socket_wrapper (&c_err, h.h, c_sock)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_socket", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_socket_wrapper(&c_err, h.h, c_sock)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_socket", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectCommand: connect to the NBD server */
-func (h *Libnbd) AioConnectCommand (argv []string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_command")
-    }
+func (h *Libnbd) AioConnectCommand(argv []string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_command")
+	}
 
-    var c_err C.struct_error
-    c_argv := arg_string_list (argv)
-    defer free_string_list (c_argv)
+	var c_err C.struct_error
+	c_argv := arg_string_list(argv)
+	defer free_string_list(c_argv)
 
-    ret := C._nbd_aio_connect_command_wrapper (&c_err, h.h, &c_argv[0])
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_command", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_command_wrapper(&c_err, h.h, &c_argv[0])
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_command", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioConnectSystemdSocketActivation: connect using systemd socket activation */
-func (h *Libnbd) AioConnectSystemdSocketActivation (argv []string) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_connect_systemd_socket_activation")
-    }
+func (h *Libnbd) AioConnectSystemdSocketActivation(argv []string) error {
+	if h.h == nil {
+		return closed_handle_error("aio_connect_systemd_socket_activation")
+	}
 
-    var c_err C.struct_error
-    c_argv := arg_string_list (argv)
-    defer free_string_list (c_argv)
+	var c_err C.struct_error
+	c_argv := arg_string_list(argv)
+	defer free_string_list(c_argv)
 
-    ret := C._nbd_aio_connect_systemd_socket_activation_wrapper (&c_err, h.h, &c_argv[0])
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_connect_systemd_socket_activation", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_connect_systemd_socket_activation_wrapper(&c_err, h.h, &c_argv[0])
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_connect_systemd_socket_activation", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for AioOptGo. */
 type AioOptGoOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
 }
 
 /* AioOptGo: end negotiation and move on to using an export */
-func (h *Libnbd) AioOptGo (optargs *AioOptGoOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_go")
-    }
+func (h *Libnbd) AioOptGo(optargs *AioOptGoOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_go")
+	}
 
-    var c_err C.struct_error
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-    }
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
 
-    ret := C._nbd_aio_opt_go_wrapper (&c_err, h.h, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_go", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_opt_go_wrapper(&c_err, h.h, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_go", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioOptAbort: end negotiation and close the connection */
-func (h *Libnbd) AioOptAbort () error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_abort")
-    }
+func (h *Libnbd) AioOptAbort() error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_abort")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_opt_abort_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_abort", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_opt_abort_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_abort", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* Struct carrying optional arguments for AioOptStarttls. */
+type AioOptStarttlsOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptStarttls: request the server to initiate TLS */
+func (h *Libnbd) AioOptStarttls(optargs *AioOptStarttlsOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_starttls")
+	}
+
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_starttls_wrapper(&c_err, h.h, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_starttls", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* Struct carrying optional arguments for AioOptExtendedHeaders. */
+type AioOptExtendedHeadersOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptExtendedHeaders: request the server to enable extended headers */
+func (h *Libnbd) AioOptExtendedHeaders(optargs *AioOptExtendedHeadersOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_extended_headers")
+	}
+
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_extended_headers_wrapper(&c_err, h.h, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_extended_headers", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* Struct carrying optional arguments for AioOptStructuredReply. */
+type AioOptStructuredReplyOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptStructuredReply: request the server to enable structured replies */
+func (h *Libnbd) AioOptStructuredReply(optargs *AioOptStructuredReplyOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_structured_reply")
+	}
+
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_structured_reply_wrapper(&c_err, h.h, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_structured_reply", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for AioOptList. */
 type AioOptListOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
 }
 
 /* AioOptList: request the server to list all exports during negotiation */
-func (h *Libnbd) AioOptList (list ListCallback, optargs *AioOptListOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_list")
-    }
+func (h *Libnbd) AioOptList(list ListCallback, optargs *AioOptListOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_list")
+	}
 
-    var c_err C.struct_error
-    var c_list C.nbd_list_callback
-    c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
-    c_list.free = (*[0]byte)(C._nbd_list_callback_free)
-    list_cbid := registerCallbackId(list)
-    c_list.user_data = C.alloc_cbid(C.long(list_cbid))
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-    }
+	var c_err C.struct_error
+	var c_list C.nbd_list_callback
+	c_list.callback = (*[0]byte)(C._nbd_list_callback_wrapper)
+	c_list.free = (*[0]byte)(C._nbd_list_callback_free)
+	list_cbid := registerCallbackId(list)
+	c_list.user_data = C.alloc_cbid(C.long(list_cbid))
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
 
-    ret := C._nbd_aio_opt_list_wrapper (&c_err, h.h, c_list, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_list", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_opt_list_wrapper(&c_err, h.h, c_list, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_list", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for AioOptInfo. */
 type AioOptInfoOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
 }
 
 /* AioOptInfo: request the server for information about an export */
-func (h *Libnbd) AioOptInfo (optargs *AioOptInfoOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_opt_info")
-    }
+func (h *Libnbd) AioOptInfo(optargs *AioOptInfoOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_opt_info")
+	}
 
-    var c_err C.struct_error
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-    }
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
 
-    ret := C._nbd_aio_opt_info_wrapper (&c_err, h.h, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_info", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_opt_info_wrapper(&c_err, h.h, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_info", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for AioOptListMetaContext. */
 type AioOptListMetaContextOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
 }
 
-/* AioOptListMetaContext: request the server to list available meta contexts */
-func (h *Libnbd) AioOptListMetaContext (context ContextCallback, optargs *AioOptListMetaContextOptargs) (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_opt_list_meta_context")
-    }
+/* AioOptListMetaContext: request list of available meta contexts, using implicit query */
+func (h *Libnbd) AioOptListMetaContext(context ContextCallback, optargs *AioOptListMetaContextOptargs) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_opt_list_meta_context")
+	}
 
-    var c_err C.struct_error
-    var c_context C.nbd_context_callback
-    c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
-    c_context.free = (*[0]byte)(C._nbd_context_callback_free)
-    context_cbid := registerCallbackId(context)
-    c_context.user_data = C.alloc_cbid(C.long(context_cbid))
-    var c_completion C.nbd_completion_callback
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-    }
+	var c_err C.struct_error
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
 
-    ret := C._nbd_aio_opt_list_meta_context_wrapper (&c_err, h.h, c_context, c_completion)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_opt_list_meta_context", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_aio_opt_list_meta_context_wrapper(&c_err, h.h, c_context, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_list_meta_context", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* Struct carrying optional arguments for AioOptListMetaContextQueries. */
+type AioOptListMetaContextQueriesOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptListMetaContextQueries: request list of available meta contexts, using explicit query */
+func (h *Libnbd) AioOptListMetaContextQueries(queries []string, context ContextCallback, optargs *AioOptListMetaContextQueriesOptargs) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_opt_list_meta_context_queries")
+	}
+
+	var c_err C.struct_error
+	c_queries := arg_string_list(queries)
+	defer free_string_list(c_queries)
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_list_meta_context_queries_wrapper(&c_err, h.h, &c_queries[0], c_context, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_list_meta_context_queries", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* Struct carrying optional arguments for AioOptSetMetaContext. */
+type AioOptSetMetaContextOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptSetMetaContext: select specific meta contexts, with implicit query list */
+func (h *Libnbd) AioOptSetMetaContext(context ContextCallback, optargs *AioOptSetMetaContextOptargs) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_opt_set_meta_context")
+	}
+
+	var c_err C.struct_error
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_set_meta_context_wrapper(&c_err, h.h, c_context, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_set_meta_context", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
+}
+
+/* Struct carrying optional arguments for AioOptSetMetaContextQueries. */
+type AioOptSetMetaContextQueriesOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+}
+
+/* AioOptSetMetaContextQueries: select specific meta contexts, with explicit query list */
+func (h *Libnbd) AioOptSetMetaContextQueries(queries []string, context ContextCallback, optargs *AioOptSetMetaContextQueriesOptargs) (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_opt_set_meta_context_queries")
+	}
+
+	var c_err C.struct_error
+	c_queries := arg_string_list(queries)
+	defer free_string_list(c_queries)
+	var c_context C.nbd_context_callback
+	c_context.callback = (*[0]byte)(C._nbd_context_callback_wrapper)
+	c_context.free = (*[0]byte)(C._nbd_context_callback_free)
+	context_cbid := registerCallbackId(context)
+	c_context.user_data = C.alloc_cbid(C.long(context_cbid))
+	var c_completion C.nbd_completion_callback
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+	}
+
+	ret := C._nbd_aio_opt_set_meta_context_queries_wrapper(&c_err, h.h, &c_queries[0], c_context, c_completion)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_opt_set_meta_context_queries", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* Struct carrying optional arguments for AioPread. */
 type AioPreadOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioPread: read from the NBD server */
-func (h *Libnbd) AioPread (buf AioBuffer, offset uint64, optargs *AioPreadOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_pread")
-    }
+func (h *Libnbd) AioPread(buf AioBuffer, offset uint64, optargs *AioPreadOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_pread")
+	}
 
-    var c_err C.struct_error
-    c_buf := buf.P
-    c_count := C.size_t (buf.Size)
-    c_offset := C.uint64_t (offset)
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := buf.P
+	c_count := C.size_t(buf.Size)
+	c_offset := C.uint64_t(offset)
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_pread_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_pread", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_pread_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_pread", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioPreadStructured. */
 type AioPreadStructuredOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioPreadStructured: read from the NBD server */
-func (h *Libnbd) AioPreadStructured (buf AioBuffer, offset uint64, chunk ChunkCallback, optargs *AioPreadStructuredOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_pread_structured")
-    }
+func (h *Libnbd) AioPreadStructured(buf AioBuffer, offset uint64, chunk ChunkCallback, optargs *AioPreadStructuredOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_pread_structured")
+	}
 
-    var c_err C.struct_error
-    c_buf := buf.P
-    c_count := C.size_t (buf.Size)
-    c_offset := C.uint64_t (offset)
-    var c_chunk C.nbd_chunk_callback
-    c_chunk.callback = (*[0]byte)(C._nbd_chunk_callback_wrapper)
-    c_chunk.free = (*[0]byte)(C._nbd_chunk_callback_free)
-    chunk_cbid := registerCallbackId(chunk)
-    c_chunk.user_data = C.alloc_cbid(C.long(chunk_cbid))
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := buf.P
+	c_count := C.size_t(buf.Size)
+	c_offset := C.uint64_t(offset)
+	var c_chunk C.nbd_chunk_callback
+	c_chunk.callback = (*[0]byte)(C._nbd_chunk_callback_wrapper)
+	c_chunk.free = (*[0]byte)(C._nbd_chunk_callback_free)
+	chunk_cbid := registerCallbackId(chunk)
+	c_chunk.user_data = C.alloc_cbid(C.long(chunk_cbid))
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_pread_structured_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_chunk, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_pread_structured", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_pread_structured_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_chunk, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_pread_structured", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioPwrite. */
 type AioPwriteOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioPwrite: write to the NBD server */
-func (h *Libnbd) AioPwrite (buf AioBuffer, offset uint64, optargs *AioPwriteOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_pwrite")
-    }
+func (h *Libnbd) AioPwrite(buf AioBuffer, offset uint64, optargs *AioPwriteOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_pwrite")
+	}
 
-    var c_err C.struct_error
-    c_buf := buf.P
-    c_count := C.size_t (buf.Size)
-    c_offset := C.uint64_t (offset)
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_buf := buf.P
+	c_count := C.size_t(buf.Size)
+	c_offset := C.uint64_t(offset)
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_pwrite_wrapper (&c_err, h.h, c_buf, c_count, c_offset, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_pwrite", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_pwrite_wrapper(&c_err, h.h, c_buf, c_count, c_offset, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_pwrite", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioDisconnect. */
 type AioDisconnectOptargs struct {
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioDisconnect: disconnect from the NBD server */
-func (h *Libnbd) AioDisconnect (optargs *AioDisconnectOptargs) error {
-    if h.h == nil {
-        return closed_handle_error ("aio_disconnect")
-    }
+func (h *Libnbd) AioDisconnect(optargs *AioDisconnectOptargs) error {
+	if h.h == nil {
+		return closed_handle_error("aio_disconnect")
+	}
 
-    var c_err C.struct_error
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_disconnect_wrapper (&c_err, h.h, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_disconnect", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_disconnect_wrapper(&c_err, h.h, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_disconnect", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* Struct carrying optional arguments for AioFlush. */
 type AioFlushOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioFlush: send flush command to the NBD server */
-func (h *Libnbd) AioFlush (optargs *AioFlushOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_flush")
-    }
+func (h *Libnbd) AioFlush(optargs *AioFlushOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_flush")
+	}
 
-    var c_err C.struct_error
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_flush_wrapper (&c_err, h.h, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_flush", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_flush_wrapper(&c_err, h.h, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_flush", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioTrim. */
 type AioTrimOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioTrim: send trim command to the NBD server */
-func (h *Libnbd) AioTrim (count uint64, offset uint64, optargs *AioTrimOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_trim")
-    }
+func (h *Libnbd) AioTrim(count uint64, offset uint64, optargs *AioTrimOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_trim")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_trim_wrapper (&c_err, h.h, c_count, c_offset, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_trim", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_trim_wrapper(&c_err, h.h, c_count, c_offset, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_trim", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioCache. */
 type AioCacheOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioCache: send cache (prefetch) command to the NBD server */
-func (h *Libnbd) AioCache (count uint64, offset uint64, optargs *AioCacheOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_cache")
-    }
+func (h *Libnbd) AioCache(count uint64, offset uint64, optargs *AioCacheOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_cache")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_cache_wrapper (&c_err, h.h, c_count, c_offset, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_cache", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_cache_wrapper(&c_err, h.h, c_count, c_offset, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_cache", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioZero. */
 type AioZeroOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
 /* AioZero: send write zeroes command to the NBD server */
-func (h *Libnbd) AioZero (count uint64, offset uint64, optargs *AioZeroOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_zero")
-    }
+func (h *Libnbd) AioZero(count uint64, offset uint64, optargs *AioZeroOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_zero")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_zero_wrapper (&c_err, h.h, c_count, c_offset, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_zero", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_zero_wrapper(&c_err, h.h, c_count, c_offset, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_zero", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* Struct carrying optional arguments for AioBlockStatus. */
 type AioBlockStatusOptargs struct {
-  /* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
-  CompletionCallbackSet bool
-  CompletionCallback CompletionCallback
-  /* Flags field is ignored unless FlagsSet == true. */
-  FlagsSet bool
-  Flags CmdFlag
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
 }
 
-/* AioBlockStatus: send block status command to the NBD server */
-func (h *Libnbd) AioBlockStatus (count uint64, offset uint64, extent ExtentCallback, optargs *AioBlockStatusOptargs) (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_block_status")
-    }
+/* AioBlockStatus: send block status command, with 32-bit callback */
+func (h *Libnbd) AioBlockStatus(count uint64, offset uint64, extent ExtentCallback, optargs *AioBlockStatusOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_block_status")
+	}
 
-    var c_err C.struct_error
-    c_count := C.uint64_t (count)
-    c_offset := C.uint64_t (offset)
-    var c_extent C.nbd_extent_callback
-    c_extent.callback = (*[0]byte)(C._nbd_extent_callback_wrapper)
-    c_extent.free = (*[0]byte)(C._nbd_extent_callback_free)
-    extent_cbid := registerCallbackId(extent)
-    c_extent.user_data = C.alloc_cbid(C.long(extent_cbid))
-    var c_completion C.nbd_completion_callback
-    var c_flags C.uint32_t
-    if optargs != nil {
-        if optargs.CompletionCallbackSet {
-            c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
-            c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
-            completion_cbid := registerCallbackId(optargs.CompletionCallback)
-            c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
-        }
-        if optargs.FlagsSet {
-            c_flags = C.uint32_t (optargs.Flags)
-        }
-    }
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_extent C.nbd_extent_callback
+	c_extent.callback = (*[0]byte)(C._nbd_extent_callback_wrapper)
+	c_extent.free = (*[0]byte)(C._nbd_extent_callback_free)
+	extent_cbid := registerCallbackId(extent)
+	c_extent.user_data = C.alloc_cbid(C.long(extent_cbid))
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
 
-    ret := C._nbd_aio_block_status_wrapper (&c_err, h.h, c_count, c_offset, c_extent, c_completion, c_flags)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_block_status", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_block_status_wrapper(&c_err, h.h, c_count, c_offset, c_extent, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_block_status", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
+}
+
+/* Struct carrying optional arguments for AioBlockStatus64. */
+type AioBlockStatus64Optargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
+}
+
+/* AioBlockStatus64: send block status command, with 64-bit callback */
+func (h *Libnbd) AioBlockStatus64(count uint64, offset uint64, extent64 Extent64Callback, optargs *AioBlockStatus64Optargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_block_status_64")
+	}
+
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	var c_extent64 C.nbd_extent64_callback
+	c_extent64.callback = (*[0]byte)(C._nbd_extent64_callback_wrapper)
+	c_extent64.free = (*[0]byte)(C._nbd_extent64_callback_free)
+	extent64_cbid := registerCallbackId(extent64)
+	c_extent64.user_data = C.alloc_cbid(C.long(extent64_cbid))
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
+
+	ret := C._nbd_aio_block_status_64_wrapper(&c_err, h.h, c_count, c_offset, c_extent64, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_block_status_64", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
+}
+
+/* Struct carrying optional arguments for AioBlockStatusFilter. */
+type AioBlockStatusFilterOptargs struct {
+	/* CompletionCallback field is ignored unless CompletionCallbackSet == true. */
+	CompletionCallbackSet bool
+	CompletionCallback    CompletionCallback
+	/* Flags field is ignored unless FlagsSet == true. */
+	FlagsSet bool
+	Flags    CmdFlag
+}
+
+/* AioBlockStatusFilter: send filtered block status command to the NBD server */
+func (h *Libnbd) AioBlockStatusFilter(count uint64, offset uint64, contexts []string, extent64 Extent64Callback, optargs *AioBlockStatusFilterOptargs) (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_block_status_filter")
+	}
+
+	var c_err C.struct_error
+	c_count := C.uint64_t(count)
+	c_offset := C.uint64_t(offset)
+	c_contexts := arg_string_list(contexts)
+	defer free_string_list(c_contexts)
+	var c_extent64 C.nbd_extent64_callback
+	c_extent64.callback = (*[0]byte)(C._nbd_extent64_callback_wrapper)
+	c_extent64.free = (*[0]byte)(C._nbd_extent64_callback_free)
+	extent64_cbid := registerCallbackId(extent64)
+	c_extent64.user_data = C.alloc_cbid(C.long(extent64_cbid))
+	var c_completion C.nbd_completion_callback
+	var c_flags C.uint32_t
+	if optargs != nil {
+		if optargs.CompletionCallbackSet {
+			c_completion.callback = (*[0]byte)(C._nbd_completion_callback_wrapper)
+			c_completion.free = (*[0]byte)(C._nbd_completion_callback_free)
+			completion_cbid := registerCallbackId(optargs.CompletionCallback)
+			c_completion.user_data = C.alloc_cbid(C.long(completion_cbid))
+		}
+		if optargs.FlagsSet {
+			c_flags = C.uint32_t(optargs.Flags)
+		}
+	}
+
+	ret := C._nbd_aio_block_status_filter_wrapper(&c_err, h.h, c_count, c_offset, &c_contexts[0], c_extent64, c_completion, c_flags)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_block_status_filter", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* AioGetFd: return file descriptor associated with this connection */
-func (h *Libnbd) AioGetFd () (int, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_get_fd")
-    }
+func (h *Libnbd) AioGetFd() (int, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_get_fd")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_get_fd_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_get_fd", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return int (ret), nil
+	ret := C._nbd_aio_get_fd_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_get_fd", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return int(ret), nil
 }
 
 /* AioGetDirection: return the read or write direction */
-func (h *Libnbd) AioGetDirection () (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_get_direction")
-    }
+func (h *Libnbd) AioGetDirection() (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_get_direction")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_get_direction_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    return uint (ret), nil
+	ret := C._nbd_aio_get_direction_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	return uint(ret), nil
 }
 
 /* AioNotifyRead: notify that the connection is readable */
-func (h *Libnbd) AioNotifyRead () error {
-    if h.h == nil {
-        return closed_handle_error ("aio_notify_read")
-    }
+func (h *Libnbd) AioNotifyRead() error {
+	if h.h == nil {
+		return closed_handle_error("aio_notify_read")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_notify_read_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_notify_read", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_notify_read_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_notify_read", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioNotifyWrite: notify that the connection is writable */
-func (h *Libnbd) AioNotifyWrite () error {
-    if h.h == nil {
-        return closed_handle_error ("aio_notify_write")
-    }
+func (h *Libnbd) AioNotifyWrite() error {
+	if h.h == nil {
+		return closed_handle_error("aio_notify_write")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_notify_write_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_notify_write", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_aio_notify_write_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_notify_write", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
 }
 
 /* AioIsCreated: check if the connection has just been created */
-func (h *Libnbd) AioIsCreated () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_created")
-    }
+func (h *Libnbd) AioIsCreated() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_created")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_created_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_created", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_created_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_created", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsConnecting: check if the connection is connecting or handshaking */
-func (h *Libnbd) AioIsConnecting () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_connecting")
-    }
+func (h *Libnbd) AioIsConnecting() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_connecting")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_connecting_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_connecting", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_connecting_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_connecting", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsNegotiating: check if connection is ready to send handshake option */
-func (h *Libnbd) AioIsNegotiating () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_negotiating")
-    }
+func (h *Libnbd) AioIsNegotiating() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_negotiating")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_negotiating_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_negotiating", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_negotiating_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_negotiating", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsReady: check if the connection is in the ready state */
-func (h *Libnbd) AioIsReady () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_ready")
-    }
+func (h *Libnbd) AioIsReady() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_ready")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_ready_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_ready", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_ready_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_ready", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsProcessing: check if the connection is processing a command */
-func (h *Libnbd) AioIsProcessing () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_processing")
-    }
+func (h *Libnbd) AioIsProcessing() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_processing")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_processing_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_processing", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_processing_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_processing", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsDead: check if the connection is dead */
-func (h *Libnbd) AioIsDead () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_dead")
-    }
+func (h *Libnbd) AioIsDead() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_dead")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_dead_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_dead", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_dead_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_dead", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioIsClosed: check if the connection is closed */
-func (h *Libnbd) AioIsClosed () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_is_closed")
-    }
+func (h *Libnbd) AioIsClosed() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_is_closed")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_is_closed_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_is_closed", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_is_closed_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_is_closed", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioCommandCompleted: check if the command completed */
-func (h *Libnbd) AioCommandCompleted (cookie uint64) (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("aio_command_completed")
-    }
+func (h *Libnbd) AioCommandCompleted(cookie uint64) (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("aio_command_completed")
+	}
 
-    var c_err C.struct_error
-    c_cookie := C.uint64_t (cookie)
+	var c_err C.struct_error
+	c_cookie := C.uint64_t(cookie)
 
-    ret := C._nbd_aio_command_completed_wrapper (&c_err, h.h, c_cookie)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_command_completed", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_aio_command_completed_wrapper(&c_err, h.h, c_cookie)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_command_completed", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* AioPeekCommandCompleted: check if any command has completed */
-func (h *Libnbd) AioPeekCommandCompleted () (uint64, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_peek_command_completed")
-    }
+func (h *Libnbd) AioPeekCommandCompleted() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_peek_command_completed")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_peek_command_completed_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_peek_command_completed", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint64 (ret), nil
+	ret := C._nbd_aio_peek_command_completed_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_peek_command_completed", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* AioInFlight: check how many aio commands are still in flight */
-func (h *Libnbd) AioInFlight () (uint, error) {
-    if h.h == nil {
-        return 0, closed_handle_error ("aio_in_flight")
-    }
+func (h *Libnbd) AioInFlight() (uint, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("aio_in_flight")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_aio_in_flight_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("aio_in_flight", c_err)
-        C.free_error (&c_err)
-        return 0, err
-    }
-    return uint (ret), nil
+	ret := C._nbd_aio_in_flight_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("aio_in_flight", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint(ret), nil
 }
 
 /* ConnectionState: return string describing the state of the connection */
-func (h *Libnbd) ConnectionState () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("connection_state")
-    }
+func (h *Libnbd) ConnectionState() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("connection_state")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_connection_state_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("connection_state", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    /* ret is statically allocated, do not free it. */
-    r := C.GoString (ret);
-    return &r, nil
+	ret := C._nbd_connection_state_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("connection_state", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	/* ret is statically allocated, do not free it. */
+	r := C.GoString(ret)
+	return &r, nil
 }
 
 /* GetPackageName: return the name of the library */
-func (h *Libnbd) GetPackageName () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_package_name")
-    }
+func (h *Libnbd) GetPackageName() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_package_name")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_package_name_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_package_name", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    /* ret is statically allocated, do not free it. */
-    r := C.GoString (ret);
-    return &r, nil
+	ret := C._nbd_get_package_name_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_package_name", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	/* ret is statically allocated, do not free it. */
+	r := C.GoString(ret)
+	return &r, nil
 }
 
 /* GetVersion: return the version of the library */
-func (h *Libnbd) GetVersion () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_version")
-    }
+func (h *Libnbd) GetVersion() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_version")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_version_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_version", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    /* ret is statically allocated, do not free it. */
-    r := C.GoString (ret);
-    return &r, nil
+	ret := C._nbd_get_version_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_version", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	/* ret is statically allocated, do not free it. */
+	r := C.GoString(ret)
+	return &r, nil
+}
+
+/* GetVersionExtra: return the extra version of the library */
+func (h *Libnbd) GetVersionExtra() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_version_extra")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_version_extra_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_version_extra", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	/* ret is statically allocated, do not free it. */
+	r := C.GoString(ret)
+	return &r, nil
 }
 
 /* KillSubprocess: kill server running as a subprocess */
-func (h *Libnbd) KillSubprocess (signum int) error {
-    if h.h == nil {
-        return closed_handle_error ("kill_subprocess")
-    }
+func (h *Libnbd) KillSubprocess(signum int) error {
+	if h.h == nil {
+		return closed_handle_error("kill_subprocess")
+	}
 
-    var c_err C.struct_error
-    c_signum := C.int (signum)
+	var c_err C.struct_error
+	c_signum := C.int(signum)
 
-    ret := C._nbd_kill_subprocess_wrapper (&c_err, h.h, c_signum)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("kill_subprocess", c_err)
-        C.free_error (&c_err)
-        return err
-    }
-    return nil
+	ret := C._nbd_kill_subprocess_wrapper(&c_err, h.h, c_signum)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("kill_subprocess", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetSubprocessPid: get the process ID of the subprocess */
+func (h *Libnbd) GetSubprocessPid() (uint64, error) {
+	if h.h == nil {
+		return 0, closed_handle_error("get_subprocess_pid")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_subprocess_pid_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_subprocess_pid", c_err)
+		C.free_error(&c_err)
+		return 0, err
+	}
+	return uint64(ret), nil
 }
 
 /* SupportsTls: true if libnbd was compiled with support for TLS */
-func (h *Libnbd) SupportsTls () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("supports_tls")
-    }
+func (h *Libnbd) SupportsTls() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("supports_tls")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_supports_tls_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("supports_tls", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_supports_tls_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("supports_tls", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* SupportsVsock: true if libnbd was compiled with support for AF_VSOCK */
+func (h *Libnbd) SupportsVsock() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("supports_vsock")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_supports_vsock_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("supports_vsock", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* SupportsUri: true if libnbd was compiled with support for NBD URIs */
-func (h *Libnbd) SupportsUri () (bool, error) {
-    if h.h == nil {
-        return false, closed_handle_error ("supports_uri")
-    }
+func (h *Libnbd) SupportsUri() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("supports_uri")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_supports_uri_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == -1 {
-        err := get_error ("supports_uri", c_err)
-        C.free_error (&c_err)
-        return false, err
-    }
-    r := int (ret)
-    if r != 0 { return true, nil } else { return false, nil }
+	ret := C._nbd_supports_uri_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("supports_uri", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
 }
 
 /* GetUri: construct an NBD URI for a connection */
-func (h *Libnbd) GetUri () (*string, error) {
-    if h.h == nil {
-        return nil, closed_handle_error ("get_uri")
-    }
+func (h *Libnbd) GetUri() (*string, error) {
+	if h.h == nil {
+		return nil, closed_handle_error("get_uri")
+	}
 
-    var c_err C.struct_error
+	var c_err C.struct_error
 
-    ret := C._nbd_get_uri_wrapper (&c_err, h.h)
-    runtime.KeepAlive (h.h)
-    if ret == nil {
-        err := get_error ("get_uri", c_err)
-        C.free_error (&c_err)
-        return nil, err
-    }
-    r := C.GoString (ret)
-    C.free (unsafe.Pointer (ret))
-    return &r, nil
+	ret := C._nbd_get_uri_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == nil {
+		err := get_error("get_uri", c_err)
+		C.free_error(&c_err)
+		return nil, err
+	}
+	r := C.GoString(ret)
+	C.free(unsafe.Pointer(ret))
+	return &r, nil
 }
 
+/* IsUri: detect if a string could be an NBD URI */
+func (h *Libnbd) IsUri(uri string) (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("is_uri")
+	}
+
+	var c_err C.struct_error
+	c_uri := C.CString(uri)
+	defer C.free(unsafe.Pointer(c_uri))
+
+	ret := C._nbd_is_uri_wrapper(&c_err, h.h, c_uri)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("is_uri", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* SetKeepalive: set keepalive on the socket */
+func (h *Libnbd) SetKeepalive(enable bool) error {
+	if h.h == nil {
+		return closed_handle_error("set_keepalive")
+	}
+
+	var c_err C.struct_error
+	c_enable := C.bool(enable)
+
+	ret := C._nbd_set_keepalive_wrapper(&c_err, h.h, c_enable)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_keepalive", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}
+
+/* GetKeepalive: return keepalive status */
+func (h *Libnbd) GetKeepalive() (bool, error) {
+	if h.h == nil {
+		return false, closed_handle_error("get_keepalive")
+	}
+
+	var c_err C.struct_error
+
+	ret := C._nbd_get_keepalive_wrapper(&c_err, h.h)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("get_keepalive", c_err)
+		C.free_error(&c_err)
+		return false, err
+	}
+	return int(ret) != 0, nil
+}
+
+/* SetTcpOption: set TCP options on the socket */
+func (h *Libnbd) SetTcpOption(option int, v int) error {
+	if h.h == nil {
+		return closed_handle_error("set_tcp_option")
+	}
+
+	var c_err C.struct_error
+	c_option := C.int(option)
+	c_v := C.int(v)
+
+	ret := C._nbd_set_tcp_option_wrapper(&c_err, h.h, c_option, c_v)
+	runtime.KeepAlive(h.h)
+	if ret == -1 {
+		err := get_error("set_tcp_option", c_err)
+		C.free_error(&c_err)
+		return err
+	}
+	return nil
+}

--- a/vendor/libguestfs.org/libnbd/callbacks.go
+++ b/vendor/libguestfs.org/libnbd/callbacks.go
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  *
  * Copyright (c) 2013 Alex Zorin
- * Copyright (C) 2016 Red Hat, Inc.
+ * Copyright Red Hat
  *
  */
 
@@ -36,7 +36,7 @@ package libnbd
 // - Create an exported Golang function whose job will be to retrieve
 //   the context and execute the callback in it
 //   (connErrCallback). Such a function should receive a callback ID
-//   and will use it to retrive the context.
+//   and will use it to retrieve the context.
 //
 // - Create a CGO function similar to the above function but with the
 //   appropriate signature to be registered as a callback in C code
@@ -54,7 +54,8 @@ package libnbd
 //   with registerCallbackId and invoke the CGO function from the
 //   previous step with the appropriate ID.
 //
-// - When unregistering the callback, don't forget to call freecallbackId.
+// - When unregistering the callback, don't forget to call
+//   nbd_internal_freeCallbackId.
 //
 // If you need to associate some additional data with the connection,
 // look at saveConnectionData, getConnectionData and
@@ -71,8 +72,8 @@ var goCallbackLock sync.RWMutex
 var goCallbacks = make(map[int]interface{})
 var nextGoCallbackId int = firstGoCallbackId
 
-//export freeCallbackId
-func freeCallbackId(goCallbackId int) {
+//export nbd_internal_freeCallbackId
+func nbd_internal_freeCallbackId(goCallbackId int) {
 	goCallbackLock.Lock()
 	delete(goCallbacks, goCallbackId)
 	goCallbackLock.Unlock()
@@ -84,7 +85,7 @@ func getCallbackId(goCallbackId int) interface{} {
 	goCallbackLock.RUnlock()
 	if ctx == nil {
 		// If this happens there must be a bug in libvirt
-		panic("Callback arrived after freeCallbackId was called")
+		panic("Callback arrived after nbd_internal_freeCallbackId was called")
 	}
 	return ctx
 }

--- a/vendor/libguestfs.org/libnbd/closures.go
+++ b/vendor/libguestfs.org/libnbd/closures.go
@@ -3,7 +3,7 @@
  * generator/generator
  * ANY CHANGES YOU MAKE TO THIS FILE WILL BE LOST.
  *
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,95 +37,120 @@ import "unsafe"
 
 /* Closures. */
 
-func copy_uint32_array (entries *C.uint32_t, count C.size_t) []uint32 {
-    ret := make([]uint32, int (count))
-    for i := 0; i < int (count); i++ {
-       entry := (*C.uint32_t) (unsafe.Pointer(uintptr(unsafe.Pointer(entries)) + (unsafe.Sizeof(*entries) * uintptr(i))))
-       ret[i] = uint32 (*entry)
-    }
-    return ret
-}
-type ChunkCallback func (subbuf []byte, offset uint64, status uint, error *int) int
-
-//export chunk_callback
-func chunk_callback (callbackid *C.long, subbuf unsafe.Pointer, count C.size_t, offset C.uint64_t, status C.uint, error *C.int) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(ChunkCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    go_error := int (*error)
-    ret := callback (C.GoBytes (subbuf, C.int (count)), uint64 (offset), uint (status), &go_error)
-    *error = C.int (go_error)
-    return C.int (ret);
+func copy_uint32_array(entries *C.uint32_t, count C.size_t) []uint32 {
+	ret := make([]uint32, count)
+	s := unsafe.Slice(entries, count)
+	for i, item := range s {
+		ret[i] = uint32(item)
+	}
+	return ret
 }
 
-type CompletionCallback func (error *int) int
-
-//export completion_callback
-func completion_callback (callbackid *C.long, error *C.int) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(CompletionCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    go_error := int (*error)
-    ret := callback (&go_error)
-    *error = C.int (go_error)
-    return C.int (ret);
+func copy_extent_array(entries *C.nbd_extent, count C.size_t) []LibnbdExtent {
+	ret := make([]LibnbdExtent, count)
+	s := unsafe.Slice(entries, count)
+	for i, item := range s {
+		ret[i].Length = uint64(item.length)
+		ret[i].Flags = uint64(item.flags)
+	}
+	return ret
 }
 
-type DebugCallback func (context string, msg string) int
+type ChunkCallback func(subbuf []byte, offset uint64, status uint, error *int) int
 
-//export debug_callback
-func debug_callback (callbackid *C.long, context *C.char, msg *C.char) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(DebugCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    ret := callback (C.GoString (context), C.GoString (msg))
-    return C.int (ret);
+//export _nbd_dispatch_chunk_callback
+func _nbd_dispatch_chunk_callback(callbackid *C.long, subbuf unsafe.Pointer, count C.size_t, offset C.uint64_t, status C.uint, error *C.int) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(ChunkCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	go_error := int(*error)
+	ret := callback(C.GoBytes(subbuf, C.int(count)), uint64(offset), uint(status), &go_error)
+	*error = C.int(go_error)
+	return C.int(ret)
 }
 
-type ExtentCallback func (metacontext string, offset uint64, entries []uint32, error *int) int
+type CompletionCallback func(error *int) int
 
-//export extent_callback
-func extent_callback (callbackid *C.long, metacontext *C.char, offset C.uint64_t, entries *C.uint32_t, nr_entries C.size_t, error *C.int) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(ExtentCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    go_error := int (*error)
-    ret := callback (C.GoString (metacontext), uint64 (offset), copy_uint32_array (entries, nr_entries), &go_error)
-    *error = C.int (go_error)
-    return C.int (ret);
+//export _nbd_dispatch_completion_callback
+func _nbd_dispatch_completion_callback(callbackid *C.long, error *C.int) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(CompletionCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	go_error := int(*error)
+	ret := callback(&go_error)
+	*error = C.int(go_error)
+	return C.int(ret)
 }
 
-type ListCallback func (name string, description string) int
+type DebugCallback func(context string, msg string) int
 
-//export list_callback
-func list_callback (callbackid *C.long, name *C.char, description *C.char) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(ListCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    ret := callback (C.GoString (name), C.GoString (description))
-    return C.int (ret);
+//export _nbd_dispatch_debug_callback
+func _nbd_dispatch_debug_callback(callbackid *C.long, context *C.char, msg *C.char) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(DebugCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	ret := callback(C.GoString(context), C.GoString(msg))
+	return C.int(ret)
 }
 
-type ContextCallback func (name string) int
+type ExtentCallback func(metacontext string, offset uint64, entries []uint32, error *int) int
 
-//export context_callback
-func context_callback (callbackid *C.long, name *C.char) C.int {
-    callbackFunc := getCallbackId (int (*callbackid));
-    callback, ok := callbackFunc.(ContextCallback);
-    if !ok {
-        panic ("inappropriate callback type");
-    }
-    ret := callback (C.GoString (name))
-    return C.int (ret);
+//export _nbd_dispatch_extent_callback
+func _nbd_dispatch_extent_callback(callbackid *C.long, metacontext *C.char, offset C.uint64_t, entries *C.uint32_t, nr_entries C.size_t, error *C.int) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(ExtentCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	go_error := int(*error)
+	ret := callback(C.GoString(metacontext), uint64(offset), copy_uint32_array(entries, nr_entries), &go_error)
+	*error = C.int(go_error)
+	return C.int(ret)
 }
 
+type Extent64Callback func(metacontext string, offset uint64, entries []LibnbdExtent, error *int) int
+
+//export _nbd_dispatch_extent64_callback
+func _nbd_dispatch_extent64_callback(callbackid *C.long, metacontext *C.char, offset C.uint64_t, entries *C.nbd_extent, nr_entries C.size_t, error *C.int) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(Extent64Callback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	go_error := int(*error)
+	ret := callback(C.GoString(metacontext), uint64(offset), copy_extent_array(entries, nr_entries), &go_error)
+	*error = C.int(go_error)
+	return C.int(ret)
+}
+
+type ListCallback func(name string, description string) int
+
+//export _nbd_dispatch_list_callback
+func _nbd_dispatch_list_callback(callbackid *C.long, name *C.char, description *C.char) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(ListCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	ret := callback(C.GoString(name), C.GoString(description))
+	return C.int(ret)
+}
+
+type ContextCallback func(name string) int
+
+//export _nbd_dispatch_context_callback
+func _nbd_dispatch_context_callback(callbackid *C.long, name *C.char) C.int {
+	callbackFunc := getCallbackId(int(*callbackid))
+	callback, ok := callbackFunc.(ContextCallback)
+	if !ok {
+		panic("inappropriate callback type")
+	}
+	ret := callback(C.GoString(name))
+	return C.int(ret)
+}

--- a/vendor/libguestfs.org/libnbd/handle.go
+++ b/vendor/libguestfs.org/libnbd/handle.go
@@ -1,5 +1,5 @@
 /* libnbd golang handle.
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,6 +56,12 @@ type Libnbd struct {
 /* Convert handle to string (just for debugging). */
 func (h *Libnbd) String() string {
 	return "&Libnbd{}"
+}
+
+/* Used for block status callback. */
+type LibnbdExtent struct {
+	Length uint64 // length of the extent
+	Flags  uint64 // flags describing properties of the extent
 }
 
 /* All functions (except Close) return ([result,] LibnbdError). */

--- a/vendor/libguestfs.org/libnbd/wrappers.go
+++ b/vendor/libguestfs.org/libnbd/wrappers.go
@@ -3,7 +3,7 @@
  * generator/generator
  * ANY CHANGES YOU MAKE TO THIS FILE WILL BE LOST.
  *
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -101,6 +101,62 @@ _nbd_clear_debug_callback_wrapper (struct error *err,
 #endif
 }
 
+uint64_t
+_nbd_stats_bytes_sent_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_STATS_BYTES_SENT
+  uint64_t ret;
+
+  ret = nbd_stats_bytes_sent (h);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_STATS_BYTES_SENT
+  missing_function (err, "stats_bytes_sent");
+#endif
+}
+
+uint64_t
+_nbd_stats_chunks_sent_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_STATS_CHUNKS_SENT
+  uint64_t ret;
+
+  ret = nbd_stats_chunks_sent (h);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_STATS_CHUNKS_SENT
+  missing_function (err, "stats_chunks_sent");
+#endif
+}
+
+uint64_t
+_nbd_stats_bytes_received_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_STATS_BYTES_RECEIVED
+  uint64_t ret;
+
+  ret = nbd_stats_bytes_received (h);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_STATS_BYTES_RECEIVED
+  missing_function (err, "stats_bytes_received");
+#endif
+}
+
+uint64_t
+_nbd_stats_chunks_received_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_STATS_CHUNKS_RECEIVED
+  uint64_t ret;
+
+  ret = nbd_stats_chunks_received (h);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_STATS_CHUNKS_RECEIVED
+  missing_function (err, "stats_chunks_received");
+#endif
+}
+
 int
 _nbd_set_handle_name_wrapper (struct error *err,
         struct nbd_handle *h, const char *handle_name)
@@ -163,6 +219,23 @@ _nbd_get_private_data_wrapper (struct error *err,
 #endif
 }
 
+ssize_t
+_nbd_get_handle_size_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_HANDLE_SIZE
+  ssize_t ret;
+
+  ret = nbd_get_handle_size (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_HANDLE_SIZE
+  missing_function (err, "get_handle_size");
+  return -1;
+#endif
+}
+
 int
 _nbd_set_export_name_wrapper (struct error *err,
         struct nbd_handle *h, const char *export_name)
@@ -194,6 +267,40 @@ _nbd_get_export_name_wrapper (struct error *err,
 #else // !LIBNBD_HAVE_NBD_GET_EXPORT_NAME
   missing_function (err, "get_export_name");
   return NULL;
+#endif
+}
+
+int
+_nbd_set_request_block_size_wrapper (struct error *err,
+        struct nbd_handle *h, bool request)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_REQUEST_BLOCK_SIZE
+  int ret;
+
+  ret = nbd_set_request_block_size (h, request);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_REQUEST_BLOCK_SIZE
+  missing_function (err, "set_request_block_size");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_request_block_size_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_REQUEST_BLOCK_SIZE
+  int ret;
+
+  ret = nbd_get_request_block_size (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_REQUEST_BLOCK_SIZE
+  missing_function (err, "get_request_block_size");
+  return -1;
 #endif
 }
 
@@ -399,6 +506,40 @@ _nbd_get_tls_username_wrapper (struct error *err,
 }
 
 int
+_nbd_set_tls_hostname_wrapper (struct error *err,
+        struct nbd_handle *h, const char *hostname)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_TLS_HOSTNAME
+  int ret;
+
+  ret = nbd_set_tls_hostname (h, hostname);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_TLS_HOSTNAME
+  missing_function (err, "set_tls_hostname");
+  return -1;
+#endif
+}
+
+char *
+_nbd_get_tls_hostname_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_TLS_HOSTNAME
+  char * ret;
+
+  ret = nbd_get_tls_hostname (h);
+  if (ret == NULL)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_TLS_HOSTNAME
+  missing_function (err, "get_tls_hostname");
+  return NULL;
+#endif
+}
+
+int
 _nbd_set_tls_psk_file_wrapper (struct error *err,
         struct nbd_handle *h, const char *filename)
 {
@@ -411,6 +552,91 @@ _nbd_set_tls_psk_file_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_SET_TLS_PSK_FILE
   missing_function (err, "set_tls_psk_file");
+  return -1;
+#endif
+}
+
+int
+_nbd_set_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h, const char *priority)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_TLS_PRIORITY
+  int ret;
+
+  ret = nbd_set_tls_priority (h, priority);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_TLS_PRIORITY
+  missing_function (err, "set_tls_priority");
+  return -1;
+#endif
+}
+
+char *
+_nbd_get_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_TLS_PRIORITY
+  char * ret;
+
+  ret = nbd_get_tls_priority (h);
+  if (ret == NULL)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_TLS_PRIORITY
+  missing_function (err, "get_tls_priority");
+  return NULL;
+#endif
+}
+
+int
+_nbd_set_request_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h, bool request)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_REQUEST_EXTENDED_HEADERS
+  int ret;
+
+  ret = nbd_set_request_extended_headers (h, request);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_REQUEST_EXTENDED_HEADERS
+  missing_function (err, "set_request_extended_headers");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_request_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_REQUEST_EXTENDED_HEADERS
+  int ret;
+
+  ret = nbd_get_request_extended_headers (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_REQUEST_EXTENDED_HEADERS
+  missing_function (err, "get_request_extended_headers");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_extended_headers_negotiated_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_EXTENDED_HEADERS_NEGOTIATED
+  int ret;
+
+  ret = nbd_get_extended_headers_negotiated (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_EXTENDED_HEADERS_NEGOTIATED
+  missing_function (err, "get_extended_headers_negotiated");
   return -1;
 #endif
 }
@@ -467,6 +693,40 @@ _nbd_get_structured_replies_negotiated_wrapper (struct error *err,
 }
 
 int
+_nbd_set_request_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, bool request)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_REQUEST_META_CONTEXT
+  int ret;
+
+  ret = nbd_set_request_meta_context (h, request);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_REQUEST_META_CONTEXT
+  missing_function (err, "set_request_meta_context");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_request_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_REQUEST_META_CONTEXT
+  int ret;
+
+  ret = nbd_get_request_meta_context (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_REQUEST_META_CONTEXT
+  missing_function (err, "get_request_meta_context");
+  return -1;
+#endif
+}
+
+int
 _nbd_set_handshake_flags_wrapper (struct error *err,
         struct nbd_handle *h, uint32_t flags)
 {
@@ -494,6 +754,40 @@ _nbd_get_handshake_flags_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_GET_HANDSHAKE_FLAGS
   missing_function (err, "get_handshake_flags");
+#endif
+}
+
+int
+_nbd_set_pread_initialize_wrapper (struct error *err,
+        struct nbd_handle *h, bool request)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_PREAD_INITIALIZE
+  int ret;
+
+  ret = nbd_set_pread_initialize (h, request);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_PREAD_INITIALIZE
+  missing_function (err, "set_pread_initialize");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_pread_initialize_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_PREAD_INITIALIZE
+  int ret;
+
+  ret = nbd_get_pread_initialize (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_PREAD_INITIALIZE
+  missing_function (err, "get_pread_initialize");
+  return -1;
 #endif
 }
 
@@ -597,6 +891,57 @@ _nbd_opt_abort_wrapper (struct error *err,
 }
 
 int
+_nbd_opt_starttls_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_STARTTLS
+  int ret;
+
+  ret = nbd_opt_starttls (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_STARTTLS
+  missing_function (err, "opt_starttls");
+  return -1;
+#endif
+}
+
+int
+_nbd_opt_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_EXTENDED_HEADERS
+  int ret;
+
+  ret = nbd_opt_extended_headers (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_EXTENDED_HEADERS
+  missing_function (err, "opt_extended_headers");
+  return -1;
+#endif
+}
+
+int
+_nbd_opt_structured_reply_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_STRUCTURED_REPLY
+  int ret;
+
+  ret = nbd_opt_structured_reply (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_STRUCTURED_REPLY
+  missing_function (err, "opt_structured_reply");
+  return -1;
+#endif
+}
+
+int
 _nbd_opt_list_wrapper (struct error *err,
         struct nbd_handle *h, nbd_list_callback list_callback)
 {
@@ -643,6 +988,59 @@ _nbd_opt_list_meta_context_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_OPT_LIST_META_CONTEXT
   missing_function (err, "opt_list_meta_context");
+  return -1;
+#endif
+}
+
+int
+_nbd_opt_list_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_LIST_META_CONTEXT_QUERIES
+  int ret;
+
+  ret = nbd_opt_list_meta_context_queries (h, queries, context_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_LIST_META_CONTEXT_QUERIES
+  missing_function (err, "opt_list_meta_context_queries");
+  return -1;
+#endif
+}
+
+int
+_nbd_opt_set_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_context_callback context_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_SET_META_CONTEXT
+  int ret;
+
+  ret = nbd_opt_set_meta_context (h, context_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_SET_META_CONTEXT
+  missing_function (err, "opt_set_meta_context");
+  return -1;
+#endif
+}
+
+int
+_nbd_opt_set_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_OPT_SET_META_CONTEXT_QUERIES
+  int ret;
+
+  ret = nbd_opt_set_meta_context_queries (h, queries, context_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_OPT_SET_META_CONTEXT_QUERIES
+  missing_function (err, "opt_set_meta_context_queries");
   return -1;
 #endif
 }
@@ -745,6 +1143,23 @@ _nbd_set_uri_allow_tls_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_SET_URI_ALLOW_TLS
   missing_function (err, "set_uri_allow_tls");
+  return -1;
+#endif
+}
+
+int
+_nbd_set_uri_allow_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h, bool allow)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_URI_ALLOW_TLS_PRIORITY
+  int ret;
+
+  ret = nbd_set_uri_allow_tls_priority (h, allow);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_URI_ALLOW_TLS_PRIORITY
+  missing_function (err, "set_uri_allow_tls_priority");
   return -1;
 #endif
 }
@@ -886,6 +1301,40 @@ _nbd_connect_systemd_socket_activation_wrapper (struct error *err,
 }
 
 int
+_nbd_set_socket_activation_name_wrapper (struct error *err,
+        struct nbd_handle *h, const char *socket_name)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_SOCKET_ACTIVATION_NAME
+  int ret;
+
+  ret = nbd_set_socket_activation_name (h, socket_name);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_SOCKET_ACTIVATION_NAME
+  missing_function (err, "set_socket_activation_name");
+  return -1;
+#endif
+}
+
+char *
+_nbd_get_socket_activation_name_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_SOCKET_ACTIVATION_NAME
+  char * ret;
+
+  ret = nbd_get_socket_activation_name (h);
+  if (ret == NULL)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_SOCKET_ACTIVATION_NAME
+  missing_function (err, "get_socket_activation_name");
+  return NULL;
+#endif
+}
+
+int
 _nbd_is_read_only_wrapper (struct error *err,
         struct nbd_handle *h)
 {
@@ -1000,6 +1449,23 @@ _nbd_can_fast_zero_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_CAN_FAST_ZERO
   missing_function (err, "can_fast_zero");
+  return -1;
+#endif
+}
+
+int
+_nbd_can_block_status_payload_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_CAN_BLOCK_STATUS_PAYLOAD
+  int ret;
+
+  ret = nbd_can_block_status_payload (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_CAN_BLOCK_STATUS_PAYLOAD
+  missing_function (err, "can_block_status_payload");
   return -1;
 #endif
 }
@@ -1284,6 +1750,44 @@ _nbd_block_status_wrapper (struct error *err,
 }
 
 int
+_nbd_block_status_64_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        nbd_extent64_callback extent64_callback, uint32_t flags)
+{
+#ifdef LIBNBD_HAVE_NBD_BLOCK_STATUS_64
+  int ret;
+
+  ret = nbd_block_status_64 (h, count, offset, extent64_callback, flags);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_BLOCK_STATUS_64
+  missing_function (err, "block_status_64");
+  return -1;
+#endif
+}
+
+int
+_nbd_block_status_filter_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        char **contexts, nbd_extent64_callback extent64_callback,
+        uint32_t flags)
+{
+#ifdef LIBNBD_HAVE_NBD_BLOCK_STATUS_FILTER
+  int ret;
+
+  ret = nbd_block_status_filter (h, count, offset, contexts,
+                                 extent64_callback, flags);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_BLOCK_STATUS_FILTER
+  missing_function (err, "block_status_filter");
+  return -1;
+#endif
+}
+
+int
 _nbd_poll_wrapper (struct error *err,
         struct nbd_handle *h, int timeout)
 {
@@ -1296,6 +1800,23 @@ _nbd_poll_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_POLL
   missing_function (err, "poll");
+  return -1;
+#endif
+}
+
+int
+_nbd_poll2_wrapper (struct error *err,
+        struct nbd_handle *h, int fd, int timeout)
+{
+#ifdef LIBNBD_HAVE_NBD_POLL2
+  int ret;
+
+  ret = nbd_poll2 (h, fd, timeout);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_POLL2
+  missing_function (err, "poll2");
   return -1;
 #endif
 }
@@ -1472,6 +1993,57 @@ _nbd_aio_opt_abort_wrapper (struct error *err,
 }
 
 int
+_nbd_aio_opt_starttls_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_STARTTLS
+  int ret;
+
+  ret = nbd_aio_opt_starttls (h, completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_STARTTLS
+  missing_function (err, "aio_opt_starttls");
+  return -1;
+#endif
+}
+
+int
+_nbd_aio_opt_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_EXTENDED_HEADERS
+  int ret;
+
+  ret = nbd_aio_opt_extended_headers (h, completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_EXTENDED_HEADERS
+  missing_function (err, "aio_opt_extended_headers");
+  return -1;
+#endif
+}
+
+int
+_nbd_aio_opt_structured_reply_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_STRUCTURED_REPLY
+  int ret;
+
+  ret = nbd_aio_opt_structured_reply (h, completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_STRUCTURED_REPLY
+  missing_function (err, "aio_opt_structured_reply");
+  return -1;
+#endif
+}
+
+int
 _nbd_aio_opt_list_wrapper (struct error *err,
         struct nbd_handle *h, nbd_list_callback list_callback,
         nbd_completion_callback completion_callback)
@@ -1521,6 +2093,65 @@ _nbd_aio_opt_list_meta_context_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_AIO_OPT_LIST_META_CONTEXT
   missing_function (err, "aio_opt_list_meta_context");
+  return -1;
+#endif
+}
+
+int
+_nbd_aio_opt_list_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_LIST_META_CONTEXT_QUERIES
+  int ret;
+
+  ret = nbd_aio_opt_list_meta_context_queries (h, queries, context_callback,
+                                               completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_LIST_META_CONTEXT_QUERIES
+  missing_function (err, "aio_opt_list_meta_context_queries");
+  return -1;
+#endif
+}
+
+int
+_nbd_aio_opt_set_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_SET_META_CONTEXT
+  int ret;
+
+  ret = nbd_aio_opt_set_meta_context (h, context_callback,
+                                      completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_SET_META_CONTEXT
+  missing_function (err, "aio_opt_set_meta_context");
+  return -1;
+#endif
+}
+
+int
+_nbd_aio_opt_set_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_OPT_SET_META_CONTEXT_QUERIES
+  int ret;
+
+  ret = nbd_aio_opt_set_meta_context_queries (h, queries, context_callback,
+                                              completion_callback);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_OPT_SET_META_CONTEXT_QUERIES
+  missing_function (err, "aio_opt_set_meta_context_queries");
   return -1;
 #endif
 }
@@ -1687,6 +2318,47 @@ _nbd_aio_block_status_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_AIO_BLOCK_STATUS
   missing_function (err, "aio_block_status");
+  return -1;
+#endif
+}
+
+int64_t
+_nbd_aio_block_status_64_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        nbd_extent64_callback extent64_callback,
+        nbd_completion_callback completion_callback, uint32_t flags)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_BLOCK_STATUS_64
+  int64_t ret;
+
+  ret = nbd_aio_block_status_64 (h, count, offset, extent64_callback,
+                                 completion_callback, flags);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_BLOCK_STATUS_64
+  missing_function (err, "aio_block_status_64");
+  return -1;
+#endif
+}
+
+int64_t
+_nbd_aio_block_status_filter_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        char **contexts, nbd_extent64_callback extent64_callback,
+        nbd_completion_callback completion_callback, uint32_t flags)
+{
+#ifdef LIBNBD_HAVE_NBD_AIO_BLOCK_STATUS_FILTER
+  int64_t ret;
+
+  ret = nbd_aio_block_status_filter (h, count, offset, contexts,
+                                     extent64_callback, completion_callback,
+                                     flags);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_AIO_BLOCK_STATUS_FILTER
+  missing_function (err, "aio_block_status_filter");
   return -1;
 #endif
 }
@@ -1977,6 +2649,23 @@ _nbd_get_version_wrapper (struct error *err,
 #endif
 }
 
+const char *
+_nbd_get_version_extra_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_VERSION_EXTRA
+  const char * ret;
+
+  ret = nbd_get_version_extra (h);
+  if (ret == NULL)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_VERSION_EXTRA
+  missing_function (err, "get_version_extra");
+  return NULL;
+#endif
+}
+
 int
 _nbd_kill_subprocess_wrapper (struct error *err,
         struct nbd_handle *h, int signum)
@@ -1994,6 +2683,23 @@ _nbd_kill_subprocess_wrapper (struct error *err,
 #endif
 }
 
+int64_t
+_nbd_get_subprocess_pid_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_SUBPROCESS_PID
+  int64_t ret;
+
+  ret = nbd_get_subprocess_pid (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_SUBPROCESS_PID
+  missing_function (err, "get_subprocess_pid");
+  return -1;
+#endif
+}
+
 int
 _nbd_supports_tls_wrapper (struct error *err,
         struct nbd_handle *h)
@@ -2007,6 +2713,23 @@ _nbd_supports_tls_wrapper (struct error *err,
   return ret;
 #else // !LIBNBD_HAVE_NBD_SUPPORTS_TLS
   missing_function (err, "supports_tls");
+  return -1;
+#endif
+}
+
+int
+_nbd_supports_vsock_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_SUPPORTS_VSOCK
+  int ret;
+
+  ret = nbd_supports_vsock (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SUPPORTS_VSOCK
+  missing_function (err, "supports_vsock");
   return -1;
 #endif
 }
@@ -2046,34 +2769,104 @@ _nbd_get_uri_wrapper (struct error *err,
 }
 
 int
+_nbd_is_uri_wrapper (struct error *err,
+        struct nbd_handle *h, const char *uri)
+{
+#ifdef LIBNBD_HAVE_NBD_IS_URI
+  int ret;
+
+  ret = nbd_is_uri (h, uri);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_IS_URI
+  missing_function (err, "is_uri");
+  return -1;
+#endif
+}
+
+int
+_nbd_set_keepalive_wrapper (struct error *err,
+        struct nbd_handle *h, bool enable)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_KEEPALIVE
+  int ret;
+
+  ret = nbd_set_keepalive (h, enable);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_KEEPALIVE
+  missing_function (err, "set_keepalive");
+  return -1;
+#endif
+}
+
+int
+_nbd_get_keepalive_wrapper (struct error *err,
+        struct nbd_handle *h)
+{
+#ifdef LIBNBD_HAVE_NBD_GET_KEEPALIVE
+  int ret;
+
+  ret = nbd_get_keepalive (h);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_GET_KEEPALIVE
+  missing_function (err, "get_keepalive");
+  return -1;
+#endif
+}
+
+int
+_nbd_set_tcp_option_wrapper (struct error *err,
+        struct nbd_handle *h, int option, int v)
+{
+#ifdef LIBNBD_HAVE_NBD_SET_TCP_OPTION
+  int ret;
+
+  ret = nbd_set_tcp_option (h, option, v);
+  if (ret == -1)
+    save_error (err);
+  return ret;
+#else // !LIBNBD_HAVE_NBD_SET_TCP_OPTION
+  missing_function (err, "set_tcp_option");
+  return -1;
+#endif
+}
+
+int
 _nbd_chunk_callback_wrapper (void *user_data, const void *subbuf,
                              size_t count, uint64_t offset, unsigned status,
                              int *error)
 {
-  return chunk_callback ((long)user_data, subbuf, count, offset, status, error);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_chunk_callback ((long *)user_data, (void *)subbuf, count, offset, status, error);
 }
 
 void
 _nbd_chunk_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 
 int
 _nbd_completion_callback_wrapper (void *user_data, int *error)
 {
-  return completion_callback ((long)user_data, error);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_completion_callback ((long *)user_data, error);
 }
 
 void
 _nbd_completion_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 
@@ -2081,15 +2874,16 @@ int
 _nbd_debug_callback_wrapper (void *user_data, const char *context,
                              const char *msg)
 {
-  return debug_callback ((long)user_data, context, msg);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_debug_callback ((long *)user_data, (char *)context, (char *)msg);
 }
 
 void
 _nbd_debug_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 
@@ -2098,15 +2892,34 @@ _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
                               uint64_t offset, uint32_t *entries,
                               size_t nr_entries, int *error)
 {
-  return extent_callback ((long)user_data, metacontext, offset, entries, nr_entries, error);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_extent_callback ((long *)user_data, (char *)metacontext, offset, entries, nr_entries, error);
 }
 
 void
 _nbd_extent_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
+  free (p);
+}
+
+int
+_nbd_extent64_callback_wrapper (void *user_data, const char *metacontext,
+                                uint64_t offset, nbd_extent *entries,
+                                size_t nr_entries, int *error)
+{
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_extent64_callback ((long *)user_data, (char *)metacontext, offset, entries, nr_entries, error);
+}
+
+void
+_nbd_extent64_callback_free (void *user_data)
+{
+  long *p = user_data;
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 
@@ -2114,30 +2927,32 @@ int
 _nbd_list_callback_wrapper (void *user_data, const char *name,
                             const char *description)
 {
-  return list_callback ((long)user_data, name, description);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_list_callback ((long *)user_data, (char *)name, (char *)description);
 }
 
 void
 _nbd_list_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 
 int
 _nbd_context_callback_wrapper (void *user_data, const char *name)
 {
-  return context_callback ((long)user_data, name);
+  // golang isn't const-correct, casts avoid warnings here:
+  return _nbd_dispatch_context_callback ((long *)user_data, (char *)name);
 }
 
 void
 _nbd_context_callback_free (void *user_data)
 {
   long *p = user_data;
-  extern void freeCallbackId (long);
-  freeCallbackId (*p);
+  extern void nbd_internal_freeCallbackId (long);
+  nbd_internal_freeCallbackId (*p);
   free (p);
 }
 

--- a/vendor/libguestfs.org/libnbd/wrappers.h
+++ b/vendor/libguestfs.org/libnbd/wrappers.h
@@ -3,7 +3,7 @@
  * generator/generator
  * ANY CHANGES YOU MAKE TO THIS FILE WILL BE LOST.
  *
- * Copyright (C) 2013-2021 Red Hat Inc.
+ * Copyright Red Hat
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -85,6 +85,14 @@ int _nbd_set_debug_callback_wrapper (struct error *err,
         struct nbd_handle *h, nbd_debug_callback debug_callback);
 int _nbd_clear_debug_callback_wrapper (struct error *err,
         struct nbd_handle *h);
+uint64_t _nbd_stats_bytes_sent_wrapper (struct error *err,
+        struct nbd_handle *h);
+uint64_t _nbd_stats_chunks_sent_wrapper (struct error *err,
+        struct nbd_handle *h);
+uint64_t _nbd_stats_bytes_received_wrapper (struct error *err,
+        struct nbd_handle *h);
+uint64_t _nbd_stats_chunks_received_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_set_handle_name_wrapper (struct error *err,
         struct nbd_handle *h, const char *handle_name);
 char * _nbd_get_handle_name_wrapper (struct error *err,
@@ -93,9 +101,15 @@ uintptr_t _nbd_set_private_data_wrapper (struct error *err,
         struct nbd_handle *h, uintptr_t private_data);
 uintptr_t _nbd_get_private_data_wrapper (struct error *err,
         struct nbd_handle *h);
+ssize_t _nbd_get_handle_size_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_set_export_name_wrapper (struct error *err,
         struct nbd_handle *h, const char *export_name);
 char * _nbd_get_export_name_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_set_request_block_size_wrapper (struct error *err,
+        struct nbd_handle *h, bool request);
+int _nbd_get_request_block_size_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_set_full_info_wrapper (struct error *err,
         struct nbd_handle *h, bool request);
@@ -121,17 +135,39 @@ int _nbd_set_tls_username_wrapper (struct error *err,
         struct nbd_handle *h, const char *username);
 char * _nbd_get_tls_username_wrapper (struct error *err,
         struct nbd_handle *h);
+int _nbd_set_tls_hostname_wrapper (struct error *err,
+        struct nbd_handle *h, const char *hostname);
+char * _nbd_get_tls_hostname_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_set_tls_psk_file_wrapper (struct error *err,
         struct nbd_handle *h, const char *filename);
+int _nbd_set_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h, const char *priority);
+char * _nbd_get_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_set_request_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h, bool request);
+int _nbd_get_request_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_get_extended_headers_negotiated_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_set_request_structured_replies_wrapper (struct error *err,
         struct nbd_handle *h, bool request);
 int _nbd_get_request_structured_replies_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_get_structured_replies_negotiated_wrapper (struct error *err,
         struct nbd_handle *h);
+int _nbd_set_request_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, bool request);
+int _nbd_get_request_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_set_handshake_flags_wrapper (struct error *err,
         struct nbd_handle *h, uint32_t flags);
 uint32_t _nbd_get_handshake_flags_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_set_pread_initialize_wrapper (struct error *err,
+        struct nbd_handle *h, bool request);
+int _nbd_get_pread_initialize_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_set_strict_mode_wrapper (struct error *err,
         struct nbd_handle *h, uint32_t flags);
@@ -145,12 +181,26 @@ int _nbd_opt_go_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_opt_abort_wrapper (struct error *err,
         struct nbd_handle *h);
+int _nbd_opt_starttls_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_opt_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_opt_structured_reply_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_opt_list_wrapper (struct error *err,
         struct nbd_handle *h, nbd_list_callback list_callback);
 int _nbd_opt_info_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_opt_list_meta_context_wrapper (struct error *err,
         struct nbd_handle *h, nbd_context_callback context_callback);
+int _nbd_opt_list_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback);
+int _nbd_opt_set_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_context_callback context_callback);
+int _nbd_opt_set_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback);
 int _nbd_add_meta_context_wrapper (struct error *err,
         struct nbd_handle *h, const char *name);
 ssize_t _nbd_get_nr_meta_contexts_wrapper (struct error *err,
@@ -163,6 +213,8 @@ int _nbd_set_uri_allow_transports_wrapper (struct error *err,
         struct nbd_handle *h, uint32_t mask);
 int _nbd_set_uri_allow_tls_wrapper (struct error *err,
         struct nbd_handle *h, int tls);
+int _nbd_set_uri_allow_tls_priority_wrapper (struct error *err,
+        struct nbd_handle *h, bool allow);
 int _nbd_set_uri_allow_local_file_wrapper (struct error *err,
         struct nbd_handle *h, bool allow);
 int _nbd_connect_uri_wrapper (struct error *err,
@@ -179,6 +231,10 @@ int _nbd_connect_command_wrapper (struct error *err,
         struct nbd_handle *h, char **argv);
 int _nbd_connect_systemd_socket_activation_wrapper (struct error *err,
         struct nbd_handle *h, char **argv);
+int _nbd_set_socket_activation_name_wrapper (struct error *err,
+        struct nbd_handle *h, const char *socket_name);
+char * _nbd_get_socket_activation_name_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_is_read_only_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_can_flush_wrapper (struct error *err,
@@ -192,6 +248,8 @@ int _nbd_can_trim_wrapper (struct error *err,
 int _nbd_can_zero_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_can_fast_zero_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_can_block_status_payload_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_can_df_wrapper (struct error *err,
         struct nbd_handle *h);
@@ -232,8 +290,17 @@ int _nbd_zero_wrapper (struct error *err,
 int _nbd_block_status_wrapper (struct error *err,
         struct nbd_handle *h, uint64_t count, uint64_t offset,
         nbd_extent_callback extent_callback, uint32_t flags);
+int _nbd_block_status_64_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        nbd_extent64_callback extent64_callback, uint32_t flags);
+int _nbd_block_status_filter_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        char **contexts, nbd_extent64_callback extent64_callback,
+        uint32_t flags);
 int _nbd_poll_wrapper (struct error *err,
         struct nbd_handle *h, int timeout);
+int _nbd_poll2_wrapper (struct error *err,
+        struct nbd_handle *h, int fd, int timeout);
 int _nbd_aio_connect_wrapper (struct error *err,
         struct nbd_handle *h, const struct sockaddr *addr,
         socklen_t addrlen);
@@ -255,6 +322,12 @@ int _nbd_aio_opt_go_wrapper (struct error *err,
         struct nbd_handle *h, nbd_completion_callback completion_callback);
 int _nbd_aio_opt_abort_wrapper (struct error *err,
         struct nbd_handle *h);
+int _nbd_aio_opt_starttls_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback);
+int _nbd_aio_opt_extended_headers_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback);
+int _nbd_aio_opt_structured_reply_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_completion_callback completion_callback);
 int _nbd_aio_opt_list_wrapper (struct error *err,
         struct nbd_handle *h, nbd_list_callback list_callback,
         nbd_completion_callback completion_callback);
@@ -262,6 +335,17 @@ int _nbd_aio_opt_info_wrapper (struct error *err,
         struct nbd_handle *h, nbd_completion_callback completion_callback);
 int _nbd_aio_opt_list_meta_context_wrapper (struct error *err,
         struct nbd_handle *h, nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback);
+int _nbd_aio_opt_list_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback);
+int _nbd_aio_opt_set_meta_context_wrapper (struct error *err,
+        struct nbd_handle *h, nbd_context_callback context_callback,
+        nbd_completion_callback completion_callback);
+int _nbd_aio_opt_set_meta_context_queries_wrapper (struct error *err,
+        struct nbd_handle *h, char **queries,
+        nbd_context_callback context_callback,
         nbd_completion_callback completion_callback);
 int64_t _nbd_aio_pread_wrapper (struct error *err,
         struct nbd_handle *h, void *buf, size_t count, uint64_t offset,
@@ -291,6 +375,14 @@ int64_t _nbd_aio_zero_wrapper (struct error *err,
 int64_t _nbd_aio_block_status_wrapper (struct error *err,
         struct nbd_handle *h, uint64_t count, uint64_t offset,
         nbd_extent_callback extent_callback,
+        nbd_completion_callback completion_callback, uint32_t flags);
+int64_t _nbd_aio_block_status_64_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        nbd_extent64_callback extent64_callback,
+        nbd_completion_callback completion_callback, uint32_t flags);
+int64_t _nbd_aio_block_status_filter_wrapper (struct error *err,
+        struct nbd_handle *h, uint64_t count, uint64_t offset,
+        char **contexts, nbd_extent64_callback extent64_callback,
         nbd_completion_callback completion_callback, uint32_t flags);
 int _nbd_aio_get_fd_wrapper (struct error *err,
         struct nbd_handle *h);
@@ -326,47 +418,76 @@ const char * _nbd_get_package_name_wrapper (struct error *err,
         struct nbd_handle *h);
 const char * _nbd_get_version_wrapper (struct error *err,
         struct nbd_handle *h);
+const char * _nbd_get_version_extra_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_kill_subprocess_wrapper (struct error *err,
         struct nbd_handle *h, int signum);
+int64_t _nbd_get_subprocess_pid_wrapper (struct error *err,
+        struct nbd_handle *h);
 int _nbd_supports_tls_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_supports_vsock_wrapper (struct error *err,
         struct nbd_handle *h);
 int _nbd_supports_uri_wrapper (struct error *err,
         struct nbd_handle *h);
 char * _nbd_get_uri_wrapper (struct error *err,
         struct nbd_handle *h);
+int _nbd_is_uri_wrapper (struct error *err,
+        struct nbd_handle *h, const char *uri);
+int _nbd_set_keepalive_wrapper (struct error *err,
+        struct nbd_handle *h, bool enable);
+int _nbd_get_keepalive_wrapper (struct error *err,
+        struct nbd_handle *h);
+int _nbd_set_tcp_option_wrapper (struct error *err,
+        struct nbd_handle *h, int option, int v);
 
-extern int chunk_callback ();
+extern int _nbd_dispatch_chunk_callback (long *callbackid, void *subbuf, size_t count, uint64_t offset, unsigned int status, int *error);
+
 
 int _nbd_chunk_callback_wrapper (void *user_data, const void *subbuf,
                                  size_t count, uint64_t offset,
                                  unsigned status, int *error);
 void _nbd_chunk_callback_free (void *user_data);
 
-extern int completion_callback ();
+extern int _nbd_dispatch_completion_callback (long *callbackid, int *error);
+
 
 int _nbd_completion_callback_wrapper (void *user_data, int *error);
 void _nbd_completion_callback_free (void *user_data);
 
-extern int debug_callback ();
+extern int _nbd_dispatch_debug_callback (long *callbackid, char *context, char *msg);
+
 
 int _nbd_debug_callback_wrapper (void *user_data, const char *context,
                                  const char *msg);
 void _nbd_debug_callback_free (void *user_data);
 
-extern int extent_callback ();
+extern int _nbd_dispatch_extent_callback (long *callbackid, char *metacontext, uint64_t offset, uint32_t *entries, size_t nr_entries, int *error);
+
 
 int _nbd_extent_callback_wrapper (void *user_data, const char *metacontext,
                                   uint64_t offset, uint32_t *entries,
                                   size_t nr_entries, int *error);
 void _nbd_extent_callback_free (void *user_data);
 
-extern int list_callback ();
+extern int _nbd_dispatch_extent64_callback (long *callbackid, char *metacontext, uint64_t offset, nbd_extent *entries, size_t nr_entries, int *error);
+
+
+int _nbd_extent64_callback_wrapper (void *user_data,
+                                    const char *metacontext,
+                                    uint64_t offset, nbd_extent *entries,
+                                    size_t nr_entries, int *error);
+void _nbd_extent64_callback_free (void *user_data);
+
+extern int _nbd_dispatch_list_callback (long *callbackid, char *name, char *description);
+
 
 int _nbd_list_callback_wrapper (void *user_data, const char *name,
                                 const char *description);
 void _nbd_list_callback_free (void *user_data);
 
-extern int context_callback ();
+extern int _nbd_dispatch_context_callback (long *callbackid, char *name);
+
 
 int _nbd_context_callback_wrapper (void *user_data, const char *name);
 void _nbd_context_callback_free (void *user_data);

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1602,8 +1602,8 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 ## explicit; go 1.16
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
-# libguestfs.org/libnbd v1.11.5
-## explicit; go 1.13
+# libguestfs.org/libnbd v1.25.4
+## explicit; go 1.17
 libguestfs.org/libnbd
 # sigs.k8s.io/controller-runtime v0.19.5 => sigs.k8s.io/controller-runtime v0.19.5
 ## explicit; go 1.22.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR bumps the libnbd version that CDI uses from the relatively outdated v1.11.5 to v1.25.4. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/containerized-data-importer/issues/3935

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

