### PR TITLE
fix: cluster wide certConfigMap for http datasources

### DIFF
--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -292,31 +292,32 @@ func createCertPool(certDir string) (*x509.CertPool, error) {
 		}
 	}
 
-	// append server CA certificates
-	files, err := os.ReadDir(certDir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error listing files in %s", certDir)
-	}
-
-	for _, file := range files {
-		if file.IsDir() || file.Name()[0] == '.' {
-			continue
-		}
-
-		fp := path.Join(certDir, file.Name())
-
-		klog.Infof("Attempting to get certs from %s", fp)
-
-		certs, err := os.ReadFile(fp)
+	// append server CA certificates if the directory exists
+	if certDir != "" {
+		files, err := os.ReadDir(certDir)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error reading file %s", fp)
+			return nil, errors.Wrapf(err, "Error listing files in %s", certDir)
 		}
 
-		if ok := certPool.AppendCertsFromPEM(certs); !ok {
-			klog.Warningf("No certs in %s", fp)
+		for _, file := range files {
+			if file.IsDir() || file.Name()[0] == '.' {
+				continue
+			}
+
+			fp := path.Join(certDir, file.Name())
+
+			klog.Infof("Attempting to get certs from %s", fp)
+
+			certs, err := os.ReadFile(fp)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Error reading file %s", fp)
+			}
+
+			if ok := certPool.AppendCertsFromPEM(certs); !ok {
+				klog.Warningf("No certs in %s", fp)
+			}
 		}
 	}
-
 	return certPool, nil
 }
 
@@ -325,7 +326,14 @@ func createHTTPClient(certDir string, insecureSkipVerify bool) (*http.Client, er
 		// Don't set timeout here, since that will be an absolute timeout, we need a relative to last progress timeout.
 	}
 
-	if certDir == "" && !insecureSkipVerify {
+	// if any cluster wide certs are configured, they will exist in the proxy cert dir
+	proxyCertDir, err := os.ReadDir(common.ImporterProxyCertDir)
+
+	if err != nil && !os.IsNotExist(err) {
+		klog.Warningf("Unable to read proxy cert directory %v", err)
+	}
+
+	if certDir == "" && len(proxyCertDir) == 0 && !insecureSkipVerify {
 		return client, nil
 	}
 	// the default transport contains Proxy configurations to use environment variables and default timeouts

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -417,16 +417,34 @@ var _ = Describe("Http client", func() {
 
 		err = os.WriteFile(path.Join(tempDir, "tls.crt"), certBytes, 0600)
 		Expect(err).ToNot(HaveOccurred())
+
+		// create and populate proxy cert dir
+		err = os.Mkdir(common.ImporterProxyCertDir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		keyPair, err = triple.NewCA("proxy.cdi.kubevirt.io")
+		Expect(err).ToNot(HaveOccurred())
+
+		certBytes = cert.EncodeCertPEM(keyPair.Cert)
+
+		err = os.WriteFile(path.Join(common.ImporterProxyCertDir, "tls.crt"), certBytes, 0600)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		if tempDir != "" {
 			os.RemoveAll(tempDir)
 		}
+
+		os.RemoveAll(common.ImporterProxyCertDir)
 	})
 
-	It("should load the cert", func() {
-		client, err := createHTTPClient(tempDir, false)
+	DescribeTable("should load", func(useCertDir bool) {
+		certDir := ""
+		if useCertDir {
+			certDir = tempDir
+		}
+		client, err := createHTTPClient(certDir, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		transport := client.Transport.(*http.Transport)
@@ -438,9 +456,12 @@ var _ = Describe("Http client", func() {
 		systemCAs, err := x509.SystemCertPool()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(activeCAs.Subjects()).Should(HaveLen(len(systemCAs.Subjects()) + 1)) //nolint:staticcheck // todo: Subjects() is deprecated - check this
-	})
-
+		// since we added certs these should be different
+		Expect(activeCAs.Equal(systemCAs)).To(BeFalse())
+	},
+		Entry("the certs when cert dir exists", true),
+		Entry("the proxy cert when cert dir doesn't exist", false),
+	)
 })
 
 var _ = Describe("Http reader", func() {

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -156,12 +156,10 @@ var _ = Describe("Imageio data source", func() {
 		Expect(dp.cancel).ToNot(BeNil())
 	})
 
-	It("NewImageioDataSource should fail without cert when InsecureSkipVerify is disabled", func() {
-		newOvirtClientFunc = getOvirtClient
+	It("NewImageioDataSource should succeed without cert when InsecureSkipVerify is disabled", func() {
 		dp, err := NewImageioDataSource(ts.URL, "", "", "", diskID, "", "", false)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("Error listing files"))
-		Expect(dp).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dp).ToNot(BeNil())
 	})
 
 	It("NewImageioDataSource should succeed with cert when InsecureSkipVerify is disabled", func() {

--- a/tests/import_proxy_test.go
+++ b/tests/import_proxy_test.go
@@ -325,6 +325,48 @@ var _ = Describe("Import Proxy tests", func() {
 				expected:      BeFalse}),
 		)
 
+		It("should import from https endpoint using global trustedCAProxy without per-DV certConfigMap", func() {
+			By("Copying file host CA cert to CDI namespace for use as trustedCAProxy")
+			caConfigMapName, err := utils.CopyConfigMap(
+				f.K8sClient, f.CdiInstallNs, utils.FileHostCertConfigMap,
+				f.CdiInstallNs, "test-trusted-ca", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Setting CDIConfig importProxy.trustedCAProxy")
+			updateCDIConfigProxy(f, "", "", "", caConfigMapName)
+
+			By("Waiting for CDI to reconcile the trustedCAProxy")
+			Eventually(func() string {
+				config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(
+					context.TODO(), common.ConfigName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				ca, _ := cont.GetImportProxyConfig(config, common.ImportProxyConfigMapName)
+				return ca
+			}, time.Second*120, time.Second).Should(Equal(caConfigMapName))
+
+			imgURL := fmt.Sprintf("https://%s.%s:%d/%s",
+				fileHostName, f.CdiInstallNs, utils.HTTPSNoAuthPort, tinyCoreIso)
+			dvName = "test-global-trusted-ca"
+
+			By("Creating DataVolume without per-DV certConfigMap")
+			dv := utils.NewDataVolumeWithHTTPImport(dvName, "400Mi", imgURL)
+			dataVolume, err := utils.CreateDataVolumeFromDefinition(f.CdiClient, f.Namespace.Name, dv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataVolume.Spec.Source.HTTP.CertConfigMap).To(BeEmpty())
+
+			By("Verifying pvc was created")
+			pvc, err := utils.WaitForPVC(f.K8sClient, dataVolume.Namespace, dvName)
+			Expect(err).ToNot(HaveOccurred())
+			f.ForceBindIfWaitForFirstConsumer(pvc)
+
+			By("Verifying proxy ConfigMap was copied to import namespace")
+			verifyImportProxyConfigMap(pvc)
+
+			By("Waiting for DataVolume to succeed")
+			err = utils.WaitForDataVolumePhase(f, f.Namespace.Name, cdiv1.Succeeded, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		DescribeTable("should proxy registry imports", func(isHTTPS, hasAuth bool) {
 			now := time.Now()
 			updateProxy(f, "", createProxyURL(isHTTPS, hasAuth, f.CdiInstallNs), "", ocpClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
You can define cluster wide certs by modifying the `importProxy.trustedCAProxy` in the CDIConfig. These `certConfigMap` will then be copied to future importer pods so there is no need to define the `datavolume.spec.source.http.certConfigMap` for every DV that needs this cert. 

However, because these cluster wide certs are considered proxyCerts, the current http data source logic would not copy them unless the DV has a defined `certConfigMap` in it's spec. 

This PR will allow proxyCerts (and in turn CA's defined at the global level) to get copied and used for http datasources even when the standard cert directory is not defined.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://redhat.atlassian.net/browse/CNV-47012


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix cluster wide certConfigMap for http datasources
```

