### PR TITLE
Add open-default-ports annotation to upload server pod

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -209,6 +209,8 @@ const (
 	UploadServerDataDir = ImporterDataDir
 	// UploadServerServiceLabel is the label selector for upload server services
 	UploadServerServiceLabel = "service"
+	// UploadServerPort is the port the upload server listens on
+	UploadServerPort = 8443
 	// UploadImageSize provides a constant to capture our env variable "UPLOAD_IMAGE_SIZE"
 	UploadImageSize = "UPLOAD_IMAGE_SIZE"
 

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -260,6 +260,9 @@ const (
 	AnnPodNetwork = "k8s.v1.cni.cncf.io/networks"
 	// AnnPodMultusDefaultNetwork is used for specifying default Pod Network
 	AnnPodMultusDefaultNetwork = "v1.multus-cni.io/default-network"
+	// AnnOpenDefaultPorts allows incoming traffic on specific ports through the
+	// pod's default network interface in OVN-Kubernetes managed clusters.
+	AnnOpenDefaultPorts = "k8s.ovn.org/open-default-ports"
 	// AnnPodSidecarInjectionIstio is used for enabling/disabling Pod istio/AspenMesh sidecar injection
 	AnnPodSidecarInjectionIstio = "sidecar.istio.io/inject"
 	// AnnPodSidecarInjectionIstioDefault is the default value passed for AnnPodSidecarInjection

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -596,8 +596,8 @@ func (r *UploadReconciler) makeUploadServiceSpec(name string, pvc *corev1.Persis
 			Ports: []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,
-					Port:       8443,
-					TargetPort: intstr.FromInt32(8443),
+					Port:       common.UploadServerPort,
+					TargetPort: intstr.FromInt32(common.UploadServerPort),
 				},
 			},
 			Selector: map[string]string{
@@ -763,7 +763,7 @@ func UploadPossibleForPVC(pvc *corev1.PersistentVolumeClaim) error {
 // GetUploadServerURL returns the url the proxy should post to for a particular pvc
 func GetUploadServerURL(namespace, pvc, uploadPath string) string {
 	serviceName := createUploadServiceNameFromPvcName(pvc)
-	return fmt.Sprintf("https://%s.%s.svc:8443%s", serviceName, namespace, uploadPath)
+	return fmt.Sprintf("https://%s.%s.svc:%d%s", serviceName, namespace, common.UploadServerPort, uploadPath)
 }
 
 // createUploadServiceName returns the name given to upload service shortened if needed
@@ -862,11 +862,8 @@ func (r *UploadReconciler) makeUploadPodContainers(args UploadPodArgs, resourceR
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 8443,
-						},
+						Path:   "/healthz",
+						Port:   intstr.FromInt32(common.UploadServerPort),
 						Scheme: corev1.URISchemeHTTPS,
 					},
 				},

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -777,7 +777,8 @@ func (r *UploadReconciler) makeUploadPodSpec(args UploadPodArgs, resourceRequire
 			Name:      args.Name,
 			Namespace: args.PVC.Namespace,
 			Annotations: map[string]string{
-				annCreatedByUpload: "yes",
+				annCreatedByUpload:     "yes",
+				cc.AnnOpenDefaultPorts: fmt.Sprintf(`[{"protocol":"tcp","port":%d}]`, common.UploadServerPort),
 			},
 			Labels: map[string]string{
 				common.CDILabelKey:              common.CDILabelValue,

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -386,6 +387,7 @@ var _ = Describe("reconcilePVC loop", func() {
 			Expect(uploadPod.GetAnnotations()[cc.AnnPodNetwork]).To(Equal("net1"))
 			Expect(uploadPod.GetAnnotations()[cc.AnnPodSidecarInjectionIstio]).To(Equal(cc.AnnPodSidecarInjectionIstioDefault))
 			Expect(uploadPod.GetAnnotations()[cc.AnnPodSidecarInjectionLinkerd]).To(Equal(cc.AnnPodSidecarInjectionLinkerdDefault))
+			Expect(uploadPod.GetAnnotations()[cc.AnnOpenDefaultPorts]).To(Equal(fmt.Sprintf(`[{"protocol":"tcp","port":%d}]`, common.UploadServerPort)))
 			// Should not pass unrelated annotations to the pod
 			Expect(uploadPod.GetAnnotations()["unrelatedAnnotation"]).To(BeEmpty())
 			expectDeadline(uploadPod)
@@ -394,6 +396,9 @@ var _ = Describe("reconcilePVC loop", func() {
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: naming.GetServiceNameFromResourceName(uploadResourceName), Namespace: "default"}, uploadService)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uploadService.Name).To(Equal(uploadResourceName))
+			Expect(uploadService.Spec.Ports[0].Port).To(Equal(int32(common.UploadServerPort)))
+			Expect(uploadPod.GetAnnotations()[cc.AnnOpenDefaultPorts]).To(
+				ContainSubstring(fmt.Sprintf(`"port":%d`, uploadService.Spec.Ports[0].Port)))
 
 			resultPvc := &corev1.PersistentVolumeClaim{}
 			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: testPvcName, Namespace: "default"}, resultPvc)


### PR DESCRIPTION
**What this PR does / why we need it**:
`virtctl image-upload` fails with a timeout when the target namespace uses OVN-Kubernetes network segmentation. The upload proxy (on the default network) cannot reach the upload server pod.

Since the upload service became headless (#4052), DNS resolves directly to the upload server pod IP. In OVN-Kubernetes clusters where the target namespace uses network segmentation, the pod's default network interface is locked down. The k8s.ovn.org/open-default-ports annotation opens port 8443 on the default interface, allowing the upload proxy to connect.

The annotation is harmless on non-OVN clusters where it is simply ignored.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: CNV-58018

**Special notes for your reviewer**:
The `k8s.ovn.org/open-default-ports` annotation is ignored by non-OVN CNI plugins — it only takes effect in OVN-Kubernetes managed clusters. See [OVN-K UDN isolation docs](https://ovn-kubernetes.io/features/user-defined-networks/user-defined-networks/) for details.

**Release note**:
```release-note
Add OVN-Kubernetes open-default-ports annotation to upload server pod to fix uploads in namespaces with network segmentation
```