### PR TITLE
Suppress ClaimMisbound Warning

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -370,6 +370,9 @@ const (
 
 	// AnnPVCPrimeName annotation is the name of the PVC' that is used to populate the PV which is then rebound to the target PVC
 	AnnPVCPrimeName = AnnAPIGroup + "/storage.populator.pvcPrime"
+
+	// ClaimMisbound event reason
+	EventReasonClaimMisbound = "ClaimMisbound"
 )
 
 // Size-detection pod error codes
@@ -2373,6 +2376,12 @@ func CopyEvents(srcPVC, targetPVC client.Object, c client.Client, recorder recor
 		if _, exists := eventMap[formattedMsg]; exists {
 			continue
 		}
+
+		// simply check if event is a ClaimMisbound event, if so, skip it
+		if newEvent.Reason == EventReasonClaimMisbound {
+			continue
+		}
+
 		recorder.Event(targetPVC, newEvent.Type, newEvent.Reason, formattedMsg)
 	}
 }

--- a/pkg/controller/populators/import-populator_test.go
+++ b/pkg/controller/populators/import-populator_test.go
@@ -198,6 +198,69 @@ var _ = Describe("Import populator tests", func() {
 			Expect(found).To(BeFalse())
 		})
 
+		It("Should not copy ClaimMisbound event from primePVC to targetPVC", func() {
+			targetPVC := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimPending)
+			targetPVC.Spec.DataSourceRef = dataSourceRef
+			volumeImportSource := getVolumeImportSource(true, nsName)
+
+			pvcPrime := getPVCPrime(targetPVC, nil) // automatically creates a pvcPrime with the same name as the targetPVC
+
+			importSucceededEvent := corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "importSucceededEvent",
+					Namespace: targetPVC.Namespace,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Name: pvcPrime.Name,
+					UID:  pvcPrime.UID,
+				},
+				Reason:  importSucceeded,
+				Message: "Import succeeded",
+			}
+			claimMisboundEvent := corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "claimMisboundEvent",
+					Namespace: targetPVC.Namespace,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Name: pvcPrime.Name,
+					UID:  pvcPrime.UID,
+				},
+				Reason:  EventReasonClaimMisbound,
+				Message: "Claim is misbound",
+			}
+
+			By("Creating reconciler with fake PVC prime events")
+			reconciler = createImportPopulatorReconciler(targetPVC, pvcPrime, volumeImportSource, sc, &importSucceededEvent, &claimMisboundEvent)
+
+			By("Reconcile")
+			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: targetPvcName, Namespace: metav1.NamespaceDefault}})
+			recorder := reconciler.recorder.(*record.FakeRecorder)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Not(BeNil()))
+
+			By("Checking targetPVC events")
+			close(recorder.Events)
+
+			// NOTE: ContainsElement expects a slice, which recorder.Events is not
+			claimMisboundEventfound := false
+			importSucceededEventFound := false
+
+			Expect(recorder.Events).To(Not(BeEmpty()))
+
+			for event := range recorder.Events {
+				if strings.Contains(event, fmt.Sprintf("%s [%s]", EventReasonClaimMisbound, pvcPrime.Name)) {
+					claimMisboundEventfound = true
+				}
+				if strings.Contains(event, fmt.Sprintf("%s [%s]", importSucceeded, pvcPrime.Name)) {
+					importSucceededEventFound = true
+				}
+			}
+			reconciler.recorder = nil
+			Expect(claimMisboundEventfound).To(BeFalse())
+			Expect(importSucceededEventFound).To(BeTrue())
+		})
+
 		It("Should trigger failed import event when pod phase is podfailed", func() {
 			targetPvc := CreatePvcInStorageClass(targetPvcName, metav1.NamespaceDefault, &sc.Name, nil, nil, corev1.ClaimPending)
 			targetPvc.Spec.DataSourceRef = dataSourceRef


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR suppresses the ClaimMisbound warning such that this warning does not enter up the Kubernetes chain. This is an expected behavior when dealing with KubeVirt's DataVolume resource, and the end user should not think there's an issue when in fact there isn't.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

There was an earlier PR except I'm merging from my origin's dev branch rather than its main branch, which is why you may see a duplicate PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Suppress ClaimMisbound Warning from prime PVCs
```

