### PR TITLE
prlimit: don't log a kill error when the command succeeds

### DIFF
--- a/pkg/system/BUILD.bazel
+++ b/pkg/system/BUILD.bazel
@@ -23,5 +23,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/pkg/system/prlimit.go
+++ b/pkg/system/prlimit.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	stderrors "errors"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -152,8 +154,12 @@ func executeWithLimits(limits *ProcessLimitValues, callback func(string), logErr
 		return nil, errors.Wrapf(err, "Couldn't start %s", command)
 	}
 	defer func() {
-		err = cmd.Process.Kill()
-		klog.Errorf("failed to kill the process; %v", err)
+		// On the success path cmd.Wait() has already reaped the process, so
+		// Kill() returns os.ErrProcessDone. That is expected here, only log
+		// when the process is still around and Kill genuinely fails.
+		if killErr := cmd.Process.Kill(); killErr != nil && !stderrors.Is(killErr, os.ErrProcessDone) {
+			klog.Errorf("failed to kill the process; %v", killErr)
+		}
 	}()
 
 	go processScanner(scanner, &buf, stdoutDone, callback)

--- a/pkg/system/prlimit_test.go
+++ b/pkg/system/prlimit_test.go
@@ -34,6 +34,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/pkg/errors"
+
+	"k8s.io/klog/v2"
 )
 
 var _ = Describe("Process Limits", func() {
@@ -72,6 +74,30 @@ var _ = Describe("Process Limits", func() {
 		Entry("address space limit fails", fakeCommandContext, newTestProcessLimiter(errors.New("Set address limit fails"), nil), limits, "faker", "", "Set address limit fails", "", "", ""),
 		Entry("command exit bad", fakeCommandContext, nullLimiter, limits, "faker", "", "exit status 1", "1", "", ""),
 	)
+
+	It("should not log a kill error when the command succeeds", func() {
+		// cmd.Wait() reaps the process on success, so the deferred Kill()
+		// hits an already-finished process. That must not surface as an
+		// error log, otherwise every successful command run looks like a
+		// failure to whoever is reading the logs.
+		var logBuf bytes.Buffer
+		klog.LogToStderr(false)
+		klog.SetOutput(&logBuf)
+		defer func() {
+			klog.SetOutput(nil)
+			klog.LogToStderr(true)
+		}()
+
+		replaceExecCommandContext(fakeCommandContext, func() {
+			replaceLimiter(nil, func() {
+				_, err := ExecWithLimits(realLimits, testProgress, "faker", "0", "", "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		klog.Flush()
+		Expect(logBuf.String()).NotTo(ContainSubstring("failed to kill the process"))
+	})
 
 	DescribeTable("limits actually work", func(timeout time.Duration, f limitFunction, command, errString string, args ...string) {
 		_, err := runFakeCommandWithTimeout(timeout, f, command, args...)


### PR DESCRIPTION
**What this PR does / why we need it**:

Every successful command run through `ExecWithLimits` (qemu-img, nbdkit, and friends) logs a misleading `failed to kill the process; os: process already finished` line at ERROR level. It's noise that makes a healthy import look like something went wrong when you're reading the logs.

The cause is the deferred cleanup in `executeWithLimits`: it calls `cmd.Process.Kill()` right after `Start`, but on the normal path `cmd.Wait()` has already reaped the process by the time the defer runs, so `Kill()` returns `os.ErrProcessDone` and that got logged unconditionally. This just guards the log so it only fires when the process is genuinely still around and Kill actually fails, and drops the needless reassignment of the outer `err`.

I added a regression test that runs a successful `ExecWithLimits` and asserts no "failed to kill the process" line ends up in the klog output. It fails on the current code and passes with the fix.

**Special notes for your reviewer**:

The one pre-existing "killed by memory limit" spec fails the same way on `main` in my container (exit status vs signal under the memory cgroup), so it's unrelated to this change. The rest of the `pkg/system` suite plus the new test pass, and `go vet ./pkg/system/` is clean.

**Release note**:
```release-note
Stop logging a spurious "failed to kill the process" error after every successful command run in the importer/uploader
```
