### PR TITLE
Add uploadproxyURL environmental variable

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -106,15 +106,19 @@ function wait_cdi_available {
 }
 
 function configure_uploadproxy_override {
-  if [[ $KUBEVIRT_PROVIDER =~ kind.* ]]; then
+  if [ -n "${UPLOAD_PROXY_URL_OVERRIDE}" ]; then
+    override="${UPLOAD_PROXY_URL_OVERRIDE}"
+  elif [[ $KUBEVIRT_PROVIDER =~ kind.* ]]; then
     # To enable port mapping, it must be configured both in the Kind configuration and the uploadProxyURLOverride.
     # We use the environment variable KIND_PORT_MAPPING to ensure the setup is applied in both locations.
     container_port=$(echo "$KIND_PORT_MAPPING" | awk -F: '{print $1}')
     host_port=$(echo "$KIND_PORT_MAPPING" | awk -F: '{print $2}')
     override="https://127.0.0.1:$host_port"
-  else
+  elif [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
     host_port=$(./cluster-up/cli.sh ports uploadproxy-lowerband | xargs)
     override="https://127.0.0.1:$host_port"
+  else
+    return
   fi
   _kubectl patch cdi ${CR_NAME} --type=merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
 }
@@ -319,11 +323,9 @@ else
   wait_cdi_available
 fi
 
-# Non external provider extra setup
+configure_uploadproxy_override
+
 if [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
-  # Configure CDI upload proxy URL override
-  configure_uploadproxy_override
-  # Tell prometheus to watch our namespace
   configure_prometheus
 fi
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add the option to set a uploadproxy URL as environmental variable, while also include external provider in this.

Use case example:
Setting up e2e CI jobs that run against an external OpenShift cluster. The cluster is behind a NAT with port remapping (e.g. 443 -> 6005), so the auto-discovered route URL https://cdi-uploadproxy-cdi.apps.<cluster>:443 doesn't work from the prow pod — the actual reachable URL is https://cdi-uploadproxy-cdi.apps.<cluster>:6005.

Since configure_uploadproxy_override is skipped for `KUBEVIRT_PROVIDER=external`, there's no clean way to set this in the existing test automation flow.

With this `export UPLOAD_PROXY_URL_OVERRIDE="https://cdi-uploadproxy-cdi.apps.<cluster>:6005"` would do the trick.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4106 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

