### PR TITLE
imageio, vcenter: add node affinity and skip tests for missing arch

### DIFF
--- a/manifests/templates/imageio.yaml.in
+++ b/manifests/templates/imageio.yaml.in
@@ -19,6 +19,8 @@ spec:
         app: imageio
         cdi.kubevirt.io/testing: ""
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       securityContext:
         runAsUser: 0
       serviceAccountName: cdi-testing-sa

--- a/manifests/templates/vcenter.yaml.in
+++ b/manifests/templates/vcenter.yaml.in
@@ -19,6 +19,8 @@ spec:
         app: vcenter
         cdi.kubevirt.io/testing: ""
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       securityContext:
         runAsUser: 0
       serviceAccountName: cdi-testing-sa


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Both imageio and vcenter don't run on aarch64 and s390x, this PR adds explicit amd64 node affinities to their manifest templates so they can properly run on multi-arch test clusters and it also adds relevant testskips in the case that the cluster has no amd64 nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

