### PR TITLE
[release-v1.64] manifests: drop explicit command overrides from test templates

### DIFF
--- a/manifests/templates/bad-webserver.yaml.in
+++ b/manifests/templates/bad-webserver.yaml.in
@@ -23,7 +23,6 @@ spec:
       - name: http
         image: {{ .DockerRepo }}/cdi-func-test-bad-webserver:{{ .DockerTag }}
         imagePullPolicy: {{ .PullPolicy }}
-        command: ["/app/tools/cdi-func-test-bad-webserver/cdi-func-test-bad-webserver-image.binary"]
         env:
         - name: CDI_NAMESPACE
           valueFrom:

--- a/manifests/templates/sample-populator.yaml.in
+++ b/manifests/templates/sample-populator.yaml.in
@@ -122,7 +122,6 @@ spec:
        - name: cdi-sample-populator
          image: {{ .DockerRepo }}/cdi-func-test-sample-populator:{{ .DockerTag }}
          imagePullPolicy: Always
-         command: ["/app/tools/cdi-func-test-sample-populator/cdi-func-test-sample-populator-image.binary"]
          args:
           - --mode=controller
           - --image-name={{ .DockerRepo }}/cdi-func-test-sample-populator:{{ .DockerTag }}

--- a/manifests/templates/test-proxy.yaml.in
+++ b/manifests/templates/test-proxy.yaml.in
@@ -26,7 +26,6 @@ spec:
       - name: http
         image: {{ .DockerRepo }}/cdi-func-test-proxy:{{ .DockerTag }}
         imagePullPolicy: {{ .PullPolicy }}
-        command: ["/app/tools/cdi-func-test-proxy/cdi-func-test-proxy-image.binary"]
         env:
         - name: CDI_NAMESPACE
           valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The bad-webserver, test-proxy, and sample-populator templates had hardcoded command paths matching the old `rules_docker` `go_image` conventions. These were always redundant since `go_image` sets the image ENTRYPOINT. Remove the command override so the pod uses the image ENTRYPOINT instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
See https://github.com/bazelbuild/rules_docker/blob/0e9c3b068d05f20adf7ccdea486fcb27e71593f3/lang/image.bzl#L206-L217.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

