### PR TITLE
Add common error symptoms to block CRI ownership doc

### DIFF
--- a/doc/block_cri_ownership_config.md
+++ b/doc/block_cri_ownership_config.md
@@ -1,5 +1,18 @@
 # device_ownership_from_security_context CRI configurable
 
+## Symptoms
+When `device_ownership_from_security_context` is not enabled in the CRI runtime configuration, CDI pods that operate on block-mode PersistentVolumes will fail with permission errors. Common error logs:
+
+- **Upload to block PVC** — the upload server fails with:
+  ```
+  Saving stream failed: Unable to transfer source data to target file: error determining if block device exists: exit status 1, blockdev: cannot open /dev/cdi-block-volume: Permission denied
+  ```
+- **Import to block PVC** — the importer pod logs `blockdev: cannot open /dev/cdi-block-volume: Permission denied`, then reports `Target size -1` and misidentifies the block volume as a filesystem volume:
+  ```
+  E0929 02:13:54.319027       1 data-processor.go:383] exit status 1, blockdev: cannot open /dev/cdi-block-volume: Permission denied
+  I0929 02:13:54.319110       1 data-processor.go:404] Target size -1.
+  ```
+
 ## Introduction
 Unlike volumes with fsGroup, devices have no official notion of deviceGroup/deviceUser that the CRI runtimes (or kubelet) would be able to use.  
 This makes it problematic for our workloads to populate block devices, and has manifested itself in the form of [this](https://github.com/kubevirt/containerized-data-importer/issues/2433#issuecomment-1287277907) community issue.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Users frequently open issues for block PVC permission errors without
finding the existing CRI configuration doc. Adding a Symptoms section
with actual error logs from reported issues improves discoverability
for both humans and LLMs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

