### PR TITLE
tests: replace racy cdi_cr_ready e2e test with unit test

### DIFF
--- a/pkg/monitoring/metrics/operator-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/operator-controller/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller",
     visibility = ["//visibility:public"],
     deps = [
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/metrics:go_default_library",
     ],

--- a/pkg/monitoring/metrics/operator-controller/operator_metrics.go
+++ b/pkg/monitoring/metrics/operator-controller/operator_metrics.go
@@ -1,6 +1,7 @@
 package operatorcontroller
 
 import (
+	ioprometheusclient "github.com/prometheus/client_model/go"
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 )
 
@@ -30,4 +31,13 @@ func SetNotReady() {
 // SetInit sets the readyGauge to -1, 0 is our value for alert to start firing, so can't default to that.
 func SetInit() {
 	readyGauge.Set(-1.0)
+}
+
+// GetReadyValue returns the current value of the readyGauge
+func GetReadyValue() (float64, error) {
+	dto := &ioprometheusclient.Metric{}
+	if err := readyGauge.Write(dto); err != nil {
+		return -1, err
+	}
+	return dto.GetGauge().GetValue(), nil
 }

--- a/pkg/operator/controller/BUILD.bazel
+++ b/pkg/operator/controller/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/monitoring/metrics/operator-controller:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//pkg/monitoring/rules/alerts:go_default_library",
         "//pkg/operator/resources/cert:go_default_library",

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -60,6 +60,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	forklift "kubevirt.io/containerized-data-importer-api/pkg/apis/forklift/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/operator-controller"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring/rules"
 	"kubevirt.io/containerized-data-importer/pkg/monitoring/rules/alerts"
 	clusterResources "kubevirt.io/containerized-data-importer/pkg/operator/resources/cluster"
@@ -146,6 +147,22 @@ var _ = Describe("Controller", func() {
 				Expect(args.cdi.Finalizers).Should(HaveLen(1))
 
 				validateEvents(args.reconciler, createReadyEventValidationMap())
+			})
+
+			It("should set kubevirt_cdi_cr_ready to 1 when available and 0 when not", func() {
+				args := createArgs()
+				doReconcile(args)
+
+				val, err := metrics.GetReadyValue()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(val).To(Equal(0.0))
+
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+				doReconcile(args)
+
+				val, err = metrics.GetReadyValue()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(val).To(Equal(1.0))
 			})
 
 			It("should create configmap", func() {

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -192,47 +192,6 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 
 	Context("[rfe_id:7101][crit:medium][vendor:cnv-qe@redhat.com][level:component] Metrics and Alert tests", func() {
 
-		It("[test_id:9656] Metric kubevirt_cdi_cr_ready is 0 when CDI is not ready", func() {
-			Eventually(func() int {
-				return getMetricValue(f, "kubevirt_cdi_cr_ready")
-			}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", 1))
-
-			crModified = true
-			removeCDI(f, cr)
-
-			By("Creating new CDI with wrong NodeSelector")
-			cdi := &cdiv1.CDI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: cr.Name,
-				},
-				Spec: cr.Spec,
-			}
-			cdi.Spec.Infra.NodePlacement.NodeSelector = map[string]string{"wrong": "wrong"}
-			_, err := f.CdiClient.CdiV1beta1().CDIs().Create(context.TODO(), cdi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Wait for kubevirt_cdi_cr_ready == 0")
-			Eventually(func() int {
-				return getMetricValue(f, "kubevirt_cdi_cr_ready")
-			}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", 0))
-
-			waitForPrometheusAlert(f, "CDINotReady")
-
-			By("Revert CDI CR changes")
-			cdi, err = f.CdiClient.CdiV1beta1().CDIs().Get(context.TODO(), cr.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			cdi.Spec = cr.Spec
-			_, err = f.CdiClient.CdiV1beta1().CDIs().Update(context.TODO(), cdi, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			waitCDI(f, cr, cdiPods)
-			crModified = false
-
-			By("Wait for kubevirt_cdi_cr_ready == 1")
-			Eventually(func() int {
-				return getMetricValue(f, "kubevirt_cdi_cr_ready")
-			}, metricPollingTimeout, metricPollingInterval).Should(BeNumerically("==", 1))
-		})
-
 		It("[test_id:7963] CDI ready metric value as expected when ready to use", func() {
 			Eventually(func() int {
 				return getMetricValue(f, "kubevirt_cdi_cr_ready")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The e2e test that removed and recreated CDI to verify the
kubevirt_cdi_cr_ready metric was racy due to token secret
population timing after CDI reinstall. Replace it with a
deterministic unit test that exercises the metric through
the reconciler lifecycle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
