### PR TITLE
populators: fix race between ann/label propagation to target PVC

### DIFF
--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -354,12 +354,8 @@ func (r *ForkliftPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.P
 }
 
 func (r *ForkliftPopulatorReconciler) updatePVCPrime(pvc, pvcPrime *corev1.PersistentVolumeClaim) error {
-	_, err := r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateAnnotations)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateAnnotations)
+	return r.updatePVC(pvc)
 }
 
 func (r *ForkliftPopulatorReconciler) updateAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim) {

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -177,7 +177,8 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		if err = cc.MaybeSetPvcMultiStageAnnotation(pvcPrime, r.getCheckpointArgs(source)); err != nil {
 			return reconcile.Result{}, err
 		}
-		if _, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations); err != nil {
+		r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations)
+		if err = r.updatePVC(pvcCopy); err != nil {
 			return reconcile.Result{}, err
 		}
 		// We requeue to keep reporting progress
@@ -196,10 +197,9 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 
 		if cc.IsPVCComplete(pvcPrime) && cc.IsUnbound(pvc) {
 			// Once the import is succeeded, we copy annotations and labels and rebind the PV from PVC to target PVC
-			if pvcCopy, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations); err != nil {
-				return reconcile.Result{}, err
-			}
-			if pvcCopy, err = r.updatePVCWithPVCPrimeLabels(pvcCopy, pvcPrime.GetLabels()); err != nil {
+			r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations)
+			r.updatePVCWithPVCPrimeLabels(pvcCopy, pvcPrime.GetLabels())
+			if err = r.updatePVC(pvcCopy); err != nil {
 				return reconcile.Result{}, err
 			}
 			if err := cc.Rebind(context.TODO(), r.client, pvcPrime, pvcCopy); err != nil {
@@ -208,7 +208,8 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 	}
 
-	if _, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations); err != nil {
+	r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateImportAnnotations)
+	if err = r.updatePVC(pvcCopy); err != nil {
 		return reconcile.Result{}, err
 	}
 	if cc.IsPVCComplete(pvcPrime) && !cc.IsMultiStageImportInProgress(pvc) {

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -18,7 +18,6 @@ package populators
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/go-logr/logr"
 
@@ -251,29 +250,17 @@ var desiredAnnotations = []string{cc.AnnPodPhase, cc.AnnPodReady, cc.AnnPodResta
 	cc.AnnRunningCondition, cc.AnnRunningConditionMessage, cc.AnnRunningConditionReason, cc.AnnPodSchedulable,
 	cc.AnnImportFatalError}
 
-func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) (*corev1.PersistentVolumeClaim, error) {
-	pvcCopy := pvc.DeepCopy()
+func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) {
 	for _, ann := range desiredAnnotations {
 		if value, ok := pvcPrime.GetAnnotations()[ann]; ok {
-			cc.AddAnnotation(pvcCopy, ann, value)
-		} else if _, ok := pvcCopy.GetAnnotations()[ann]; ok {
-			// if the desired Annotation was deleted from pvcPrime
-			// delete it also in the target pvc
-			delete(pvcCopy.Annotations, ann)
+			cc.AddAnnotation(pvc, ann, value)
+		} else if _, ok := pvc.GetAnnotations()[ann]; ok {
+			delete(pvc.Annotations, ann)
 		}
 	}
 	if updateFunc != nil {
-		updateFunc(pvcCopy, pvcPrime)
+		updateFunc(pvc, pvcPrime)
 	}
-
-	if !reflect.DeepEqual(pvc.ObjectMeta, pvcCopy.ObjectMeta) {
-		err := r.client.Update(context.TODO(), pvcCopy)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return pvcCopy, nil
 }
 
 func (r *ReconcilerBase) updatePVCPrimeNameAnnotation(pvc *corev1.PersistentVolumeClaim, pvcPrimeName string) (bool, error) {
@@ -289,15 +276,12 @@ func (r *ReconcilerBase) updatePVCPrimeNameAnnotation(pvc *corev1.PersistentVolu
 	return true, nil
 }
 
-func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolumeClaim, pvcPrimeLabels map[string]string) (*corev1.PersistentVolumeClaim, error) {
-	pvcCopy := pvc.DeepCopy()
-	cc.CopyAllowedLabels(pvcPrimeLabels, pvcCopy, false)
-	if !reflect.DeepEqual(pvc.ObjectMeta, pvcCopy.ObjectMeta) {
-		if err := r.client.Update(context.TODO(), pvcCopy); err != nil {
-			return nil, err
-		}
-	}
-	return pvcCopy, nil
+func (r *ReconcilerBase) updatePVCWithPVCPrimeLabels(pvc *corev1.PersistentVolumeClaim, pvcPrimeLabels map[string]string) {
+	cc.CopyAllowedLabels(pvcPrimeLabels, pvc, false)
+}
+
+func (r *ReconcilerBase) updatePVC(pvc *corev1.PersistentVolumeClaim) error {
+	return r.client.Update(context.TODO(), pvc)
 }
 
 // reconcile functions

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -165,8 +165,8 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 		}
 	}
 
-	_, err = r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
-	if err != nil {
+	r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
+	if err := r.updatePVC(pvcCopy); err != nil {
 		return reconcile.Result{}, err
 	}
 	if cc.IsPVCComplete(pvcPrime) {

--- a/pkg/controller/populators/upload-populator_test.go
+++ b/pkg/controller/populators/upload-populator_test.go
@@ -200,7 +200,9 @@ var _ = Describe("Datavolume controller reconcile loop", func() {
 		cc.AddAnnotation(pvcPrime, cc.AnnPVCPrimeName, pvcPrime.Name)
 
 		r := createUploadPopulatorReconciler(pvc, pvcPrime)
-		pvc, err := r.updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime, r.updateUploadAnnotations)
+		pvcCopy := pvc.DeepCopy()
+		r.updatePVCWithPVCPrimeAnnotations(pvcCopy, pvcPrime, r.updateUploadAnnotations)
+		err := r.updatePVC(pvcCopy)
 		Expect(err).ToNot(HaveOccurred())
 
 		//should always remove the pvc prime annotation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the populator path, annotations (including AnnPodPhase) and labels
were copied from PVC Prime to the target PVC in two separate API
updates. The DV controller could observe AnnPodPhase=Succeeded from
the first update and transition the DV to Succeeded before labels
(e.g. instancetype.kubevirt.io/*) landed in the second update. This
caused the DataImportCron controller to create VolumeSnapshots without
the registry image labels, and since the recovery path for snapshots
is circular (snapshot->DataSource->snapshot), the labels were
permanently lost.

Refactor updatePVCWithPVCPrimeAnnotations and
updatePVCWithPVCPrimeLabels to only mutate in-memory, letting callers
issue a single client.Update after applying all mutations. This
ensures annotations and labels are always visible atomically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: instancetype labels from containerdisk doesn't get propogated to VolumeSnapshot/DataSource on multiarch clusters
```

