### PR TITLE
Remove prlimit (RLIMIT_AS) address space limiting from qemu-img execution

### DIFF
--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -40,9 +40,8 @@ import (
 )
 
 const (
-	networkTimeoutSecs = 3600    //max is 10000
-	maxMemory          = 1 << 30 //value from OpenStack Nova
-	maxCPUSecs         = 30      //value from OpenStack Nova
+	networkTimeoutSecs = 3600 //max is 10000
+	maxCPUSecs         = 30   //value from OpenStack Nova
 	matcherString      = "\\((\\d?\\d\\.\\d\\d)\\/100%\\)"
 )
 
@@ -75,7 +74,7 @@ var (
 	ErrLargerPVCRequired = errors.New("A larger PVC is required")
 
 	qemuExecFunction = system.ExecWithLimits
-	qemuInfoLimits   = &system.ProcessLimitValues{AddressSpaceLimit: maxMemory, CPUTimeLimit: maxCPUSecs}
+	qemuInfoLimits   = &system.ProcessLimitValues{CPUTimeLimit: maxCPUSecs}
 	qemuIterface     = NewQEMUOperations()
 	re               = regexp.MustCompile(matcherString)
 

--- a/pkg/image/qemu_test.go
+++ b/pkg/image/qemu_test.go
@@ -150,7 +150,7 @@ func init() {
 	ownerUID = "1111-1111-111"
 }
 
-var expectedLimits = &system.ProcessLimitValues{AddressSpaceLimit: 1 << 30, CPUTimeLimit: 30}
+var expectedLimits = &system.ProcessLimitValues{CPUTimeLimit: 30}
 
 var _ = Describe("Convert to Raw", func() {
 	var tmpDir, destPath string

--- a/pkg/system/BUILD.bazel
+++ b/pkg/system/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/pkg/system/prlimit.go
+++ b/pkg/system/prlimit.go
@@ -21,57 +21,20 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
-	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
 )
 
-// ProcessLimiter defines the methods limiting resources of a Process
-type ProcessLimiter interface {
-	SetAddressSpaceLimit(pid int, value uint64) error
-	SetCPUTimeLimit(pid int, value uint64) error
-}
-
 // ProcessLimitValues specifies the resource limits available to a process
 type ProcessLimitValues struct {
-	AddressSpaceLimit uint64
-	CPUTimeLimit      uint64
+	CPUTimeLimit uint64
 }
-
-type processLimiter struct{}
 
 var execCommand = exec.Command
 var execCommandContext = exec.CommandContext
-
-var limiter = NewProcessLimiter()
-
-// NewProcessLimiter returns a new ProcessLimiter
-func NewProcessLimiter() ProcessLimiter {
-	return &processLimiter{}
-}
-
-func (p *processLimiter) SetAddressSpaceLimit(pid int, value uint64) error {
-	return prlimit(pid, unix.RLIMIT_AS, &syscall.Rlimit{Cur: value, Max: value})
-}
-
-func (p *processLimiter) SetCPUTimeLimit(pid int, value uint64) error {
-	return prlimit(pid, unix.RLIMIT_CPU, &syscall.Rlimit{Cur: value, Max: value})
-}
-
-// SetAddressSpaceLimit sets a limit on total address space of a process
-func SetAddressSpaceLimit(pid int, value uint64) error {
-	return limiter.SetAddressSpaceLimit(pid, value)
-}
-
-// SetCPUTimeLimit sets a limit on the total cpu time a process may have
-func SetCPUTimeLimit(pid int, value uint64) error {
-	return limiter.SetCPUTimeLimit(pid, value)
-}
 
 // scanLinesWithCR is an alternate split function that works with carriage returns as well
 // as new lines.
@@ -159,13 +122,6 @@ func executeWithLimits(limits *ProcessLimitValues, callback func(string), logErr
 	go processScanner(scanner, &buf, stdoutDone, callback)
 	go processScanner(errScanner, &errBuf, stderrDone, callback)
 
-	if limits != nil && limits.AddressSpaceLimit > 0 {
-		klog.V(3).Infof("Setting Address space limit to %d\n", limits.AddressSpaceLimit)
-		err = SetAddressSpaceLimit(cmd.Process.Pid, limits.AddressSpaceLimit)
-		if err != nil {
-			return nil, errors.Wrap(err, "Couldn't set address space limit")
-		}
-	}
 	<-stdoutDone
 	<-stderrDone
 	// The wait has to be after the reading channels are finished otherwise there is a race where the wait completes and closes stdout/err before anything
@@ -182,12 +138,4 @@ func executeWithLimits(limits *ProcessLimitValues, callback func(string), logErr
 		return errBuf.Bytes(), errors.Wrapf(err, "%s execution failed", command)
 	}
 	return output, nil
-}
-
-func prlimit(pid int, limit int, value *syscall.Rlimit) error {
-	_, _, e1 := syscall.RawSyscall6(syscall.SYS_PRLIMIT64, uintptr(pid), uintptr(limit), uintptr(unsafe.Pointer(value)), 0, 0, 0)
-	if e1 != 0 {
-		return errors.Wrapf(e1, "error setting prlimit on %d with value %d on pid %d", limit, value, pid)
-	}
-	return nil
 }

--- a/pkg/system/prlimit_test.go
+++ b/pkg/system/prlimit_test.go
@@ -18,17 +18,13 @@ package system
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	rand "crypto/rand"
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,48 +33,29 @@ import (
 )
 
 var _ = Describe("Process Limits", func() {
-	limits := &ProcessLimitValues{1, 1}
-	nullLimiter := newTestProcessLimiter(nil, nil)
+	limits := &ProcessLimitValues{CPUTimeLimit: 1}
 
-	realLimits := &ProcessLimitValues{1 << 30, 10}
-
-	//workaround for issue #3341 and #3467
-	if runtime.GOARCH == "s390x" || runtime.GOARCH == "arm64" {
-		realLimits = &ProcessLimitValues{1 << 31, 10}
-	}
-
-	DescribeTable("exec", func(commandOverride func(context.Context, string, ...string) *exec.Cmd, limiter ProcessLimiter, limits *ProcessLimitValues, command, output, errString string, args ...string) {
+	DescribeTable("exec", func(commandOverride func(context.Context, string, ...string) *exec.Cmd, limits *ProcessLimitValues, command, output, errString string, args ...string) {
 		replaceExecCommandContext(commandOverride, func() {
-			replaceLimiter(limiter, func() {
-				result, err := ExecWithLimits(limits, testProgress, command, args...)
-				strOutput := string(result)
+			result, err := ExecWithLimits(limits, testProgress, command, args...)
+			strOutput := string(result)
 
-				Expect(strOutput).To(Equal(output))
+			Expect(strOutput).To(Equal(output))
 
-				if err != nil {
-					if errString == "" {
-						Expect(err).NotTo(HaveOccurred())
-					} else {
-						Expect(errors.Cause(err).Error()).To(Equal(errString))
-					}
-				} else if errString != "" {
-					Expect(err).To(HaveOccurred())
+			if err != nil {
+				if errString == "" {
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					Expect(errors.Cause(err).Error()).To(Equal(errString))
 				}
-			})
+			} else if errString != "" {
+				Expect(err).To(HaveOccurred())
+			}
 		})
 	},
-		Entry("command success with real limits", fakeCommandContext, nil, realLimits, "faker", "", "", "0", "", ""),
-		Entry("command start fails", badCommand, nullLimiter, limits, "faker", "", "fork/exec /usr/bin/doesnotexist: no such file or directory", "", "", ""),
-		Entry("address space limit fails", fakeCommandContext, newTestProcessLimiter(errors.New("Set address limit fails"), nil), limits, "faker", "", "Set address limit fails", "", "", ""),
-		Entry("command exit bad", fakeCommandContext, nullLimiter, limits, "faker", "", "exit status 1", "1", "", ""),
-	)
-
-	DescribeTable("limits actually work", func(timeout time.Duration, f limitFunction, command, errString string, args ...string) {
-		_, err := runFakeCommandWithTimeout(timeout, f, command, args...)
-		Expect(err.Error()).To(Equal(errString))
-	},
-		Entry("killed by cpu time limit", 10*time.Second, func(p int) error { return SetCPUTimeLimit(p, 1) }, "spinner", "signal: killed"),
-		Entry("killed by memory limit", 10*time.Second, func(p int) error { return SetAddressSpaceLimit(p, (1<<21)*10) }, "hog", "exit status 2"),
+		Entry("command success", fakeCommandContext, limits, "faker", "", "", "0", "", ""),
+		Entry("command start fails", badCommand, limits, "faker", "", "fork/exec /usr/bin/doesnotexist: no such file or directory", "", "", ""),
+		Entry("command exit bad", fakeCommandContext, limits, "faker", "", "exit status 1", "1", "", ""),
 	)
 
 	It("Carriage return split should work", func() {
@@ -99,35 +76,8 @@ var _ = Describe("Process Limits", func() {
 	})
 })
 
-type testProcessLimiter struct {
-	addressSpaceError error
-	cpuTimeError      error
-}
-
-func newTestProcessLimiter(addressSpaceError, cpuTimeError error) ProcessLimiter {
-	return &testProcessLimiter{addressSpaceError, cpuTimeError}
-}
-
-func (p *testProcessLimiter) SetAddressSpaceLimit(pid int, value uint64) error {
-	return p.addressSpaceError
-}
-
-func (p *testProcessLimiter) SetCPUTimeLimit(pid int, value uint64) error {
-	return p.cpuTimeError
-}
-
 func testProgress(line string) {
 	// No-op
-}
-
-func fakeCommand(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestHelperProcess", "--", command}
-	cs = append(cs, args...)
-
-	//nolint:gosec // This is not production code
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	return cmd
 }
 
 func fakeCommandContext(ctx context.Context, command string, args ...string) *exec.Cmd {
@@ -142,38 +92,6 @@ func fakeCommandContext(ctx context.Context, command string, args ...string) *ex
 
 func badCommand(ctx context.Context, command string, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "/usr/bin/doesnotexist")
-}
-
-type limitFunction func(int) error
-
-func runFakeCommandWithTimeout(duration time.Duration, f limitFunction, command string, args ...string) ([]byte, error) {
-	var buf bytes.Buffer
-	cmd := fakeCommand(command, args...)
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	err := cmd.Start()
-	Expect(err).NotTo(HaveOccurred())
-	defer func() {
-		_ = cmd.Process.Kill()
-	}()
-
-	err = f(cmd.Process.Pid)
-	Expect(err).NotTo(HaveOccurred())
-
-	done := make(chan error)
-	go func() { done <- cmd.Wait() }()
-
-	timeout := time.After(duration)
-
-	select {
-	case <-timeout:
-		Fail("Process was not killed")
-	case err := <-done:
-		return buf.Bytes(), err
-	}
-
-	// shouldn't get here
-	return nil, errors.New("This shouldn't happen")
 }
 
 func TestHelperProcess(t *testing.T) {
@@ -197,10 +115,6 @@ func TestHelperProcess(t *testing.T) {
 	switch args[0] {
 	case "faker":
 		doFaker(args[1:])
-	case "spinner":
-		doSpinner(args[1:])
-	case "hog":
-		doHog(args[1:])
 	}
 
 	//shouldn't get here
@@ -219,40 +133,11 @@ func doFaker(args []string) {
 	os.Exit(rc)
 }
 
-func doSpinner(args []string) {
-	for { //nolint:staticcheck,revive
-
-	}
-}
-
-func doHog(args []string) {
-	var arrays [][]byte
-
-	for i := 0; i < (1 << 20); i++ {
-		bytes := make([]byte, 1024)
-		_, err := rand.Read(bytes)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		arrays = append(arrays, bytes) //nolint:staticcheck
-	}
-}
-
 func replaceExecCommandContext(replacement func(context.Context, string, ...string) *exec.Cmd, f func()) {
 	orig := execCommandContext
 	if replacement != nil {
 		execCommandContext = replacement
 		defer func() { execCommandContext = orig }()
-	}
-	f()
-}
-
-func replaceLimiter(replacement ProcessLimiter, f func()) {
-	orig := limiter
-	if replacement != nil {
-		limiter = replacement
-		defer func() { limiter = orig }()
 	}
 	f()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

CDI used `prlimit(RLIMIT_AS)` to cap the address space of `qemu-img` subprocesses at 1 GiB (a value borrowed from OpenStack Nova). `RLIMIT_AS` limits *virtual* address space, not physical/RSS memory. The Go runtime reserves large virtual address ranges via `mmap` (GC arenas, span management) that never translate to physical memory, so `RLIMIT_AS` is fundamentally incompatible with Go programs ([golang/go#69105](https://github.com/golang/go/issues/69105)) and has caused `SIGSEGV` / `runtime: cannot allocate memory` flakiness across architectures (e.g. s390x, #3341).

The protection is also redundant and narrow:
- CDI runs in Kubernetes pods, where the container runtime already enforces real (RSS) memory limits via cgroups.
- The limit was only ever applied to the `qemu-img info` call; all other `qemu-img` operations already passed `nil` limits.

This PR removes the `RLIMIT_AS`/`RLIMIT_CPU` prlimit syscall mechanism and the now-unused `ProcessLimiter` abstraction.

**Special notes for your reviewer**:

`ExecWithLimits` and `ProcessLimitValues.CPUTimeLimit` are intentionally retained — `CPUTimeLimit` still drives the `context.WithTimeout` that kills hung subprocesses (e.g. the 30s `qemu-img info` timeout). Only the `prlimit`-based limiting (the unused `SetCPUTimeLimit`/`RLIMIT_CPU` and the `SetAddressSpaceLimit`/`RLIMIT_AS` path) is removed. `go build`, `go vet`, `gofmt`, and `go test ./pkg/system/... ./pkg/image/...` all pass locally.

**Which issue(s) this PR fixes**:

Fixes #4186

**Release note**:

```release-note
Removed the RLIMIT_AS address space limit on qemu-img subprocesses, which was incompatible with the Go runtime's virtual memory model and redundant with Kubernetes pod/cgroup memory limits.
```