### PR TITLE
fix: set default storageclass for external provider

### DIFF
--- a/cluster-sync/external/provider.sh
+++ b/cluster-sync/external/provider.sh
@@ -30,7 +30,10 @@ function configure_storage() {
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/hostpathprovisioner_cr.yaml -n hostpath-provisioner
     _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$HPP_RELEASE/storageclass-wffc-csi.yaml
     _kubectl patch storageclass hostpath-provisioner -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  elif [ -n "${BLOCK_SC}" ]; then
+    echo "Default storage class set to ${BLOCK_SC}"
+    _kubectl patch storageclass "${BLOCK_SC}" -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
   else
-    echo "Local storage not needed for external provider..."
+    echo "No storage configuration for external provider..."
   fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When using external provider we should ensure the specified sc is annotated as the default before tests run. 
This mirrors the [behavior of the kubevirtci provider](https://github.com/kubevirt/containerized-data-importer/blob/4bd6ba382ff50e2ddf1ddf4b271f222c5a5a492d/cluster-sync/kubevirtci/provider.sh#L13-L38)

On shared external clusters, tests like `monitoring_test.go` and `datavolume_test.go` temporarily clear the
default SC annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc: @akalenyu 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

