### PR TITLE
cleanup, util: remove CopyDir and CopyFile

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,13 +6,11 @@ import (
 	"crypto/md5" //nolint:gosec // This is not a security-sensitive use case
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"math"
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -247,63 +245,4 @@ func ResolveVolumeMode(volumeMode *v1.PersistentVolumeMode) v1.PersistentVolumeM
 		retVolumeMode = v1.PersistentVolumeBlock
 	}
 	return retVolumeMode
-}
-
-// CopyFile copies a file from one location to another.
-func CopyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-	return out.Close()
-}
-
-// CopyDir copies a dir from one location to another.
-func CopyDir(source string, dest string) error {
-	// get properties of source dir
-	sourceinfo, err := os.Stat(source)
-	if err != nil {
-		return err
-	}
-
-	// create dest dir
-	err = os.MkdirAll(dest, sourceinfo.Mode())
-	if err != nil {
-		return err
-	}
-
-	directory, _ := os.Open(source)
-	objects, err := directory.Readdir(-1)
-
-	for _, obj := range objects {
-		src := filepath.Join(source, obj.Name())
-		dst := filepath.Join(dest, obj.Name())
-
-		if obj.IsDir() {
-			// create sub-directories - recursively
-			err = CopyDir(src, dst)
-			if err != nil {
-				fmt.Println(err)
-			}
-		} else {
-			// perform copy
-			err = CopyFile(src, dst)
-			if err != nil {
-				fmt.Println(err)
-			}
-		}
-	}
-	return err
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,42 +21,6 @@ var (
 	fileDir, _ = filepath.Abs(TestImagesDir)
 )
 
-var _ = Describe("Copy files", func() {
-	var destTmp string
-	var err error
-
-	BeforeEach(func() {
-		destTmp, err = os.MkdirTemp("", "dest")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		err = os.RemoveAll(destTmp)
-		Expect(err).NotTo(HaveOccurred())
-		os.Remove("test.txt")
-	})
-
-	It("Should copy file from source to dest, with valid source and dest", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		sourceMd5, err := Md5sum(filepath.Join(TestImagesDir, "content.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		targetMd5, err := Md5sum(filepath.Join(destTmp, "target.tar"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sourceMd5).Should(Equal(targetMd5))
-	})
-
-	It("Should not copy file from source to dest, with invalid source", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar22"), filepath.Join(destTmp, "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("Should not copy file from source to dest, with invalid target", func() {
-		err = CopyFile(filepath.Join(TestImagesDir, "content.tar"), filepath.Join("/invalidpath", "target.tar"))
-		Expect(err).To(HaveOccurred())
-	})
-})
-
 var _ = Describe("Util", func() {
 	It("Should match RandAlphaNum", func() {
 		got := RandAlphaNum(8)

--- a/tools/cdi-func-test-file-host-init/main.go
+++ b/tools/cdi-func-test-file-host-init/main.go
@@ -66,8 +66,8 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	if err := util.CopyDir("/tmp/source/", *outDir); err != nil {
-		klog.Fatal(err)
+	if err := os.CopyFS(*outDir, os.DirFS("/tmp/source/")); err != nil {
+		klog.Fatal(errors.Wrap(err, "failed to copy source directory"))
 	}
 
 	klog.Info("File initialization completed without error.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CopyDir was leaking FDs and was only being used for cdi-func-test-file-host-init. Replaces its call with os.CopyFS. Remove CopyFile since CopyDir was its only caller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

