### PR TITLE
build: bump builder Go to 1.25.12

### DIFF
--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -38,7 +38,7 @@ ADD https://storage.googleapis.com/builddeps/swagger2markup-cli-1.3.3.jar /opt/s
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11
 
-ENV GIMME_GO_VERSION=1.24.9 GOPATH="/go" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.25.12 GOPATH="/go" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the CDI bazel builder Dockerfile to Go **1.25.12**.

This is the first step of the usual builder bump process (Dockerfile → quay publish → consume). A follow-up PR will:
- point `BUILDER_IMAGE` at the new quay tag
- bump `go` to 1.25.0, `rules_go` to v0.57.0, and CVE-impacted deps (+ vendor)

Motivation: published CDI v1.65/v1.66 images are still on Go 1.24.9 stdlib (incl. Critical CVE-2025-68121); clearing Trivy Crit/High needs a Go 1.25 rebuild.

Per @akalenyu feedback on the previous combined PR.

**Which issue(s) this PR fixes** *(optional)*:
Fixes #

**Special notes for your reviewer**:
Follow-up consume branch is prepared at `cve-bump-go125-deps-consume` on my fork and will be opened once this merges and the builder image is on quay.

**Release note**:
```release-note
NONE
```