### PR TITLE
Extract datavolumes/source from view role into standalone ClusterRole

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -712,6 +712,48 @@ var _ = Describe("Controller", func() {
 				))
 			})
 
+			It("should not have datavolumes/source in view ClusterRole", func() {
+				args := createArgs()
+				doReconcile(args)
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+
+				crole := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cdi.kubevirt.io:view",
+					},
+				}
+				obj, err := getObject(args.client, crole)
+				Expect(err).ToNot(HaveOccurred())
+				crole = obj.(*rbacv1.ClusterRole)
+
+				Expect(crole.Rules).ToNot(ContainElement(
+					HaveField("Resources", ContainElement("datavolumes/source")),
+				))
+			})
+
+			It("should create clone-sourcer ClusterRole", func() {
+				args := createArgs()
+				doReconcile(args)
+				Expect(setDeploymentsReady(args)).To(BeTrue())
+
+				crole := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cdi.kubevirt.io:clone-sourcer",
+					},
+				}
+				obj, err := getObject(args.client, crole)
+				Expect(err).ToNot(HaveOccurred())
+				crole = obj.(*rbacv1.ClusterRole)
+
+				Expect(crole.Rules).To(ConsistOf(rbacv1.PolicyRule{
+					APIGroups: []string{"cdi.kubevirt.io"},
+					Resources: []string{"datavolumes/source"},
+					Verbs:     []string{"create"},
+				}))
+
+				Expect(crole.Labels).ToNot(HaveKey(HavePrefix("rbac.authorization.k8s.io/aggregate-to-")))
+			})
+
 			Context("RBAC testing", func() {
 				// https://kubernetes.io/docs/concepts/security/rbac-good-practices/#persistent-volume-creation
 				checkPersistentVolumeCreateViolation := func(rsc string, rule *rbacv1.PolicyRule) {
@@ -2242,6 +2284,7 @@ func createNotReadyEventValidationMap() map[string]bool {
 	match[normalCreateSuccess+" *v1.ClusterRole cdi.kubevirt.io:admin"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi.kubevirt.io:edit"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi.kubevirt.io:view"] = false
+	match[normalCreateSuccess+" *v1.ClusterRole cdi.kubevirt.io:clone-sourcer"] = false
 	match[normalCreateSuccess+" *v1.ClusterRole cdi.kubevirt.io:config-reader"] = false
 	match[normalCreateSuccess+" *v1.ClusterRoleBinding cdi.kubevirt.io:config-reader"] = false
 	match[normalCreateSuccess+" *v1.ServiceAccount cdi-apiserver"] = false

--- a/pkg/operator/resources/cluster/rbac.go
+++ b/pkg/operator/resources/cluster/rbac.go
@@ -30,6 +30,7 @@ func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:admin", "admin", getAdminPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:edit", "edit", getEditPolicyRules()),
 		utils.ResourceBuilder.CreateAggregateClusterRole("cdi.kubevirt.io:view", "view", getViewPolicyRules()),
+		utils.ResourceBuilder.CreateClusterRole("cdi.kubevirt.io:clone-sourcer", getCloneSourcerPolicyRules()),
 		createConfigReaderClusterRole("cdi.kubevirt.io:config-reader"),
 		createConfigReaderClusterRoleBinding("cdi.kubevirt.io:config-reader"),
 	}
@@ -133,6 +134,11 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 				"watch",
 			},
 		},
+	}
+}
+
+func getCloneSourcerPolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
 				"cdi.kubevirt.io",

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -274,17 +274,6 @@ var _ = Describe("Aggregated role definition tests", Serial, func() {
 				"watch",
 			},
 		},
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"datavolumes/source",
-			},
-			Verbs: []string{
-				"create",
-			},
-		},
 	}
 
 	f := framework.NewFramework("aggregated-role-definition-tests")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Move datavolumes/source create permission to a new non-aggregated
ClusterRole (cdi.kubevirt.io:clone-sourcer) that admins can explicitly
bind to users who need to source clones.

Usage: allow user1 to source clones from source-namespace:

```
kubectl create rolebinding allow-clone-sourcing \
    --clusterrole=cdi.kubevirt.io:clone-sourcer \
    --user=user1 -n source-namespace
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

