### PR TITLE
Add storagecapabilities for DirectPV CSI driver

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -145,6 +145,8 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"csi.san.synology.com/iscsi": {{rwx, block}, {rwo, block}, {rwo, file}},
 	"csi.san.synology.com/nfs":   {{rwx, file}, {rwo, file}},
 	"csi.san.synology.com/smb":   {{rwx, file}, {rwo, file}},
+	// DirectPV
+	"directpv-min-io": {{rwo, file}},
 }
 
 // SourceFormatsByProvisionerKey defines the advised data import cron source format


### PR DESCRIPTION
This adds storage capabilities for DirectPV CSI driver (provisioner key directpv-min-io). DirectPV is a local-storage CSI driver from MinIO that only supports ReadWriteOnce and Filesystem with xfs, similar to topolvm and hostpath-provisioner. Without this entry the StorageProfile for directpv-min-io stays empty and CDIStorageProfilesIncomplete fires on clusters where OpenShift Virtualization (CDI) is installed alongside DirectPV. The DirectPV maintainer is already aware of this PR.

```release-note
Added support for DirectPV CSI driver
```
