### PR TITLE
VDDK: use instance UUIDs instead of BIOS UUIDs

### DIFF
--- a/pkg/importer/BUILD.bazel
+++ b/pkg/importer/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
             "//vendor/github.com/vmware/govmomi/vim25/methods:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
             "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
+            "//vendor/k8s.io/utils/ptr:go_default_library",
             "//vendor/libguestfs.org/libnbd:go_default_library",
         ],
         "//conditions:default": [],

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -535,7 +535,8 @@ func (vmware *VMwareClient) FindSnapshotDisk(snapshotRef *types.ManagedObjectRef
 	return nil, fmt.Errorf("Could not find disk image with ID %s in snapshot %s", diskID, snapshotRef.Value)
 }
 
-// FindVM takes the UUID of the VM to migrate and finds its MOref
+// FindVM takes the instance UUID of the VM to migrate and finds its MOref,
+// with a fallback to looking for the VM with that UUID as the BIOS UUID.
 func FindVM(context context.Context, conn *govmomi.Client, uuid string) (string, *object.VirtualMachine, error) {
 	// Get the list of datacenters to search for VM UUID
 	finder := find.NewFinder(conn.Client, true)
@@ -544,16 +545,39 @@ func FindVM(context context.Context, conn *govmomi.Client, uuid string) (string,
 		klog.Errorf("Unable to retrieve datacenter list: %v", err)
 		return "", nil, err
 	}
+	if len(datacenters) == 0 {
+		return "", nil, errors.New("no datacenters found")
+	}
 
-	// Search for VM matching given UUID, and save the MOref
+	// Search for VM matching given instance UUID, and save the MOref
 	var moref string
 	var instanceUUID bool
 	var vm *object.VirtualMachine
 	searcher := object.NewSearchIndex(conn.Client)
 	for _, datacenter := range datacenters {
+		instanceUUID = true
 		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, &instanceUUID)
-		if err != nil || ref == nil {
-			klog.Infof("VM %s not found in datacenter %s.", uuid, datacenter)
+		if err != nil {
+			return "", nil, err
+		} else if ref == nil {
+			klog.Infof("VM instance UUID %s not found in datacenter %s.", uuid, datacenter)
+		} else {
+			moref = ref.Reference().Value
+			klog.Infof("VM %s found in datacenter %s: %s", uuid, datacenter, moref)
+			vm = object.NewVirtualMachine(conn.Client, ref.Reference())
+			return moref, vm, nil
+		}
+	}
+	klog.Infof("VM instance UUID %s not found in any datacenter, trying as BIOS UUID instead.", uuid)
+
+	// Fallback: BIOS UUID
+	for _, datacenter := range datacenters {
+		instanceUUID = false
+		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, &instanceUUID)
+		if err != nil {
+			return "", nil, err
+		} else if ref == nil {
+			klog.Infof("VM BIOS UUID %s not found in datacenter %s.", uuid, datacenter)
 		} else {
 			moref = ref.Reference().Value
 			klog.Infof("VM %s found in datacenter %s: %s", uuid, datacenter, moref)

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -46,6 +46,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/image"
@@ -551,12 +552,10 @@ func FindVM(context context.Context, conn *govmomi.Client, uuid string) (string,
 
 	// Search for VM matching given instance UUID, and save the MOref
 	var moref string
-	var instanceUUID bool
 	var vm *object.VirtualMachine
 	searcher := object.NewSearchIndex(conn.Client)
 	for _, datacenter := range datacenters {
-		instanceUUID = true
-		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, &instanceUUID)
+		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, ptr.To(true))
 		if err != nil {
 			return "", nil, err
 		} else if ref == nil {
@@ -572,8 +571,7 @@ func FindVM(context context.Context, conn *govmomi.Client, uuid string) (string,
 
 	// Fallback: BIOS UUID
 	for _, datacenter := range datacenters {
-		instanceUUID = false
-		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, &instanceUUID)
+		ref, err := searcher.FindByUuid(context, datacenter, uuid, true, ptr.To(false))
 		if err != nil {
 			return "", nil, err
 		} else if ref == nil {

--- a/tools/vddk-test/entrypoint.sh
+++ b/tools/vddk-test/entrypoint.sh
@@ -14,18 +14,16 @@ export GOVC_INSECURE=1
 TESTSTORE=/tmp/teststore
 mkdir -p $TESTSTORE
 
-/usr/bin/govc datacenter.create testdc
+/usr/bin/govc datacenter.create testdc1
+/usr/bin/govc datacenter.create testdc2
+/usr/bin/govc datacenter.create testdc3
+export GOVC_DATACENTER=testdc2
 /usr/bin/govc cluster.create testcluster
 /usr/bin/govc cluster.add -hostname testhost -username user -password pass -noverify
 /usr/bin/govc datastore.create -type local -name teststore -path $TESTSTORE testcluster/*
 
 /usr/bin/govc vm.create testvm
-while read line; do
-    if [[ $line =~ (^[\s]*UUID:[\s]*)(.*)$ ]]; then
-        uuid="${BASH_REMATCH[2]}"
-        echo $uuid > /tmp/vmid
-    fi
-done < <(govc vm.info testvm)
+/usr/bin/govc object.collect -s=true vm/testvm config.instanceUuid > /tmp/vmid
 
 /usr/bin/govc vm.disk.create -vm testvm -name testvm/testdisk.vmdk -size 2GB
 while read line; do


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request changes the VDDK importer to look up VMs from VMware using the VM's instance UUID field. BIOS UUIDs can be duplicated, resulting in disk transfers from the wrong VM, so forklift is going to start sending instance UUIDs instead. This pull request leaves a fallback to look up the BIOS UUID if the instance UUID can't be found, which should preserve existing behavior in most cases.

**Which issue(s) this PR fixes**
Fixes [MTV-5264](https://redhat.atlassian.net/browse/MTV-5264)/[CNV-87549](https://redhat.atlassian.net/browse/CNV-87549)

**Special notes for your reviewer**:
I have a small VDDK E2E test image change to give this some test coverage, since there's not any existing unit test infrastructure for this part of the code. I would like to put this in a separate pull request to avoid backporting E2E test image changes, which I think cause trouble with builds/CI. If this is not actually a consideration, I can put it back.

**Release note**:
```release-note
VDDK: look up VMs with instance UUIDs instead of BIOS UUIDs
```

