### PR TITLE
Add minimum supported PVC size for HPE XP and Hitachi HSPC provisioners

### DIFF
--- a/pkg/controller/storageprofile-controller_test.go
+++ b/pkg/controller/storageprofile-controller_test.go
@@ -489,6 +489,8 @@ var _ = Describe("Storage profile controller reconcile loop", func() {
 		Entry("provisioner with minimum and StorageProfile annotated with no-size", "ebs.csi.aws.com/io1", ptr.To(""), ptr.To("")),
 		Entry("provisioner without minimum and StorageProfile annotated", "rbd.csi.ceph.com", ptr.To("1Mi"), ptr.To("1Mi")),
 		Entry("provisioner without minimum and StorageProfile not annotated", "prov", nil, nil),
+		Entry("HPE XP provisioner with minimum and StorageProfile not annotated", "xspc.csi.hpe.com", nil, ptr.To("1Gi")),
+		Entry("Hitachi HSPC provisioner with minimum and StorageProfile not annotated", "hspc.csi.hitachi.com", nil, ptr.To("1Gi")),
 	)
 
 	Context("DataImportCron annotations", func() {

--- a/pkg/storagecapabilities/storagecapabilities.go
+++ b/pkg/storagecapabilities/storagecapabilities.go
@@ -92,7 +92,7 @@ var CapabilitiesByProvisionerKey = map[string][]StorageCapabilities{
 	"pd.csi.storage.gke.io":           {{rwo, block}, {rwo, file}},
 	"pd.csi.storage.gke.io/hyperdisk": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// Hitachi
-	"hspc.csi.hitachi.com": {{rwx, block}, {rwo, block}, {rwo, file}},
+	ProvisionerHitachiHSPC: {{rwx, block}, {rwo, block}, {rwo, file}},
 	// HPE
 	"csi.hpe.com": {{rwx, block}, {rwo, block}, {rwo, file}},
 	// IBM HCI/GPFS2 (Spectrum Scale / Spectrum Fusion)
@@ -178,7 +178,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
 	"csi-isilon.dellemc.com":                   cdiv1.CloneStrategyCsiClone,
 	"csi-powermax.dellemc.com":                 cdiv1.CloneStrategyCsiClone,
 	"csi-powerstore.dellemc.com":               cdiv1.CloneStrategyHostAssisted,
-	"hspc.csi.hitachi.com":                     cdiv1.CloneStrategyCsiClone,
+	ProvisionerHitachiHSPC:                     cdiv1.CloneStrategyCsiClone,
 	"csi.hpe.com":                              cdiv1.CloneStrategyCsiClone,
 	"spectrumscale.csi.ibm.com":                cdiv1.CloneStrategyCsiClone,
 	"block.csi.ibm.com":                        cdiv1.CloneStrategyCsiClone,
@@ -233,6 +233,9 @@ var MinimumSupportedPVCSizeByProvisionerKey = map[string]string{
 	"vpc.file.csi.ibm.io/rfs-rwo": "1Gi",
 	"vpc.file.csi.ibm.io/dp2":     "10Gi",
 	"vpc.file.csi.ibm.io/dp2-rwo": "10Gi",
+	// HPE XP8 (OEM of Hitachi VSP) and Hitachi HSPC enforce a minimum LDEV size
+	ProvisionerHPEXP:       "1Gi",
+	ProvisionerHitachiHSPC: "1Gi",
 }
 
 // UseReadWriteOnceForDataImportCronByProvisionerKey is a hash of provisioners which require RWO access mode for DataImportCron PVCs
@@ -283,6 +286,10 @@ const (
 	ProvisionerPortworxPureBlock = "pxd.portworx.com/pure_block"
 	// ProvisionerPortworxPureFAFile is the Portworx CSI provisioner key derived for StorageClasses with parameter backend=pure_fa_file
 	ProvisionerPortworxPureFAFile = "pxd.portworx.com/pure_fa_file"
+	// ProvisionerHitachiHSPC is the Hitachi Storage Plug-in for Containers CSI provisioner
+	ProvisionerHitachiHSPC = "hspc.csi.hitachi.com"
+	// ProvisionerHPEXP is the HPE XP8 CSI provisioner (OEM of Hitachi VSP)
+	ProvisionerHPEXP = "xspc.csi.hpe.com"
 )
 
 // UnsupportedProvisioners is a hash of provisioners which are known not to work with CDI


### PR DESCRIPTION
## Summary

- Add `xspc.csi.hpe.com` and `hspc.csi.hitachi.com` to `MinimumSupportedPVCSizeByProvisionerKey` with `1Gi` minimum
- Add corresponding test entries in the StorageProfile controller test

## Why this approach

The HPE XP8 CSI driver (`xspc.csi.hpe.com`) is an OEM of the Hitachi Storage
Plug-in for Containers (`hspc.csi.hitachi.com`). Both target the same VSP
storage platform, which allocates LDEVs in fixed-size pages and enforces a
minimum volume size of 1Gi.

KubeVirt's backend storage for persistent TPM/EFI requests a hardcoded 10Mi
PVC (`PVCSize` in `pkg/storage/backend-storage/backend-storage.go`). On
clusters where HPE XP8 is the only storage backend, this PVC fails to
provision, and the VM cannot start. The failure surfaces after Migration
Toolkit for Virtualization (MTV) migrations, where the user has no control
over the persistent-state PVC size.

PR #3711 introduced `cdi.kubevirt.io/minimumSupportedPvcSize` and the CDI
mutating webhook that bumps sub-minimum PVC requests. PR #3746 added
auto-detection for AWS EBS and GKE PD. This change follows the same pattern
for HPE XP and Hitachi HSPC.

No custom `storageClassToProvisionerKeyMapper` entry is needed — neither
driver uses StorageClass parameter variants, so `storageProvisionerKey()`
falls through to using the provisioner name directly (line 407).

`hspc.csi.hitachi.com` already exists in `CapabilitiesByProvisionerKey` and
`CloneStrategyByProvisionerKey` but was missing from the minimum size map.
`xspc.csi.hpe.com` is new to this file entirely — adding its capabilities
and clone strategy is tracked separately.

## Test plan

- [x] Added two `Entry` rows to the existing `DescribeTable` for minimum
  supported PVC size annotation — one per provisioner, verifying auto-annotation
  to `1Gi` when the StorageProfile is not yet annotated
- [x] Pattern matches existing test entries (e.g., `pd.csi.storage.gke.io/hyperdisk`)

Fixes https://github.com/kubevirt/containerized-data-importer/issues/4227

```release-note
added minimum size for HPE XP and Hitachi HSPC provisioners
```