### PR TITLE
storagecapabilities: advertise RWX-Filesystem for linstor.csi.linbit.com

### DIFF
--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -55,7 +55,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"rook-ceph.cephfs.csi.ceph.com":         {{rwx, file}, {rwo, file}},
 	"openshift-storage.cephfs.csi.ceph.com": {{rwx, file}, {rwo, file}},
 	// LINSTOR
-	"linstor.csi.linbit.com": createAllButRWXFileCapabilities(),
+	"linstor.csi.linbit.com": createLinstorCapabilities(),
 	// DELL Unity XT
 	"csi-unity.dellemc.com":     createAllButRWXFileCapabilities(),
 	"csi-unity.dellemc.com/nfs": createAllFSCapabilities(),
@@ -557,6 +557,28 @@ func createAllButRWXFileCapabilities() []StorageCapabilities {
 	return []StorageCapabilities{
 		{rwx, block},
 		{rwo, block},
+		{rwo, file},
+		{rox, block},
+		{rox, file},
+	}
+}
+
+// createLinstorCapabilities returns the capabilities for linstor.csi.linbit.com.
+//
+// Block is listed first so it stays the preferred volume mode: on LINSTOR/DRBD
+// shared access (RWX) is served natively at the Block level via DRBD
+// dual-primary, so a fully-unspecified request defaults to {rwx, block} (no
+// NFS). {rwx, file} is also advertised, after the block modes, because LINSTOR
+// can serve RWX in Filesystem mode through its highly-available NFS-Ganesha
+// export (linstor-csi-nfs-server). Advertising it lets shared-filesystem
+// workloads be satisfied on LINSTOR — notably KubeVirt vm-state backend storage,
+// which is Filesystem-mode and must be RWX to live-migrate. {rwo, file} is kept
+// for ordinary non-shared filesystem volumes.
+func createLinstorCapabilities() []StorageCapabilities {
+	return []StorageCapabilities{
+		{rwx, block},
+		{rwo, block},
+		{rwx, file},
 		{rwo, file},
 		{rox, block},
 		{rox, file},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `{ReadWriteMany, Filesystem}` to the storage-capabilities set for `linstor.csi.linbit.com`, after the block modes:

```
{rwx, block}, {rwo, block}, {rwx, file}, {rwo, file}, {rox, block}, {rox, file}
```

LINSTOR can serve RWX in Filesystem mode through its highly-available NFS-Ganesha export (`linstor-csi-nfs-server`). Advertising it lets CDI/KubeVirt satisfy shared-filesystem workloads on LINSTOR. Concrete motivation: KubeVirt's vm-state backend-storage PVC (persistent EFI/TPM) is Filesystem-mode and must be ReadWriteMany to live-migrate; without `{rwx, file}` in the profile it is forced to ReadWriteOnce on a LINSTOR default class, pinning the VM to its node and blocking live-migration.

This also gives `linstor.csi.linbit.com` its own documented constructor instead of sharing the generic `createAllButRWXFileCapabilities()` helper with Dell Unity / Huawei.

**Ordering**: `{rwx, block}` stays first, so a fully-unspecified request still defaults to Block (DRBD dual-primary, no NFS) — the right default for normal VM disks. `{rwx, file}` is placed before `{rwo, file}`, so a request that pins `volumeMode=Filesystem` without an accessMode now defaults to RWX, i.e. a per-volume NFS-Ganesha export.

**Special notes for your reviewer**:

/cc @WanzenBug — as the LINBIT maintainer of linstor-csi and author of the NFS-Ganesha RWX feature, your review is the one that matters here. Two things to confirm:
1. advertising `{rwx, file}` for `linstor.csi.linbit.com` is correct now that the NFS export exists, and
2. the ordering — `{rwx, file}` before `{rwo, file}` makes a bare Filesystem request default to an NFS share; placing it after `{rwo, file}` keeps `{rwo, file}` the Filesystem default and reaches NFS only on an explicit RWX request. The current placement is the more aggressive one.

**Release note**:

```release-note
storagecapabilities: advertise ReadWriteMany + Filesystem for linstor.csi.linbit.com (served via LINSTOR's NFS-Ganesha export), enabling shared-filesystem and live-migratable vm-state volumes on LINSTOR.
```
