### PR TITLE
[release-v1.60] Makefile, hack: Allow compiling ginkgo + tests without Bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test: test-unit test-functional test-lint ## execute all tests (_NOTE:_ 'WHAT' i
 
 test-unit: WHAT = ./pkg/... ./cmd/...
 test-unit: ## Run unit tests.
-	${DO_BAZ} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
+	${DO} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
 
 test-functional: WHAT = ./tests/...
 test-functional: build-functest ## Run functional tests (in tests/ subdirectory).

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ build-functest: ## Build the functional tests (content of tests/ subdirectory)
 	${DO_BAZ} ./hack/build/build-ginkgo.sh
 	${DO_BAZ} ./hack/build/build-functest.sh
 
+go-build-functest: ## Build functional tests without Bazel
+	${DO} ./hack/build/go-build-ginkgo.sh
+	${DO} ./hack/build/build-functest.sh
+
 test: test-unit test-functional test-lint ## execute all tests (_NOTE:_ 'WHAT' is expected to match the go cli pattern for paths e.g. './pkg/...'.  This differs slightly from rest of the 'make' targets)
 
 test-unit: WHAT = ./pkg/... ./cmd/...
@@ -126,7 +130,7 @@ docker-registry-cleanup: ## Clean up all cached images from docker registry. Acc
 publish: manifests push ## Generate a cdi-controller and operator manifests and push the built container images to the registry defined in DOCKER_PREFIX
 
 manifests: ## Generate a cdi-controller and operator manifests in '_out/manifests/'.  Accepts [make variables]\(#make-variables\) DOCKER_TAG, DOCKER_PREFIX, VERBOSITY, PULL_POLICY, CSV_VERSION, QUAY_REPOSITORY, QUAY_NAMESPACE
-	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
+	${DO} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
 
 release-description: ## Generate a release announcement detailing changes between 2 commits (typically tags).  Expects 'RELREF' and 'PREREF' to be set
 	./hack/build/release-description.sh ${RELREF} ${PREREF}
@@ -212,7 +216,7 @@ format: ## Format shell and go source files."
 	help all clean \
 	update-codegen generate bootstrap-ginkgo generate-verify gomod-update apidocs \
 	deps-update deps-verify rpm-deps \
-	build-functest test test-unit test-functional goveralls coverage \
+	build-functest go-build-functest test test-unit test-functional goveralls coverage \
 	docker-registry-cleanup publish manifests release-description builder-push openshift-ci-image-push \
 	cluster-up cluster-down cluster-down-purge cluster-sync \
 	bazel-generate bazel-build bazel-build-images bazel-push-images push \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,6 +98,70 @@ bazeldnf_dependencies()
 
 #buildifier_dependencies()
 
+# GCS bucket rules_docker is not available anymore, artifacts are now published
+# to mirror.bazel.build:
+# - https://github.com/bazelbuild/rules_docker/issues/2291
+#
+# Stick to rules_docker 0.16 because version 0.26 is not preserving the
+# capability net_bind_service from the binary virt-launcher-monitoring.
+RULES_DOCKER_GO_BINARY_RELEASE = "aad94363e63d31d574cf701df484b3e8b868a96a"
+
+http_file(
+    name = "go_puller_linux_amd64",
+    executable = True,
+    sha256 = "08b8963cce9234f57055bafc7cadd1624cdce3c5990048cea1df453d7d288bc6",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-amd64")],
+)
+
+http_file(
+    name = "go_puller_linux_arm64",
+    executable = True,
+    sha256 = "912ee7c469b3e4bf15ba5d1f0ee500e7ec6724518862703fa8b09e4d58ce3ee6",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-arm64")],
+)
+
+http_file(
+    name = "go_puller_linux_s390x",
+    executable = True,
+    sha256 = "a5527b7b3b4a266e4680a4ad8939429665d4173f26b35d5d317385134369e438",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-s390x")],
+)
+
+http_file(
+    name = "go_puller_darwin",
+    executable = True,
+    sha256 = "4855c4f5927f8fb0f885510ab3e2a166d5fa7cde765fbe9aec97dc6b2761bb22",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-darwin-amd64")],
+)
+
+http_file(
+    name = "loader_linux_amd64",
+    executable = True,
+    sha256 = "5e5ada66beff07f9188bdc1f99c3fa37c407fc0048cd78b9c2047e9c5516f20b",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-amd64")],
+)
+
+http_file(
+    name = "loader_linux_arm64",
+    executable = True,
+    sha256 = "a80966d17b25dbc9313e9fc1cae74ded5916fa64dba0d33438c8adad338b44d3",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-arm64")],
+)
+
+http_file(
+    name = "loader_linux_s390x",
+    executable = True,
+    sha256 = "0c0ebc3e0a502542547a38b51f4686a049897eeb4cbc0e2f07fc25276c57866f",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-s390x")],
+)
+
+http_file(
+    name = "loader_darwin",
+    executable = True,
+    sha256 = "8c9986b2b506febbff737090d9ec485cec1376c52789747573521a85194341c1",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-darwin-amd64")],
+)
+
 # bazel docker rules
 http_archive(
     name = "io_bazel_rules_docker",

--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -28,6 +28,10 @@ determine_cri_bin() {
     fi
 }
 
+function go_build() {
+    GOPROXY=${GOPROXY:-""} go build "$@"
+}
+
 CDI_DIR="$(cd $(dirname $0)/../../ && pwd -P)"
 CDI_GO_PACKAGE=kubevirt.io/containerized-data-importer
 BIN_DIR=${CDI_DIR}/bin

--- a/hack/build/go-build-ginkgo.sh
+++ b/hack/build/go-build-ginkgo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source hack/build/common.sh
+
+PLATFORM=$(uname -m)
+case ${PLATFORM} in
+x86_64* | i?86_64* | amd64*)
+  ARCH="amd64"
+  ;;
+aarch64* | arm64*)
+  ARCH="arm64"
+  ;;
+s390x)
+  ARCH="s390x"
+  ;;
+*)
+  echo "invalid Arch, only support x86_64, aarch64 and s390x"
+  exit 1
+  ;;
+esac
+
+rm -rf "${TESTS_OUT_DIR}/ginkgo"
+mkdir -p "${TESTS_OUT_DIR}"
+
+GOOS=linux GOPROXY=${GOPROXY:-off} GOARCH=${ARCH} go_build -o "${TESTS_OUT_DIR}/ginkgo" "${CDI_DIR}/vendor/github.com/onsi/ginkgo/v2/ginkgo/main.go"

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -22,6 +22,11 @@ source "${script_dir}"/config.sh
 
 WORK_DIR="/go/src/kubevirt.io/containerized-data-importer"
 
+if [ ! -d "${CACHE_DIR}" ]; then
+  echo "Creating cache directory: ${CACHE_DIR}"
+  mkdir -p "${CACHE_DIR}"
+fi
+
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"
 ${CDI_CRI} run ${USE_TTY} \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/containerized-data-importer/pull/4141 that adds the necessary cache directory.

See https://github.com/kubevirt/containerized-data-importer/pull/4177 failure for more context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

