### PR TITLE
Tests: Allow storage class cleanup by adding OCS external label

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -1854,6 +1854,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				},
 				Provisioner: "unknown-provisioner",
 			}
+
+			utils.AddOCSExternalLabel(f.K8sClient, sc)
+
 			sc, err := f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tempScName = sc.Name
@@ -2490,6 +2493,9 @@ var _ = Describe("[vendor:cnv-qe@redhat.com][level:component]DataVolume tests", 
 				ResourceVersion: "",
 				Annotations:     sc.Annotations,
 			}
+
+			utils.AddOCSExternalLabel(f.K8sClient, sc)
+
 			testSc, err = f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -588,6 +588,8 @@ func (f *Framework) CreateNonDefaultVariationOfStorageClass(sc *storagev1.Storag
 		Annotations: scCopy.Annotations,
 	}
 
+	utils.AddOCSExternalLabel(f.K8sClient, scCopy)
+
 	return f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), scCopy, metav1.CreateOptions{})
 }
 

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -206,7 +206,9 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 
 			numAddedStorageClasses = 2
 			for i := 0; i < numAddedStorageClasses; i++ {
-				_, err = f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), createUnknownStorageClass(fmt.Sprintf("unknown-sc-%d", i), "kubernetes.io/non-existent-provisioner"), metav1.CreateOptions{})
+				sc := createUnknownStorageClass(fmt.Sprintf("unknown-sc-%d", i), "kubernetes.io/non-existent-provisioner")
+				utils.AddOCSExternalLabel(f.K8sClient, sc)
+				_, err = f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -240,6 +242,7 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 			for i := 0; i < numAddedStorageClasses; i++ {
 				sc := createUnknownStorageClass(fmt.Sprintf("unknown-sc-%d", i), "kubernetes.io/non-existent-provisioner")
 				cc.AddAnnotation(sc, cc.AnnDefaultVirtStorageClass, "true")
+				utils.AddOCSExternalLabel(f.K8sClient, sc)
 				_, err := f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -356,7 +359,10 @@ var _ = Describe("[Destructive] Monitoring Tests", Serial, func() {
 		})
 
 		It("[test_id:9659] StorageProfile incomplete metric expected value remains unchanged for provisioner known to not work", func() {
-			sc, err := f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), createUnknownStorageClass("unknown-sc-0", storagecapabilities.ProvisionerNoobaa), metav1.CreateOptions{})
+			sc := createUnknownStorageClass("unknown-sc-0", storagecapabilities.ProvisionerNoobaa)
+			utils.AddOCSExternalLabel(f.K8sClient, sc)
+
+			sc, err := f.K8sClient.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			numAddedStorageClasses = 1
 

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -321,6 +321,14 @@ func hasString(strings []string, str string) bool {
 	return false
 }
 
+// AddOCSExternalLabel labels the StorageClass so the OCS provider-side gRPC server
+// excludes it from GetDesiredClientState(), allowing test teardown to delete it.
+func AddOCSExternalLabel(client kubernetes.Interface, obj metav1.Object) {
+	if IsOpenshift(client) {
+		cc.AddLabel(obj, "storageclass.ocs.openshift.io/is-external", "true")
+	}
+}
+
 // IsOpenshift checks if we are on OpenShift platform
 func IsOpenshift(client kubernetes.Interface) bool {
 	//OpenShift 3.X check


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

On OpenShift clusters with ODF, storage classes created by the tests are recreated by the operator during teardown because they are still referenced by the storage consumer. As a result, the test cleanup cannot delete them.

Adding the `storageclass.ocs.openshift.io/is-external` label should allow the teardown to clean them up successfully.

**Special notes for your reviewer**:

This fix is recommended in https://redhat.atlassian.net/browse/DFBUGS-4795?focusedCommentId=16934614. It currently is the only solution offered for the sc deletion issue.  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

