### PR TITLE
Enable readOnlyRootFilesystem for all CDI containers

### DIFF
--- a/cmd/cdi-cloner/BUILD.bazel
+++ b/cmd/cdi-cloner/BUILD.bazel
@@ -63,5 +63,6 @@ go_test(
         "//pkg/util/prometheus:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )

--- a/cmd/cdi-cloner/clone-source.go
+++ b/cmd/cdi-cloner/clone-source.go
@@ -91,12 +91,9 @@ func createHTTPClient(clientKey, clientCert, serverCert []byte) *http.Client {
 }
 
 func startPrometheus() {
-	certsDirectory, err := os.MkdirTemp("", "certsdir")
-	if err != nil {
-		klog.Fatalf("Error %s creating temp dir", err)
+	if err := prometheusutil.StartPrometheusEndpointNoCertGeneration(common.PrometheusCertDir); err != nil {
+		klog.Warningf("Failed to start prometheus endpoint: %v", err)
 	}
-
-	prometheusutil.StartPrometheusEndpoint(certsDirectory)
 }
 
 func createProgressReader(readCloser io.ReadCloser, ownerUID string, totalBytes uint64) (io.ReadCloser, error) {

--- a/cmd/cdi-cloner/clone-source_test.go
+++ b/cmd/cdi-cloner/clone-source_test.go
@@ -1,44 +1,39 @@
 package main
 
 import (
-	"errors"
-	"io"
 	"os"
-	"time"
+	"path"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/util/cert"
 
 	prometheusutil "kubevirt.io/containerized-data-importer/pkg/util/prometheus"
 )
 
 var _ = Describe("Prometheus Endpoint", func() {
-	It("Should start prometheus endpoint", func() {
-		By("Creating cert directory, we can store self signed CAs")
+	It("Should start prometheus endpoint with pre-generated certs", func() {
 		certsDirectory, err := os.MkdirTemp("", "certsdir")
 		Expect(err).NotTo(HaveOccurred())
-		empty, err := isDirEmpty(certsDirectory)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(empty).To(BeTrue())
-		prometheusutil.StartPrometheusEndpoint(certsDirectory)
-		time.Sleep(time.Second)
-		empty, err = isDirEmpty(certsDirectory)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(empty).To(BeFalse())
 		defer os.RemoveAll(certsDirectory)
+
+		certBytes, keyBytes, err := cert.GenerateSelfSignedCertKey("test", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(path.Join(certsDirectory, "tls.crt"), certBytes, 0600)).To(Succeed())
+		Expect(os.WriteFile(path.Join(certsDirectory, "tls.key"), keyBytes, 0600)).To(Succeed())
+
+		Expect(prometheusutil.StartPrometheusEndpointNoCertGeneration(certsDirectory)).To(Succeed())
+	})
+
+	It("Should fail if certs are missing", func() {
+		certsDirectory, err := os.MkdirTemp("", "certsdir")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(certsDirectory)
+
+		err = prometheusutil.StartPrometheusEndpointNoCertGeneration(certsDirectory)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cert file"))
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
 	})
 })
-
-func isDirEmpty(dirName string) (bool, error) {
-	f, err := os.Open(dirName)
-	if err != nil {
-		return false, err
-	}
-	defer f.Close()
-
-	_, err = f.Readdirnames(1)
-	if errors.Is(err, io.EOF) {
-		return true, nil
-	}
-	return false, err
-}

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -99,12 +99,9 @@ func touchDoneFile() {
 func main() {
 	defer klog.Flush()
 
-	certsDirectory, err := os.MkdirTemp("", "certsdir")
-	if err != nil {
-		panic(err)
+	if err := prometheusutil.StartPrometheusEndpointNoCertGeneration(common.PrometheusCertDir); err != nil {
+		klog.Warningf("Failed to start prometheus endpoint: %v", err)
 	}
-	defer os.RemoveAll(certsDirectory)
-	prometheusutil.StartPrometheusEndpoint(certsDirectory)
 	klog.V(1).Infoln("Starting importer")
 
 	source, _ := util.ParseEnvVar(common.ImporterSource, false)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -50,6 +50,14 @@ const (
 	PrometheusLabelValue = "true"
 	// PrometheusServiceName is the name of the prometheus service created by the operator.
 	PrometheusServiceName = "cdi-prometheus-metrics"
+	// PrometheusCertDir is the directory where prometheus TLS certs are mounted in worker pods.
+	PrometheusCertDir = "/etc/prometheus-certs"
+	// PrometheusCertVolName is the name of the volume containing the prometheus TLS certs
+	PrometheusCertVolName = "prometheus-certs"
+	// TmpVolumeName is the name of the emptyDir volume providing a writable /tmp.
+	TmpVolumeName = "tmp-dir"
+	// TmpMountPath is the mount path for the writable /tmp volume.
+	TmpMountPath = "/tmp"
 	// MetricsReaderServiceAccountName is the name of the ServiceAccount with access to the various CDI metric endpoints
 	MetricsReaderServiceAccountName = "cdi-metrics-reader"
 	// MetricsReaderTokenName is the name of the secret containing the cdi-metrics-reader ServiceAccount token

--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -524,8 +524,16 @@ func (r *CloneReconciler) CreateCloneSourcePod(image, pullPolicy string, pvc *co
 	pod := MakeCloneSourcePodSpec(sourceVolumeMode, image, pullPolicy, ownerKey, imagePullSecrets, serverCABundle, pvc, sourcePvc, podResourceRequirements, workloadNodePlacement)
 	util.SetRecommendedLabels(pod, r.installerLabels, "cdi-controller")
 
+	if err := cc.CreatePrometheusCertSecret(context.TODO(), r.client, pod.Name, pod.Namespace, r.installerLabels); err != nil {
+		return nil, err
+	}
+
 	if err := r.client.Create(context.TODO(), pod); err != nil {
 		return nil, errors.Wrap(err, "source pod API create errored")
+	}
+
+	if err := cc.SetPrometheusCertSecretOwnerRef(context.TODO(), r.client, pod); err != nil {
+		return nil, err
 	}
 
 	log.V(1).Info("cloning source pod (image) created\n", "pod.Namespace", pod.Namespace, "pod.Name", pod.Name, "image", image)
@@ -740,6 +748,7 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, addVars...)
 	cc.CopyAllowedAnnotations(targetPvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
+	cc.AppendPrometheusCertVolume(&pod.Spec, pod.Name)
 	return pod
 }
 

--- a/pkg/controller/clone-controller_test.go
+++ b/pkg/controller/clone-controller_test.go
@@ -265,6 +265,27 @@ var _ = Describe("Clone controller reconcile loop", func() {
 			Expect(sourcePod.Spec.Containers[0].VolumeMounts[0].ReadOnly).To(BeTrue())
 			Expect(sourcePod.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly).To(BeFalse())
 		}
+		By("Verifying prometheus cert volume and mount are present")
+		var promVolFound bool
+		for _, v := range sourcePod.Spec.Volumes {
+			if v.Name == common.PrometheusCertVolName {
+				promVolFound = true
+				Expect(v.VolumeSource.Secret).NotTo(BeNil())
+				Expect(v.VolumeSource.Secret.SecretName).To(Equal(cc.PrometheusCertSecretName(sourcePod.Name)))
+				break
+			}
+		}
+		Expect(promVolFound).To(BeTrue(), "prometheus cert volume should be present")
+		var promMountFound bool
+		for _, m := range sourcePod.Spec.Containers[0].VolumeMounts {
+			if m.Name == common.PrometheusCertVolName {
+				promMountFound = true
+				Expect(m.MountPath).To(Equal(common.PrometheusCertDir))
+				Expect(m.ReadOnly).To(BeTrue())
+				break
+			}
+		}
+		Expect(promMountFound).To(BeTrue(), "prometheus cert volume mount should be present")
 		Expect(sourcePod.Spec.Containers[0].TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 		Expect(sourcePod.GetLabels()[cc.CloneUniqueID]).To(Equal("default-testPvc1-source-pod"))
 		Expect(sourcePod.GetLabels()[common.AppKubernetesPartOfLabel]).To(Equal("testing"))

--- a/pkg/controller/common/BUILD.bazel
+++ b/pkg/controller/common/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log:go_default_library",

--- a/pkg/controller/common/BUILD.bazel
+++ b/pkg/controller/common/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/feature-gates:go_default_library",
         "//pkg/token:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cert:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/utils:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
@@ -52,6 +53,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/common:go_default_library",
+        "//pkg/util/cert:go_default_library",
         "//staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -65,6 +65,7 @@ import (
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"kubevirt.io/containerized-data-importer/pkg/token"
 	"kubevirt.io/containerized-data-importer/pkg/util"
+	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
@@ -74,6 +75,9 @@ const (
 
 	// ScratchVolName provides a const to use for creating scratch pvc volumes in pod specs
 	ScratchVolName = "cdi-scratch-vol"
+
+	// PrometheusCertSecretSuffix is appended to the pod name to form the prometheus cert Secret name
+	PrometheusCertSecretSuffix = "-prometheus-certs"
 
 	// AnnAPIGroup is the APIGroup for CDI
 	AnnAPIGroup = "cdi.kubevirt.io"
@@ -1247,35 +1251,115 @@ func SetRestrictedSecurityContext(podSpec *corev1.PodSpec) {
 	if hasVolumeMounts {
 		podSpec.SecurityContext.FSGroup = ptr.To[int64](common.QemuSubGid)
 	}
-
-	addTmpVolume(podSpec)
 }
 
-const tmpVolumeName = "tmp-dir"
+// PrometheusCertSecretName returns the Secret name for a pod's prometheus certs.
+func PrometheusCertSecretName(podName string) string {
+	return podName + PrometheusCertSecretSuffix
+}
 
-// addTmpVolume adds an emptyDir volume at /tmp to support readOnlyRootFilesystem
-func addTmpVolume(podSpec *corev1.PodSpec) {
-	for _, v := range podSpec.Volumes {
-		if v.Name == tmpVolumeName {
-			return
-		}
-	}
+// AppendPrometheusCertVolume adds the prometheus cert Secret volume and mount to a pod spec.
+func AppendPrometheusCertVolume(podSpec *corev1.PodSpec, podName string) {
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-		Name: tmpVolumeName,
+		Name: common.PrometheusCertVolName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: PrometheusCertSecretName(podName),
+			},
+		},
+	})
+	mount := corev1.VolumeMount{
+		Name:      common.PrometheusCertVolName,
+		MountPath: common.PrometheusCertDir,
+		ReadOnly:  true,
+	}
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, mount)
+	}
+}
+
+// AppendTmpVolume adds an emptyDir volume mounted at /tmp to a pod spec.
+func AppendTmpVolume(podSpec *corev1.PodSpec) {
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: common.TmpVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	})
-	tmpMount := corev1.VolumeMount{
-		Name:      tmpVolumeName,
-		MountPath: "/tmp",
-	}
-	for i := range podSpec.InitContainers {
-		podSpec.InitContainers[i].VolumeMounts = append(podSpec.InitContainers[i].VolumeMounts, tmpMount)
+	mount := corev1.VolumeMount{
+		Name:      common.TmpVolumeName,
+		MountPath: common.TmpMountPath,
 	}
 	for i := range podSpec.Containers {
-		podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, tmpMount)
+		podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, mount)
 	}
+}
+
+// CreatePrometheusCertSecret creates a Secret containing a self-signed TLS cert/key pair
+// for the prometheus metrics endpoint of a worker pod. It must be called BEFORE creating
+// the pod so the Secret is available when the kubelet mounts the volume.
+// The returned Secret does not have an OwnerReference yet; call SetPrometheusCertSecretOwnerRef
+// after the pod is created to set it.
+func CreatePrometheusCertSecret(ctx context.Context, c client.Client, podName, namespace string, installerLabels map[string]string) error {
+	certBytes, keyBytes, err := cert.GenerateSelfSignedCertKey(podName, nil, nil)
+	if err != nil {
+		return fmt.Errorf("generating prometheus cert for pod %s/%s: %w", namespace, podName, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PrometheusCertSecretName(podName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				common.CDILabelKey:        common.CDILabelValue,
+				common.PrometheusLabelKey: common.PrometheusLabelValue,
+			},
+		},
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certBytes,
+			corev1.TLSPrivateKeyKey: keyBytes,
+		},
+	}
+
+	if installerLabels != nil {
+		util.SetRecommendedLabels(secret, installerLabels, common.CDIControllerName)
+	}
+
+	if err := c.Create(ctx, secret); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			klog.Warningf("Prometheus cert secret for pod %s/%s already exists", namespace, podName)
+			return nil
+		}
+		return fmt.Errorf("creating prometheus cert secret for pod %s/%s: %w", namespace, podName, err)
+	}
+	return nil
+}
+
+// SetPrometheusCertSecretOwnerRef updates the prometheus cert Secret to add an OwnerReference
+// to the given pod, so the Secret is garbage-collected when the pod is deleted.
+// Must be called AFTER the pod is created (since it needs the pod's UID).
+func SetPrometheusCertSecretOwnerRef(ctx context.Context, c client.Client, pod *corev1.Pod) error {
+	secret := &corev1.Secret{}
+	secretName := PrometheusCertSecretName(pod.Name)
+	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pod.Namespace}, secret); err != nil {
+		return fmt.Errorf("getting prometheus cert secret %s/%s: %w", pod.Namespace, secretName, err)
+	}
+
+	secret.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "v1",
+			Kind:               "Pod",
+			Name:               pod.Name,
+			UID:                pod.GetUID(),
+			BlockOwnerDeletion: ptr.To(true),
+			Controller:         ptr.To(true),
+		},
+	}
+
+	if err := c.Update(ctx, secret); err != nil {
+		return fmt.Errorf("setting owner reference on prometheus cert secret %s/%s: %w", pod.Namespace, secretName, err)
+	}
+	return nil
 }
 
 // SetNodeNameIfPopulator sets NodeName in a pod spec when the PVC is being handled by a CDI volume populator

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1230,6 +1230,7 @@ func SetRestrictedSecurityContext(podSpec *corev1.PodSpec) {
 			container.SecurityContext.AllowPrivilegeEscalation = ptr.To[bool](false)
 			container.SecurityContext.RunAsNonRoot = ptr.To[bool](true)
 			container.SecurityContext.RunAsUser = ptr.To[int64](common.QemuSubGid)
+			container.SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
 			if len(container.VolumeMounts) > 0 {
 				hasVolumeMounts = true
 			}
@@ -1245,6 +1246,35 @@ func SetRestrictedSecurityContext(podSpec *corev1.PodSpec) {
 	}
 	if hasVolumeMounts {
 		podSpec.SecurityContext.FSGroup = ptr.To[int64](common.QemuSubGid)
+	}
+
+	addTmpVolume(podSpec)
+}
+
+const tmpVolumeName = "tmp-dir"
+
+// addTmpVolume adds an emptyDir volume at /tmp to support readOnlyRootFilesystem
+func addTmpVolume(podSpec *corev1.PodSpec) {
+	for _, v := range podSpec.Volumes {
+		if v.Name == tmpVolumeName {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: tmpVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+	tmpMount := corev1.VolumeMount{
+		Name:      tmpVolumeName,
+		MountPath: "/tmp",
+	}
+	for i := range podSpec.InitContainers {
+		podSpec.InitContainers[i].VolumeMounts = append(podSpec.InitContainers[i].VolumeMounts, tmpMount)
+	}
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, tmpMount)
 	}
 }
 

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -18,6 +18,7 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
+	"kubevirt.io/containerized-data-importer/pkg/util/cert"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
@@ -555,54 +556,6 @@ var _ = Describe("SetRestrictedSecurityContext", func() {
 		Expect(*podSpec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 	})
 
-	Context("tmp volume", func() {
-		It("should add an emptyDir volume named tmp-dir", func() {
-			SetRestrictedSecurityContext(podSpec)
-			var found bool
-			for _, vol := range podSpec.Volumes {
-				if vol.Name == tmpVolumeName {
-					Expect(vol.VolumeSource.EmptyDir).NotTo(BeNil())
-					found = true
-					break
-				}
-			}
-			Expect(found).To(BeTrue(), "expected tmp-dir volume to be present")
-		})
-
-		It("should mount /tmp on all containers and init containers", func() {
-			SetRestrictedSecurityContext(podSpec)
-			for _, c := range append(podSpec.Containers, podSpec.InitContainers...) {
-				var hasTmpMount bool
-				for _, m := range c.VolumeMounts {
-					if m.Name == tmpVolumeName && m.MountPath == "/tmp" {
-						hasTmpMount = true
-						break
-					}
-				}
-				Expect(hasTmpMount).To(BeTrue(), "container %s should have /tmp mount", c.Name)
-			}
-		})
-
-		It("should not duplicate tmp-dir volume if already present", func() {
-			podSpec.Volumes = []v1.Volume{
-				{
-					Name: tmpVolumeName,
-					VolumeSource: v1.VolumeSource{
-						EmptyDir: &v1.EmptyDirVolumeSource{},
-					},
-				},
-			}
-			SetRestrictedSecurityContext(podSpec)
-			count := 0
-			for _, vol := range podSpec.Volumes {
-				if vol.Name == tmpVolumeName {
-					count++
-				}
-			}
-			Expect(count).To(Equal(1))
-		})
-	})
-
 	Context("FSGroup", func() {
 		It("should set FSGroup when containers have VolumeMounts", func() {
 			podSpec.Containers[0].VolumeMounts = []v1.VolumeMount{
@@ -619,5 +572,152 @@ var _ = Describe("SetRestrictedSecurityContext", func() {
 				Expect(*podSpec.SecurityContext.FSGroup).NotTo(Equal(common.QemuSubGid))
 			}
 		})
+	})
+})
+
+var _ = Describe("AppendPrometheusCertVolume", func() {
+	It("should add prometheus cert volume and mount to pod spec", func() {
+		podSpec := &v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "test-container"},
+			},
+		}
+		AppendPrometheusCertVolume(podSpec, "my-pod")
+
+		Expect(podSpec.Volumes).To(HaveLen(1))
+		Expect(podSpec.Volumes[0].Name).To(Equal(common.PrometheusCertVolName))
+		Expect(podSpec.Volumes[0].VolumeSource.Secret).NotTo(BeNil())
+		Expect(podSpec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal(PrometheusCertSecretName("my-pod")))
+
+		Expect(podSpec.Containers[0].VolumeMounts).To(HaveLen(1))
+		Expect(podSpec.Containers[0].VolumeMounts[0].Name).To(Equal(common.PrometheusCertVolName))
+		Expect(podSpec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.PrometheusCertDir))
+		Expect(podSpec.Containers[0].VolumeMounts[0].ReadOnly).To(BeTrue())
+	})
+})
+
+var _ = Describe("AppendTmpVolume", func() {
+	It("should add emptyDir tmp volume and mount to pod spec", func() {
+		podSpec := &v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "test-container"},
+			},
+		}
+		AppendTmpVolume(podSpec)
+
+		Expect(podSpec.Volumes).To(HaveLen(1))
+		Expect(podSpec.Volumes[0].Name).To(Equal(common.TmpVolumeName))
+		Expect(podSpec.Volumes[0].VolumeSource.EmptyDir).NotTo(BeNil())
+
+		Expect(podSpec.Containers[0].VolumeMounts).To(HaveLen(1))
+		Expect(podSpec.Containers[0].VolumeMounts[0].Name).To(Equal(common.TmpVolumeName))
+		Expect(podSpec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.TmpMountPath))
+	})
+})
+
+var _ = Describe("PrometheusCertSecretName", func() {
+	It("should return correct secret name", func() {
+		Expect(PrometheusCertSecretName("importer-pod")).To(Equal("importer-pod" + PrometheusCertSecretSuffix))
+	})
+})
+
+var _ = Describe("GeneratePrometheusCertBytes", func() {
+	It("should generate valid cert and key bytes", func() {
+		certBytes, keyBytes, err := cert.GenerateSelfSignedCertKey("test-pod", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(certBytes).NotTo(BeEmpty())
+		Expect(keyBytes).NotTo(BeEmpty())
+	})
+})
+
+var _ = Describe("CreatePrometheusCertSecret and SetPrometheusCertSecretOwnerRef", func() {
+	var pod *v1.Pod
+
+	BeforeEach(func() {
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+				UID:       types.UID("test-uid"),
+			},
+		}
+	})
+
+	It("should create a secret with correct name and data (no OwnerRef)", func() {
+		s := scheme.Scheme
+		Expect(v1.AddToScheme(s)).To(Succeed())
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+		err := CreatePrometheusCertSecret(context.TODO(), cl, pod.Name, pod.Namespace, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		secret := &v1.Secret{}
+		err = cl.Get(context.TODO(), types.NamespacedName{
+			Name:      PrometheusCertSecretName(pod.Name),
+			Namespace: pod.Namespace,
+		}, secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data).To(HaveKey("tls.crt"))
+		Expect(secret.Data).To(HaveKey("tls.key"))
+		Expect(secret.OwnerReferences).To(BeEmpty())
+	})
+
+	It("should set OwnerReference after pod exists", func() {
+		s := scheme.Scheme
+		Expect(v1.AddToScheme(s)).To(Succeed())
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+		err := CreatePrometheusCertSecret(context.TODO(), cl, pod.Name, pod.Namespace, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = SetPrometheusCertSecretOwnerRef(context.TODO(), cl, pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		secret := &v1.Secret{}
+		err = cl.Get(context.TODO(), types.NamespacedName{
+			Name:      PrometheusCertSecretName(pod.Name),
+			Namespace: pod.Namespace,
+		}, secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.OwnerReferences).To(HaveLen(1))
+		Expect(secret.OwnerReferences[0].Name).To(Equal(pod.Name))
+		Expect(secret.OwnerReferences[0].UID).To(Equal(pod.UID))
+	})
+
+	It("should not error if secret already exists", func() {
+		s := scheme.Scheme
+		Expect(v1.AddToScheme(s)).To(Succeed())
+
+		existingSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PrometheusCertSecretName(pod.Name),
+				Namespace: pod.Namespace,
+			},
+		}
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(existingSecret).Build()
+
+		err := CreatePrometheusCertSecret(context.TODO(), cl, pod.Name, pod.Namespace, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should apply installer labels when provided", func() {
+		s := scheme.Scheme
+		Expect(v1.AddToScheme(s)).To(Succeed())
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+		labels := map[string]string{
+			"app.kubernetes.io/part-of": "testing",
+			"app.kubernetes.io/version": "v1.0.0",
+		}
+		err := CreatePrometheusCertSecret(context.TODO(), cl, pod.Name, pod.Namespace, labels)
+		Expect(err).NotTo(HaveOccurred())
+
+		secret := &v1.Secret{}
+		err = cl.Get(context.TODO(), types.NamespacedName{
+			Name:      PrometheusCertSecretName(pod.Name),
+			Namespace: pod.Namespace,
+		}, secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "testing"))
 	})
 })

--- a/pkg/controller/common/util_test.go
+++ b/pkg/controller/common/util_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -488,5 +489,135 @@ var _ = Describe("IsWebhookPvcRenderingEnabled", func() {
 
 		_, err := IsWebhookPvcRenderingEnabled(cl)
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("SetRestrictedSecurityContext", func() {
+	var podSpec *v1.PodSpec
+
+	BeforeEach(func() {
+		podSpec = &v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "main"},
+			},
+			InitContainers: []v1.Container{
+				{Name: "init"},
+			},
+		}
+	})
+
+	DescribeTable("should enforce container-level SecurityContext fields",
+		func(check func(sc *v1.SecurityContext)) {
+			SetRestrictedSecurityContext(podSpec)
+			for _, c := range append(podSpec.Containers, podSpec.InitContainers...) {
+				Expect(c.SecurityContext).NotTo(BeNil(), "container %s", c.Name)
+				check(c.SecurityContext)
+			}
+		},
+		Entry("ReadOnlyRootFilesystem=true", func(sc *v1.SecurityContext) {
+			Expect(sc.ReadOnlyRootFilesystem).NotTo(BeNil())
+			Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+		}),
+		Entry("AllowPrivilegeEscalation=false", func(sc *v1.SecurityContext) {
+			Expect(sc.AllowPrivilegeEscalation).NotTo(BeNil())
+			Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+		}),
+		Entry("RunAsNonRoot=true", func(sc *v1.SecurityContext) {
+			Expect(sc.RunAsNonRoot).NotTo(BeNil())
+			Expect(*sc.RunAsNonRoot).To(BeTrue())
+		}),
+		Entry("RunAsUser=QemuSubGid", func(sc *v1.SecurityContext) {
+			Expect(sc.RunAsUser).NotTo(BeNil())
+			Expect(*sc.RunAsUser).To(Equal(common.QemuSubGid))
+		}),
+		Entry("drops ALL capabilities", func(sc *v1.SecurityContext) {
+			Expect(sc.Capabilities).NotTo(BeNil())
+			Expect(sc.Capabilities.Drop).To(ContainElement(v1.Capability("ALL")))
+		}),
+		Entry("SeccompProfile=RuntimeDefault", func(sc *v1.SecurityContext) {
+			Expect(sc.SeccompProfile).NotTo(BeNil())
+			Expect(sc.SeccompProfile.Type).To(Equal(v1.SeccompProfileTypeRuntimeDefault))
+		}),
+	)
+
+	It("should set pod-level SeccompProfile to RuntimeDefault", func() {
+		SetRestrictedSecurityContext(podSpec)
+		Expect(podSpec.SecurityContext).NotTo(BeNil())
+		Expect(podSpec.SecurityContext.SeccompProfile).NotTo(BeNil())
+		Expect(podSpec.SecurityContext.SeccompProfile.Type).To(Equal(v1.SeccompProfileTypeRuntimeDefault))
+	})
+
+	It("should enforce ReadOnlyRootFilesystem=true even if previously set to false", func() {
+		podSpec.Containers[0].SecurityContext = &v1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(false),
+		}
+		SetRestrictedSecurityContext(podSpec)
+		Expect(*podSpec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+	})
+
+	Context("tmp volume", func() {
+		It("should add an emptyDir volume named tmp-dir", func() {
+			SetRestrictedSecurityContext(podSpec)
+			var found bool
+			for _, vol := range podSpec.Volumes {
+				if vol.Name == tmpVolumeName {
+					Expect(vol.VolumeSource.EmptyDir).NotTo(BeNil())
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "expected tmp-dir volume to be present")
+		})
+
+		It("should mount /tmp on all containers and init containers", func() {
+			SetRestrictedSecurityContext(podSpec)
+			for _, c := range append(podSpec.Containers, podSpec.InitContainers...) {
+				var hasTmpMount bool
+				for _, m := range c.VolumeMounts {
+					if m.Name == tmpVolumeName && m.MountPath == "/tmp" {
+						hasTmpMount = true
+						break
+					}
+				}
+				Expect(hasTmpMount).To(BeTrue(), "container %s should have /tmp mount", c.Name)
+			}
+		})
+
+		It("should not duplicate tmp-dir volume if already present", func() {
+			podSpec.Volumes = []v1.Volume{
+				{
+					Name: tmpVolumeName,
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			}
+			SetRestrictedSecurityContext(podSpec)
+			count := 0
+			for _, vol := range podSpec.Volumes {
+				if vol.Name == tmpVolumeName {
+					count++
+				}
+			}
+			Expect(count).To(Equal(1))
+		})
+	})
+
+	Context("FSGroup", func() {
+		It("should set FSGroup when containers have VolumeMounts", func() {
+			podSpec.Containers[0].VolumeMounts = []v1.VolumeMount{
+				{Name: "data", MountPath: "/data"},
+			}
+			SetRestrictedSecurityContext(podSpec)
+			Expect(podSpec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*podSpec.SecurityContext.FSGroup).To(Equal(common.QemuSubGid))
+		})
+
+		It("should not set FSGroup when no VolumeMounts are present", func() {
+			SetRestrictedSecurityContext(podSpec)
+			if podSpec.SecurityContext.FSGroup != nil {
+				Expect(*podSpec.SecurityContext.FSGroup).NotTo(Equal(common.QemuSubGid))
+			}
+		})
 	})
 })

--- a/pkg/controller/dataimportcron-controller.go
+++ b/pkg/controller/dataimportcron-controller.go
@@ -1704,6 +1704,7 @@ func InitPollerPod(c client.Client, cron *cdiv1.DataImportCron, pod *corev1.PodT
 	podSpec.Affinity = workloadNodePlacement.Affinity
 
 	cc.SetRestrictedSecurityContext(podSpec)
+	cc.AppendTmpVolume(podSpec)
 	// No need for specifid uid/fsgroup here since this doesn't write or use qemu
 	if podSpec.SecurityContext != nil {
 		podSpec.SecurityContext.FSGroup = nil

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -239,14 +239,14 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(Equal(noProxy))
 
 			volMounts := containers[0].VolumeMounts
-			Expect(volMounts).To(HaveLen(1))
+			Expect(volMounts).To(HaveLen(2))
 			Expect(volMounts[0]).To(Equal(corev1.VolumeMount{
 				Name:      ProxyCertVolName,
 				MountPath: common.ImporterProxyCertDir,
 			}))
 
 			volumes := cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes
-			Expect(volumes).To(HaveLen(1))
+			Expect(volumes).To(HaveLen(2))
 			Expect(volumes[0]).To(Equal(corev1.Volume{
 				Name: ProxyCertVolName,
 				VolumeSource: corev1.VolumeSource{
@@ -350,8 +350,11 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(getEnvVar(env, common.ImportProxyHTTPS)).To(BeEmpty())
 			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(BeEmpty())
 
-			Expect(containers[0].VolumeMounts).To(BeEmpty())
-			Expect(jobPodTemplateSpec.Volumes).To(BeEmpty())
+			Expect(containers[0].VolumeMounts).To(HaveLen(1))
+			Expect(containers[0].VolumeMounts[0].Name).To(Equal("tmp-dir"))
+			Expect(containers[0].VolumeMounts[0].MountPath).To(Equal("/tmp"))
+			Expect(jobPodTemplateSpec.Volumes).To(HaveLen(1))
+			Expect(jobPodTemplateSpec.Volumes[0].Name).To(Equal("tmp-dir"))
 		})
 
 		It("Should verify CronJob container terminationMessagePolicy is correctly set", func() {

--- a/pkg/controller/dataimportcron-controller_test.go
+++ b/pkg/controller/dataimportcron-controller_test.go
@@ -244,6 +244,10 @@ var _ = Describe("All DataImportCron Tests", func() {
 				Name:      ProxyCertVolName,
 				MountPath: common.ImporterProxyCertDir,
 			}))
+			Expect(volMounts[1]).To(Equal(corev1.VolumeMount{
+				Name:      common.TmpVolumeName,
+				MountPath: common.TmpMountPath,
+			}))
 
 			volumes := cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes
 			Expect(volumes).To(HaveLen(2))
@@ -255,6 +259,12 @@ var _ = Describe("All DataImportCron Tests", func() {
 							Name: trustedCAProxy,
 						},
 					},
+				},
+			}))
+			Expect(volumes[1]).To(Equal(corev1.Volume{
+				Name: common.TmpVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			}))
 
@@ -351,10 +361,11 @@ var _ = Describe("All DataImportCron Tests", func() {
 			Expect(getEnvVar(env, common.ImportProxyNoProxy)).To(BeEmpty())
 
 			Expect(containers[0].VolumeMounts).To(HaveLen(1))
-			Expect(containers[0].VolumeMounts[0].Name).To(Equal("tmp-dir"))
-			Expect(containers[0].VolumeMounts[0].MountPath).To(Equal("/tmp"))
+			Expect(containers[0].VolumeMounts[0].Name).To(Equal(common.TmpVolumeName))
+			Expect(containers[0].VolumeMounts[0].MountPath).To(Equal(common.TmpMountPath))
 			Expect(jobPodTemplateSpec.Volumes).To(HaveLen(1))
-			Expect(jobPodTemplateSpec.Volumes[0].Name).To(Equal("tmp-dir"))
+			Expect(jobPodTemplateSpec.Volumes[0].Name).To(Equal(common.TmpVolumeName))
+			Expect(jobPodTemplateSpec.Volumes[0].VolumeSource.EmptyDir).NotTo(BeNil())
 		})
 
 		It("Should verify CronJob container terminationMessagePolicy is correctly set", func() {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -989,7 +989,15 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 	// add any labels from pvc to the importer pod
 	util.MergeLabels(srcLabels, pod.Labels)
 
+	if err = cc.CreatePrometheusCertSecret(context.TODO(), client, pod.Name, pod.Namespace, installerLabels); err != nil {
+		return nil, err
+	}
+
 	if err = client.Create(context.TODO(), pod); err != nil {
+		return nil, err
+	}
+
+	if err = cc.SetPrometheusCertSecretOwnerRef(context.TODO(), client, pod); err != nil {
 		return nil, err
 	}
 
@@ -1072,6 +1080,8 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 
 	cc.CopyAllowedAnnotations(args.pvc, pod)
 	cc.SetRestrictedSecurityContext(&pod.Spec)
+	cc.AppendTmpVolume(&pod.Spec)
+	cc.AppendPrometheusCertVolume(&pod.Spec, pod.Name)
 	// We explicitly define a NodeName for dynamically provisioned PVCs
 	// when the PVC is being handled by a populator (PVC')
 	cc.SetNodeNameIfPopulator(args.pvc, &pod.Spec)

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1053,7 +1053,7 @@ var _ = Describe("Create Importer Pod", func() {
 			Expect(pod.Spec.Containers[0].VolumeDevices[0].DevicePath).To(Equal(common.WriteBlockPath))
 			if scratchPvcName != nil {
 				By("Verifying scratch space is set if available")
-				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(cc.ScratchVolName))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.ScratchDataDir))
 			}
@@ -1062,7 +1062,7 @@ var _ = Describe("Create Importer Pod", func() {
 			Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.ImporterDataDir))
 			if scratchPvcName != nil {
 				By("Verifying scratch space is set if available")
-				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
 				Expect(pod.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(cc.ScratchVolName))
 				Expect(pod.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(common.ScratchDataDir))
 			}

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -1053,18 +1053,26 @@ var _ = Describe("Create Importer Pod", func() {
 			Expect(pod.Spec.Containers[0].VolumeDevices[0].DevicePath).To(Equal(common.WriteBlockPath))
 			if scratchPvcName != nil {
 				By("Verifying scratch space is set if available")
-				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(cc.ScratchVolName))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.ScratchDataDir))
+				Expect(pod.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(common.TmpVolumeName))
+				Expect(pod.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(common.TmpMountPath))
+				Expect(pod.Spec.Containers[0].VolumeMounts[2].Name).To(Equal(common.PrometheusCertVolName))
+				Expect(pod.Spec.Containers[0].VolumeMounts[2].MountPath).To(Equal(common.PrometheusCertDir))
 			}
 		} else {
 			Expect(pod.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(cc.DataVolName))
 			Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(common.ImporterDataDir))
 			if scratchPvcName != nil {
 				By("Verifying scratch space is set if available")
-				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(4))
 				Expect(pod.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(cc.ScratchVolName))
 				Expect(pod.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(common.ScratchDataDir))
+				Expect(pod.Spec.Containers[0].VolumeMounts[2].Name).To(Equal(common.TmpVolumeName))
+				Expect(pod.Spec.Containers[0].VolumeMounts[2].MountPath).To(Equal(common.TmpMountPath))
+				Expect(pod.Spec.Containers[0].VolumeMounts[3].Name).To(Equal(common.PrometheusCertVolName))
+				Expect(pod.Spec.Containers[0].VolumeMounts[3].MountPath).To(Equal(common.PrometheusCertDir))
 			}
 		}
 		By("Verifying container spec is correct")

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -80,6 +80,9 @@ const (
 	normalCreateEnsured              = "Normal CreateResourceSuccess Successfully ensured"
 	normalDeleteResourceSuccess      = "Normal DeleteResourceSuccess Deleted deployment cdi-deployment successfully"
 	normalDeleteResourceSuccesWorker = "Normal DeleteResourceSuccess Deleted worker resources successfully"
+
+	tmpVolumeName = "tmp-dir"
+	tmpMountPath  = "/tmp"
 )
 
 type args struct {
@@ -255,6 +258,45 @@ var _ = Describe("Controller", func() {
 
 				for _, d := range deploymentList.Items {
 					Expect(d.Spec.Template.GetAnnotations()[secv1.RequiredSCCAnnotation]).To(Equal(common.RestrictedSCCName))
+
+					for _, c := range d.Spec.Template.Spec.Containers {
+						Expect(c.SecurityContext).ToNot(BeNil(),
+							"container %s in deployment %s has no SecurityContext", c.Name, d.Name)
+						Expect(c.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil(),
+							"container %s in deployment %s has no ReadOnlyRootFilesystem", c.Name, d.Name)
+						Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(),
+							"container %s in deployment %s should have ReadOnlyRootFilesystem=true", c.Name, d.Name)
+					}
+
+					if d.Name == common.CDIControllerResourceName {
+						hasTmpVolume := false
+						for _, vol := range d.Spec.Template.Spec.Volumes {
+							if vol.Name == tmpVolumeName {
+								Expect(vol.VolumeSource.EmptyDir).ToNot(BeNil())
+								hasTmpVolume = true
+								break
+							}
+						}
+						Expect(hasTmpVolume).To(BeTrue(),
+							"deployment %s should have %s emptyDir volume for readiness probe %s/ready", d.Name, tmpVolumeName, tmpMountPath)
+
+						for _, c := range d.Spec.Template.Spec.Containers {
+							hasTmpMount := false
+							for _, m := range c.VolumeMounts {
+								if m.Name == tmpVolumeName && m.MountPath == tmpMountPath {
+									hasTmpMount = true
+									break
+								}
+							}
+							Expect(hasTmpMount).To(BeTrue(),
+								"container %s in deployment %s should mount %s", c.Name, d.Name, tmpMountPath)
+						}
+					} else {
+						for _, vol := range d.Spec.Template.Spec.Volumes {
+							Expect(vol.Name).ToNot(Equal(tmpVolumeName),
+								"deployment %s should not have %s volume (minimalist approach)", d.Name, tmpVolumeName)
+						}
+					}
 				}
 
 				scc := &secv1.SecurityContextConstraints{

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -80,9 +80,6 @@ const (
 	normalCreateEnsured              = "Normal CreateResourceSuccess Successfully ensured"
 	normalDeleteResourceSuccess      = "Normal DeleteResourceSuccess Deleted deployment cdi-deployment successfully"
 	normalDeleteResourceSuccesWorker = "Normal DeleteResourceSuccess Deleted worker resources successfully"
-
-	tmpVolumeName = "tmp-dir"
-	tmpMountPath  = "/tmp"
 )
 
 type args struct {
@@ -271,30 +268,30 @@ var _ = Describe("Controller", func() {
 					if d.Name == common.CDIControllerResourceName {
 						hasTmpVolume := false
 						for _, vol := range d.Spec.Template.Spec.Volumes {
-							if vol.Name == tmpVolumeName {
+							if vol.Name == common.TmpVolumeName {
 								Expect(vol.VolumeSource.EmptyDir).ToNot(BeNil())
 								hasTmpVolume = true
 								break
 							}
 						}
 						Expect(hasTmpVolume).To(BeTrue(),
-							"deployment %s should have %s emptyDir volume for readiness probe %s/ready", d.Name, tmpVolumeName, tmpMountPath)
+							"deployment %s should have %s emptyDir volume for readiness probe %s/ready", d.Name, common.TmpVolumeName, common.TmpMountPath)
 
 						for _, c := range d.Spec.Template.Spec.Containers {
 							hasTmpMount := false
 							for _, m := range c.VolumeMounts {
-								if m.Name == tmpVolumeName && m.MountPath == tmpMountPath {
+								if m.Name == common.TmpVolumeName && m.MountPath == common.TmpMountPath {
 									hasTmpMount = true
 									break
 								}
 							}
 							Expect(hasTmpMount).To(BeTrue(),
-								"container %s in deployment %s should mount %s", c.Name, d.Name, tmpMountPath)
+								"container %s in deployment %s should mount %s", c.Name, d.Name, common.TmpMountPath)
 						}
 					} else {
 						for _, vol := range d.Spec.Template.Spec.Volumes {
-							Expect(vol.Name).ToNot(Equal(tmpVolumeName),
-								"deployment %s should not have %s volume (minimalist approach)", d.Name, tmpVolumeName)
+							Expect(vol.Name).ToNot(Equal(common.TmpVolumeName),
+								"deployment %s should not have %s volume (minimalist approach)", d.Name, common.TmpVolumeName)
 						}
 					}
 				}

--- a/pkg/operator/resources/namespaced/BUILD.bazel
+++ b/pkg/operator/resources/namespaced/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -31,5 +31,16 @@ go_library(
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["controller_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/operator/resources/namespaced/BUILD.bazel
+++ b/pkg/operator/resources/namespaced/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/common:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -36,6 +36,8 @@ import (
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
+const tmpVolumeName = "tmp-dir"
+
 func createControllerResources(args *FactoryArgs) []client.Object {
 	return []client.Object{
 		createControllerServiceAccount(),
@@ -265,6 +267,10 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
+			Name:      tmpVolumeName,
+			MountPath: "/tmp",
+		},
+		{
 			Name:      "cdi-api-signing-key",
 			MountPath: controller.TokenKeyDir,
 		},
@@ -294,6 +300,12 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: tmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 		{
 			Name: "cdi-api-signing-key",
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -36,8 +36,6 @@ import (
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
-const tmpVolumeName = "tmp-dir"
-
 func createControllerResources(args *FactoryArgs) []client.Object {
 	return []client.Object{
 		createControllerServiceAccount(),
@@ -267,8 +265,8 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
 		{
-			Name:      tmpVolumeName,
-			MountPath: "/tmp",
+			Name:      common.TmpVolumeName,
+			MountPath: common.TmpMountPath,
 		},
 		{
 			Name:      "cdi-api-signing-key",
@@ -301,7 +299,7 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{
-			Name: tmpVolumeName,
+			Name: common.TmpVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/pkg/operator/resources/namespaced/controller_test.go
+++ b/pkg/operator/resources/namespaced/controller_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"kubevirt.io/containerized-data-importer/pkg/common"
 )
 
 func TestController(t *testing.T) {
@@ -34,20 +36,20 @@ var _ = Describe("cdi-controller Deployment", func() {
 	It("should have an emptyDir volume for /tmp", func() {
 		var found bool
 		for _, vol := range deployment.Spec.Template.Spec.Volumes {
-			if vol.Name == tmpVolumeName {
+			if vol.Name == common.TmpVolumeName {
 				Expect(vol.VolumeSource.EmptyDir).NotTo(BeNil())
 				found = true
 				break
 			}
 		}
-		Expect(found).To(BeTrue(), "expected volume %s to be present", tmpVolumeName)
+		Expect(found).To(BeTrue(), "expected volume %s to be present", common.TmpVolumeName)
 	})
 
 	It("should mount /tmp on all containers", func() {
 		for _, c := range deployment.Spec.Template.Spec.Containers {
 			var hasTmpMount bool
 			for _, m := range c.VolumeMounts {
-				if m.Name == tmpVolumeName && m.MountPath == "/tmp" {
+				if m.Name == common.TmpVolumeName && m.MountPath == common.TmpMountPath {
 					hasTmpMount = true
 					break
 				}

--- a/pkg/operator/resources/namespaced/controller_test.go
+++ b/pkg/operator/resources/namespaced/controller_test.go
@@ -1,0 +1,83 @@
+package namespaced
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Resources Controller Suite")
+}
+
+var _ = Describe("cdi-controller Deployment", func() {
+	var deployment = createControllerDeployment(
+		"controller:latest", "importer:latest", "cloner:latest",
+		"ovirt-populator:latest", "uploadserver:latest",
+		"1", "Always", nil, "", nil, 1,
+	)
+
+	It("should set ReadOnlyRootFilesystem to true", func() {
+		containers := deployment.Spec.Template.Spec.Containers
+		Expect(containers).NotTo(BeEmpty())
+		for _, c := range containers {
+			Expect(c.SecurityContext).NotTo(BeNil(), "container %s", c.Name)
+			Expect(c.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil(), "container %s", c.Name)
+			Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(), "container %s", c.Name)
+		}
+	})
+
+	It("should have an emptyDir volume for /tmp", func() {
+		var found bool
+		for _, vol := range deployment.Spec.Template.Spec.Volumes {
+			if vol.Name == tmpVolumeName {
+				Expect(vol.VolumeSource.EmptyDir).NotTo(BeNil())
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "expected volume %s to be present", tmpVolumeName)
+	})
+
+	It("should mount /tmp on all containers", func() {
+		for _, c := range deployment.Spec.Template.Spec.Containers {
+			var hasTmpMount bool
+			for _, m := range c.VolumeMounts {
+				if m.Name == tmpVolumeName && m.MountPath == "/tmp" {
+					hasTmpMount = true
+					break
+				}
+			}
+			Expect(hasTmpMount).To(BeTrue(), "container %s should have /tmp mount", c.Name)
+		}
+	})
+
+	It("should use /tmp/ready in readiness probe", func() {
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.ReadinessProbe).NotTo(BeNil())
+		Expect(container.ReadinessProbe.Exec).NotTo(BeNil())
+		Expect(container.ReadinessProbe.Exec.Command).To(ContainElement("/tmp/ready"))
+	})
+})
+
+var _ = DescribeTable("deployment SecurityContext",
+	func(create func() corev1.SecurityContext) {
+		sc := create()
+		Expect(sc.ReadOnlyRootFilesystem).NotTo(BeNil())
+		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+		Expect(sc.AllowPrivilegeEscalation).NotTo(BeNil())
+		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+	},
+	Entry("cdi-apiserver", func() corev1.SecurityContext {
+		d := createAPIServerDeployment("img:latest", "1", "Always", nil, "", nil, 1)
+		return *d.Spec.Template.Spec.Containers[0].SecurityContext
+	}),
+	Entry("cdi-uploadproxy", func() corev1.SecurityContext {
+		d := createUploadProxyDeployment("img:latest", "1", "Always", nil, "", nil, 1)
+		return *d.Spec.Template.Spec.Containers[0].SecurityContext
+	}),
+)

--- a/pkg/operator/resources/utils/BUILD.bazel
+++ b/pkg/operator/resources/utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -15,5 +15,16 @@ go_library(
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
         "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["common_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -68,6 +68,7 @@ func CreateContainer(name, image, verbosity, pullPolicy string) corev1.Container
 		},
 		AllowPrivilegeEscalation: ptr.To[bool](false),
 		RunAsNonRoot:             ptr.To[bool](true),
+		ReadOnlyRootFilesystem:   ptr.To(true),
 	}
 	return *container
 }
@@ -88,6 +89,7 @@ func CreatePortsContainer(name, image, pullPolicy string, ports []corev1.Contain
 		},
 		AllowPrivilegeEscalation: ptr.To[bool](false),
 		RunAsNonRoot:             ptr.To[bool](true),
+		ReadOnlyRootFilesystem:   ptr.To(true),
 	}
 	return *container
 }

--- a/pkg/operator/resources/utils/common_test.go
+++ b/pkg/operator/resources/utils/common_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Resources Utils Suite")
+}
+
+func verifyRestrictedSecurityContext(sc *corev1.SecurityContext) {
+	ExpectWithOffset(1, sc).NotTo(BeNil())
+	ExpectWithOffset(1, sc.ReadOnlyRootFilesystem).NotTo(BeNil())
+	ExpectWithOffset(1, *sc.ReadOnlyRootFilesystem).To(BeTrue())
+	ExpectWithOffset(1, sc.AllowPrivilegeEscalation).NotTo(BeNil())
+	ExpectWithOffset(1, *sc.AllowPrivilegeEscalation).To(BeFalse())
+	ExpectWithOffset(1, sc.RunAsNonRoot).NotTo(BeNil())
+	ExpectWithOffset(1, *sc.RunAsNonRoot).To(BeTrue())
+	ExpectWithOffset(1, sc.Capabilities).NotTo(BeNil())
+	ExpectWithOffset(1, sc.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+	ExpectWithOffset(1, sc.SeccompProfile).NotTo(BeNil())
+	ExpectWithOffset(1, sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+var _ = DescribeTable("container factory SecurityContext",
+	func(create func() corev1.Container) {
+		container := create()
+		verifyRestrictedSecurityContext(container.SecurityContext)
+	},
+	Entry("CreateContainer", func() corev1.Container {
+		return CreateContainer("test", "img:latest", "1", "Always")
+	}),
+	Entry("CreatePortsContainer", func() corev1.Container {
+		return CreatePortsContainer("test", "img:latest", "Always", []corev1.ContainerPort{{ContainerPort: 8080}})
+	}),
+)

--- a/pkg/util/prometheus/BUILD.bazel
+++ b/pkg/util/prometheus/BUILD.bazel
@@ -25,5 +25,6 @@ go_test(
         "//pkg/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )

--- a/pkg/util/prometheus/prometheus.go
+++ b/pkg/util/prometheus/prometheus.go
@@ -16,6 +16,9 @@ import (
 	"kubevirt.io/containerized-data-importer/pkg/util"
 )
 
+const CertFileName = "tls.crt"
+const KeyFileName = "tls.key"
+
 // ProgressReader is a counting reader that reports progress to prometheus.
 type ProgressReader struct {
 	util.CountingReader
@@ -102,13 +105,13 @@ func StartPrometheusEndpoint(certsDirectory string) {
 		return
 	}
 
-	certFile := path.Join(certsDirectory, "tls.crt")
+	certFile := path.Join(certsDirectory, CertFileName)
 	if err = os.WriteFile(certFile, certBytes, 0600); err != nil {
 		klog.Error("Error writing cert file")
 		return
 	}
 
-	keyFile := path.Join(certsDirectory, "tls.key")
+	keyFile := path.Join(certsDirectory, KeyFileName)
 	if err = os.WriteFile(keyFile, keyBytes, 0600); err != nil {
 		klog.Error("Error writing key file")
 		return
@@ -125,4 +128,33 @@ func StartPrometheusEndpoint(certsDirectory string) {
 			return
 		}
 	}()
+}
+
+// StartPrometheusEndpointNoCertGeneration starts the prometheus HTTP endpoint without generating self-signed TLS certificates
+// but using the certificates from the ones passed in the directory.
+func StartPrometheusEndpointNoCertGeneration(certsDirectory string) error {
+	certFile := path.Join(certsDirectory, CertFileName)
+	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+		klog.Errorf("Cert file %s does not exist", certFile)
+		return fmt.Errorf("cert file %s does not exist", certFile)
+	}
+	keyFile := path.Join(certsDirectory, KeyFileName)
+	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
+		klog.Errorf("Key file %s does not exist", keyFile)
+		return fmt.Errorf("key file %s does not exist", keyFile)
+	}
+
+	go func() {
+		server := &http.Server{
+			Addr:              ":8443",
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           promhttp.Handler(),
+		}
+
+		if err := server.ListenAndServeTLS(certFile, keyFile); err != nil {
+			klog.Errorf("Prometheus endpoint failed: %v", err)
+		}
+	}()
+
+	return nil
 }

--- a/pkg/util/prometheus/prometheus_test.go
+++ b/pkg/util/prometheus/prometheus_test.go
@@ -2,11 +2,18 @@ package prometheus
 
 import (
 	"bytes"
+	"crypto/tls"
 	"io"
+	"net/http"
+	"os"
+	"path"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/util/cert"
 
 	metrics "kubevirt.io/containerized-data-importer/pkg/monitoring/metrics/cdi-cloner"
 	"kubevirt.io/containerized-data-importer/pkg/util"
@@ -161,5 +168,85 @@ var _ = Describe("Update Progress", func() {
 		Expect(promReader.CountingReader.Reader).To(Equal(thirdReader.Reader))
 		Expect(promReader.CountingReader.Current).To(Equal(uint64(16)))
 		Expect(false).To(Equal(result))
+	})
+})
+
+var _ = Describe("StartPrometheusEndpointNoCertGeneration", func() {
+	var certsDir string
+
+	BeforeEach(func() {
+		var err error
+		certsDir, err = os.MkdirTemp("", "prometheus-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(certsDir)
+	})
+
+	It("should return nil when both cert and key files exist", func() {
+		certBytes, keyBytes, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(path.Join(certsDir, CertFileName), certBytes, 0600)).To(Succeed())
+		Expect(os.WriteFile(path.Join(certsDir, KeyFileName), keyBytes, 0600)).To(Succeed())
+
+		err = StartPrometheusEndpointNoCertGeneration(certsDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		httpClient := &http.Client{
+			Timeout: 2 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
+		Eventually(func() error {
+			_, err := httpClient.Get("https://localhost:8443/metrics")
+			return err
+		}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+	})
+
+	It("should return an error if the cert file does not exist", func() {
+		err := StartPrometheusEndpointNoCertGeneration(certsDir)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cert file"))
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
+	})
+
+	It("should return an error if only the cert file exists (key missing)", func() {
+		certBytes, _, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(path.Join(certsDir, CertFileName), certBytes, 0600)).To(Succeed())
+
+		err = StartPrometheusEndpointNoCertGeneration(certsDir)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("key file"))
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
+	})
+
+	It("should return an error if only the key file exists (cert missing)", func() {
+		_, keyBytes, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(path.Join(certsDir, KeyFileName), keyBytes, 0600)).To(Succeed())
+
+		err = StartPrometheusEndpointNoCertGeneration(certsDir)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cert file"))
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
+	})
+})
+
+var _ = Describe("StartPrometheusEndpoint", func() {
+	It("should generate cert and key files in the specified directory", func() {
+		certsDir, err := os.MkdirTemp("", "prometheus-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(certsDir)
+
+		StartPrometheusEndpoint(certsDir)
+
+		Eventually(func() bool {
+			_, certErr := os.Stat(path.Join(certsDir, "tls.crt"))
+			_, keyErr := os.Stat(path.Join(certsDir, "tls.key"))
+			return certErr == nil && keyErr == nil
+		}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enables `readOnlyRootFilesystem: true` for all CDI containers.
The change touches two central SecurityContext configuration points:
- `CreateContainer()` / `CreatePortsContainer()` in `pkg/operator/resources/utils/common.go` — covers the 4 static deployments (`cdi-operator`, `cdi-apiserver`, `cdi-controller`, `cdi-uploadproxy`)
- `SetRestrictedSecurityContext()` in `pkg/controller/common/util.go` — covers all transient worker pods (`importer`, `cloner`, `uploadserver`, `populators`)

**Prometheus TLS certs refactoring:**
Previously, `importer` and `cloner `generated self-signed TLS certs at runtime using `os.MkdirTemp`, requiring a writable `/tmp`. This PR refactors the approach: the controller now generates certs and stores them in a pod-owned Secret, mounted read-only at `/etc/prometheus-certs`

An emptyDir volume mounted at `/tmp` is added **only** where there is confirmed evidence of writes:
- **cdi-controller** — creates `/tmp/ready` for its readiness probe: [`cmd/cdi-controller/controller.go#L390`](https://github.com/kubevirt/containerized-data-importer/blob/main/cmd/cdi-controller/controller.go#L390)
- **Worker pods** (importer, cloner, uploadserver, dataimportcron) — no `/tmp` emptyDir needed because of the Prometheus TLS certs refactoring
- **vddk importer** — writes `/tmp/nbd.sock` and `/tmp/nbd.pid`: [`pkg/importer/vddk-datasource_amd64.go#L69-L70`](https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/importer/vddk-datasource_amd64.go#L69-L70)
- **ovirt-populator** — writes `/tmp/ovirt.pass` and `/tmp/ca.pem`: [`cmd/ovirt-populator/ovirt-populator.go#L70-L72`](https://github.com/kubevirt/containerized-data-importer/blob/main/cmd/ovirt-populator/ovirt-populator.go#L70-L72)

For cdi-controller the emptyDir is added explicitly in the deployment spec.
Static deployments without evidence of `/tmp` writes (cdi-operator, cdi-apiserver, cdi-uploadproxy) do **not** get an emptyDir — if any of them fails at runtime, CI will surface it and a targeted volume can be added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I added some missing unit tests and also E2E coverage checking that really each container has the readOnlyFileSystem set to true.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable readOnlyRootFilesystem for all CDI containers
```

