### PR TITLE
docs: add k3s/RKE2 guidance for device_ownership_from_security_context

### DIFF
--- a/doc/block_cri_ownership_config.md
+++ b/doc/block_cri_ownership_config.md
@@ -39,5 +39,24 @@ CRI-O:
 device_ownership_from_security_context = true
 ```
 
+## k3s and RKE2 (managed containerd configuration)
+Distributions such as k3s and RKE2 generate the containerd `config.toml` on every service start, so editing the file directly does not persist: the change is overwritten on the next restart.
+
+On k3s, prefer the built-in flag, which sets `device_ownership_from_security_context = true` in the generated config (available in recent releases, for example v1.32+):
+```bash
+# CLI flag on server/agent
+k3s server --nonroot-devices
+
+# or in /etc/rancher/k3s/config.yaml
+nonroot-devices: true
+```
+Restart the k3s service on each node afterwards, then recreate any affected CDI pods (already-running pods keep their original device ownership).
+
+If your version does not have the flag, the supported customization path is a containerd config template (`config-v3.toml.tmpl` for containerd v2, `config.toml.tmpl` for containerd v1, in the same directory as the generated `config.toml`). Note one pitfall: TOML does not allow redefining a table, so appending a `[plugins."io.containerd.cri.v1.runtime"]` section after `{{ template "base" . }}` fails with `table io.containerd.cri.v1.runtime already exists` and containerd will not start, leaving the node NotReady. To modify a value that the base template already sets, the template must be a full copy of the generated `config.toml` with the value edited in place. A full-copy template does not pick up future base config changes, so review it after upgrades.
+
+RKE2 uses the same template mechanism and the same pitfall applies; check whether your RKE2 version offers an equivalent flag before falling back to a template.
+
+Verified on k3s v1.34.6 (containerd 2.x) with rook-ceph RBD block-mode PVCs: see [kubevirt/kubevirt#14335](https://github.com/kubevirt/kubevirt/issues/14335).
+
 ## Source
 https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/


### PR DESCRIPTION
**What this PR does / why we need it**:

The block CRI ownership doc shows containerd config snippets, but on k3s and RKE2 the containerd config.toml is regenerated on every service start, so following the doc as written silently does nothing there. This adds a section covering:

- the k3s `nonroot-devices` flag (the clean route, confirmed by users in kubevirt/kubevirt#14335 but never documented)
- the containerd config template fallback, including the TOML duplicate-table pitfall: appending the cri runtime section after `{{ template "base" . }}` makes containerd fail to start with `table io.containerd.cri.v1.runtime already exists`, leaving the node NotReady
- the caveat that a full-copy template freezes the base config and should be reviewed after upgrades

Verified end to end on k3s v1.34.6 (containerd 2.2) with rook-ceph RBD block-mode PVCs: importer fails with `blockdev: cannot open /dev/cdi-block-volume: Permission denied` before the change, import and live migration succeed after.

**Which issue(s) this PR fixes**:
Documentation follow-up to kubevirt/kubevirt#14335 (closed by the lifecycle bot without the fix being documented; a commenter there explicitly asked for docs).

**Special notes for your reviewer**:
Doc-only change.

```release-note
NONE
```