### PR TITLE
Fix AfterEach in ingress manifest tests to restore override first

### DIFF
--- a/tests/cdiconfig_test.go
+++ b/tests/cdiconfig_test.go
@@ -179,9 +179,21 @@ var _ = Describe("CDI ingress config tests, using manifests", Serial, func() {
 	BeforeEach(func() {
 		cfg, err := clientcmd.BuildConfigFromFlags(f.KubeURL, f.KubeConfig)
 		Expect(err).ToNot(HaveOccurred())
-		By("Checking if a route exists, we set that as default")
 		openshiftClient, err := route1client.NewForConfig(cfg)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Making sure no url is set")
+		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		if config.Spec.UploadProxyURLOverride != nil {
+			err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+				origUploadProxyOverride = config.UploadProxyURLOverride
+				config.UploadProxyURLOverride = nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Checking if a route exists, we set that as default")
 		_, err = openshiftClient.RouteV1().Routes(f.CdiInstallNs).Get(context.TODO(), "cdi-uploadproxy", metav1.GetOptions{})
 		if err == nil {
 			By("setting defaultURL to route")
@@ -197,16 +209,6 @@ var _ = Describe("CDI ingress config tests, using manifests", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 			defaultURL = *config.Status.UploadProxyURL
 		}
-		By("Making sure no url is set")
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		if config.Spec.UploadProxyURLOverride != nil {
-			err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
-				origUploadProxyOverride = config.UploadProxyURLOverride
-				config.UploadProxyURLOverride = nil
-			})
-			Expect(err).ToNot(HaveOccurred())
-		}
 		Eventually(func() string {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -218,9 +220,6 @@ var _ = Describe("CDI ingress config tests, using manifests", Serial, func() {
 	})
 
 	AfterEach(func() {
-		_, err := f.RunKubectlCommand("delete", "-f", manifestFile, "-n", f.CdiInstallNs)
-		Expect(err).ShouldNot(HaveOccurred())
-
 		matchingVals := []string{defaultURL}
 		if origUploadProxyOverride != nil {
 			matchingVals = append(matchingVals, *origUploadProxyOverride)
@@ -229,6 +228,11 @@ var _ = Describe("CDI ingress config tests, using manifests", Serial, func() {
 		Expect(utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
 			config.UploadProxyURLOverride = origUploadProxyOverride
 		})).To(Succeed())
+
+		if manifestFile != "" {
+			_, err := f.RunKubectlCommand("delete", "-f", manifestFile, "-n", f.CdiInstallNs)
+			Expect(err).ShouldNot(HaveOccurred())
+		}
 
 		Eventually(func() string {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
@@ -294,9 +298,21 @@ var _ = Describe("CDI ingress config tests", Serial, func() {
 	BeforeEach(func() {
 		cfg, err := clientcmd.BuildConfigFromFlags(f.KubeURL, f.KubeConfig)
 		Expect(err).ToNot(HaveOccurred())
-		By("Checking if a route exists, we set that as default")
 		openshiftClient, err := route1client.NewForConfig(cfg)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Making sure no url is set")
+		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		if config.Spec.UploadProxyURLOverride != nil {
+			err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
+				origUploadProxyOverride = config.UploadProxyURLOverride
+				config.UploadProxyURLOverride = nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Checking if a route exists, we set that as default")
 		_, err = openshiftClient.RouteV1().Routes(f.CdiInstallNs).Get(context.TODO(), "cdi-uploadproxy", metav1.GetOptions{})
 		if err == nil {
 			By("setting defaultURL to route")
@@ -311,16 +327,6 @@ var _ = Describe("CDI ingress config tests", Serial, func() {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			defaultURL = *config.Status.UploadProxyURL
-		}
-		By("Making sure no url is set")
-		config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		if config.Spec.UploadProxyURLOverride != nil {
-			err = utils.UpdateCDIConfig(f.CrClient, func(config *cdiv1.CDIConfigSpec) {
-				origUploadProxyOverride = config.UploadProxyURLOverride
-				config.UploadProxyURLOverride = nil
-			})
-			Expect(err).ToNot(HaveOccurred())
 		}
 		Eventually(func() string {
 			config, err := f.CdiClient.CdiV1beta1().CDIConfigs().Get(context.TODO(), common.ConfigName, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix a bug in the `cdiconfig_test.go` ingress config test BeforeEach that permanently wipes `uploadProxyURLOverride` when an override is set externally (e.g. via `UPLOAD_PROXY_URL_OVERRIDE` in CI see s390x rehearsal job in https://github.com/kubevirt/project-infra/pull/4832).

The CDI ingress config tests and CDI ingress config tests, using manifests check the route-based URL before saving the existing override. When an override like `:6005` is set, `status.uploadProxyURL` reflects that override and doesn't match the route prefix, so the `Eventually` times out. Since `origUploadProxyOverride` was never saved, the `AfterEach` restores `nil` — wiping the override for all subsequent tests.

This was discovered while debugging upload proxy connection timeouts in the [s390x e2e Prow job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/4832/rehearsal-pull-containerized-data-importer-e2e-s390x/2052041974650769408), where all upload tests failed with `dial tcp <ip>:443: connect: connection timed out` because the `:6005` override was silently wiped mid-run.

The fix 

- reorders BeforeEach to save+clear the override before the route URL check, matching the [CDI route config tests ](https://github.com/kubevirt/containerized-data-importer/blob/6957003039f0565f16066c1cd085cebf146e9057/tests/cdiconfig_test.go#L424-L437)which already do this correctly. 
- Moves the manifest cleanup in AfterEach (for the "using manifests" variant) after the override restore, so a manifest delete failure doesn't prevent restoration.

Validated by running focused cdiconfig + upload tests on both main (override wiped to nil after ingress tests) and this branch (override preserved at :6005).

/cc @awels @dollierp 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

