### PR TITLE
[release-v1.65] import-controller: only clear scratch-specific bound condition annotations

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -165,7 +165,7 @@ func (r *CloneReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	log.V(1).Info("reconciling Clone PVCs")
 
 	if checkPVC(pvc, cc.AnnCloneRequest, log) {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundConditionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -2242,9 +2242,9 @@ func sortEvents(events *corev1.EventList, usingPopulator bool, pvcPrimeName stri
 	})
 }
 
-// UpdatePVCBoundContionFromEvents updates the bound condition annotations on the PVC based on recent events
+// UpdatePVCBoundConditionFromEvents updates the bound condition annotations on the PVC based on recent events
 // This function can be used by both controller and populator packages to update PVC bound condition information
-func UpdatePVCBoundContionFromEvents(pvc *corev1.PersistentVolumeClaim, c client.Client, log logr.Logger) error {
+func UpdatePVCBoundConditionFromEvents(pvc *corev1.PersistentVolumeClaim, c client.Client, log logr.Logger) error {
 	currentPvcCopy := pvc.DeepCopy()
 
 	anno := pvc.GetAnnotations()

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -206,7 +206,7 @@ func (r *ImportReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 
 	// only want to update bound condition for relevant type
 	if checkPVC(pvc, cc.AnnEndpoint, log) || checkPVC(pvc, cc.AnnSource, log) {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundConditionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -458,7 +458,7 @@ func (r *ImportReconciler) updatePvcFromPod(pvc *corev1.PersistentVolumeClaim, p
 				return err
 			}
 		}
-	} else {
+	} else if anno[cc.AnnBoundConditionReason] == creatingScratch {
 		// No scratch space, or scratch space is bound, remove annotation
 		delete(anno, cc.AnnBoundCondition)
 		delete(anno, cc.AnnBoundConditionMessage)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -839,6 +839,40 @@ var _ = Describe("Update PVC from POD", func() {
 			},
 		))
 	})
+
+	It("Should not remove non-scratch bound condition annotations", func() {
+		eventBasedBoundReason := "Pending"
+		eventBasedBoundMessage := "PVC testPvc1 Pending"
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{
+			cc.AnnEndpoint:              testEndPoint,
+			cc.AnnPodPhase:              string(corev1.PodPending),
+			cc.AnnBoundCondition:        "false",
+			cc.AnnBoundConditionMessage: eventBasedBoundMessage,
+			cc.AnnBoundConditionReason:  eventBasedBoundReason,
+		}, nil, corev1.ClaimPending)
+		pod := cc.CreateImporterTestPod(pvc, "testPvc1", nil)
+		pod.Status = corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{
+							Message: "Pending",
+						},
+					},
+				},
+			},
+		}
+		reconciler = createImportReconciler(pvc, pod)
+		err := reconciler.updatePvcFromPod(pvc, pod, reconciler.log)
+		Expect(err).ToNot(HaveOccurred())
+		resPvc := &corev1.PersistentVolumeClaim{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testPvc1", Namespace: "default"}, resPvc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resPvc.GetAnnotations()[cc.AnnBoundCondition]).To(Equal("false"))
+		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionMessage]).To(Equal(eventBasedBoundMessage))
+		Expect(resPvc.GetAnnotations()[cc.AnnBoundConditionReason]).To(Equal(eventBasedBoundReason))
+	})
 })
 
 var _ = Describe("Create Importer Pod", func() {

--- a/pkg/controller/populators/clone-populator.go
+++ b/pkg/controller/populators/clone-populator.go
@@ -264,7 +264,7 @@ func (r *ClonePopulatorReconciler) Reconcile(ctx context.Context, req reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, r.log); err != nil {
+	if err := cc.UpdatePVCBoundConditionFromEvents(pvc, r.client, r.log); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/populators/import-populator.go
+++ b/pkg/controller/populators/import-populator.go
@@ -167,7 +167,7 @@ func (r *ImportPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	// copy over any new events from pvcPrime to pvc
 	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
-	err = cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
+	err = cc.UpdatePVCBoundConditionFromEvents(pvcCopy, r.client, r.log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/populators/upload-populator.go
+++ b/pkg/controller/populators/upload-populator.go
@@ -146,7 +146,7 @@ func (r *UploadPopulatorReconciler) reconcileTargetPVC(pvc, pvcPrime *corev1.Per
 	// copy over any new events from pvcPrime to pvc
 	cc.CopyEvents(pvcPrime, pvcCopy, r.client, r.recorder)
 
-	err := cc.UpdatePVCBoundContionFromEvents(pvcCopy, r.client, r.log)
+	err := cc.UpdatePVCBoundConditionFromEvents(pvcCopy, r.client, r.log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -142,7 +142,7 @@ func (r *UploadReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 	}
 
 	if isUpload || isCloneTarget {
-		if err := cc.UpdatePVCBoundContionFromEvents(pvc, r.client, log); err != nil {
+		if err := cc.UpdatePVCBoundConditionFromEvents(pvc, r.client, log); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of third commit in 1.36 bump: https://github.com/kubevirt/containerized-data-importer/pull/4176/changes/6891189fd3a2b85f8f2d3dc3e5fde2cbbe1bcdee;
Guard annotation deletion in updatePvcFromPod to only remove bound
condition annotations set by the scratch flow (reason == creatingScratch).
Prevents clobbering event-based annotations from UpdatePVCBoundConditionFromEvents,
which caused DV Bound condition message flapping on non-populator imports.

Also fix UpdatePVCBoundContionFromEvents -> UpdatePVCBoundConditionFromEvents typo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: hotloop in non populator path preventing volume bind
```

