### PR TITLE
cdi: expose secure pprof endpoints for controller and operator 

### DIFF
--- a/cmd/cdi-controller/controller.go
+++ b/cmd/cdi-controller/controller.go
@@ -6,6 +6,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"strconv"
 
@@ -209,6 +211,13 @@ func start() {
 			BindAddress:    ":8443",
 			SecureServing:  true,
 			FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
+			ExtraHandlers: map[string]http.Handler{
+				"/debug/pprof/":        http.HandlerFunc(pprof.Index),
+				"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),
+				"/debug/pprof/profile": http.HandlerFunc(pprof.Profile),
+				"/debug/pprof/symbol":  http.HandlerFunc(pprof.Symbol),
+				"/debug/pprof/trace":   http.HandlerFunc(pprof.Trace),
+			},
 			// Disable HTTP/2 to prevent rapid reset vulnerability
 			// See CVE-2023-44487, CVE-2023-39325
 			TLSOpts: []func(*tls.Config){func(c *tls.Config) {

--- a/cmd/cdi-operator/operator.go
+++ b/cmd/cdi-operator/operator.go
@@ -20,6 +20,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"runtime"
 	"strconv"
@@ -111,6 +113,13 @@ func main() {
 			BindAddress:    ":8443",
 			SecureServing:  true,
 			FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
+			ExtraHandlers: map[string]http.Handler{
+				"/debug/pprof/":        http.HandlerFunc(pprof.Index),
+				"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),
+				"/debug/pprof/profile": http.HandlerFunc(pprof.Profile),
+				"/debug/pprof/symbol":  http.HandlerFunc(pprof.Symbol),
+				"/debug/pprof/trace":   http.HandlerFunc(pprof.Trace),
+			},
 			// Disable HTTP/2 to prevent rapid reset vulnerability
 			// See CVE-2023-44487, CVE-2023-39325
 			TLSOpts: []func(*tls.Config){func(c *tls.Config) {

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -44,3 +44,22 @@ spec:
 ```
 
 Changing the verbosity level will automatically restart the CDI components to re-initialize the loggers with the new value.
+
+## Profiling with pprof
+
+The CDI controller and operator expose [pprof](https://pkg.go.dev/net/http/pprof) endpoints on their metrics server (port 8443) for live runtime profiling which include heap allocations, goroutine stacks, CPU profiles, etc.
+
+Access requires the `cdi-pprof-reader` ClusterRole:
+
+```bash
+kubectl create clusterrolebinding pprof-access \
+  --clusterrole=cdi-pprof-reader \
+  --user=$(kubectl config current-context)
+```
+
+Then port-forward and profile (e.g., heap profile):
+
+```bash
+kubectl port-forward -n cdi deploy/cdi-deployment 8443
+go tool pprof -http=:8080 https+insecure://localhost:8443/debug/pprof/heap
+```

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -54,6 +54,8 @@ const (
 	MetricsReaderServiceAccountName = "cdi-metrics-reader"
 	// MetricsReaderTokenName is the name of the secret containing the cdi-metrics-reader ServiceAccount token
 	MetricsReaderTokenName = "cdi-metrics-reader-token" //nolint:gosec
+	// PprofReaderClusterRoleName is the name of the ClusterRole granting access to pprof endpoints
+	PprofReaderClusterRoleName = "cdi-pprof-reader"
 	// KubePersistentVolumeFillingUpSuppressLabelKey is the label name that helps suppress this alert for our PVCs
 	KubePersistentVolumeFillingUpSuppressLabelKey = "alerts.k8s.io/KubePersistentVolumeFillingUp"
 	// KubePersistentVolumeFillingUpSuppressLabelValue is the label value that helps suppress this alert for our PVCs

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -673,6 +673,28 @@ var _ = Describe("Controller", func() {
 				Expect(crb.Subjects[0].Namespace).To(Equal(cdiNamespace))
 			})
 
+			It("should create pprof-reader ClusterRole", func() {
+				args := createArgs()
+				doReconcile(args)
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+
+				crole := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: common.PprofReaderClusterRoleName,
+					},
+				}
+				obj, err := getObject(args.client, crole)
+				Expect(err).ToNot(HaveOccurred())
+				crole = obj.(*rbacv1.ClusterRole)
+
+				Expect(crole.Rules).To(ContainElement(
+					SatisfyAll(
+						HaveField("NonResourceURLs", ContainElements("/debug/pprof", "/debug/pprof/*")),
+						HaveField("Verbs", ContainElement("get")),
+					),
+				))
+			})
+
 			Context("RBAC testing", func() {
 				// https://kubernetes.io/docs/concepts/security/rbac-good-practices/#persistent-volume-creation
 				checkPersistentVolumeCreateViolation := func(rsc string, rule *rbacv1.PolicyRule) {
@@ -2242,6 +2264,7 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.ServiceAccount cdi-metrics-reader"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi-metrics-reader"] = false
 	match[normalCreateSuccess+" *v1.ClusterRoleBinding cdi-metrics-reader"] = false
+	match[normalCreateSuccess+" *v1.ClusterRole cdi-pprof-reader"] = false
 	match[normalCreateEnsured+" SecurityContextConstraint exists"] = false
 
 	return match

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -36,6 +36,7 @@ func createControllerResources(args *FactoryArgs) []client.Object {
 		createControllerClusterRoleBinding(args.Namespace),
 		createMetricsReaderClusterRole(),
 		createMetricsReaderClusterRoleBinding(args.Namespace),
+		createPprofReaderClusterRole(),
 	}
 }
 
@@ -336,4 +337,18 @@ func createMetricsReaderClusterRoleBinding(namespace string) *rbacv1.ClusterRole
 		common.MetricsReaderServiceAccountName,
 		namespace,
 	)
+}
+
+func createPprofReaderClusterRole() *rbacv1.ClusterRole {
+	return utils.ResourceBuilder.CreateClusterRole(common.PprofReaderClusterRoleName, []rbacv1.PolicyRule{
+		{
+			NonResourceURLs: []string{
+				"/debug/pprof",
+				"/debug/pprof/*",
+			},
+			Verbs: []string{
+				"get",
+			},
+		},
+	})
 }

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -217,6 +217,15 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 			"get",
 		},
 	})
+	rules = append(rules, rbacv1.PolicyRule{
+		NonResourceURLs: []string{
+			"/debug/pprof",
+			"/debug/pprof/*",
+		},
+		Verbs: []string{
+			"get",
+		},
+	})
 	return rules
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
pprof is Go's built-in profiling toolkit that exposes runtime diagnostics (e.g., heap allocations, goroutine stacks, CPU profiles, etc.) over HTTP. Exposing these endpoints enables live debugging of memory leaks, goroutine leaks, and CPU hotspots in running controller and operator pods without redeployment or recompilation.

This PR exposes the handlers via the existing metrics server by relying on controller-runtime's ExtraHandlers along with the previously introduced `WithAuthenticationAndAuthorization` which serves to secure the handlers with TLS and RBAC auth. A new ClusterRole (cdi-pprof-reader) is added to grant pprof access independently of metrics scraping.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Registering the handlers adds no runtime overhead, the Go runtime already tracks the underlying profiling data, and CPU/trace profiles only activate on-demand when explicitly requested.

This PR depends on https://github.com/kubevirt/containerized-data-importer/pull/4121, review only the last commit.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose secure pprof endpoints on controller and operator for live runtime diagnostics
```