### PR TITLE
fix: tests, util: append DockerTag to container images

### DIFF
--- a/tests/dataimportcron_test.go
+++ b/tests/dataimportcron_test.go
@@ -453,7 +453,7 @@ var _ = Describe("DataImportCron", Serial, func() {
 		By("Create DataImportCron with only initial poller job")
 		cron = utils.NewDataImportCron(cronName, "1Gi", scheduleOnceAYear, dataSourceName, importsToKeep, *reg)
 		retentionPolicy := cdiv1.DataImportCronRetainNone
-		url := fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix)
+		url := utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
 		pullMethod := cdiv1.RegistryPullNode
 		cron.Spec.RetentionPolicy = &retentionPolicy
 		cron.Spec.Template.Spec.Source.Registry.URL = &url
@@ -854,7 +854,7 @@ func getDataVolumeSourceRegistry(f *framework.Framework) (*cdiv1.DataVolumeSourc
 		url = fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs)
 		pullMethod = cdiv1.RegistryPullPod
 	} else {
-		url = fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix)
+		url = utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
 		pullMethod = cdiv1.RegistryPullNode
 	}
 	reg.URL = &url

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -1010,19 +1010,25 @@ var _ = Describe("Preallocation", func() {
 	dvName := "import-dv"
 
 	var (
-		dataVolume              *cdiv1.DataVolume
-		err                     error
-		tinyCoreIsoURL          = func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
-		tinyCoreQcow2URL        = func() string { return fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs) }
-		tinyCoreTarURL          = func() string { return fmt.Sprintf(utils.TarArchiveURL, f.CdiInstallNs) }
-		tinyCoreRegistryURL     = func() string { return fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs) }
-		imageioURL              = func() string { return fmt.Sprintf(utils.ImageioURL, f.CdiInstallNs) }
-		vcenterURL              = func() string { return fmt.Sprintf(utils.VcenterURL, f.CdiInstallNs) }
-		config                  *cdiv1.CDIConfig
-		origSpec                *cdiv1.CDIConfigSpec
-		trustedRegistryURL      = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
-		trustedRegistryURLQcow2 = func() string { return fmt.Sprintf(utils.TrustedRegistryURLQcow2, f.DockerPrefix) }
-		trustedRegistryIS       = func() string { return fmt.Sprintf(utils.TrustedRegistryIS, f.DockerPrefix) }
+		dataVolume          *cdiv1.DataVolume
+		err                 error
+		tinyCoreIsoURL      = func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
+		tinyCoreQcow2URL    = func() string { return fmt.Sprintf(utils.TinyCoreQcow2URL, f.CdiInstallNs) }
+		tinyCoreTarURL      = func() string { return fmt.Sprintf(utils.TarArchiveURL, f.CdiInstallNs) }
+		tinyCoreRegistryURL = func() string { return fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs) }
+		imageioURL          = func() string { return fmt.Sprintf(utils.ImageioURL, f.CdiInstallNs) }
+		vcenterURL          = func() string { return fmt.Sprintf(utils.VcenterURL, f.CdiInstallNs) }
+		config              *cdiv1.CDIConfig
+		origSpec            *cdiv1.CDIConfigSpec
+		trustedRegistryURL  = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
+		}
+		trustedRegistryURLQcow2 = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.CirrosQcow2ImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
+		}
+		trustedRegistryIS = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName)).String()
+		}
 	)
 
 	BeforeEach(func() {
@@ -1343,9 +1349,11 @@ var _ = Describe("Import populator", func() {
 		pvcPrime           *v1.PersistentVolumeClaim
 		tinyCoreIsoURL     = func() string { return fmt.Sprintf(utils.TinyCoreIsoURL, f.CdiInstallNs) }
 		tinyCoreArchiveURL = func() string { return fmt.Sprintf(utils.TarArchiveURL, f.CdiInstallNs) }
-		trustedRegistryURL = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
-		imageioURL         = func() string { return fmt.Sprintf(utils.ImageioURL, f.CdiInstallNs) }
-		vcenterURL         = func() string { return fmt.Sprintf(utils.VcenterURL, f.CdiInstallNs) }
+		trustedRegistryURL = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
+		}
+		imageioURL = func() string { return fmt.Sprintf(utils.ImageioURL, f.CdiInstallNs) }
+		vcenterURL = func() string { return fmt.Sprintf(utils.VcenterURL, f.CdiInstallNs) }
 	)
 
 	// importPopulationPVCDefinition creates a PVC with import datasourceref
@@ -2096,8 +2104,12 @@ var _ = Describe("Containerdisk envs to PVC labels", func() {
 
 	var (
 		tinyCoreRegistryURL = func() string { return fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs) }
-		trustedRegistryURL  = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
-		trustedRegistryIS   = func() string { return fmt.Sprintf(utils.TrustedRegistryIS, f.DockerPrefix) }
+		trustedRegistryURL  = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
+		}
+		trustedRegistryIS = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName)).String()
+		}
 	)
 
 	DescribeTable("Import should add KUBEVIRT_IO_ env vars to PVC labels when source is registry", func(pullMethod cdiv1.RegistryPullMethod, urlFn func() string, isImageStream bool) {
@@ -2191,7 +2203,9 @@ var _ = Describe("Multi-arch image pull", func() {
 	var (
 		f                         = framework.NewFramework(namespacePrefix)
 		tinyCoreMultiarchRegistry = func() string { return fmt.Sprintf(utils.TinyCoreIsoRegistryURL, f.CdiInstallNs) }
-		trustedRegistryURL        = func() string { return fmt.Sprintf(utils.TrustedRegistryURL, f.DockerPrefix) }
+		trustedRegistryURL        = func() string {
+			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
+		}
 	)
 
 	It("Should succeed to pull multi-arch image matching architecture with pull method Pod", func() {

--- a/tests/transport_test.go
+++ b/tests/transport_test.go
@@ -48,12 +48,11 @@ var _ = Describe("Transport Tests", func() {
 			err error // prevent shadowing
 		)
 
-		var endpoint string
+		opts := []utils.RegistryOption{utils.WithBase(ep()), utils.WithImage(file)}
 		if registryImportMethod == string(cdiv1.RegistryPullNode) {
-			endpoint = ep() + "/" + file + ":" + f.DockerTag
-		} else {
-			endpoint = ep() + "/" + file
+			opts = append(opts, utils.WithTag(f.DockerTag))
 		}
+		endpoint := utils.NewRegistryImage(opts...).String()
 
 		pvcAnn := map[string]string{
 			controller.AnnEndpoint:             endpoint,

--- a/tests/utils/BUILD.bazel
+++ b/tests/utils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "populators.go",
         "pv.go",
         "pvc.go",
+        "registry.go",
         "secrets.go",
         "services.go",
         "storageprofile.go",

--- a/tests/utils/datavolume.go
+++ b/tests/utils/datavolume.go
@@ -84,13 +84,6 @@ const (
 	ImageioImageURL = "https://imageio.%s:12345"
 	// VcenterURL provides URL of vCenter/ESX simulator
 	VcenterURL = "https://vcenter.%s:8989/sdk"
-	// TrustedRegistryURL provides the base path to trusted registry test url for the tinycore.iso image wrapped in docker container
-	TrustedRegistryURL = "docker://%s/cdi-func-test-tinycore"
-	// TrustedRegistryURLQcow2 provides the base path to trusted registry test url for the cirros qcow2 image wrapped in docker container
-	TrustedRegistryURLQcow2 = "docker://%s/cdi-func-test-cirros-qcow2"
-	// TrustedRegistryIS provides the base path to trusted registry test fake imagestream for the tinycore.iso image wrapped in docker container
-	TrustedRegistryIS = "%s/cdi-func-test-tinycore"
-
 	// MD5PrefixSize is the number of bytes used by the MD5 constants below
 	MD5PrefixSize = int64(100000)
 	// TinyCoreMD5 is the MD5 hash of first 100k bytes of tinyCore image

--- a/tests/utils/registry.go
+++ b/tests/utils/registry.go
@@ -1,0 +1,59 @@
+package utils
+
+const (
+	TinyCoreImageName    = "cdi-func-test-tinycore"
+	CirrosQcow2ImageName = "cdi-func-test-cirros-qcow2"
+)
+
+type RegistryImageBuilder struct {
+	scheme string
+	base   string
+	image  string
+	tag    string
+}
+
+type RegistryOption func(r *RegistryImageBuilder)
+
+func NewRegistryImage(opts ...RegistryOption) *RegistryImageBuilder {
+	registryImageBuilder := &RegistryImageBuilder{}
+	for _, f := range opts {
+		f(registryImageBuilder)
+	}
+	return registryImageBuilder
+}
+
+func (r *RegistryImageBuilder) String() string {
+	url := r.scheme + r.base + "/" + r.image
+	if r.tag != "" {
+		url += ":" + r.tag
+	}
+	return url
+}
+
+func WithBase(base string) RegistryOption {
+	return func(r *RegistryImageBuilder) {
+		r.base = base
+	}
+}
+
+func WithImage(image string) RegistryOption {
+	return func(r *RegistryImageBuilder) {
+		r.image = image
+	}
+}
+
+func WithScheme(scheme string) RegistryOption {
+	return func(r *RegistryImageBuilder) {
+		r.scheme = scheme
+	}
+}
+
+func WithTag(tag string) RegistryOption {
+	return func(r *RegistryImageBuilder) {
+		r.tag = tag
+	}
+}
+
+func WithDocker() RegistryOption {
+	return WithScheme("docker://")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously, tests using pullMethod node did not append DockerTag to the image URI, causing kubelet to default to :latest which does not exist in certain base registries where the test suite may run against.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

