### PR TITLE
fix(bazel-docker): avoid container cleanup affecting build exit code

### DIFF
--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -62,8 +62,12 @@ echo "Starting rsyncd"
 RSYNC_CID_CDI=$(${CDI_CRI} run -d -v "${BUILDER_VOLUME}:/root:rw,z" --security-opt label=disable $DISABLE_SECCOMP --cap-add SYS_CHROOT --expose 873 -P --entrypoint "/entrypoint-bazel.sh" ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
+    local exit_code=$?
+    set +e
     ${CDI_CRI} stop --time 1 ${RSYNC_CID_CDI} >/dev/null 2>&1
     ${CDI_CRI} rm -f ${RSYNC_CID_CDI} >/dev/null 2>&1
+    set -e
+    return ${exit_code}
 }
 trap finish EXIT
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Preserve the original exit code in the finish() trap so that container
stop/rm failures (e.g. Error 125) don't mask the actual build result.

Reference: https://github.com/kubevirt/kubevirt/pull/16843

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

