### PR TITLE
Fix in-docker to not error out with VCS status

### DIFF
--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -36,6 +36,7 @@ ${CDI_CRI} run ${USE_TTY} \
     -e RUN_UID=$(id -u) \
     -e RUN_GID=$(id -g) \
     -e KUBEVIRTCI_RUNTIME=${KUBEVIRTCI_RUNTIME} \
+    -e GIT_CONFIG_PARAMETERS="'safe.directory=/go/src/kubevirt.io/containerized-data-importer'" \
     -e GOCACHE=/gocache \
     -w ${WORK_DIR} \
     ${BUILDER_IMAGE} "$1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes issue calling make cluster-sync locally.

error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.

fixed by setting environment variable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

