### PR TITLE
Refactor PVC event propagation for populators

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -165,7 +165,7 @@ func (r *CloneReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	log.V(1).Info("reconciling Clone PVCs")
 
 	if checkPVC(pvc, cc.AnnCloneRequest, log) {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundCondition(pvc, r.client); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2176,10 +2176,10 @@ func ResolveDataSourceChain(ctx context.Context, client client.Client, dataSourc
 	return resolved, nil
 }
 
-func sortEvents(events *corev1.EventList, usingPopulator bool, pvcPrimeName string) {
-	// Sort event lists by containing primeName substring and most recent timestamp
+// Sorts events in time based order, prioritizing events that were emitted from prime PVCs
+func sortEvents(events *corev1.EventList, pvcPrimeName string) {
 	sort.Slice(events.Items, func(i, j int) bool {
-		if usingPopulator {
+		if pvcPrimeName != "" {
 			firstContainsPrime := strings.Contains(events.Items[i].Message, pvcPrimeName)
 			secondContainsPrime := strings.Contains(events.Items[j].Message, pvcPrimeName)
 
@@ -2201,9 +2201,44 @@ func sortEvents(events *corev1.EventList, usingPopulator bool, pvcPrimeName stri
 	})
 }
 
-// UpdatePVCBoundContionFromEvents updates the bound condition annotations on the PVC based on recent events
-// This function can be used by both controller and populator packages to update PVC bound condition information
-func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client.Client, log logr.Logger) error {
+func getLatestEventMessage(pvc *corev1.PersistentVolumeClaim, primeName string, c client.Client) string {
+	events := &corev1.EventList{}
+	err := c.List(context.TODO(), events,
+		client.InNamespace(pvc.GetNamespace()),
+		client.MatchingFields{"involvedObject.name": pvc.GetName(),
+			"involvedObject.uid": string(pvc.GetUID())},
+	)
+	if err != nil {
+		klog.Info("Unable to list events for pvc", "pvc", pvc.Name)
+		return ""
+	}
+
+	if len(events.Items) == 0 {
+		return ""
+	}
+
+	sortEvents(events, primeName)
+
+	if primeName != "" {
+		// prime events get emitted on target PVCs with their name prefixed in square brackets
+		fmtPrimeName := fmt.Sprintf("[%s] : ", primeName)
+		primeIdx := strings.Index(events.Items[0].Message, fmtPrimeName)
+		if primeIdx == -1 {
+			return ""
+		}
+		return events.Items[0].Message[primeIdx+len(fmtPrimeName):]
+	}
+
+	return events.Items[0].Message
+}
+
+// UpdatePVCBoundCondition updates the bound condition annotations on the target PVC
+//
+// For populators, the message will come from the prime PVCs bound condition if explicitly set,
+// otherwise it will use the prime PVC's latest event message
+//
+// For non-populators, the bound message will come from the PVCs latest event message
+func UpdatePVCBoundCondition(pvc *corev1.PersistentVolumeClaim, c client.Client) error {
 	currentPvcCopy := pvc.DeepCopy()
 
 	anno := pvc.GetAnnotations()
@@ -2211,8 +2246,12 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 		return nil
 	}
 
+	// we only want to update bound conditions for non prime pvcs
+	if _, exists := anno[AnnPopulatorKind]; exists {
+		return nil
+	}
+
 	if IsBound(pvc) {
-		anno := pvc.GetAnnotations()
 		delete(anno, AnnBoundCondition)
 		delete(anno, AnnBoundConditionReason)
 		delete(anno, AnnBoundConditionMessage)
@@ -2231,46 +2270,32 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 		return nil
 	}
 
-	// set bound condition by getting the latest event
-	events := &corev1.EventList{}
-
-	err := c.List(context.TODO(), events,
-		client.InNamespace(pvc.GetNamespace()),
-		client.MatchingFields{"involvedObject.name": pvc.GetName(),
-			"involvedObject.uid": string(pvc.GetUID())},
-	)
-
-	if err != nil {
-		// Log the error but don't fail the reconciliation
-		log.Error(err, "Unable to list events for PVC bound condition update", "pvc", pvc.Name)
-		return nil
-	}
-
-	if len(events.Items) == 0 {
-		return nil
-	}
-
-	pvcPrime, usingPopulator := anno[AnnPVCPrimeName]
-
-	// Sort event lists by containing primeName substring and most recent timestamp
-	sortEvents(events, usingPopulator, pvcPrime)
-
 	boundMessage := ""
-	// check if prime name annotation exists
-	if usingPopulator {
-		// if we are using populators get the latest event from prime pvc
-		pvcPrime = fmt.Sprintf("[%s] : ", pvcPrime)
+	primeName, usingPopulator := anno[AnnPVCPrimeName]
 
-		// if the first event does not contain a prime message, none will so return
-		primeIdx := strings.Index(events.Items[0].Message, pvcPrime)
-		if primeIdx == -1 {
-			log.V(1).Info("No bound message found, skipping bound condition update", "pvc", pvc.Name)
-			return nil
+	if usingPopulator {
+		pvcPrime := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(context.TODO(), types.NamespacedName{Name: primeName, Namespace: pvc.GetNamespace()}, pvcPrime); err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.V(4).Info("Could not find prime pvc associated to this pvc", "pvc", pvc.Name)
+				return nil
+			}
+			return err
 		}
-		boundMessage = events.Items[0].Message[primeIdx+len(pvcPrime):]
+
+		// prioritize the prime PVC's bound condition message over events
+		if msg, exists := pvcPrime.Annotations[AnnBoundConditionMessage]; exists {
+			boundMessage = msg
+		} else {
+			boundMessage = getLatestEventMessage(pvc, primeName, c)
+		}
 	} else {
-		// if not using populators just get the latest event
-		boundMessage = events.Items[0].Message
+		boundMessage = getLatestEventMessage(pvc, primeName, c)
+	}
+
+	// return early if no message was found
+	if boundMessage == "" {
+		return nil
 	}
 
 	// since we checked status of phase above, we know this is pending
@@ -2288,8 +2313,6 @@ func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client
 
 // CopyEvents gets srcPvc events and re-emits them on the target PVC with the src name prefix
 func CopyEvents(srcPVC, targetPVC client.Object, c client.Client, recorder record.EventRecorder) {
-	srcPrefixMsg := fmt.Sprintf("[%s] : ", srcPVC.GetName())
-
 	newEvents := &corev1.EventList{}
 	err := c.List(context.TODO(), newEvents,
 		client.InNamespace(srcPVC.GetNamespace()),
@@ -2327,11 +2350,14 @@ func CopyEvents(srcPVC, targetPVC client.Object, c client.Client, recorder recor
 			continue
 		}
 
-		formattedMsg := srcPrefixMsg + msg
+		// format new event message to indicate that it came from the src pvc
+		formattedMsg := fmt.Sprintf("[%s] : %s", srcPVC.GetName(), msg)
+
 		// check if we already emitted this event with the src prefix
 		if _, exists := eventMap[formattedMsg]; exists {
 			continue
 		}
+
 		recorder.Event(targetPVC, newEvent.Type, newEvent.Reason, formattedMsg)
 	}
 }

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -380,7 +380,7 @@ var _ = Describe("sortEvents", func() {
 				{LastTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Second)), Message: "first long message"},
 			},
 		}
-		sortEvents(events, false, "")
+		sortEvents(events, "")
 		Expect(events.Items[0].Message).To(Equal("first long message"))
 		Expect(events.Items[1].Message).To(Equal("first"))
 		Expect(events.Items[2].Message).To(Equal("second"))
@@ -398,7 +398,7 @@ var _ = Describe("sortEvents", func() {
 				{LastTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Second)), Message: "first"},
 			},
 		}
-		sortEvents(events, true, "primeName")
+		sortEvents(events, "primeName")
 		Expect(events.Items[0].Message).To(Equal("[primeName] first prime but more interesting"))
 		Expect(events.Items[1].Message).To(Equal("[primeName] first prime"))
 		Expect(events.Items[2].Message).To(Equal("[primeName] second prime"))

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -205,7 +205,7 @@ func (r *ImportReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 
 	// only want to update bound condition for relevant type
 	if checkPVC(pvc, cc.AnnEndpoint, log) || checkPVC(pvc, cc.AnnSource, log) {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundCondition(pvc, r.client); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -439,9 +439,11 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 		}
 	} else {
 		// No scratch space, or scratch space is bound, remove annotation
-		delete(anno, cc.AnnBoundCondition)
-		delete(anno, cc.AnnBoundConditionMessage)
-		delete(anno, cc.AnnBoundConditionReason)
+		if anno[cc.AnnBoundConditionReason] == creatingScratch {
+			delete(anno, cc.AnnBoundCondition)
+			delete(anno, cc.AnnBoundConditionMessage)
+			delete(anno, cc.AnnBoundConditionReason)
+		}
 	}
 
 	if pvc.GetLabels() == nil {

--- a/pkg/controller/populators/clone-populator.go
+++ b/pkg/controller/populators/clone-populator.go
@@ -264,7 +264,7 @@ func (r *ClonePopulatorReconciler) Reconcile(ctx context.Context, req reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, r.log); err != nil {
+	if err := cc.UpdatePVCBoundCondition(pvc, r.client); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -167,7 +167,7 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	// copy over any new events from pvcPrime to pvc
 	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
-	err = cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
+	err = cc.UpdatePVCBoundCondition(pvcCopy, r.client)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -654,6 +654,54 @@ var _ = Describe("Import populator tests", func() {
 			Expect(targetPvc.Annotations[AnnPopulatorProgress]).To(BeEquivalentTo("13.45%"))
 		})
 	})
+
+	DescribeTable("Should set bound condition message from prime PVC", func(primeAnnotations map[string]string, eventMessage, expectedBoundMessage string) {
+		primeName := "prime-pvc"
+		targetPvc := CreatePvcInStorageClass("target-pvc", metav1.NamespaceDefault, nil,
+			map[string]string{AnnPVCPrimeName: primeName}, nil, corev1.ClaimPending)
+
+		primePvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        primeName,
+				Namespace:   metav1.NamespaceDefault,
+				Annotations: primeAnnotations,
+			},
+		}
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "target-pvc-event",
+				Namespace: metav1.NamespaceDefault,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Name:      targetPvc.Name,
+				Namespace: targetPvc.Namespace,
+				UID:       targetPvc.UID,
+			},
+			Message:       eventMessage,
+			LastTimestamp: metav1.Now(),
+		}
+
+		reconciler = createImportPopulatorReconciler(targetPvc, primePvc, event)
+		err := UpdatePVCBoundCondition(targetPvc, reconciler.client)
+		Expect(err).ToNot(HaveOccurred())
+
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: targetPvc.Name, Namespace: metav1.NamespaceDefault}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionMessage]).To(Equal(expectedBoundMessage))
+		Expect(resPvc.GetAnnotations()[AnnBoundCondition]).To(Equal("false"))
+		Expect(resPvc.GetAnnotations()[AnnBoundConditionReason]).To(Equal("Pending"))
+	},
+		Entry("using prime PVC annotation directly",
+			map[string]string{AnnBoundConditionMessage: "Important bound message"},
+			"event message",
+			"Important bound message"),
+		Entry("falling back to event parsing when prime has no bound condition annotation",
+			nil,
+			fmt.Sprintf("[%s] : event message", "prime-pvc"),
+			"event message"),
+	)
 })
 
 func createImportPopulatorReconciler(objects ...runtime.Object) *ImportPopulatorReconciler {

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -146,7 +146,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	// copy over any new events from pvcPrime to pvc
 	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
-	err := cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
+	err := cc.UpdatePVCBoundCondition(pvcCopy, r.client)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -142,7 +142,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 	}
 
 	if isUpload || isCloneTarget {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundCondition(pvc, r.client); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`UpdatePVCBoundContionFromEvents` was originally implemented to assist with propagating events from a prime PVC to the target DV so that if something went wrong in the prime PVC, a user could check the DV resource and it's bound condition message would display the latest event message. Unbound DV's already inherit the bound condition message from the associated PVC, so the intent of this function was to get the latest event messages from a prime PVC and set it as the bound condition of the target PVC so that it could be later read by the DV.

However, this function over-complicates this process by also allowing prime PVCs to update their bound condition message to their own latest event message. All that is needed for this propagation is for events from prime PVCs to get copied to the target PVCs (already implemented as apart of #3764) and then _only_ the target PVC needs their bound condition updated for it to appear in the DV. Allowing prime PVCs through this update flow introduced unnecessary Patch calls and more potential for race conditions with no real benefit.

The main motivation for this refactor is also to allow certain cases when the prime PVC's bound condition is explicitly set by a separate component, such as here when a VDDK config map is missing from a cluster. This should take priority over events and should be reported back up to the DV instead of the events.

https://github.com/kubevirt/containerized-data-importer/blob/5e5bce673f315ed36a01d3d989370b01198d9d7f/pkg/controller/import-controller.go#L555-L560 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://redhat.atlassian.net/browse/CNV-57727

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refactor PVC event propagation for populators
```

