### PR TITLE
Add http endpoint block list

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3941,6 +3941,14 @@
     "description": "CDIConfigSpec defines specification for user configuration",
     "type": "object",
     "properties": {
+     "allowedSourceURLs": {
+      "description": "AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.). This allows importing from in-cluster services or private endpoints. Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)",
+      "type": "array",
+      "items": {
+       "type": "string",
+       "default": ""
+      }
+     },
      "dataVolumeTTLSeconds": {
       "description": "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default. Deprecated: Removed in v1.62.",
       "type": "integer",

--- a/doc/cdi-config.md
+++ b/doc/cdi-config.md
@@ -16,6 +16,7 @@ CDI configuration in specified by administrators in the `spec.config` of the `CD
 | preallocation            | nil           | Preallocation setting to use unless a per-dataVolume value is set                                                                                                                                                            |
 | importProxy              | nil           | The proxy configuration to be used by the importer pod when accessing a http data source. When the ImportProxy is empty, the Cluster Wide-Proxy (Openshift) configurations are used. ImportProxy has four parameters: `ImportProxy.HTTPProxy` that defines the proxy http url, the `ImportProxy.HTTPSProxy` that determines the roxy https url, and the `ImportProxy.noProxy` which enforce that a list of hostnames and/or CIDRs will be not proxied, and finally, the `ImportProxy.TrustedCAProxy`, the ConfigMap name of an user-provided trusted certificate authority (CA) bundle to be added to the importer pod CA bundle. |
 | insecureRegistries       | nil           | List of TLS disabled registries. |
+| allowedSourceURLs        | nil           | List of CIDR blocks or hostnames allowed for HTTP/HTTPS data sources even if they fall within restricted private IP ranges. Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc). See [Network Security](ssrf-protection.md) for details. |
 | tlsSecurityProfile       | nil           | Used by operators to apply cluster-wide TLS security settings to operands. |
 
 filesystemOverhead configuration:
@@ -37,6 +38,20 @@ kubectl patch cdi cdi  --type='json' -p='[{ "op" : "add" , "path" : "/spec/confi
 ```bash
 kubectl patch cdi cdi  --type='json' -p='[{ "op" : "add" , "path" : "/spec/config/filesystemOverhead/global" , "value" : "0.0" }]'
 ```
+
+To configure allowed source URLs for HTTP/HTTPS imports from private networks:
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": [
+      "10.96.0.0/12",
+      "minio.storage.svc"
+    ]
+  }
+}'
+```
+See [Network Security for HTTP-Based Sources](ssrf-protection.md) for more details.
+
 ## Getting
 
 CDI configuration may be retrieved by any authenticated user in the cluster by checking the `status` of the `CDIConfig` singleton

--- a/doc/ssrf-protection.md
+++ b/doc/ssrf-protection.md
@@ -1,0 +1,513 @@
+# Network Security for HTTP-Based DataVolume Sources
+
+## Overview
+
+CDI includes network access controls for HTTP-based DataVolume sources to prevent unintended access to internal network endpoints.
+
+**Applies to:**
+- HTTP/HTTPS imports (`spec.source.http`)
+- S3 imports (`spec.source.s3`)
+- ImageIO imports (oVirt/RHV) (`spec.source.imageio`)
+
+By default, DataVolume imports are restricted from accessing private network addresses. This helps ensure that import operations only connect to intended external resources.
+
+## Default Network Restrictions
+
+### Restricted IP Ranges
+
+The following CIDR ranges are restricted by default for HTTP-based DataVolume sources:
+
+| Range | Purpose |
+|-------|---------|
+| `169.254.0.0/16` | Link-local addresses (AWS/Azure/GCP metadata endpoints) |
+| `10.0.0.0/8` | RFC 1918 private networks |
+| `172.16.0.0/12` | RFC 1918 private networks |
+| `192.168.0.0/16` | RFC 1918 private networks |
+| `100.64.0.0/10` | Carrier-grade NAT (CGNAT) |
+| `127.0.0.0/8` | Loopback addresses |
+| `0.0.0.0/8` | Current network |
+| `224.0.0.0/4` | Multicast |
+| `240.0.0.0/4` | Reserved |
+| `fd00::/8` | IPv6 unique local addresses |
+| `fe80::/10` | IPv6 link-local |
+| `::1/128` | IPv6 loopback |
+
+### Implementation Details
+
+Network access controls are implemented with multiple validation layers:
+
+**For HTTP/HTTPS/S3 sources:**
+1. Early URL validation in `NewHTTPDataSource()`/`NewS3DataSource()` - validates the endpoint host before any network calls
+2. DialContext hook in HTTP client - validates every TCP connection attempt (defense in depth)
+
+**For ImageIO sources:**
+1. Early endpoint validation in `NewImageioDataSource()` - validates the oVirt API endpoint before connection
+2. Transfer URL validation in `createImageioReader()` - validates the ImageIO transfer URL returned by oVirt API (prevents compromised oVirt server or DNS rebinding attacks)
+3. DialContext hook in HTTP client - validates every connection (defense in depth)
+
+This layered approach ensures that even if one validation layer is bypassed, others remain in place.
+
+## Configuring Allowlist for In-Cluster Services
+
+For legitimate use cases where DataVolumes need to import from internal endpoints (e.g., in-cluster Minio, Ceph RGW, or private registries), cluster administrators can configure an allowlist in the CDIConfig resource.
+
+### Allowlist Configuration
+
+The allowlist is configured in `CDIConfig.spec.allowedSourceURLs` and supports three formats:
+
+1. **CIDR notation** - Allow an entire IP range
+2. **Exact IP address** - Allow a specific IP
+3. **Hostname** - Allow a hostname and its subdomains (case-insensitive)
+
+**Important:** Only cluster administrators can configure the allowlist. The CDIConfig resource is cluster-scoped, so namespace users cannot bypass SSRF protection.
+
+### Examples
+
+#### Allow Kubernetes Service CIDR
+
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["10.96.0.0/12"]
+  }
+}'
+```
+
+#### Allow Multiple In-Cluster Services
+
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": [
+      "10.96.0.0/12",
+      "minio.storage.svc",
+      "ceph-rgw.rook-ceph.svc",
+      "192.168.1.100"
+    ]
+  }
+}'
+```
+
+#### Check Current Configuration
+
+```bash
+kubectl get cdiconfig config -o jsonpath='{.spec.allowedSourceURLs}'
+```
+
+### Allowlist Entry Types
+
+#### CIDR Notation
+
+```yaml
+allowedSourceURLs:
+  - "10.96.0.0/12"      # Kubernetes service CIDR
+  - "172.30.0.0/16"     # OpenShift service CIDR
+```
+
+Allows any IP within the specified range.
+
+#### Exact IP Address
+
+```yaml
+allowedSourceURLs:
+  - "192.168.1.100"     # Specific internal server
+  - "10.0.50.25"        # Specific endpoint
+```
+
+Allows only the exact IP address specified.
+
+#### Hostname Matching
+
+```yaml
+allowedSourceURLs:
+  - "minio.default.svc"           # In-cluster Minio
+  - "registry.example.com"        # Private registry
+```
+
+Hostname matching includes:
+- Exact match: `minio.default.svc` matches `minio.default.svc`
+- Subdomain match: `minio.default.svc` matches `api.minio.default.svc`
+- Case-insensitive: `MINIO.DEFAULT.SVC` matches `minio.default.svc`
+
+**Note:** Hostnames are resolved to IPs, and those IPs are validated against the blocklist. An allowlisted hostname that resolves to a public IP is automatically permitted (public IPs are not blocked by default).
+
+## DataVolume Examples
+
+### Restricted Import
+
+Imports from private IP addresses will fail unless explicitly allowed:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: private-source
+spec:
+  source:
+    http:
+      url: http://10.0.0.1/disk.img
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 1Gi
+```
+
+Error message in events:
+```
+host "10.0.0.1" resolves to blocked IP 10.0.0.1 (SSRF protection)
+```
+
+### Public HTTP Import (Works by Default)
+
+This DataVolume works without any configuration because the URL resolves to a public IP:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: public-image
+spec:
+  source:
+    http:
+      url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi
+```
+
+### In-Cluster Service Import (Requires Allowlist)
+
+After configuring the allowlist with `minio.default.svc`, this DataVolume will work:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: minio-import
+spec:
+  source:
+    http:
+      url: http://minio.default.svc:9000/bucket/disk.qcow2
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 5Gi
+```
+
+### Private IP Import with CIDR Allowlist
+
+After configuring the allowlist with `10.96.0.0/12`, this DataVolume will work:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: internal-import
+spec:
+  source:
+    http:
+      url: http://10.96.1.100:8080/images/disk.img
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 20Gi
+```
+
+### S3 Import Examples
+
+S3 imports have the same network restrictions as HTTP imports.
+
+**Allowed S3 endpoint with allowlist:**
+```yaml
+# First configure allowlist
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["10.96.0.0/12"]
+  }
+}'
+
+# Then create DataVolume
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: allowed-s3
+spec:
+  source:
+    s3:
+      url: http://10.96.1.5:9000/bucket/disk.img
+      secretRef: s3-credentials
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi
+```
+
+### ImageIO (oVirt/RHV) Import Examples
+
+ImageIO imports validate both the oVirt API endpoint and the ImageIO transfer URL.
+
+**Allowed oVirt endpoint with allowlist:**
+```yaml
+# First configure allowlist
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["192.168.1.0/24"]
+  }
+}'
+
+# Then create DataVolume
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: allowed-imageio
+spec:
+  source:
+    imageio:
+      url: http://192.168.1.10/ovirt-engine/api
+      secretRef: ovirt-credentials
+      diskId: "disk-123"
+  pvc:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 20Gi
+```
+
+### Important: ImageIO Dual Validation
+
+ImageIO imports validate **two separate URLs**:
+
+1. **oVirt Engine API URL** - The endpoint in `spec.source.imageio.url` (e.g., `http://ovirt-engine.example.com/ovirt-engine/api`)
+2. **ImageIO Transfer URL** - Returned by the oVirt API during image transfer setup (e.g., `http://imageio-proxy.example.com:54323`)
+
+**Both URLs must pass SSRF validation.** If your oVirt deployment uses different hostnames or IPs for the engine API and ImageIO transfer service, **both must be in the allowlist**.
+
+#### Common ImageIO Deployment Patterns
+
+**Pattern 1: Same hostname for engine and transfer**
+```yaml
+allowedSourceURLs:
+  - "ovirt-engine.example.com"  # Covers both engine API and transfer URL
+```
+
+**Pattern 2: Separate hostnames**
+```yaml
+allowedSourceURLs:
+  - "ovirt-engine.example.com"   # Engine API
+  - "imageio-proxy.example.com"  # ImageIO transfer service
+```
+
+**Pattern 3: IP-based with CIDR**
+```yaml
+allowedSourceURLs:
+  - "192.168.1.0/24"  # Covers both engine (192.168.1.10) and transfer URLs in same subnet
+```
+
+**Pattern 4: Mixed hostname and IP**
+```yaml
+allowedSourceURLs:
+  - "ovirt-engine.example.com"  # Engine API hostname
+  - "192.168.1.0/24"            # Transfer URLs may use IPs
+```
+
+#### Troubleshooting ImageIO Validation
+
+If an ImageIO import fails with "transfer URL validation failed", check the importer pod logs:
+
+```bash
+kubectl logs -l cdi.kubevirt.io/dataVolume=<datavolume-name>
+```
+
+Look for the actual transfer URL that oVirt returned:
+```
+Error: transfer URL validation failed: host "192.168.1.50:54323" resolves to blocked IP 192.168.1.50
+```
+
+Then add the transfer URL's hostname or IP range to the allowlist:
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": [
+      "ovirt-engine.example.com",
+      "192.168.1.0/24"
+    ]
+  }
+}'
+```
+
+## Validation Behavior
+
+### Validation Order
+
+For each HTTP/HTTPS import:
+
+1. **Early URL validation** - The destination hostname/IP is validated before any network calls
+2. **DNS resolution** - The hostname is resolved to IP addresses
+3. **Allowlist check** - If any resolved IP matches an allowlist entry, the import proceeds
+4. **Blocklist check** - If any resolved IP matches a blocked range (and wasn't allowlisted), the import fails
+5. **Connection validation** - The DialContext hook validates each connection attempt (defense in depth)
+
+### Multiple IP Addresses
+
+If a hostname resolves to multiple IP addresses:
+- **At least one IP must be allowed** - If any resolved IP matches the allowlist or is a public IP, the import proceeds
+- **All IPs are checked** - If all resolved IPs are blocked (and none are allowlisted), the import fails
+
+Example: `internal.example.com` resolves to `[10.0.0.1, 8.8.8.8]`
+- Without allowlist: **Allowed** (8.8.8.8 is public)
+- With allowlist `["10.0.0.0/8"]`: **Allowed** (10.0.0.1 matches allowlist)
+
+## HTTP Proxy Support
+
+Network access controls are **compatible with HTTP proxy support**. CDI continues to respect `HTTP_PROXY` and `HTTPS_PROXY` environment variables for importer pods.
+
+The validation works by checking the **destination URL** before making network calls, so restricted destinations are rejected early even when using a proxy.
+
+**Important:** If you allowlist a hostname or IP range, ensure that your HTTP proxy implements appropriate egress controls.
+
+## Configuration Security
+
+### Allowlist Permissions
+
+- **Cluster-admin only**: Only users with write access to the cluster-scoped CDIConfig resource can modify the allowlist
+- **Namespace users cannot override**: Regular users cannot add allowlist entries
+- **Global allowlist**: The allowlist applies to all namespaces in the cluster (there is no per-namespace allowlist)
+
+### Recommendations
+
+1. **Minimize allowlist entries**: Only add entries for services that genuinely need to be accessible via DataVolume HTTP imports
+
+2. **Use narrow CIDR ranges**: Instead of allowing entire private ranges, use specific subnets:
+   - Good: `10.96.0.0/12` (Kubernetes service CIDR)
+   - Avoid: `10.0.0.0/8` (entire private range)
+
+3. **Prefer hostnames over IPs**: Hostname-based allowlist entries are more maintainable as infrastructure changes
+
+4. **Monitor for failures**: Watch for DataVolume failures with "SSRF protection" errors, which may indicate legitimate use cases that need allowlisting
+
+5. **Audit allowlist changes**: Track changes to CDIConfig.spec.allowedSourceURLs in your audit logs
+
+## Troubleshooting
+
+### DataVolume Stuck in "ImportScheduled" with Network Error
+
+**Symptom:** DataVolume events show:
+```
+SSRF protection: host "10.0.0.1" resolves to blocked IP 10.0.0.1
+```
+
+**Solution:** The destination IP is blocked. If this is a legitimate internal endpoint:
+
+```bash
+# Add the IP or CIDR to the allowlist
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["10.0.0.0/24"]
+  }
+}'
+
+# Delete and recreate the DataVolume
+kubectl delete dv <datavolume-name>
+kubectl apply -f <datavolume.yaml>
+```
+
+### Allowlist Not Taking Effect
+
+**Symptom:** Added allowlist entry but DataVolume still fails with SSRF error
+
+**Check:**
+
+1. Verify the allowlist was applied:
+   ```bash
+   kubectl get cdiconfig config -o yaml | grep -A 10 allowedSourceURLs
+   ```
+
+2. Check importer pod logs for allowlist confirmation:
+   ```bash
+   kubectl logs -l cdi.kubevirt.io/dataVolume=<datavolume-name> | grep allowlist
+   ```
+   
+   Expected output:
+   ```
+   SSRF protection allowlist: [10.96.0.0/12 minio.default.svc]
+   ```
+
+3. Ensure the DataVolume was created **after** the allowlist was configured (existing pods don't pick up config changes)
+
+### Hostname Resolves to Blocked IP
+
+**Symptom:** DataVolume with hostname URL fails even though hostname is allowlisted
+
+**Example:**
+```yaml
+allowedSourceURLs: ["internal.example.com"]
+```
+
+DataVolume with `http://internal.example.com/disk.img` fails with:
+```
+SSRF protection: host "internal.example.com" resolves to blocked IP 10.0.0.1
+```
+
+**Root Cause:** The hostname `internal.example.com` is allowlisted, but it resolved to a blocked IP (`10.0.0.1`). Hostname allowlisting permits the hostname itself, but the resolved IP must also be allowed.
+
+**Solution:** Add the CIDR range or exact IP to the allowlist:
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["internal.example.com", "10.0.0.0/24"]
+  }
+}'
+```
+
+## Migration from Older Versions
+
+### Upgrading CDI
+
+**Impact:** Existing DataVolumes that import from **private IP addresses** will fail after upgrading unless configured in the allowlist.
+
+**Migration Steps:**
+
+1. **Before upgrade**: Audit existing DataVolumes for private IP usage:
+   ```bash
+   kubectl get dv -A -o json | \
+     jq -r '.items[] | select(.spec.source.http.url | test("^https?://(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|169\\.254\\.|127\\.)")) | "\(.metadata.namespace)/\(.metadata.name): \(.spec.source.http.url)"'
+   ```
+
+2. **After upgrade**: Configure allowlist for legitimate internal endpoints
+
+3. **Re-create affected DataVolumes**: DataVolumes created before the allowlist was configured need to be deleted and recreated
+
+### Example Migration
+
+**Before upgrade**: DataVolume importing from in-cluster Minio at `10.96.1.5`:
+```yaml
+spec:
+  source:
+    http:
+      url: http://10.96.1.5:9000/bucket/disk.qcow2
+```
+
+**After upgrade** (without allowlist): ❌ Fails with SSRF error
+
+**After adding allowlist**:
+```bash
+kubectl patch cdiconfig config --type=merge -p '{
+  "spec": {
+    "allowedSourceURLs": ["10.96.0.0/12"]
+  }
+}'
+```
+
+**Re-create DataVolume**: ✅ Now works
+
+## Related Documentation
+
+- [CDI Configuration](cdi-config.md)
+- [DataVolumes](datavolumes.md)
+- [Import from HTTP/S3](datavolumes.md#http-source)

--- a/pkg/apis/core/v1beta1/openapi_generated.go
+++ b/pkg/apis/core/v1beta1/openapi_generated.go
@@ -16663,6 +16663,21 @@ func schema_pkg_apis_core_v1beta1_CDIConfigSpec(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"allowedSourceURLs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.). This allows importing from in-cluster services or private endpoints. Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"dataVolumeTTLSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default. Deprecated: Removed in v1.62.",

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -165,6 +165,8 @@ const (
 	InstallerVersionLabel = "INSTALLER_VERSION_LABEL"
 	// ImporterExtraHeader provides a constant to include extra HTTP headers, as the prefix to a format string
 	ImporterExtraHeader = "IMPORTER_EXTRA_HEADER_"
+	// ImporterAllowedSourceURLs provides a constant for the allowlist of source URLs (CIDRs or hostnames)
+	ImporterAllowedSourceURLs = "IMPORTER_ALLOWED_SOURCE_URLS"
 	// ImporterSecretExtraHeadersDir is where the secrets containing extra HTTP headers will be mounted
 	ImporterSecretExtraHeadersDir = "/extraheaders"
 	// ImporterRegistryImageArchitecture provides a constant to capture our env variable "IMPORTER_REGISTRY_IMAGE_ARCHITECTURE"

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -105,6 +105,7 @@ type importPodEnvVar struct {
 	cacheMode                 string
 	registryImageArchitecture string
 	checksum                  string
+	allowedSourceURLs         string
 }
 
 type importerPodArgs struct {
@@ -687,6 +688,12 @@ func (r *ImportReconciler) createImportEnvVar(pvc *corev1.PersistentVolumeClaim)
 			r.log.V(3).Info("no proxy CA certiticate will be supplied:", "error", err.Error())
 		}
 		podEnvVar.certConfigMapProxy = field
+
+		// Add allowlist from CDIConfig for SSRF protection
+		if len(cdiConfig.Spec.AllowedSourceURLs) > 0 {
+			podEnvVar.allowedSourceURLs = strings.Join(cdiConfig.Spec.AllowedSourceURLs, ",")
+			r.log.V(3).Info("SSRF protection allowlist configured", "allowlist", podEnvVar.allowedSourceURLs)
+		}
 	}
 
 	fsOverhead, err := GetFilesystemOverhead(context.TODO(), r.client, pvc)
@@ -1432,6 +1439,12 @@ func makeImportEnv(podEnvVar *importPodEnvVar, uid types.UID) []corev1.EnvVar {
 			Name:  common.ImporterChecksum,
 			Value: podEnvVar.checksum,
 		},
+	}
+	if podEnvVar.allowedSourceURLs != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  common.ImporterAllowedSourceURLs,
+			Value: podEnvVar.allowedSourceURLs,
+		})
 	}
 	if podEnvVar.secretName != "" && podEnvVar.source != cc.SourceGCS {
 		env = append(env, corev1.EnvVar{

--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/monitoring/metrics/cdi-importer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/checksum:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//pkg/util/prometheus:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -42,6 +43,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	utilnet "kubevirt.io/containerized-data-importer/pkg/util/net"
 )
 
 const (
@@ -96,6 +98,14 @@ func NewHTTPDataSource(endpoint, accessKey, secKey, certDir string, contentType 
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse endpoint %q", endpoint)
 	}
+
+	// Validate endpoint host against SSRF blocklist BEFORE making any network calls
+	// This prevents proxy-based bypasses where DialContext only sees the proxy IP
+	allowlist := getAllowedSourceURLs()
+	if err := utilnet.ValidateEndpointHost(ep.Host, allowlist); err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	extraHeaders, secretExtraHeaders, err := getExtraHeaders()
@@ -320,38 +330,95 @@ func createCertPool(certDir string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
+// getAllowedSourceURLs reads the allowlist from environment variable
+func getAllowedSourceURLs() []string {
+	allowlistStr := os.Getenv(common.ImporterAllowedSourceURLs)
+	if allowlistStr == "" {
+		return nil
+	}
+	parts := strings.Split(allowlistStr, ",")
+	var result []string
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
 func createHTTPClient(certDir string, insecureSkipVerify bool) (*http.Client, error) {
 	client := &http.Client{
 		// Don't set timeout here, since that will be an absolute timeout, we need a relative to last progress timeout.
 	}
 
-	if certDir == "" && !insecureSkipVerify {
-		return client, nil
-	}
-	// the default transport contains Proxy configurations to use environment variables and default timeouts
+	// Clone default transport to preserve proxy settings and timeouts
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		// #nosec G402 -- InsecureSkipVerify is intentionally set based on user configuration
-		InsecureSkipVerify: insecureSkipVerify,
+
+	// Read allowlist from environment
+	allowlist := getAllowedSourceURLs()
+	if len(allowlist) > 0 {
+		klog.Infof("SSRF protection allowlist: %v", allowlist)
 	}
 
-	if !insecureSkipVerify {
-		certPool, err := createCertPool(certDir)
-		if err != nil {
-			return nil, err
+	// Add SSRF protection via DialContext hook (defense in depth)
+	// Note: Primary protection is early URL validation in NewHTTPDataSource()
+	defaultDialContext := transport.DialContext
+	if defaultDialContext == nil {
+		defaultDialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// Validate that the connection target is not blocked (SSRF protection)
+		// addr is "hostname:port" or "ip:port" - ValidateEndpointHost handles both
+		if err := utilnet.ValidateEndpointHost(addr, allowlist); err != nil {
+			return nil, fmt.Errorf("SSRF protection: %w", err)
 		}
-		tlsConfig.RootCAs = certPool
+		return defaultDialContext(ctx, network, addr)
 	}
 
-	transport.TLSClientConfig = tlsConfig
+	// Configure TLS if needed
+	if certDir != "" || insecureSkipVerify {
+		tlsConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			// #nosec G402 -- InsecureSkipVerify is intentionally set based on user configuration
+			InsecureSkipVerify: insecureSkipVerify,
+		}
+
+		if !insecureSkipVerify {
+			certPool, err := createCertPool(certDir)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.RootCAs = certPool
+		}
+
+		transport.TLSClientConfig = tlsConfig
+	}
+
 	transport.GetProxyConnectHeader = func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error) {
 		h := http.Header{}
 		h.Add("User-Agent", defaultUserAgent)
 		return h, nil
 	}
-	client.Transport = transport
 
+	// Validate redirect targets to prevent SSRF bypass via redirects
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+
+		// Validate redirect target host against blocklist and allowlist
+		if err := utilnet.ValidateEndpointHost(req.URL.Host, allowlist); err != nil {
+			return fmt.Errorf("SSRF protection (redirect): %w", err)
+		}
+		return nil
+	}
+
+	client.Transport = transport
 	return client, nil
 }
 
@@ -373,11 +440,26 @@ func createHTTPReader(ctx context.Context, ep *url.URL, accessKey, secKey, certD
 	}
 
 	allExtraHeaders := append(extraHeaders, secretExtraHeaders...)
+	allowlist := getAllowedSourceURLs()
 
+	// Merge SSRF validation with basic auth/header handling in CheckRedirect
 	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
-		if len(accessKey) > 0 && len(secKey) > 0 {
-			r.SetBasicAuth(accessKey, secKey) // Redirects will lose basic auth, so reset them manually
+		// Enforce redirect limit
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
 		}
+
+		// Validate redirect target host against blocklist and allowlist (SSRF protection)
+		if err := utilnet.ValidateEndpointHost(r.URL.Host, allowlist); err != nil {
+			return fmt.Errorf("SSRF protection (redirect): %w", err)
+		}
+
+		// Apply basic auth to redirect (redirects lose basic auth)
+		if len(accessKey) > 0 && len(secKey) > 0 {
+			r.SetBasicAuth(accessKey, secKey)
+		}
+
+		// Apply extra headers to redirect
 		addExtraheaders(r, allExtraHeaders)
 		return nil
 	}
@@ -573,7 +655,12 @@ func getServerInfo(ctx context.Context, infoURL string) (*common.ServerInfo, err
 		return nil, errors.Wrap(err, "failed to construct request for containerimage-server info")
 	}
 
-	client := &http.Client{}
+	// Use createHTTPClient with SSRF protection instead of bare http.Client
+	client, err := createHTTPClient("", false)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create HTTP client for containerimage-server info")
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed request containerimage-server info")

--- a/pkg/importer/http-datasource_test.go
+++ b/pkg/importer/http-datasource_test.go
@@ -41,17 +41,21 @@ var (
 
 var _ = Describe("Http data source", func() {
 	var (
-		ts        *httptest.Server
-		dp        *HTTPDataSource
-		err       error
-		flushRead []byte
-		tmpDir    string
+		ts                        *httptest.Server
+		dp                        *HTTPDataSource
+		err                       error
+		flushRead                 []byte
+		tmpDir                    string
+		originalAllowedSourceURLs string
 	)
 
 	BeforeEach(func() {
 		createNbdkitCurl = image.NewMockNbdkitCurl
 		By("[BeforeEach] Creating test server")
 		ts = createTestServer(imageDir, nil)
+		// Save and set allowlist for SSRF protection (allow test server at 127.0.0.1)
+		originalAllowedSourceURLs = os.Getenv(common.ImporterAllowedSourceURLs)
+		os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
 		dp = nil
 		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
@@ -73,6 +77,12 @@ var _ = Describe("Http data source", func() {
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		By("[AfterEach] closing test server")
 		ts.Close()
+		// Restore original allowlist
+		if originalAllowedSourceURLs == "" {
+			os.Unsetenv(common.ImporterAllowedSourceURLs)
+		} else {
+			os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)
+		}
 	})
 
 	It("NewHTTPDataSource should fail when called with an invalid endpoint", func() {
@@ -85,6 +95,169 @@ var _ = Describe("Http data source", func() {
 		image := ts.URL + "/" + cirrosFileName
 		_, err = NewHTTPDataSource(image, "", "", "/invaliddir", cdiv1.DataVolumeKubeVirt, "")
 		Expect(err).To(HaveOccurred())
+	})
+
+	Context("SSRF Protection", func() {
+		var savedAllowlist string
+		var allowlistWasSet bool
+
+		BeforeEach(func() {
+			savedAllowlist, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		})
+
+		AfterEach(func() {
+			if allowlistWasSet {
+				Expect(os.Setenv(common.ImporterAllowedSourceURLs, savedAllowlist)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+			}
+		})
+
+		DescribeTable("should validate IPs according to blocklist and allowlist",
+			func(endpoint string, allowlist string, expectSSRFError bool) {
+				// Replace TEST_SERVER placeholder with actual server URL
+				if endpoint == "TEST_SERVER" {
+					endpoint = ts.URL + "/" + cirrosFileName
+				}
+
+				// Set allowlist for this test (empty string = unset)
+				if allowlist == "" {
+					Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+				} else {
+					Expect(os.Setenv(common.ImporterAllowedSourceURLs, allowlist)).To(Succeed())
+				}
+
+				ds, dsErr := NewHTTPDataSource(endpoint, "", "", "", cdiv1.DataVolumeKubeVirt, "")
+				if expectSSRFError {
+					Expect(dsErr).To(HaveOccurred())
+					Expect(dsErr.Error()).To(ContainSubstring("SSRF protection"))
+				} else {
+					// Should not get SSRF error (may get other errors like connection refused)
+					if dsErr != nil {
+						Expect(dsErr.Error()).NotTo(ContainSubstring("SSRF protection"))
+					} else {
+						Expect(ds).NotTo(BeNil())
+						ds.Close()
+					}
+				}
+			},
+			// Blocked by default without allowlist
+			Entry("block AWS IMDS", "http://169.254.169.254/latest/meta-data/", "", true),
+			Entry("block Azure IMDS", "http://169.254.169.254/metadata/instance", "", true),
+			Entry("block private 10.x", "http://10.0.0.1/data", "", true),
+			Entry("block private 192.168.x", "http://192.168.1.1/data", "", true),
+			Entry("block CGNAT", "http://100.64.0.1/data", "", true),
+			Entry("block loopback on different port", "http://127.0.0.1:8080/data", "", true),
+
+			// Allowed via allowlist
+			Entry("allow localhost test server via allowlist", "TEST_SERVER", "127.0.0.1", false),
+			Entry("allow localhost CIDR on different port", "http://127.0.0.1:9999/data", "127.0.0.0/8", false),
+		)
+
+		It("should validate URL host early to prevent proxy-based bypass", func() {
+			// Even if HTTP_PROXY is set, validation happens on the URL host, not the proxy
+			savedHTTPProxy, proxyWasSet := os.LookupEnv("HTTP_PROXY")
+
+			// Unset allowlist to test default blocking (suite-level BeforeEach set it to 127.0.0.1)
+			err := os.Unsetenv(common.ImporterAllowedSourceURLs)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Set HTTP_PROXY to a hypothetical allowed proxy
+			Expect(os.Setenv("HTTP_PROXY", "http://127.0.0.1:3128")).To(Succeed())
+
+			// Restore HTTP_PROXY after test
+			defer func() {
+				var restoreErr error
+				if proxyWasSet {
+					restoreErr = os.Setenv("HTTP_PROXY", savedHTTPProxy)
+				} else {
+					restoreErr = os.Unsetenv("HTTP_PROXY")
+				}
+				Expect(restoreErr).NotTo(HaveOccurred())
+			}()
+
+			// Try to access AWS IMDS - should fail immediately with SSRF error
+			// even though the proxy (127.0.0.1) is in the allowlist from BeforeEach
+			_, err = NewHTTPDataSource("http://169.254.169.254/latest/meta-data/", "", "", "", cdiv1.DataVolumeKubeVirt, "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("SSRF protection"))
+			Expect(err.Error()).To(ContainSubstring("169.254.169.254"))
+		})
+
+		DescribeTable("should validate redirects",
+			func(setupServer func() *httptest.Server, allowlist string, expectError bool, errorSubstring string, expectedSize uint64) {
+				server := setupServer()
+				defer server.Close()
+
+				savedAllowlist := os.Getenv(common.ImporterAllowedSourceURLs)
+				defer func() {
+					if savedAllowlist == "" {
+						os.Unsetenv(common.ImporterAllowedSourceURLs)
+					} else {
+						os.Setenv(common.ImporterAllowedSourceURLs, savedAllowlist)
+					}
+				}()
+
+				os.Setenv(common.ImporterAllowedSourceURLs, allowlist)
+
+				ep, err := url.Parse(server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				reader, total, _, err := createHTTPReader(context.Background(), ep, "", "", "", nil, nil, cdiv1.DataVolumeKubeVirt)
+				if expectError {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(errorSubstring))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(total).To(Equal(expectedSize))
+					reader.Close()
+				}
+			},
+			Entry("reject redirect to blocked IP",
+				func() *httptest.Server {
+					return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+					}))
+				},
+				"127.0.0.1", // Allow localhost for initial request
+				true,        // Expect error
+				"SSRF protection",
+				uint64(0),
+			),
+			Entry("accept redirect to allowed IP",
+				func() *httptest.Server {
+					// Server that handles both initial request and redirect target
+					return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.URL.Path == "/target" {
+							// Target path - return content
+							w.Header().Set("Content-Length", "1024")
+							w.WriteHeader(http.StatusOK)
+						} else {
+							// Initial request - redirect to target path on same server
+							http.Redirect(w, r, "/target", http.StatusFound)
+						}
+					}))
+				},
+				"127.0.0.1", // Allow localhost
+				false,       // No error expected
+				"",
+				uint64(1024),
+			),
+			Entry("enforce 10-redirect limit",
+				func() *httptest.Server {
+					var redirectCount int
+					return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						redirectCount++
+						// Always redirect with query param to create unique URLs
+						http.Redirect(w, r, fmt.Sprintf("/?redirect=%d", redirectCount), http.StatusFound)
+					}))
+				},
+				"127.0.0.1", // Allow localhost
+				true,        // Expect error
+				"10 redirects",
+				uint64(0),
+			),
+		)
 	})
 
 	DescribeTable("calling info should", func(image string, contentType cdiv1.DataVolumeContentType, expectedPhase ProcessingPhase, want []byte, wantErr bool, brokenForQemuImg bool) {
@@ -444,6 +617,23 @@ var _ = Describe("Http client", func() {
 })
 
 var _ = Describe("Http reader", func() {
+	var originalAllowedSourceURLs string
+
+	BeforeEach(func() {
+		// Save and set allowlist for SSRF protection (allow localhost test servers)
+		originalAllowedSourceURLs = os.Getenv(common.ImporterAllowedSourceURLs)
+		os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
+	})
+
+	AfterEach(func() {
+		// Restore original allowlist
+		if originalAllowedSourceURLs == "" {
+			os.Unsetenv(common.ImporterAllowedSourceURLs)
+		} else {
+			os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)
+		}
+	})
+
 	It("should fail when passed an invalid cert directory", func() {
 		_, total, _, err := createHTTPReader(context.Background(), nil, "", "", "/invalid", nil, nil, cdiv1.DataVolumeKubeVirt)
 		Expect(err).To(HaveOccurred())

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -41,6 +41,7 @@ import (
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	utilnet "kubevirt.io/containerized-data-importer/pkg/util/net"
 )
 
 // ImageioDataSource is the data provider for ovirt-imageio.
@@ -69,6 +70,19 @@ type ImageioDataSource struct {
 
 // NewImageioDataSource creates a new instance of the ovirt-imageio data provider.
 func NewImageioDataSource(endpoint string, accessKey string, secKey string, certDir string, diskID string, currentCheckpoint string, previousCheckpoint string, insecureSkipVerify bool) (*ImageioDataSource, error) {
+	// Parse endpoint to extract host for SSRF validation
+	ep, err := ParseEndpoint(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse endpoint %q", endpoint)
+	}
+
+	// Validate endpoint host against SSRF blocklist BEFORE making any network calls
+	// This prevents access to cloud metadata endpoints and other internal resources
+	allowlist := getAllowedSourceURLs()
+	if err := utilnet.ValidateEndpointHost(ep.Host, allowlist); err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	imageioReader, contentLength, it, conn, err := createImageioReader(ctx, endpoint, accessKey, secKey, certDir, diskID, currentCheckpoint, previousCheckpoint, insecureSkipVerify)
 	if err != nil {
@@ -549,6 +563,17 @@ func createImageioReader(ctx context.Context, ep string, accessKey string, secKe
 	transferURL, available := it.TransferUrl()
 	if !available {
 		return nil, uint64(0), it, conn, errors.New("Error transfer url not available")
+	}
+
+	// Validate transferURL against SSRF blocklist (defense in depth)
+	// The transferURL comes from oVirt API response, so validate it before use
+	transferEp, err := ParseEndpoint(transferURL)
+	if err != nil {
+		return nil, uint64(0), it, conn, errors.Wrapf(err, "unable to parse transfer URL %q", transferURL)
+	}
+	allowlist := getAllowedSourceURLs()
+	if err := utilnet.ValidateEndpointHost(transferEp.Host, allowlist); err != nil {
+		return nil, uint64(0), it, conn, errors.Wrap(err, "transfer URL validation failed")
 	}
 
 	// For raw images, see if the transfer can be sped up with the extents API

--- a/pkg/importer/imageio-datasource_test.go
+++ b/pkg/importer/imageio-datasource_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 	"kubevirt.io/containerized-data-importer/pkg/util/cert/triple"
@@ -40,8 +41,10 @@ var renewalTime time.Time
 
 var _ = Describe("Imageio reader", func() {
 	var (
-		ts      *httptest.Server
-		tempDir string
+		ts                        *httptest.Server
+		tempDir                   string
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 
 	BeforeEach(func() {
@@ -56,6 +59,10 @@ var _ = Describe("Imageio reader", func() {
 		it.SetId(diskID)
 		errDiskCreate = nil
 		diskAvailable = true
+		// Save and set allowlist for SSRF protection (allows localhost test server)
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		err := os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -64,6 +71,12 @@ var _ = Describe("Imageio reader", func() {
 			os.RemoveAll(tempDir)
 		}
 		ts.Close()
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("should fail creating client", func() {
@@ -84,9 +97,11 @@ var _ = Describe("Imageio reader", func() {
 
 var _ = Describe("Imageio data source", func() {
 	var (
-		ts      *httptest.Server
-		tempDir string
-		err     error
+		ts                        *httptest.Server
+		tempDir                   string
+		err                       error
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 
 	BeforeEach(func() {
@@ -101,6 +116,9 @@ var _ = Describe("Imageio data source", func() {
 		it.SetId(diskID)
 		diskAvailable = true
 		errDiskCreate = nil
+		// Save and set allowlist for SSRF protection (allows localhost test server)
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		Expect(os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -109,6 +127,12 @@ var _ = Describe("Imageio data source", func() {
 			os.RemoveAll(tempDir)
 		}
 		ts.Close()
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("NewImageioDataSource should fail when called with an invalid endpoint", func() {
@@ -223,6 +247,61 @@ var _ = Describe("Imageio data source", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	Context("SSRF Protection", func() {
+		var savedAllowlist string
+		var savedAllowlistWasSet bool
+
+		BeforeEach(func() {
+			savedAllowlist, savedAllowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		})
+
+		AfterEach(func() {
+			if savedAllowlistWasSet {
+				Expect(os.Setenv(common.ImporterAllowedSourceURLs, savedAllowlist)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+			}
+		})
+
+		DescribeTable("should validate endpoint IPs according to blocklist and allowlist",
+			func(endpoint string, allowlist string, expectSSRFError bool) {
+				if allowlist != "" {
+					Expect(os.Setenv(common.ImporterAllowedSourceURLs, allowlist)).To(Succeed())
+				} else {
+					Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+				}
+
+				_, dsErr := NewImageioDataSource(endpoint, "", "", tempDir, diskID, "", "", false)
+				if expectSSRFError {
+					Expect(dsErr).To(HaveOccurred())
+					Expect(dsErr.Error()).To(ContainSubstring("SSRF protection"))
+				} else {
+					// May fail for other reasons (connection, etc) but not SSRF
+					if dsErr != nil {
+						Expect(dsErr.Error()).NotTo(ContainSubstring("SSRF protection"))
+					}
+				}
+			},
+			// Blocked by default
+			Entry("block AWS IMDS", "http://169.254.169.254/ovirt-engine/api", "", true),
+			Entry("block Azure IMDS", "http://169.254.169.254/metadata/instance", "", true),
+			Entry("block private 10.x", "http://10.0.0.1/ovirt-engine/api", "", true),
+			Entry("block private 192.168.x", "http://192.168.1.1/ovirt-engine/api", "", true),
+			Entry("block CGNAT", "http://100.64.0.1/ovirt-engine/api", "", true),
+			Entry("block loopback (non-allowlisted)", "http://127.0.0.1:8080/ovirt-engine/api", "", true),
+
+			// Allowed by allowlist (CIDR) - includes 127.0.0.1 for mock transfer URL
+			Entry("allow 10.96.1.1 via CIDR allowlist", "http://10.96.1.1/ovirt-engine/api", "10.96.0.0/12,127.0.0.1", false),
+			Entry("allow 192.168.1.100 via exact IP", "http://192.168.1.100/ovirt-engine/api", "192.168.1.100,127.0.0.1", false),
+
+			// Allowed by allowlist (multiple entries) - includes 127.0.0.1 for mock transfer URL
+			Entry("allow via multiple allowlist entries", "http://10.96.1.1/ovirt-engine/api", "172.16.0.0/12,10.96.0.0/12,127.0.0.1", false),
+
+			// Allowed by allowlist (hostname) - includes 127.0.0.1 for mock transfer URL
+			Entry("allow via hostname allowlist", "http://ovirt-engine.example.com/ovirt-engine/api", "ovirt-engine.example.com,127.0.0.1", false),
+		)
+	})
+
 })
 
 var _ = Describe("Imageio client preparation", func() {
@@ -288,8 +367,10 @@ var _ = Describe("Imageio pollprogress", func() {
 
 var _ = Describe("Imageio cancel", func() {
 	var (
-		ts      *httptest.Server
-		tempDir string
+		ts                        *httptest.Server
+		tempDir                   string
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 
 	BeforeEach(func() {
@@ -304,6 +385,10 @@ var _ = Describe("Imageio cancel", func() {
 		it.SetId(diskID)
 		diskAvailable = true
 		errDiskCreate = nil
+		// Save and set allowlist for SSRF protection (allows localhost test server)
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		err := os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -314,6 +399,12 @@ var _ = Describe("Imageio cancel", func() {
 			os.RemoveAll(tempDir)
 		}
 		ts.Close()
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("should clean up transfer on SIGTERM", func() {
@@ -419,12 +510,14 @@ var _ = Describe("Imageio cancel", func() {
 
 var _ = Describe("imageio snapshots", func() {
 	var (
-		ts               *httptest.Server
-		tempDir          string
-		snapshotID       string
-		parentSnapshotID string
-		snapshotSize     int64
-		diskSize         int64
+		ts                        *httptest.Server
+		tempDir                   string
+		snapshotID                string
+		parentSnapshotID          string
+		snapshotSize              int64
+		diskSize                  int64
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 
 	BeforeEach(func() {
@@ -474,6 +567,11 @@ var _ = Describe("imageio snapshots", func() {
 
 		disk.SetStorageDomains(storageDomains)
 		disk.SetStorageDomain(storageDomain)
+
+		// Save and set allowlist for SSRF protection (allows localhost test server)
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		err := os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -482,6 +580,12 @@ var _ = Describe("imageio snapshots", func() {
 			os.RemoveAll(tempDir)
 		}
 		ts.Close()
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("should correctly get initial snapshot transfer", func() {
@@ -505,8 +609,10 @@ var _ = Describe("imageio snapshots", func() {
 
 var _ = Describe("Imageio extents", func() {
 	var (
-		ts      *httptest.Server
-		tempDir string
+		ts                        *httptest.Server
+		tempDir                   string
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 	BeforeEach(func() {
 		newOvirtClientFunc = createMockOvirtClient
@@ -531,6 +637,11 @@ var _ = Describe("Imageio extents", func() {
 		it.SetTransferUrl(ts.URL + "/ovirt-engine/api/tickets/" + diskID)
 		errDiskCreate = nil
 		diskAvailable = true
+
+		// Save and set allowlist for SSRF protection (allows localhost test server)
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		err := os.Setenv(common.ImporterAllowedSourceURLs, "127.0.0.1")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -541,6 +652,12 @@ var _ = Describe("Imageio extents", func() {
 			os.RemoveAll(tempDir)
 		}
 		ts.Close()
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("should create an extents reader when the feature is enabled", func() {

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	utilnet "kubevirt.io/containerized-data-importer/pkg/util/net"
 )
 
 const (
@@ -56,6 +57,14 @@ func NewS3DataSource(endpoint, accessKey, secKey string, certDir string) (*S3Dat
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse endpoint %q", endpoint)
 	}
+
+	// Validate endpoint host against SSRF blocklist BEFORE making any network calls
+	// This prevents access to cloud metadata endpoints and other internal resources
+	allowlist := getAllowedSourceURLs()
+	if err := utilnet.ValidateEndpointHost(ep.Host, allowlist); err != nil {
+		return nil, err
+	}
+
 	s3Reader, err := createS3Reader(ep, accessKey, secKey, certDir)
 	if err != nil {
 		return nil, err

--- a/pkg/importer/s3-datasource_test.go
+++ b/pkg/importer/s3-datasource_test.go
@@ -11,13 +11,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 var _ = Describe("S3 data source", func() {
 	var (
-		sd     *S3DataSource
-		tmpDir string
-		err    error
+		sd                        *S3DataSource
+		tmpDir                    string
+		err                       error
+		originalAllowedSourceURLs string
+		allowlistWasSet           bool
 	)
 
 	BeforeEach(func() {
@@ -25,6 +29,11 @@ var _ = Describe("S3 data source", func() {
 		tmpDir, err = os.MkdirTemp("", "scratch")
 		Expect(err).NotTo(HaveOccurred())
 		By("tmpDir: " + tmpDir)
+
+		// Save and set allowlist for S3 test endpoints
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		// Allow localhost for S3 tests (DNS rebinding protection requires resolvable hostnames)
+		Expect(os.Setenv(common.ImporterAllowedSourceURLs, "localhost,127.0.0.0/8,::1/128")).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -33,6 +42,13 @@ var _ = Describe("S3 data source", func() {
 			sd.Close()
 		}
 		os.RemoveAll(tmpDir)
+
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
 	})
 
 	It("NewS3DataSource should Error, when passed in an invalid endpoint", func() {
@@ -42,19 +58,19 @@ var _ = Describe("S3 data source", func() {
 
 	It("NewS3DataSource should Error, when failing to create S3 client", func() {
 		newClientFunc = failMockS3Client
-		sd, err = NewS3DataSource("http://amazon.com", "", "", "")
+		sd, err = NewS3DataSource("http://localhost", "", "", "")
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("NewS3DataSource should Error, when failing to get object", func() {
 		newClientFunc = createErrMockS3Client
-		sd, err = NewS3DataSource("http://amazon.com", "", "", "")
+		sd, err = NewS3DataSource("http://localhost", "", "", "")
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("NewS3DataSource should fail when called with an invalid certdir", func() {
 		newClientFunc = getS3Client
-		sd, err = NewS3DataSource("http://amazon.com", "", "", "/invaliddir")
+		sd, err = NewS3DataSource("http://localhost", "", "", "/invaliddir")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -64,7 +80,7 @@ var _ = Describe("S3 data source", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = file.Close()
 		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		sd.s3Reader = file
 		result, err := sd.Info()
@@ -76,7 +92,7 @@ var _ = Describe("S3 data source", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(cirrosFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		sd.s3Reader = file
 		result, err := sd.Info()
@@ -88,7 +104,7 @@ var _ = Describe("S3 data source", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(tinyCoreFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		sd.s3Reader = file
 		result, err := sd.Info()
@@ -103,7 +119,7 @@ var _ = Describe("S3 data source", func() {
 		sourceFile, err := os.Open(fileName)
 		Expect(err).NotTo(HaveOccurred())
 
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = sourceFile
@@ -137,7 +153,7 @@ var _ = Describe("S3 data source", func() {
 		sourceFile, err := os.Open(cirrosFilePath)
 		Expect(err).NotTo(HaveOccurred())
 
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = sourceFile
@@ -155,7 +171,7 @@ var _ = Describe("S3 data source", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(tinyCoreFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = file
@@ -171,7 +187,7 @@ var _ = Describe("S3 data source", func() {
 		// Don't need to defer close, since ud.Close will close the reader
 		file, err := os.Open(tinyCoreFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		sd, err = NewS3DataSource("http://region.amazon.com/bucket-1/object-1", "", "", "")
+		sd, err = NewS3DataSource("http://localhost/bucket-1/object-1", "", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		// Replace minio.Object with a reader we can use.
 		sd.s3Reader = file
@@ -181,6 +197,62 @@ var _ = Describe("S3 data source", func() {
 		result, err = sd.TransferFile("/invalidpath/invalidfile", false)
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
+	})
+
+	Context("SSRF Protection", func() {
+		var savedAllowlist string
+		var savedAllowlistWasSet bool
+
+		BeforeEach(func() {
+			savedAllowlist, savedAllowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		})
+
+		AfterEach(func() {
+			if savedAllowlistWasSet {
+				Expect(os.Setenv(common.ImporterAllowedSourceURLs, savedAllowlist)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+			}
+		})
+
+		DescribeTable("should validate IPs according to blocklist and allowlist",
+			func(endpoint string, allowlist string, expectSSRFError bool) {
+				if allowlist != "" {
+					Expect(os.Setenv(common.ImporterAllowedSourceURLs, allowlist)).To(Succeed())
+				} else {
+					Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+				}
+
+				_, dsErr := NewS3DataSource(endpoint, "", "", "")
+				if expectSSRFError {
+					Expect(dsErr).To(HaveOccurred())
+					Expect(dsErr.Error()).To(ContainSubstring("SSRF protection"))
+				} else {
+					// May fail for other reasons (connection, DNS, etc) but not SSRF
+					if dsErr != nil {
+						Expect(dsErr.Error()).NotTo(ContainSubstring("SSRF protection"))
+					}
+				}
+			},
+			// Blocked by default
+			Entry("block AWS IMDS", "http://169.254.169.254/bucket/object", "", true),
+			Entry("block Azure IMDS", "http://169.254.169.254/bucket/object", "", true),
+			Entry("block private 10.x", "http://10.0.0.1/bucket/object", "", true),
+			Entry("block private 192.168.x", "http://192.168.1.1/bucket/object", "", true),
+			Entry("block CGNAT", "http://100.64.0.1/bucket/object", "", true),
+			Entry("block loopback", "http://127.0.0.1:9000/bucket/object", "", true),
+
+			// Allowed by allowlist (CIDR)
+			Entry("allow 10.96.1.1 via CIDR allowlist", "http://10.96.1.1/bucket/object", "10.96.0.0/12", false),
+			Entry("allow 192.168.1.100 via exact IP", "http://192.168.1.100/bucket/object", "192.168.1.100", false),
+
+			// Allowed by allowlist (multiple entries)
+			Entry("allow via multiple allowlist entries", "http://10.96.1.1/bucket/object", "172.16.0.0/12,10.96.0.0/12", false),
+
+			// Localhost blocked without allowlist (loopback, not public)
+			Entry("block localhost without allowlist", "http://localhost/bucket/object", "", true),
+			Entry("allow localhost with allowlist", "http://localhost/bucket/object", "localhost,127.0.0.0/8,::1/128", false),
+		)
 	})
 
 	It("GetS3Client should return a real client", func() {

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -51,6 +51,7 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/image"
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-importer"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	utilnet "kubevirt.io/containerized-data-importer/pkg/util/net"
 )
 
 // May be overridden in tests
@@ -902,6 +903,16 @@ func createVddkDataSource(endpoint string, accessKey string, secKey string, thum
 	if currentCheckpoint == "" && previousCheckpoint != "" {
 		// Not sure what to do with just previous set by itself, return error
 		return nil, errors.New("previous checkpoint set without current")
+	}
+
+	// Validate endpoint host BEFORE making any network calls (SSRF protection)
+	ep, err := ParseEndpoint(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse endpoint %q", endpoint)
+	}
+	allowlist := getAllowedSourceURLs()
+	if err := utilnet.ValidateEndpointHost(ep.Host, allowlist); err != nil {
+		return nil, err
 	}
 
 	// Log in to VMware to make sure disks and snapshots are present

--- a/pkg/importer/vddk-datasource_test.go
+++ b/pkg/importer/vddk-datasource_test.go
@@ -54,6 +54,9 @@ func defaultMockNbdExport() mockNbdExport {
 var currentExport mockNbdExport
 
 var _ = Describe("VDDK data source", func() {
+	var originalAllowedSourceURLs string
+	var allowlistWasSet bool
+
 	BeforeEach(func() {
 		mockSinkBuffer = bytes.Repeat([]byte{0x00}, 512)
 		newVddkDataSource = createMockVddkDataSource
@@ -64,10 +67,27 @@ var _ = Describe("VDDK data source", func() {
 		currentExport = defaultMockNbdExport()
 		currentVMwareFunctions = defaultMockVMwareFunctions()
 		currentMockNbdFunctions = defaultMockNbdFunctions()
+
+		// Save and set allowlist for VDDK test endpoints
+		originalAllowedSourceURLs, allowlistWasSet = os.LookupEnv(common.ImporterAllowedSourceURLs)
+		Expect(os.Setenv(common.ImporterAllowedSourceURLs, "localhost,127.0.0.0/8,::1/128")).To(Succeed())
+
+		// Set IMPORTER_ENDPOINT for tests that use empty endpoint string
+		Expect(os.Setenv(common.ImporterEndpoint, "http://localhost")).To(Succeed())
 	})
 
 	AfterEach(func() {
 		newVddkDataSource = createVddkDataSource
+
+		// Restore original allowlist
+		if allowlistWasSet {
+			Expect(os.Setenv(common.ImporterAllowedSourceURLs, originalAllowedSourceURLs)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(common.ImporterAllowedSourceURLs)).To(Succeed())
+		}
+
+		// Clean up IMPORTER_ENDPOINT
+		Expect(os.Unsetenv(common.ImporterEndpoint)).To(Succeed())
 	})
 
 	It("NewVDDKDataSource should fail when called with an invalid endpoint", func() {
@@ -434,7 +454,7 @@ var _ = Describe("VDDK data source", func() {
 			return nil
 		}
 
-		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", targetDiskName, "", "", "", v1.PersistentVolumeFilesystem)
+		_, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", targetDiskName, "", "", "", v1.PersistentVolumeFilesystem)
 		if expectedSuccess {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(returnedDiskName).To(Equal(targetDiskName))
@@ -492,7 +512,7 @@ var _ = Describe("VDDK data source", func() {
 			return nil
 		}
 
-		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "disk1", expectedSnapshot, "", "", v1.PersistentVolumeFilesystem)
+		_, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "disk1", expectedSnapshot, "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(receivedSnapshotRef).To(Equal(expectedSnapshot))
 	})
@@ -512,7 +532,7 @@ var _ = Describe("VDDK data source", func() {
 			return nil
 		}
 
-		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "false", v1.PersistentVolumeFilesystem)
+		_, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "false", v1.PersistentVolumeFilesystem)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("disk 'testdisk.vmdk' is not present in VM hardware config or snapshot list"))
 	})
@@ -530,7 +550,7 @@ var _ = Describe("VDDK data source", func() {
 			}
 			return nil
 		}
-		_, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "snapshot-1", "snapshot-2", "false", v1.PersistentVolumeFilesystem)
+		_, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "snapshot-1", "snapshot-2", "false", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		mockTerminationChannel <- os.Interrupt
 		Expect(err).ToNot(HaveOccurred())
@@ -549,10 +569,10 @@ var _ = Describe("VDDK data source", func() {
 			}
 			return nil
 		}
-		_, err := NewVDDKDataSource("http://esx.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
+		_, err := NewVDDKDataSource("http://127.0.0.1", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(MaxPreadLength).To(Equal(MaxPreadLengthESX))
-		_, err = NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
+		_, err = NewVDDKDataSource("http://127.0.0.1/vcenter", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(MaxPreadLength).To(Equal(MaxPreadLengthVC))
 	})
@@ -561,7 +581,7 @@ var _ = Describe("VDDK data source", func() {
 		const testVersion = "testVersion"
 		const testHost = "testHost"
 
-		source, err := NewVDDKDataSource("http://esx.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "testdisk.vmdk", "", "", "", v1.PersistentVolumeFilesystem)
+		source, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", "testdisk.vmdk", "", "", "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 
 		vddkVersion = testVersion
@@ -656,7 +676,7 @@ var _ = Describe("VDDK data source", func() {
 			return resp, nil
 		}
 
-		ds, err := NewVDDKDataSource("http://vcenter.test", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, snapshotName, changeID, "", v1.PersistentVolumeFilesystem)
+		ds, err := NewVDDKDataSource("http://localhost", "user", "pass", "aa:bb:cc:dd", "1-2-3-4", diskName, snapshotName, changeID, "", v1.PersistentVolumeFilesystem)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = ds.TransferFile("", false)
 		Expect(err).ToNot(HaveOccurred())
@@ -1102,7 +1122,7 @@ func createMockVMwareClient(endpoint string, accessKey string, secKey string, th
 }
 
 func createMockNbdKitWrapper(vmware *VMwareClient, diskFileName, snapshot string) (*NbdKitWrapper, error) {
-	u, _ := url.Parse("http://vcenter.test")
+	u, _ := url.Parse("http://localhost")
 	return &NbdKitWrapper{
 		n:      &image.Nbdkit{},
 		Socket: u,

--- a/pkg/operator/resources/crds_generated.go
+++ b/pkg/operator/resources/crds_generated.go
@@ -114,6 +114,15 @@ spec:
               config:
                 description: CDIConfig at CDI level
                 properties:
+                  allowedSourceURLs:
+                    description: |-
+                      AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources
+                      even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.).
+                      This allows importing from in-cluster services or private endpoints.
+                      Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)
+                    items:
+                      type: string
+                    type: array
                   dataVolumeTTLSeconds:
                     description: |-
                       DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.
@@ -2631,6 +2640,15 @@ spec:
               config:
                 description: CDIConfig at CDI level
                 properties:
+                  allowedSourceURLs:
+                    description: |-
+                      AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources
+                      even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.).
+                      This allows importing from in-cluster services or private endpoints.
+                      Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)
+                    items:
+                      type: string
+                    type: array
                   dataVolumeTTLSeconds:
                     description: |-
                       DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.
@@ -5104,6 +5122,15 @@ spec:
           spec:
             description: CDIConfigSpec defines specification for user configuration
             properties:
+              allowedSourceURLs:
+                description: |-
+                  AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources
+                  even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.).
+                  This allows importing from in-cluster services or private endpoints.
+                  Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)
+                items:
+                  type: string
+                type: array
               dataVolumeTTLSeconds:
                 description: |-
                   DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.

--- a/pkg/util/net/BUILD.bazel
+++ b/pkg/util/net/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["blocklist.go"],
+    importpath = "kubevirt.io/containerized-data-importer/pkg/util/net",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/klog/v2:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "blocklist_test.go",
+        "net_suite_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/util/net/blocklist.go
+++ b/pkg/util/net/blocklist.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2024 The CDI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// Blocked CIDR ranges for SSRF protection
+var blockedCIDRs = []string{
+	"169.254.0.0/16", // Link-local (AWS/Azure IMDS)
+	"10.0.0.0/8",     // RFC 1918 private
+	"172.16.0.0/12",  // RFC 1918 private
+	"192.168.0.0/16", // RFC 1918 private
+	"100.64.0.0/10",  // CGNAT (RFC 6598)
+	"127.0.0.0/8",    // Loopback
+	"0.0.0.0/8",      // Current network
+	"224.0.0.0/4",    // Multicast
+	"240.0.0.0/4",    // Reserved
+	"fd00::/8",       // IPv6 ULA
+	"fe80::/10",      // IPv6 link-local
+	"::1/128",        // IPv6 loopback
+}
+
+// Validate hardcoded blocklist at package initialization
+func init() {
+	for _, cidr := range blockedCIDRs {
+		if _, err := netip.ParsePrefix(cidr); err != nil {
+			panic(fmt.Sprintf("invalid hardcoded CIDR %q in blockedCIDRs: %v", cidr, err))
+		}
+	}
+}
+
+// IsBlockedIP returns true if the IP is in a blocked CIDR range
+func IsBlockedIP(ip string) (bool, error) {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false, fmt.Errorf("invalid IP address %q: %w", ip, err)
+	}
+
+	// Normalize IPv4-mapped IPv6 addresses to IPv4 to prevent SSRF bypass
+	// e.g., ::ffff:169.254.169.254 -> 169.254.169.254
+	addr = addr.Unmap()
+
+	for _, cidr := range blockedCIDRs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			continue
+		}
+		if prefix.Contains(addr) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsAllowedIP returns true if the IP matches any allowlist entry (CIDR or exact IP)
+func IsAllowedIP(ip string, allowlist []string) (bool, error) {
+	if len(allowlist) == 0 {
+		return false, nil
+	}
+
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false, fmt.Errorf("invalid IP address %q: %w", ip, err)
+	}
+
+	// Normalize IPv4-mapped IPv6 addresses to IPv4 for consistent matching
+	// e.g., ::ffff:192.168.1.1 -> 192.168.1.1
+	addr = addr.Unmap()
+
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		// Try parsing as CIDR first
+		if strings.Contains(entry, "/") {
+			prefix, err := netip.ParsePrefix(entry)
+			if err != nil {
+				klog.Warningf("Ignoring malformed CIDR in allowlist: %q: %v", entry, err)
+				continue
+			}
+			if prefix.Contains(addr) {
+				return true, nil
+			}
+		} else {
+			// Try parsing as single IP
+			allowedAddr, err := netip.ParseAddr(entry)
+			if err != nil {
+				klog.Warningf("Ignoring invalid IP in allowlist: %q: %v", entry, err)
+				continue
+			}
+			if allowedAddr.Unmap() == addr {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// IsAllowedHostname returns true if the hostname matches any allowlist entry
+// Only exact matches are allowed for security reasons
+func IsAllowedHostname(hostname string, allowlist []string) (bool, error) {
+	if len(allowlist) == 0 {
+		return false, nil
+	}
+
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	for _, entry := range allowlist {
+		entry = strings.ToLower(strings.TrimSpace(entry))
+		if entry == "" {
+			continue
+		}
+		// Skip CIDR entries for hostname matching
+		if strings.Contains(entry, "/") {
+			if _, err := netip.ParsePrefix(entry); err != nil {
+				klog.Warningf("Ignoring malformed CIDR in allowlist: %q: %v", entry, err)
+			}
+			continue
+		}
+		// Skip IP addresses for hostname matching
+		if _, err := netip.ParseAddr(entry); err == nil {
+			continue
+		}
+		// Exact hostname match only (no subdomain matching for security)
+		if entry == hostname {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ValidateEndpointHost validates that a hostname resolves to allowed IPs
+// allowlist entries can be CIDRs (10.96.0.0/12) or hostnames (minio.default.svc)
+func ValidateEndpointHost(host string, allowlist []string) error {
+	// Parse host:port or just host
+	hostname, _, err := net.SplitHostPort(host)
+	if err != nil {
+		hostname = host
+	}
+
+	// Resolve hostname to IPs
+	// Note: We always validate resolved IPs against blocklist, even for allowlisted hostnames,
+	// to prevent DNS rebinding attacks (e.g., allowlisted hostname → 169.254.169.254)
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve host %q: %w", hostname, err)
+	}
+
+	if len(ips) == 0 {
+		return fmt.Errorf("host %q resolved to no IPs", hostname)
+	}
+
+	// Check each resolved IP against allowlist then blocklist
+	// Require ALL IPs to pass validation (not just one)
+	for _, ip := range ips {
+		ipStr := ip.String()
+
+		// Check allowlist first
+		allowed, err := IsAllowedIP(ipStr, allowlist)
+		if err != nil {
+			return err
+		}
+		if allowed {
+			// This IP is explicitly allowed, continue to next IP
+			continue
+		}
+
+		// Not in allowlist, check if it's blocked
+		blocked, err := IsBlockedIP(ipStr)
+		if err != nil {
+			return err
+		}
+		if blocked {
+			// This IP is blocked and not in allowlist - fail immediately
+			return fmt.Errorf("host %q resolves to blocked IP %s (SSRF protection)", hostname, ipStr)
+		}
+
+		// This IP is neither allowed nor blocked (i.e., it's a public IP) - OK, continue to next IP
+	}
+
+	// All IPs passed validation (either explicitly allowed or public)
+	return nil
+}

--- a/pkg/util/net/blocklist_test.go
+++ b/pkg/util/net/blocklist_test.go
@@ -1,0 +1,181 @@
+package net_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	utilnet "kubevirt.io/containerized-data-importer/pkg/util/net"
+)
+
+var _ = Describe("IP Blocklist and Allowlist", func() {
+	DescribeTable("IsBlockedIP should",
+		func(ip string, expectBlocked bool, expectError bool) {
+			blocked, err := utilnet.IsBlockedIP(ip)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(blocked).To(Equal(expectBlocked))
+			}
+		},
+		// Link-local (IMDS)
+		Entry("block 169.254.169.254", "169.254.169.254", true, false),
+		Entry("block 169.254.0.1", "169.254.0.1", true, false),
+
+		// RFC 1918 private
+		Entry("block 10.0.0.1", "10.0.0.1", true, false),
+		Entry("block 172.16.0.1", "172.16.0.1", true, false),
+		Entry("block 192.168.1.1", "192.168.1.1", true, false),
+
+		// Loopback
+		Entry("block 127.0.0.1", "127.0.0.1", true, false),
+		Entry("block ::1", "::1", true, false),
+
+		// Public IPs (allowed)
+		Entry("allow 1.1.1.1", "1.1.1.1", false, false),
+		Entry("allow 8.8.8.8", "8.8.8.8", false, false),
+		Entry("allow 2606:4700:4700::1111", "2606:4700:4700::1111", false, false),
+
+		// Invalid
+		Entry("error on invalid IP", "not-an-ip", false, true),
+	)
+
+	DescribeTable("IsAllowedIP should",
+		func(ip string, allowlist []string, expectAllowed bool, expectError bool) {
+			allowed, err := utilnet.IsAllowedIP(ip, allowlist)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(allowed).To(Equal(expectAllowed))
+			}
+		},
+		// CIDR matching
+		Entry("match single IP in CIDR", "10.96.1.1", []string{"10.96.0.0/12"}, true, false),
+		Entry("match edge of CIDR", "10.96.0.1", []string{"10.96.0.0/12"}, true, false),
+		Entry("not match outside CIDR", "10.95.0.1", []string{"10.96.0.0/12"}, false, false),
+
+		// Exact IP matching
+		Entry("match exact IP", "192.168.1.100", []string{"192.168.1.100"}, true, false),
+		Entry("not match different IP", "192.168.1.101", []string{"192.168.1.100"}, false, false),
+
+		// Multiple entries
+		Entry("match first entry", "10.0.0.1", []string{"10.0.0.0/8", "192.168.0.0/16"}, true, false),
+		Entry("match second entry", "192.168.1.1", []string{"10.0.0.0/8", "192.168.0.0/16"}, true, false),
+
+		// Empty allowlist
+		Entry("empty allowlist", "10.0.0.1", []string{}, false, false),
+		Entry("nil allowlist", "10.0.0.1", nil, false, false),
+	)
+
+	DescribeTable("IsAllowedHostname should",
+		func(hostname string, allowlist []string, expectAllowed bool) {
+			allowed, err := utilnet.IsAllowedHostname(hostname, allowlist)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(Equal(expectAllowed))
+		},
+		// Exact hostname match
+		Entry("match exact hostname", "minio.default.svc", []string{"minio.default.svc"}, true),
+		Entry("not match different hostname", "redis.default.svc", []string{"minio.default.svc"}, false),
+
+		// Subdomain matching removed for security (exact match only)
+		Entry("not match subdomain", "api.minio.default.svc", []string{"minio.default.svc"}, false),
+		Entry("not match deep subdomain", "v1.api.minio.default.svc", []string{"minio.default.svc"}, false),
+
+		// Case insensitive
+		Entry("match case insensitive", "MINIO.DEFAULT.SVC", []string{"minio.default.svc"}, true),
+
+		// Empty allowlist
+		Entry("empty allowlist", "minio.default.svc", []string{}, false),
+	)
+
+	DescribeTable("ValidateEndpointHost should",
+		func(host string, allowlist []string, expectError bool) {
+			err := utilnet.ValidateEndpointHost(host, allowlist)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// Public hosts (no allowlist needed)
+		Entry("allow public cloudflare.com", "cloudflare.com", nil, false),
+		Entry("allow public google.com:443", "google.com:443", nil, false),
+
+		// Blocked IPs without allowlist
+		Entry("block 169.254.169.254", "169.254.169.254", nil, true),
+		Entry("block 10.0.0.1", "10.0.0.1", nil, true),
+
+		// Blocked IPs with allowlist
+		Entry("allow 10.96.1.1 via CIDR allowlist", "10.96.1.1", []string{"10.96.0.0/12"}, false),
+		Entry("allow 192.168.1.100 via exact IP", "192.168.1.100", []string{"192.168.1.100"}, false),
+
+		// DNS rebinding protection: hostname allowlist doesn't bypass IP blocklist
+		Entry("block localhost even with hostname allowlist", "localhost", []string{"localhost"}, true),
+		Entry("allow localhost with combined hostname+IP allowlist", "localhost", []string{"localhost", "127.0.0.0/8", "::1/128"}, false),
+	)
+
+	Context("IPv4-mapped IPv6 SSRF bypass prevention", func() {
+		DescribeTable("IsBlockedIP should block IPv4-mapped IPv6 addresses",
+			func(ip string, expectBlocked bool) {
+				blocked, err := utilnet.IsBlockedIP(ip)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(blocked).To(Equal(expectBlocked))
+			},
+			// AWS/Azure IMDS bypass attempts
+			Entry("block ::ffff:169.254.169.254 (AWS IMDS)", "::ffff:169.254.169.254", true),
+			Entry("block ::ffff:169.254.0.1 (link-local)", "::ffff:169.254.0.1", true),
+
+			// RFC 1918 private IP bypass attempts
+			Entry("block ::ffff:10.0.0.1 (private 10.x)", "::ffff:10.0.0.1", true),
+			Entry("block ::ffff:172.16.0.1 (private 172.16.x)", "::ffff:172.16.0.1", true),
+			Entry("block ::ffff:192.168.1.1 (private 192.168.x)", "::ffff:192.168.1.1", true),
+
+			// CGNAT bypass attempt
+			Entry("block ::ffff:100.64.0.1 (CGNAT)", "::ffff:100.64.0.1", true),
+
+			// Loopback bypass attempts
+			Entry("block ::ffff:127.0.0.1 (loopback)", "::ffff:127.0.0.1", true),
+			Entry("block ::ffff:127.1.1.1 (loopback)", "::ffff:127.1.1.1", true),
+
+			// Public IPs as IPv4-mapped should be allowed
+			Entry("allow ::ffff:1.1.1.1 (public)", "::ffff:1.1.1.1", false),
+			Entry("allow ::ffff:8.8.8.8 (public)", "::ffff:8.8.8.8", false),
+		)
+
+		DescribeTable("IsAllowedIP should handle IPv4-mapped IPv6 addresses",
+			func(ip string, allowlist []string, expectAllowed bool) {
+				allowed, err := utilnet.IsAllowedIP(ip, allowlist)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(allowed).To(Equal(expectAllowed))
+			},
+			// IPv4-mapped IPv6 should match IPv4 CIDR allowlist
+			Entry("match ::ffff:10.96.1.1 against 10.96.0.0/12", "::ffff:10.96.1.1", []string{"10.96.0.0/12"}, true),
+			Entry("match ::ffff:192.168.1.100 against exact IPv4", "::ffff:192.168.1.100", []string{"192.168.1.100"}, true),
+
+			// IPv4-mapped IPv6 should NOT match if outside allowlist
+			Entry("not match ::ffff:10.95.0.1 against 10.96.0.0/12", "::ffff:10.95.0.1", []string{"10.96.0.0/12"}, false),
+
+			// Regular IPv4 should match IPv4-mapped allowlist entry
+			Entry("match 192.168.1.100 against ::ffff:192.168.1.100", "192.168.1.100", []string{"::ffff:192.168.1.100"}, true),
+		)
+
+		DescribeTable("ValidateEndpointHost should block IPv4-mapped IPv6 literals",
+			func(host string, allowlist []string, expectError bool) {
+				err := utilnet.ValidateEndpointHost(host, allowlist)
+				if expectError {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("SSRF protection"))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+			// Should block IPv4-mapped IPv6 IMDS bypass without allowlist
+			Entry("block ::ffff:169.254.169.254 without allowlist", "::ffff:169.254.169.254", nil, true),
+			Entry("block ::ffff:10.0.0.1 without allowlist", "::ffff:10.0.0.1", nil, true),
+
+			// Should allow with appropriate allowlist
+			Entry("allow ::ffff:10.96.1.1 with CIDR allowlist", "::ffff:10.96.1.1", []string{"10.96.0.0/12"}, false),
+		)
+	})
+})

--- a/pkg/util/net/net_suite_test.go
+++ b/pkg/util/net/net_suite_test.go
@@ -1,0 +1,13 @@
+package net_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Net Suite")
+}

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -1063,6 +1063,12 @@ type CDIConfigSpec struct {
 	Preallocation *bool `json:"preallocation,omitempty"`
 	// InsecureRegistries is a list of TLS disabled registries
 	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
+	// AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources
+	// even if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.).
+	// This allows importing from in-cluster services or private endpoints.
+	// Format: CIDR (10.96.0.0/12) or hostname (minio.default.svc)
+	// +optional
+	AllowedSourceURLs []string `json:"allowedSourceURLs,omitempty"`
 	// DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.
 	// Deprecated: Removed in v1.62.
 	// +optional

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -535,6 +535,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
+		"allowedSourceURLs":        "AllowedSourceURLs is a list of CIDR blocks or hostnames that are allowed for HTTP/S data sources\neven if they fall within the default SSRF protection blocklist (private IPs, link-local, etc.).\nThis allows importing from in-cluster services or private endpoints.\nFormat: CIDR (10.96.0.0/12) or hostname (minio.default.svc)\n+optional",
 		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.\nDeprecated: Removed in v1.62.\n+optional",
 		"tlsSecurityProfile":       "TLSSecurityProfile is used by operators to apply cluster-wide TLS security settings to operands.",
 		"imagePullSecrets":         "The imagePullSecrets used to pull the container images",

--- a/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -190,6 +190,11 @@ func (in *CDIConfigSpec) DeepCopyInto(out *CDIConfigSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowedSourceURLs != nil {
+		in, out := &in.AllowedSourceURLs, &out.AllowedSourceURLs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DataVolumeTTLSeconds != nil {
 		in, out := &in.DataVolumeTTLSeconds, &out.DataVolumeTTLSeconds
 		*out = new(int32)

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -148,6 +148,13 @@ func BuildTestSuite() {
 
 		utils.CacheTestsData(framework.ClientsInstance.K8sClient, framework.ClientsInstance.CdiInstallNs)
 
+		// Configure SSRF allowlist for test file-host service
+		fmt.Fprintf(GinkgoWriter, "Configuring SSRF allowlist for test file-host service\n")
+		err = utils.ConfigureAllowedSourceURLs(crClient, framework.ClientsInstance.CdiInstallNs)
+		if err != nil {
+			Fail(fmt.Sprintf("ERROR, unable to configure SSRF allowlist: %v", err))
+		}
+
 		if path := os.Getenv("TESTS_WORKDIR"); path != "" {
 			if err := os.Chdir(path); err != nil {
 				Fail(fmt.Sprintf("ERROR, unable to chdir to test dir for manifest/image files: %v", err))

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -219,6 +221,35 @@ func UpdateCDIConfigWithOptions(c client.Client, opts metav1.UpdateOptions, upda
 // UpdateCDIConfig updates CDIConfig
 func UpdateCDIConfig(c client.Client, updateFunc func(*cdiv1.CDIConfigSpec)) error {
 	return UpdateCDIConfigWithOptions(c, metav1.UpdateOptions{}, updateFunc)
+}
+
+// ConfigureAllowedSourceURLs configures SSRF allowlist for test file-host service
+func ConfigureAllowedSourceURLs(c client.Client, cdiInstallNs string) error {
+	// Retry on conflict when multiple test suites update CDIConfig concurrently
+	// Use 2-minute timeout to handle client-side rate limiting during parallel test execution
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := UpdateCDIConfig(c, func(config *cdiv1.CDIConfigSpec) {
+			// Allow cluster service CIDRs and test services for SSRF protection
+			config.AllowedSourceURLs = []string{
+				"10.96.0.0/12",  // Standard Kubernetes service CIDR
+				"172.30.0.0/16", // OpenShift service CIDR
+				"localhost",     // Localhost for test services
+				"127.0.0.0/8",   // IPv4 loopback
+				"::1/128",       // IPv6 loopback
+				fmt.Sprintf("%s.%s", FileHostName, cdiInstallNs),     // cdi-file-host service
+				fmt.Sprintf("%s.%s", RegistryHostName, cdiInstallNs), // cdi-docker-registry-host service
+				fmt.Sprintf("imageio.%s", cdiInstallNs),              // imageio service
+				"registry",                                           // In-cluster registry shortname
+			}
+		})
+		if err != nil {
+			// Retry on conflict, timeouts, or rate limiting (context.DeadlineExceeded)
+			if apierrors.IsConflict(err) || apierrors.IsServerTimeout(err) || apierrors.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+				return false, nil
+			}
+		}
+		return err == nil, err
+	})
 }
 
 // EnableFeatureGate sets specified FeatureGate in the CDIConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Added a block list of known CIDRs that should not have any http end points on them, like internal ip addresses.
- Resolve URLs to IP addresses before checking.
- Added an allowList to override the block list if the block list was too aggressive.
- Added unit tests for both block and allow lists
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent user from attempting to connect to internal IP addresses using a datavolume
```

