### PR TITLE
poller: Use JSON Patch instead of Update to avoid conflicts

### DIFF
--- a/pkg/operator/resources/cluster/cronjob.go
+++ b/pkg/operator/resources/cluster/cronjob.go
@@ -45,6 +45,7 @@ func getCronJobClusterPolicyRules() []rbacv1.PolicyRule {
 				"get",
 				"list",
 				"update",
+				"patch",
 			},
 		},
 	}

--- a/tools/cdi-source-update-poller/BUILD.bazel
+++ b/tools/cdi-source-update-poller/BUILD.bazel
@@ -10,11 +10,12 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/common:go_default_library",
         "//pkg/controller:go_default_library",
-        "//pkg/controller/common:go_default_library",
         "//pkg/importer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
     ],
 )
 

--- a/tools/cdi-source-update-poller/main.go
+++ b/tools/cdi-source-update-poller/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	neturl "net/url"
@@ -11,12 +13,13 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
 
 	cdiClientset "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller"
-	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/pkg/importer"
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
@@ -81,17 +84,39 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed getting DataImportCron %s/%s: %v", cronNamespace, cronName, err)
 	}
-	cc.AddAnnotation(dataImportCron, controller.AnnLastCronTime, time.Now().Format(time.RFC3339))
+
+	patch := []patchOp{
+		newAnnotationPatch(controller.AnnLastCronTime, time.Now().Format(time.RFC3339)),
+	}
 
 	if digest != "" && digest != dataImportCron.Annotations[controller.AnnSourceDesiredDigest] {
-		cc.AddAnnotation(dataImportCron, controller.AnnSourceDesiredDigest, digest)
+		patch = append(patch, newAnnotationPatch(controller.AnnSourceDesiredDigest, digest))
 		log.Printf("Digest updated")
 	} else {
 		log.Printf("No digest update")
 	}
 
-	_, err = cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Update(context.TODO(), dataImportCron, metav1.UpdateOptions{})
+	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		log.Fatalf("Failed updating DataImportCron %s/%s: %v", cronNamespace, cronName, err)
+		log.Fatalf("Failed marshalling patch for DataImportCron %s/%s: %v", cronNamespace, cronName, err)
+	}
+
+	_, err = cdiClient.CdiV1beta1().DataImportCrons(cronNamespace).Patch(context.TODO(), cronName, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		log.Fatalf("Failed patching DataImportCron %s/%s: %v", cronNamespace, cronName, err)
+	}
+}
+
+type patchOp struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+func newAnnotationPatch(key, value string) patchOp {
+	return patchOp{
+		Op:    "add",
+		Path:  fmt.Sprintf("/metadata/annotations/%s", openapicommon.EscapeJsonPointer(key)),
+		Value: value,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The poller pod's Update() call on DataImportCron races with the
controller reconciler, causing "the object has been modified" errors.
Switch to a JSON Patch that only touches the relevant annotations,
eliminating resourceVersion conflicts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

