### PR TITLE
feat: transition to using the ImageVolume API for Registery imports with pull method node

### DIFF
--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -707,29 +707,22 @@ func (r *DataImportCronReconciler) updateContainerImageDesiredDigest(ctx context
 			Affinity:                      workloadNodePlacement.Affinity,
 			Volumes: []corev1.Volume{
 				{
-					Name: "shared-volume",
+					Name: "image-volume",
 					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
+						Image: &corev1.ImageVolumeSource{
+							Reference:  containerImage,
+							PullPolicy: corev1.PullIfNotPresent,
+						},
 					},
-				},
-			},
-			InitContainers: []corev1.Container{
-				{
-					Name:                     "init",
-					Image:                    r.image,
-					ImagePullPolicy:          corev1.PullPolicy(r.pullPolicy),
-					Command:                  []string{"sh", "-c", "cp /usr/bin/cdi-containerimage-server /shared/server"},
-					VolumeMounts:             []corev1.VolumeMount{{Name: "shared-volume", MountPath: "/shared"}},
-					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			Containers: []corev1.Container{
 				{
 					Name:                     "image-container",
-					Image:                    containerImage,
-					ImagePullPolicy:          corev1.PullAlways,
-					Command:                  []string{"/shared/server", "-h"},
-					VolumeMounts:             []corev1.VolumeMount{{Name: "shared-volume", MountPath: "/shared"}},
+					Image:                    r.image,
+					ImagePullPolicy:          corev1.PullPolicy(r.pullPolicy),
+					Command:                  []string{"sleep", "0.1"},
+					VolumeMounts:             []corev1.VolumeMount{{Name: "image-volume", MountPath: "/image"}},
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As of k8s 1.36 [image-volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes) are now stable. 
ImageVolumes enable the mounting of container images as volume without the need for an init container.
This API allows us to streamline the existing pull method node Registry import that currently leverages a similar init container based approach for that exact use case. 

Reference:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


