### PR TITLE
Avoid PVC writes during scheduler retry to prevent SchedulerError loop

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2325,9 +2325,11 @@ func UpdatePVCBoundConditionFromEvents(pvc *corev1.PersistentVolumeClaim, c clie
 	anno[AnnBoundConditionReason] = "Pending"
 	anno[AnnBoundConditionMessage] = boundMessage
 
-	patch := client.MergeFrom(currentPvcCopy)
-	if err := c.Patch(context.TODO(), pvc, patch); err != nil {
-		return err
+	if !reflect.DeepEqual(currentPvcCopy, pvc) {
+		patch := client.MergeFrom(currentPvcCopy)
+		if err := c.Patch(context.TODO(), pvc, patch); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -309,6 +309,9 @@ func (r *ImportReconciler) reconcilePvc(pvc *corev1.PersistentVolumeClaim, log l
 	}
 
 	if !cc.IsPVCComplete(pvc) {
+		if pod != nil && isPodWaitingForScheduler(pod) {
+			return reconcile.Result{}, nil
+		}
 		// We are not done yet, force a re-reconcile in 2 seconds to get an update.
 		log.V(1).Info("Force Reconcile pvc import not finished", "pvc.Name", pvc.Name)
 
@@ -378,7 +381,27 @@ func (r *ImportReconciler) initPvcPodName(pvc *corev1.PersistentVolumeClaim, log
 	return nil
 }
 
+// isPodWaitingForScheduler returns true when PodScheduled is False for a reason
+// other than Unschedulable (e.g. SchedulerError from VolumeBinding RV races).
+func isPodWaitingForScheduler(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodPending {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type != corev1.PodScheduled {
+			continue
+		}
+		return cond.Status == corev1.ConditionFalse && cond.Reason != corev1.PodReasonUnschedulable
+	}
+	return false
+}
+
 func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod, log logr.Logger) error {
+	// Avoid PVC writes while the scheduler is retrying to prevent RV churn.
+	if isPodWaitingForScheduler(pod) && pvc.Annotations[cc.AnnPodPhase] != "" {
+		return nil
+	}
+
 	// Keep a copy of the original for comparison later.
 	currentPvcCopy := pvc.DeepCopyObject()
 

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1012,6 +1012,58 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionMessage]).To(Equal(eventBasedBoundMessage))
 		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionReason]).To(Equal(eventBasedBoundReason))
 	})
+
+	It("Should not update PVC while pod is waiting on scheduler (non-Unschedulable)", func() {
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{
+			cc.AnnEndpoint:  testEndPoint,
+			cc.AnnPodPhase:  string(corev1.PodPending),
+			cc.AnnImportPod: "importer-testPvc1",
+		}, nil, corev1.ClaimPending)
+		pod := cc.CreateImporterTestPod(pvc, "testPvc1", nil)
+		pod.Status = corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+				Reason: "SchedulerError",
+			}},
+		}
+		reconciler = createImportReconciler(pvc, pod)
+		originalRV := pvc.ResourceVersion
+
+		err := reconciler.updatePvcFromPod(pvc, pod, reconciler.log)
+		Expect(err).ToNot(HaveOccurred())
+
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.ResourceVersion).To(Equal(originalRV))
+	})
+
+	It("Should update AnnPodSchedulable when pod is Unschedulable", func() {
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{
+			cc.AnnEndpoint: testEndPoint,
+			cc.AnnPodPhase: string(corev1.PodPending),
+		}, nil, corev1.ClaimPending)
+		pod := cc.CreateImporterTestPod(pvc, "testPvc1", nil)
+		pod.Status = corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+				Reason: corev1.PodReasonUnschedulable,
+			}},
+		}
+		reconciler = createImportReconciler(pvc, pod)
+
+		err := reconciler.updatePvcFromPod(pvc, pod, reconciler.log)
+		Expect(err).ToNot(HaveOccurred())
+
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.GetAnnotations()[cc.AnnPodSchedulable]).To(Equal("false"))
+	})
 })
 
 var _ = Describe("Create Importer Pod", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The import controller watches both PVCs and owned pods. When the importer pod is pending and the scheduler hits a VolumeBinding error, each reconcile writes PVC annotations, bumping resourceVersion. This fires the PVC watch causing an immediate re-reconcile (bypassing the 2s RequeueAfter), which writes again, creating a tight loop at ~10 writes/sec.

The scheduler's VolumeBinding plugin assumes a PVC resourceVersion during filtering and expects it unchanged at reserve time. The constant writes make this race unwinnable, so the pod is never scheduled.

Fix: skip PVC writes and RequeueAfter while the pod has PodScheduled=False with a transient reason (e.g. SchedulerError). Pod/PVC watches resume reconciliation once scheduling succeeds.

Fixes #MTV-6199

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed excessive PVC resource writes on retry
```

