### PR TITLE
Inflate snapshot restore size for block-to-filesystem sizeless clone

### DIFF
--- a/pkg/controller/clone/common.go
+++ b/pkg/controller/clone/common.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 
@@ -128,18 +126,6 @@ func GetGlobalCloneStrategyOverride(ctx context.Context, c client.Client) (*cdiv
 	}
 
 	return cr.Spec.CloneStrategyOverride, nil
-}
-
-// GetSnapshotContentFromSnapshot returns the VolumeSnapshotContent of a given VolumeSnapshot
-func GetSnapshotContentFromSnapshot(ctx context.Context, c client.Client, snapshot *snapshotv1.VolumeSnapshot) (*snapshotv1.VolumeSnapshotContent, error) {
-	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
-		return nil, fmt.Errorf("volumeSnapshotContent name not found")
-	}
-	vsc := &snapshotv1.VolumeSnapshotContent{}
-	if err := c.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
-		return nil, err
-	}
-	return vsc, nil
 }
 
 // GetStorageClassForClaim returns the storageclass for a PVC

--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -388,7 +388,7 @@ func (p *Planner) computeStrategyForSourceSnapshot(ctx context.Context, args *Ch
 	}
 
 	// Do snapshot and storage class validation
-	vsc, err := GetSnapshotContentFromSnapshot(ctx, p.Client, sourceSnapshot)
+	vsc, err := cc.GetSnapshotContentFromSnapshot(ctx, p.Client, sourceSnapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -792,7 +792,7 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
 }
 
 func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace string, targetClaim *corev1.PersistentVolumeClaim, snapshot *snapshotv1.VolumeSnapshot, client client.Client) (*corev1.PersistentVolumeClaim, error) {
-	vsc, err := GetSnapshotContentFromSnapshot(ctx, client, snapshot)
+	vsc, err := cc.GetSnapshotContentFromSnapshot(ctx, client, snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -802,10 +802,7 @@ func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace strin
 	}
 	targetCpy := targetClaim.DeepCopy()
 	fallbackVolumeMode := targetCpy.Spec.VolumeMode
-	volumeMode, err := getVolumeModeForTempSourceClaim(log, snapshot, vsc, fallbackVolumeMode)
-	if err != nil {
-		return nil, err
-	}
+	volumeMode := cc.GetSnapshotSourceVolumeMode(log, snapshot, vsc, fallbackVolumeMode)
 	// Get the appropriate size from the snapshot
 	if snapshot.Status == nil || snapshot.Status.RestoreSize == nil || snapshot.Status.RestoreSize.Sign() == -1 {
 		return nil, fmt.Errorf("snapshot has no RestoreSize")
@@ -861,20 +858,4 @@ func getStorageClassNameForTempSourceClaim(ctx context.Context, vsc *snapshotv1.
 	}
 	sort.Strings(matches)
 	return matches[0], nil
-}
-
-func getVolumeModeForTempSourceClaim(log logr.Logger, snapshot *snapshotv1.VolumeSnapshot, vsc *snapshotv1.VolumeSnapshotContent, fallback *corev1.PersistentVolumeMode) (*corev1.PersistentVolumeMode, error) {
-	if vsc.Spec.SourceVolumeMode != nil {
-		// Since 1.29 we should always return here
-		// Older versions did not populate this field and thus need more care
-		return vsc.Spec.SourceVolumeMode, nil
-	}
-
-	if v, ok := snapshot.Annotations[cc.AnnSourceVolumeMode]; ok {
-		mode := corev1.PersistentVolumeMode(v)
-		return &mode, nil
-	}
-
-	log.V(1).Info("Could not infer source volume mode of snapshot, creating a temporary restore with target PVC volume mode")
-	return fallback, nil
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1585,6 +1585,37 @@ func InflateSizeWithOverhead(ctx context.Context, c client.Client, imgSize int64
 	return returnSize, nil
 }
 
+// GetSnapshotContentFromSnapshot returns the VolumeSnapshotContent of a given VolumeSnapshot
+func GetSnapshotContentFromSnapshot(ctx context.Context, c client.Client, snapshot *snapshotv1.VolumeSnapshot) (*snapshotv1.VolumeSnapshotContent, error) {
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
+		return nil, fmt.Errorf("volumeSnapshotContent name not found")
+	}
+	vsc := &snapshotv1.VolumeSnapshotContent{}
+	if err := c.Get(ctx, types.NamespacedName{Name: *snapshot.Status.BoundVolumeSnapshotContentName}, vsc); err != nil {
+		return nil, err
+	}
+	return vsc, nil
+}
+
+// GetSnapshotSourceVolumeMode determines the volume mode of the PVC that was
+// used to create the given snapshot. It checks (in order):
+// 1. VolumeSnapshotContent.Spec.SourceVolumeMode (available since k8s 1.29)
+// 2. AnnSourceVolumeMode annotation on the snapshot
+// 3. Falls back to the provided fallback volume mode
+func GetSnapshotSourceVolumeMode(log logr.Logger, snapshot *snapshotv1.VolumeSnapshot, vsc *snapshotv1.VolumeSnapshotContent, fallback *corev1.PersistentVolumeMode) *corev1.PersistentVolumeMode {
+	if vsc != nil && vsc.Spec.SourceVolumeMode != nil {
+		return vsc.Spec.SourceVolumeMode
+	}
+
+	if v, ok := snapshot.Annotations[AnnSourceVolumeMode]; ok {
+		mode := corev1.PersistentVolumeMode(v)
+		return &mode
+	}
+
+	log.V(1).Info("Could not infer source volume mode of snapshot, assuming same as target")
+	return fallback
+}
+
 // IsBound returns if the pvc is bound
 func IsBound(pvc *corev1.PersistentVolumeClaim) bool {
 	return pvc != nil && pvc.Status.Phase == corev1.ClaimBound

--- a/pkg/controller/datavolume/snapshot-clone-controller.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller.go
@@ -293,9 +293,26 @@ func (r *SnapshotCloneReconciler) detectCloneSize(log logr.Logger, syncState *dv
 	if pvcSpec.Resources.Requests == nil {
 		pvcSpec.Resources.Requests = corev1.ResourceList{}
 	}
-	pvcSpec.Resources.Requests[corev1.ResourceStorage] = *syncState.snapshot.Status.RestoreSize
 
-	log.V(3).Info("set pvc request size", "size", pvcSpec.Resources.Requests[corev1.ResourceStorage])
+	restoreSize := syncState.snapshot.Status.RestoreSize
+	requestSize := *restoreSize
+
+	if util.ResolveVolumeMode(pvcSpec.VolumeMode) == corev1.PersistentVolumeFilesystem {
+		vsc, err := cc.GetSnapshotContentFromSnapshot(context.TODO(), r.client, syncState.snapshot)
+		if err != nil {
+			return err
+		}
+		sourceVolumeMode := cc.GetSnapshotSourceVolumeMode(log, syncState.snapshot, vsc, pvcSpec.VolumeMode)
+		if sourceVolumeMode != nil && *sourceVolumeMode == corev1.PersistentVolumeBlock {
+			requestSize, err = cc.InflateSizeWithOverhead(context.TODO(), r.client, restoreSize.Value(), pvcSpec)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	pvcSpec.Resources.Requests[corev1.ResourceStorage] = requestSize
+	log.V(3).Info("set pvc request size", "size", requestSize)
 
 	return nil
 }

--- a/pkg/controller/datavolume/snapshot-clone-controller_test.go
+++ b/pkg/controller/datavolume/snapshot-clone-controller_test.go
@@ -430,7 +430,7 @@ var _ = Describe("All DataVolume Tests", func() {
 					}
 					dv.Spec.PVC = nil
 					snapshot := createSnapshotInVolumeSnapshotClass("test-snap", dv.Namespace, &expectedSnapshotClass, nil, nil, true)
-					reconciler = createSnapshotCloneReconciler(storageClass, csiDriver, dv, snapshot)
+					reconciler = createSnapshotCloneReconciler(storageClass, csiDriver, dv, snapshot, createDefaultVolumeSnapshotContent())
 					result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
@@ -442,6 +442,82 @@ var _ = Describe("All DataVolume Tests", func() {
 					err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(*snapshot.Status.RestoreSize))
+				})
+
+				It("should inflate size when cloning from block snapshot to filesystem target with size omitted", func() {
+					dv := newCloneFromSnapshotDataVolume("test-dv")
+					vm := corev1.PersistentVolumeFilesystem
+					dv.Spec.Storage = &cdiv1.StorageSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						VolumeMode:  &vm,
+					}
+					dv.Spec.PVC = nil
+					snapshot := createSnapshotInVolumeSnapshotClass("test-snap", dv.Namespace, &expectedSnapshotClass, nil, nil, true)
+					blockMode := corev1.PersistentVolumeBlock
+					vsc := &snapshotv1.VolumeSnapshotContent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-snapshot-content-name",
+						},
+						Spec: snapshotv1.VolumeSnapshotContentSpec{
+							Driver:           "csi-plugin",
+							SourceVolumeMode: &blockMode,
+						},
+					}
+					cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+					cdiConfig.Status = cdiv1.CDIConfigStatus{
+						ScratchSpaceStorageClass: testStorageClass,
+						FilesystemOverhead: &cdiv1.FilesystemOverhead{
+							Global: cdiv1.Percent("0.055"),
+						},
+					}
+					cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
+					reconciler = createSnapshotCloneReconcilerWithoutConfig(storageClass, csiDriver, dv, snapshot, vsc, cdiConfig)
+					result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
+					pvc := &corev1.PersistentVolumeClaim{}
+					err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+					Expect(err).ToNot(HaveOccurred())
+					pvcSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+					Expect(pvcSize.Cmp(*snapshot.Status.RestoreSize)).To(Equal(1),
+						"PVC size %s should be greater than restore size %s due to filesystem overhead inflation",
+						pvcSize.String(), snapshot.Status.RestoreSize.String())
+				})
+
+				It("should inflate size using AnnSourceVolumeMode annotation when VolumeSnapshotContent has no source volume mode", func() {
+					dv := newCloneFromSnapshotDataVolume("test-dv")
+					vm := corev1.PersistentVolumeFilesystem
+					dv.Spec.Storage = &cdiv1.StorageSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						VolumeMode:  &vm,
+					}
+					dv.Spec.PVC = nil
+					snapshot := createSnapshotInVolumeSnapshotClass("test-snap", dv.Namespace, &expectedSnapshotClass, nil, nil, true)
+					snapshot.Annotations = map[string]string{
+						AnnSourceVolumeMode: string(corev1.PersistentVolumeBlock),
+					}
+					vsc := createDefaultVolumeSnapshotContent()
+					cdiConfig := MakeEmptyCDIConfigSpec(common.ConfigName)
+					cdiConfig.Status = cdiv1.CDIConfigStatus{
+						ScratchSpaceStorageClass: testStorageClass,
+						FilesystemOverhead: &cdiv1.FilesystemOverhead{
+							Global: cdiv1.Percent("0.055"),
+						},
+					}
+					cdiConfig.Spec.FeatureGates = []string{featuregates.HonorWaitForFirstConsumer}
+					reconciler = createSnapshotCloneReconcilerWithoutConfig(storageClass, csiDriver, dv, snapshot, vsc, cdiConfig)
+					result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
+					pvc := &corev1.PersistentVolumeClaim{}
+					err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+					Expect(err).ToNot(HaveOccurred())
+					pvcSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+					Expect(pvcSize.Cmp(*snapshot.Status.RestoreSize)).To(Equal(1),
+						"PVC size %s should be greater than restore size %s due to filesystem overhead inflation",
+						pvcSize.String(), snapshot.Status.RestoreSize.String())
 				})
 
 				It("should add cloneType annotation", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When cloning from a block-mode snapshot to a filesystem-mode target PVC
with no explicit size, detectCloneSize now inflates the restore size
with filesystem overhead. This prevents clone validation failures caused
by insufficient space for filesystem metadata.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Tackling https://github.com/kubevirt/containerized-data-importer/pull/3901 from a different angle according to https://github.com/kubevirt/containerized-data-importer/pull/3901#issuecomment-4134720097

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Host assisted clone should adjust requested storage when cloning from block to filesystem volume mode
```

