### PR TITLE
[release-v1.59] Makefile, hack: Allow compiling ginkgo + tests without Bazel- #4192

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test: test-unit test-functional test-lint
 
 test-unit: WHAT = ./pkg/... ./cmd/...
 test-unit:
-	${DO_BAZ} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
+	${DO} "ACK_GINKGO_DEPRECATIONS=${ACK_GINKGO_DEPRECATIONS} ./hack/build/run-unit-tests.sh ${WHAT}"
 
 test-functional:  WHAT = ./tests/...
 test-functional: build-functest

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
 		goveralls \
 		release-description \
 		bazel-generate bazel-build bazel-build-images bazel-push-images \
+		go-build-functest \
 		fossa \
 		lint-metrics
 
@@ -68,6 +69,10 @@ apidocs:
 build-functest:
 	${DO_BAZ} ./hack/build/build-functest.sh
 
+go-build-functest:
+	${DO} ./hack/build/go-build-ginkgo.sh
+	${DO} ./hack/build/build-functest.sh
+
 # WHAT must match go tool style package paths for test targets (e.g. ./path/to/my/package/...)
 test: test-unit test-functional test-lint
 
@@ -96,7 +101,7 @@ format:
 	${DO_BAZ} "./hack/build/format.sh"
 
 manifests:
-	${DO_BAZ} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
+	${DO} "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} VERBOSITY=${VERBOSITY} PULL_POLICY=${PULL_POLICY} CR_NAME=${CR_NAME} CDI_NAMESPACE=${CDI_NAMESPACE} ./hack/build/build-manifests.sh"
 
 goveralls: test-unit
 	${DO} "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/build/goveralls.sh"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,6 +98,70 @@ bazeldnf_dependencies()
 
 #buildifier_dependencies()
 
+# GCS bucket rules_docker is not available anymore, artifacts are now published
+# to mirror.bazel.build:
+# - https://github.com/bazelbuild/rules_docker/issues/2291
+#
+# Stick to rules_docker 0.16 because version 0.26 is not preserving the
+# capability net_bind_service from the binary virt-launcher-monitoring.
+RULES_DOCKER_GO_BINARY_RELEASE = "aad94363e63d31d574cf701df484b3e8b868a96a"
+
+http_file(
+    name = "go_puller_linux_amd64",
+    executable = True,
+    sha256 = "08b8963cce9234f57055bafc7cadd1624cdce3c5990048cea1df453d7d288bc6",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-amd64")],
+)
+
+http_file(
+    name = "go_puller_linux_arm64",
+    executable = True,
+    sha256 = "912ee7c469b3e4bf15ba5d1f0ee500e7ec6724518862703fa8b09e4d58ce3ee6",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-arm64")],
+)
+
+http_file(
+    name = "go_puller_linux_s390x",
+    executable = True,
+    sha256 = "a5527b7b3b4a266e4680a4ad8939429665d4173f26b35d5d317385134369e438",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-s390x")],
+)
+
+http_file(
+    name = "go_puller_darwin",
+    executable = True,
+    sha256 = "4855c4f5927f8fb0f885510ab3e2a166d5fa7cde765fbe9aec97dc6b2761bb22",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-darwin-amd64")],
+)
+
+http_file(
+    name = "loader_linux_amd64",
+    executable = True,
+    sha256 = "5e5ada66beff07f9188bdc1f99c3fa37c407fc0048cd78b9c2047e9c5516f20b",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-amd64")],
+)
+
+http_file(
+    name = "loader_linux_arm64",
+    executable = True,
+    sha256 = "a80966d17b25dbc9313e9fc1cae74ded5916fa64dba0d33438c8adad338b44d3",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-arm64")],
+)
+
+http_file(
+    name = "loader_linux_s390x",
+    executable = True,
+    sha256 = "0c0ebc3e0a502542547a38b51f4686a049897eeb4cbc0e2f07fc25276c57866f",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-s390x")],
+)
+
+http_file(
+    name = "loader_darwin",
+    executable = True,
+    sha256 = "8c9986b2b506febbff737090d9ec485cec1376c52789747573521a85194341c1",
+    urls = [("https://mirror.bazel.build/storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-darwin-amd64")],
+)
+
 # bazel docker rules
 http_archive(
     name = "io_bazel_rules_docker",

--- a/hack/build/bazel-docker.sh
+++ b/hack/build/bazel-docker.sh
@@ -121,8 +121,6 @@ fi
 if [ -n "$DOCKER_CA_CERT_FILE" ]; then
     volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
 fi
-# add tmpfs path for testing purposes
-volumes="$volumes --tmpfs /mnt/cditmpfs"
 
 # Ensure that a bazel server is running
 if [ -z "$(${CDI_CRI} ps --format '{{.Names}}' | grep ${BAZEL_BUILDER_SERVER})" ]; then

--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -28,6 +28,10 @@ determine_cri_bin() {
     fi
 }
 
+function go_build() {
+    GOPROXY=${GOPROXY:-""} go build "$@"
+}
+
 CDI_DIR="$(cd $(dirname $0)/../../ && pwd -P)"
 CDI_GO_PACKAGE=kubevirt.io/containerized-data-importer
 BIN_DIR=${CDI_DIR}/bin

--- a/hack/build/go-build-ginkgo.sh
+++ b/hack/build/go-build-ginkgo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source hack/build/common.sh
+
+PLATFORM=$(uname -m)
+case ${PLATFORM} in
+x86_64* | i?86_64* | amd64*)
+  ARCH="amd64"
+  ;;
+aarch64* | arm64*)
+  ARCH="arm64"
+  ;;
+s390x)
+  ARCH="s390x"
+  ;;
+*)
+  echo "invalid Arch, only support x86_64, aarch64 and s390x"
+  exit 1
+  ;;
+esac
+
+rm -rf "${TESTS_OUT_DIR}/ginkgo"
+mkdir -p "${TESTS_OUT_DIR}"
+
+GOOS=linux GOPROXY=${GOPROXY:-off} GOARCH=${ARCH} go_build -o "${TESTS_OUT_DIR}/ginkgo" "${CDI_DIR}/vendor/github.com/onsi/ginkgo/v2/ginkgo/main.go"

--- a/hack/build/in-docker.sh
+++ b/hack/build/in-docker.sh
@@ -22,6 +22,11 @@ source "${script_dir}"/config.sh
 
 WORK_DIR="/go/src/kubevirt.io/containerized-data-importer"
 
+if [ ! -d "${CACHE_DIR}" ]; then
+  echo "Creating cache directory: ${CACHE_DIR}"
+  mkdir -p "${CACHE_DIR}"
+fi
+
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"
 ${CDI_CRI} run ${USE_TTY} \

--- a/pkg/image/directio.go
+++ b/pkg/image/directio.go
@@ -26,17 +26,47 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// OSInterface collects system level operations that need to be mocked out
+// during tests.
+type OSInterface interface {
+	Stat(path string) (os.FileInfo, error)
+	Remove(path string) error
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+}
+
+// RealOS is used to dispatch the real system level operations.
+type RealOS struct{}
+
+// Stat will call os.Stat to get the FileInfo for a given path
+func (RealOS) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// Remove will call os.Remove to remove the path.
+func (RealOS) Remove(path string) error {
+	return os.Remove(path)
+}
+
+// OpenFile will call os.OpenFile to return the file.
+func (RealOS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
 // DirectIOChecker checks if a certain destination supports direct I/O (bypassing page cache)
 type DirectIOChecker interface {
 	CheckBlockDevice(path string) (bool, error)
 	CheckFile(path string) (bool, error)
 }
 
-type directIOChecker struct{}
+type directIOChecker struct {
+	OSInterface OSInterface
+}
 
 // NewDirectIOChecker returns a new direct I/O checker
-func NewDirectIOChecker() DirectIOChecker {
-	return &directIOChecker{}
+func NewDirectIOChecker(osInterface OSInterface) DirectIOChecker {
+	return &directIOChecker{
+		OSInterface: osInterface,
+	}
 }
 
 func (c *directIOChecker) CheckBlockDevice(path string) (bool, error) {
@@ -45,10 +75,10 @@ func (c *directIOChecker) CheckBlockDevice(path string) (bool, error) {
 
 func (c *directIOChecker) CheckFile(path string) (bool, error) {
 	flags := syscall.O_RDONLY
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	if _, err := c.OSInterface.Stat(path); errors.Is(err, os.ErrNotExist) {
 		// try to create the file and perform the check
 		flags = flags | syscall.O_CREAT
-		defer os.Remove(path)
+		defer removeTempFileAndCheckErr(c.OSInterface, path)
 	}
 	return c.check(path, flags)
 }
@@ -56,12 +86,12 @@ func (c *directIOChecker) CheckFile(path string) (bool, error) {
 // based on https://github.com/kubevirt/kubevirt/blob/c4fc4ab72a868399f5331438f35b8c33e7dd0720/pkg/virt-launcher/virtwrap/converter/converter.go#L346
 func (c *directIOChecker) check(path string, flags int) (bool, error) {
 	// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-	f, err := os.OpenFile(path, flags|syscall.O_DIRECT, 0600)
+	f, err := c.OSInterface.OpenFile(path, flags|syscall.O_DIRECT, 0600)
 	if err != nil {
 		// EINVAL is returned if the filesystem does not support the O_DIRECT flag
 		if perr := (&os.PathError{}); errors.As(err, &perr) && errors.Is(perr, syscall.EINVAL) {
 			// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-			f, err := os.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
+			f, err := c.OSInterface.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
 			if err == nil {
 				defer closeIOAndCheckErr(f)
 				return false, nil
@@ -76,5 +106,11 @@ func (c *directIOChecker) check(path string, flags int) (bool, error) {
 func closeIOAndCheckErr(c io.Closer) {
 	if ferr := c.Close(); ferr != nil {
 		klog.Errorf("Error when closing file: \n%s\n", ferr)
+	}
+}
+
+func removeTempFileAndCheckErr(osInterface OSInterface, path string) {
+	if ferr := osInterface.Remove(path); ferr != nil {
+		klog.Errorf("Error when removing file: \n%s\n", ferr)
 	}
 }

--- a/pkg/image/qemu.go
+++ b/pkg/image/qemu.go
@@ -85,7 +85,7 @@ var (
 		{"--preallocation=falloc"},
 		{"--preallocation=full"},
 	}
-	odirectChecker = NewDirectIOChecker()
+	odirectChecker = NewDirectIOChecker(RealOS{})
 )
 
 func init() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/containerized-data-importer/pull/4141 that adds the necessary cache directory.

See https://github.com/kubevirt/containerized-data-importer/pull/4177 failure for more context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

