### PR TITLE
fix context leaks in GCS datasource and registry transport

### DIFF
--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -13,13 +13,16 @@ package main
 //    ImporterSecretKey     Optional. Secret key is the password to your account.
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -99,6 +102,9 @@ func touchDoneFile() {
 func main() {
 	defer klog.Flush()
 
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	certsDirectory, err := os.MkdirTemp("", "certsdir")
 	if err != nil {
 		panic(err)
@@ -146,7 +152,7 @@ func main() {
 		}
 	} else {
 		waitForReadyFile()
-		exitCode := handleImport(source, contentType, volumeMode, imageSize, filesystemOverhead, preallocation)
+		exitCode := handleImport(ctx, source, contentType, volumeMode, imageSize, filesystemOverhead, preallocation)
 		if exitCode != 0 {
 			os.Exit(exitCode)
 		}
@@ -174,6 +180,7 @@ func handleEmptyImage(contentType string, imageSize string, availableDestSpace i
 }
 
 func handleImport(
+	ctx context.Context,
 	source string,
 	contentType string,
 	volumeMode v1.PersistentVolumeMode,
@@ -182,7 +189,7 @@ func handleImport(
 	preallocation bool) int {
 	klog.V(1).Infoln("begin import process")
 
-	ds := newDataSource(source, contentType, volumeMode)
+	ds := newDataSource(ctx, source, contentType, volumeMode)
 	defer ds.Close()
 
 	processor := newDataProcessor(contentType, volumeMode, ds, imageSize, filesystemOverhead, preallocation)
@@ -271,7 +278,7 @@ func getImporterDestPath(contentType string, volumeMode v1.PersistentVolumeMode)
 	return dest
 }
 
-func newDataSource(source string, contentType string, volumeMode v1.PersistentVolumeMode) importer.DataSourceInterface {
+func newDataSource(ctx context.Context, source string, contentType string, volumeMode v1.PersistentVolumeMode) importer.DataSourceInterface {
 	ep, _ := util.ParseEnvVar(common.ImporterEndpoint, false)
 	acc, _ := util.ParseEnvVar(common.ImporterAccessKeyID, false)
 	sec, _ := util.ParseEnvVar(common.ImporterSecretKey, false)
@@ -303,7 +310,7 @@ func newDataSource(source string, contentType string, volumeMode v1.PersistentVo
 		}
 		return ds
 	case cc.SourceRegistry:
-		ds := importer.NewRegistryDataSource(ep, acc, sec, registryImageArchitecture, certDir, insecureTLS)
+		ds := importer.NewRegistryDataSource(ctx, ep, acc, sec, registryImageArchitecture, certDir, insecureTLS)
 		return ds
 	case cc.SourceS3:
 		ds, err := importer.NewS3DataSource(ep, acc, sec, certDir)

--- a/pkg/importer/gcs-datasource.go
+++ b/pkg/importer/gcs-datasource.go
@@ -40,6 +40,8 @@ type GCSDataSource struct {
 	readers *FormatReaders
 	// The image file in scratch space.
 	url *url.URL
+	// cancel cancels the context used for the GCS client and reader
+	cancel context.CancelFunc
 }
 
 // NewGCSDataSource creates a new instance of the GCSDataSource
@@ -58,7 +60,7 @@ func NewGCSDataSource(endpoint, keyFile string) (*GCSDataSource, error) {
 	}
 
 	// Getting Context
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*60) //nolint:govet // todo - solve this: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 
 	if ep.Scheme == "gs" {
 		// Using gs:// endpoint and extracting bucket and object name
@@ -71,8 +73,8 @@ func NewGCSDataSource(endpoint, keyFile string) (*GCSDataSource, error) {
 
 	// Creating GCS Client
 	client, err := getGcsClient(ctx, keyFile, options...)
-
 	if err != nil {
+		cancel()
 		klog.Errorf("GCS Importer: Error creating GCS Client")
 		return nil, err
 	}
@@ -80,6 +82,7 @@ func NewGCSDataSource(endpoint, keyFile string) (*GCSDataSource, error) {
 	// Creating GCS Reader
 	gcsReader, err := newReaderFunc(ctx, client, bucket, object)
 	if err != nil {
+		cancel()
 		klog.Errorf("GCS Importer: Error creating Reader")
 		return nil, err
 	}
@@ -88,6 +91,7 @@ func NewGCSDataSource(endpoint, keyFile string) (*GCSDataSource, error) {
 		ep:        ep,
 		keyFile:   keyFile,
 		gcsReader: gcsReader,
+		cancel:    cancel,
 	}, nil
 }
 
@@ -160,6 +164,9 @@ func (sd *GCSDataSource) GetTerminationMessage() *common.TerminationMessage {
 // Close closes any readers or other open resources.
 func (sd *GCSDataSource) Close() error {
 	var err error
+	if sd.cancel != nil {
+		sd.cancel()
+	}
 	if sd.readers != nil {
 		err = sd.readers.Close()
 	}

--- a/pkg/importer/gcs-datasource_test.go
+++ b/pkg/importer/gcs-datasource_test.go
@@ -473,7 +473,36 @@ var _ = Describe("Google Cloud Storage data source", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
 	})
+
+	It("Close should cancel the context before closing readers", func() {
+		file, err := os.Open(filepath.Join(imageDir, "cirros.raw"))
+		Expect(err).NotTo(HaveOccurred())
+
+		order := []string{}
+		readers, err := NewFormatReaders(&trackingReadCloser{ReadCloser: file, order: &order}, uint64(0), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		sd = &GCSDataSource{
+			readers: readers,
+			cancel: func() {
+				order = append(order, "cancel")
+			},
+		}
+
+		Expect(sd.Close()).To(Succeed())
+		Expect(order).To(Equal([]string{"cancel", "reader"}))
+	})
 })
+
+type trackingReadCloser struct {
+	io.ReadCloser
+	order *[]string
+}
+
+func (t *trackingReadCloser) Close() error {
+	*t.order = append(*t.order, "reader")
+	return t.ReadCloser.Close()
+}
 
 // Create Cloud Storage Object Reader pointing to a sample image
 func mockGcsObjectReader(ctx context.Context, client *storage.Client, bucket, object string) (io.ReadCloser, error) {

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -17,6 +17,7 @@ limitations under the License.
 package importer
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -41,6 +42,7 @@ const (
 // 1. Info -> Transfer
 // 2. Transfer -> Convert
 type RegistryDataSource struct {
+	ctx               context.Context
 	endpoint          string
 	accessKey         string
 	secKey            string
@@ -55,7 +57,7 @@ type RegistryDataSource struct {
 }
 
 // NewRegistryDataSource creates a new instance of the Registry Data Source.
-func NewRegistryDataSource(endpoint, accessKey, secKey, imageArchitecture, certDir string, insecureTLS bool) *RegistryDataSource {
+func NewRegistryDataSource(ctx context.Context, endpoint, accessKey, secKey, imageArchitecture, certDir string, insecureTLS bool) *RegistryDataSource {
 	allCertDir, err := CreateCertificateDir(certDir)
 	if err != nil {
 		klog.Infof("Error creating allCertDir %v", err)
@@ -68,6 +70,7 @@ func NewRegistryDataSource(endpoint, accessKey, secKey, imageArchitecture, certD
 		allCertDir = certDir
 	}
 	return &RegistryDataSource{
+		ctx:               ctx,
 		endpoint:          endpoint,
 		accessKey:         accessKey,
 		secKey:            secKey,
@@ -99,7 +102,7 @@ func (rd *RegistryDataSource) Transfer(path string, preallocation bool) (Process
 	}
 
 	klog.V(1).Infof("Copying registry image to scratch space.")
-	rd.info, err = CopyRegistryImage(rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.imageArchitecture, rd.certDir, rd.insecureTLS, preallocation)
+	rd.info, err = CopyRegistryImage(rd.ctx, rd.endpoint, path, containerDiskImageDir, rd.accessKey, rd.secKey, rd.imageArchitecture, rd.certDir, rd.insecureTLS, preallocation)
 	if err != nil {
 		return ProcessingPhaseError, errors.Wrapf(err, "Failed to read registry image")
 	}

--- a/pkg/importer/registry-datasource_test.go
+++ b/pkg/importer/registry-datasource_test.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +37,7 @@ var _ = Describe("Registry data source", func() {
 	})
 
 	It("should return transfer after info is called", func() {
-		ds = NewRegistryDataSource("", "", "", "", "", true)
+		ds = NewRegistryDataSource(context.Background(), "", "", "", "", "", true)
 		result, err := ds.Info()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ProcessingPhaseTransferScratch).To(Equal(result))
@@ -46,7 +47,7 @@ var _ = Describe("Registry data source", func() {
 		if scratchPath == "" {
 			scratchPath = tmpDir
 		}
-		ds = NewRegistryDataSource(ep, accKey, secKey, "", certDir, insecureRegistry)
+		ds = NewRegistryDataSource(context.Background(), ep, accKey, secKey, "", certDir, insecureRegistry)
 
 		// Need to pass in a real path if we don't want scratch space needed error.
 		result, err := ds.Transfer(scratchPath, false)
@@ -66,14 +67,14 @@ var _ = Describe("Registry data source", func() {
 	)
 
 	It("TransferFile should not be called", func() {
-		ds = NewRegistryDataSource("", "", "", "", "", true)
+		ds = NewRegistryDataSource(context.Background(), "", "", "", "", "", true)
 		result, err := ds.TransferFile("file", false)
 		Expect(err).To(HaveOccurred())
 		Expect(ProcessingPhaseError).To(Equal(result))
 	})
 
 	It("GetTerminationMessage should contain labels collected from the image", func() {
-		ds = NewRegistryDataSource("", "", "", "", "", true)
+		ds = NewRegistryDataSource(context.Background(), "", "", "", "", "", true)
 		ds.info = &types.ImageInspectInfo{
 			Env: []string{
 				"INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE=u1.small",

--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -44,10 +44,6 @@ const (
 
 var errReadingLayer = errors.New("Error reading layer")
 
-func commandTimeoutContext() (context.Context, context.CancelFunc) {
-	return context.WithCancel(context.Background())
-}
-
 func buildSourceContext(accessKey, secKey, imageArchitecture, certDir string, insecureRegistry bool) *types.SystemContext {
 	ctx := &types.SystemContext{}
 	if accessKey != "" && secKey != "" {
@@ -195,11 +191,12 @@ func safeJoinPaths(dir, path string) (v string, err error) {
 	return "", fmt.Errorf("%s: %s", "content filepath is tainted", path)
 }
 
-func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir string, insecureRegistry, stopAtFirst, preallocation bool) (*types.ImageInspectInfo, error) {
+func copyRegistryImage(ctx context.Context, url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir string, insecureRegistry, stopAtFirst, preallocation bool) (*types.ImageInspectInfo, error) {
 	klog.Infof("Downloading image from '%v', copying file from '%v' to '%v'", url, pathPrefix, destDir)
 
-	ctx, cancel := commandTimeoutContext()
-	defer cancel()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	srcCtx := buildSourceContext(accessKey, secKey, imageArchitecture, certDir, insecureRegistry)
 
 	src, err := readImageSource(ctx, srcCtx, url)
@@ -217,7 +214,7 @@ func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchite
 
 	// in the event that target is not a manifest list / image index
 	if srcCtx.ArchitectureChoice != "" {
-		if err := validateImagePlatformMatch(srcCtx, imgCloser); err != nil {
+		if err := validateImagePlatformMatch(ctx, srcCtx, imgCloser); err != nil {
 			klog.Errorf("Error validating architecture: %v", err)
 			return nil, fmt.Errorf("Error validating architecture: %w", err)
 		}
@@ -257,8 +254,8 @@ func copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchite
 	return info, nil
 }
 
-func validateImagePlatformMatch(sys *types.SystemContext, img types.Image) error {
-	config, err := img.OCIConfig(context.Background())
+func validateImagePlatformMatch(ctx context.Context, sys *types.SystemContext, img types.Image) error {
+	config, err := img.OCIConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -274,11 +271,12 @@ func validateImagePlatformMatch(sys *types.SystemContext, img types.Image) error
 // secKey: secretKey for the registry described in url.
 // certDir: directory public CA keys are stored for registry identity verification
 // insecureRegistry: boolean if true will allow insecure registries.
-func GetImageDigest(url, accessKey, secKey, certDir string, insecureRegistry bool) (string, error) {
+func GetImageDigest(ctx context.Context, url, accessKey, secKey, certDir string, insecureRegistry bool) (string, error) {
 	klog.Infof("Inspecting image from '%v'", url)
 
-	ctx, cancel := commandTimeoutContext()
-	defer cancel()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	srcCtx := buildSourceContext(accessKey, secKey, "", certDir, insecureRegistry)
 
 	src, err := readImageSource(ctx, srcCtx, url)
@@ -287,7 +285,7 @@ func GetImageDigest(url, accessKey, secKey, certDir string, insecureRegistry boo
 	}
 	defer closeImage(src)
 
-	imageManifest, _, err := src.GetManifest(context.Background(), nil)
+	imageManifest, _, err := src.GetManifest(ctx, nil)
 	if err != nil {
 		return "", err
 	}
@@ -309,8 +307,8 @@ func GetImageDigest(url, accessKey, secKey, certDir string, insecureRegistry boo
 // imageArchitecture: image index filter for CPU architecture.
 // certDir: directory public CA keys are stored for registry identity verification
 // insecureRegistry: boolean if true will allow insecure registries.
-func CopyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir string, insecureRegistry, preallocation bool) (*types.ImageInspectInfo, error) {
-	return copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir, insecureRegistry, true, preallocation)
+func CopyRegistryImage(ctx context.Context, url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir string, insecureRegistry, preallocation bool) (*types.ImageInspectInfo, error) {
+	return copyRegistryImage(ctx, url, destDir, pathPrefix, accessKey, secKey, imageArchitecture, certDir, insecureRegistry, true, preallocation)
 }
 
 // CopyRegistryImageAll download image from registry with docker image API. It will extract all files under the pathPrefix
@@ -321,6 +319,6 @@ func CopyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, imageArchite
 // secKey: secretKey for the registry described in url.
 // certDir: directory public CA keys are stored for registry identity verification
 // insecureRegistry: boolean if true will allow insecure registries.
-func CopyRegistryImageAll(url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry, preallocation bool) (*types.ImageInspectInfo, error) {
-	return copyRegistryImage(url, destDir, pathPrefix, accessKey, secKey, "", certDir, insecureRegistry, false, preallocation)
+func CopyRegistryImageAll(ctx context.Context, url, destDir, pathPrefix, accessKey, secKey, certDir string, insecureRegistry, preallocation bool) (*types.ImageInspectInfo, error) {
+	return copyRegistryImage(ctx, url, destDir, pathPrefix, accessKey, secKey, "", certDir, insecureRegistry, false, preallocation)
 }

--- a/pkg/importer/transport_test.go
+++ b/pkg/importer/transport_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package importer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -42,7 +43,7 @@ var _ = Describe("Registry Importer", func() {
 	})
 
 	DescribeTable("Should extract a single file", func(source string) {
-		info, err := CopyRegistryImage(source, tmpDir, "disk/cirros-0.3.4-x86_64-disk.img", "", "", "", "", false, false)
+		info, err := CopyRegistryImage(context.Background(), source, tmpDir, "disk/cirros-0.3.4-x86_64-disk.img", "", "", "", "", false, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(info).ToNot(BeNil())
 
@@ -53,7 +54,7 @@ var _ = Describe("Registry Importer", func() {
 		Entry("when one of the image layers is malformed", malformedSource),
 	)
 	It("Should extract files prefixed by path", func() {
-		info, err := CopyRegistryImageAll(source, tmpDir, "etc/", "", "", "", false, false)
+		info, err := CopyRegistryImageAll(context.Background(), source, tmpDir, "etc/", "", "", "", false, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(info).ToNot(BeNil())
 
@@ -64,7 +65,7 @@ var _ = Describe("Registry Importer", func() {
 		Expect(file).To(BeARegularFile())
 	})
 	It("Should return an error if a single file is not found", func() {
-		info, err := CopyRegistryImage(source, tmpDir, "disk/invalid.img", "", "", "", "", false, false)
+		info, err := CopyRegistryImage(context.Background(), source, tmpDir, "disk/invalid.img", "", "", "", "", false, false)
 		Expect(err).To(HaveOccurred())
 		Expect(info).To(BeNil())
 
@@ -73,12 +74,12 @@ var _ = Describe("Registry Importer", func() {
 		Expect(err).To(HaveOccurred())
 	})
 	It("Should return an error if no files matches a prefix", func() {
-		info, err := CopyRegistryImageAll(source, tmpDir, "invalid/", "", "", "", false, false)
+		info, err := CopyRegistryImageAll(context.Background(), source, tmpDir, "invalid/", "", "", "", false, false)
 		Expect(err).To(HaveOccurred())
 		Expect(info).To(BeNil())
 	})
 	DescribeTable("Should correctly assert image architecture", func(source string, architecture string, wantErr bool) {
-		info, err := CopyRegistryImage(source, tmpDir, "disk/", "", "", architecture, "", false, false)
+		info, err := CopyRegistryImage(context.Background(), source, tmpDir, "disk/", "", "", architecture, "", false, false)
 		if wantErr {
 			Expect(err).To(HaveOccurred())
 			Expect(info).To(BeNil())
@@ -92,4 +93,5 @@ var _ = Describe("Registry Importer", func() {
 		Entry("when archive is an image index and architecture doesn't match specified architecture", multiArchSource, "invalid", true),
 		Entry("when archive is an image index and architecture matches specified architecture", multiArchSource, "amd64", false),
 	)
+
 })

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,13 +52,16 @@ func init() {
 }
 
 func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	allCertDir, err := importer.CreateCertificateDir(certDir)
 	if err != nil {
 		log.Printf("Ignore common certificate dir: %v", err)
 		allCertDir = certDir
 	}
 
-	digest, err := importer.GetImageDigest(url, accessKey, secretKey, allCertDir, insecureTLS)
+	digest, err := importer.GetImageDigest(ctx, url, accessKey, secretKey, allCertDir, insecureTLS)
 	if err != nil {
 		log.Fatalf("Failed to get image digest: %v", err)
 	}
@@ -77,7 +82,7 @@ func main() {
 		log.Fatalf("Failed to create Clientset: %v", err)
 	}
 
-	dataImportCron, err := cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Get(context.TODO(), cronName, metav1.GetOptions{})
+	dataImportCron, err := cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Get(ctx, cronName, metav1.GetOptions{})
 	if err != nil {
 		log.Fatalf("Failed getting DataImportCron %s/%s: %v", cronNamespace, cronName, err)
 	}
@@ -90,7 +95,7 @@ func main() {
 		log.Printf("No digest update")
 	}
 
-	_, err = cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Update(context.TODO(), dataImportCron, metav1.UpdateOptions{})
+	_, err = cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Update(ctx, dataImportCron, metav1.UpdateOptions{})
 	if err != nil {
 		log.Fatalf("Failed updating DataImportCron %s/%s: %v", cronNamespace, cronName, err)
 	}


### PR DESCRIPTION
What this PR does / why we need it:

Three context bugs in pkg/importer that have been quietly leaking resources:

1. NewGCSDataSource discards the cancel func from context.WithTimeout - there's even a nolint:govet todo comment acknowledging it. The context is never cancelled so goroutines/timers leak on every GCS import. Fix: store cancel in the struct, call it in Close() (and on error paths).

2. GetImageDigest creates a timeout ctx via commandTimeoutContext() but then passes context.Background() to src.GetManifest() - so the timeout has no effect on the actual manifest fetch, it can hang forever.

3. validateImagePlatformMatch hardcodes context.Background() even though the caller has a proper timeout ctx. Fixed by threading ctx through as a param.

How to reproduce 1 (GCS leak):
- profile memory while running repeated GCS imports
- or just look at pkg/importer/gcs-datasource.go:61, the nolint comment spells it out

How to reproduce 2 (GetManifest ignores timeout):
- call GetImageDigest against a slow/unresponsive registry with a short timeout - it won't respect the timeout

Release note:
```release-note
NONE
```