### PR TITLE
[RFC] importer: let the ready file wait outlast the image pull

### DIFF
--- a/cmd/cdi-importer/BUILD.bazel
+++ b/cmd/cdi-importer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -26,6 +26,19 @@ go_binary(
     name = "cdi-importer",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "importer_suite_test.go",
+        "importer_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )
 
 pkg_tar(

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -38,29 +38,54 @@ import (
 
 const (
 	completeMessage = "Import Complete"
+
+	// readyFileTimeout bounds the wait for the containerimage-server sidecar
+	// to signal readiness. For RegistryPullNode imports that signal cannot
+	// appear until kubelet has pulled the sidecar image, which is the disk
+	// image being imported, so the bound has to tolerate a pull of arbitrary
+	// size. It is a backstop against a sidecar that never becomes ready, not
+	// a limit on how long a healthy pull may take.
+	readyFileTimeout = 30 * time.Minute
+
+	// readyFilePollInterval is how often the ready file is polled.
+	readyFilePollInterval = time.Second
 )
 
 func init() {
 	klog.InitFlags(nil)
 }
 
+// awaitReadyFile polls for readyFile until it appears or the timeout elapses,
+// reporting whether it appeared. The file is polled once more when the timeout
+// elapses, so a file that appears during the final interval is still seen.
+func awaitReadyFile(readyFile string, timeout, interval time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}
+
 func waitForReadyFile() {
-	const readyFileTimeoutSeconds = 60
 	readyFile, _ := util.ParseEnvVar(common.ImporterReadyFile, false)
 	if readyFile == "" {
 		return
 	}
-	for i := 0; i < readyFileTimeoutSeconds; i++ {
-		if _, err := os.Stat(readyFile); err == nil {
-			return
+	klog.Infof("Waiting up to %v for file %s", readyFileTimeout, readyFile)
+	start := time.Now()
+	if !awaitReadyFile(readyFile, readyFileTimeout, readyFilePollInterval) {
+		err := util.WriteTerminationMessage(fmt.Sprintf("Timeout waiting for file %s", readyFile))
+		if err != nil {
+			klog.Errorf("%+v", err)
 		}
-		time.Sleep(time.Second)
+		os.Exit(1)
 	}
-	err := util.WriteTerminationMessage(fmt.Sprintf("Timeout waiting for file %s", readyFile))
-	if err != nil {
-		klog.Errorf("%+v", err)
-	}
-	os.Exit(1)
+	klog.Infof("File %s appeared after %v", readyFile, time.Since(start).Truncate(time.Second))
 }
 
 func getHTTPEp(ep string) string {

--- a/cmd/cdi-importer/importer.go
+++ b/cmd/cdi-importer/importer.go
@@ -42,7 +42,6 @@ const (
 
 func init() {
 	klog.InitFlags(nil)
-	flag.Parse()
 }
 
 func waitForReadyFile() {
@@ -97,6 +96,7 @@ func touchDoneFile() {
 }
 
 func main() {
+	flag.Parse()
 	defer klog.Flush()
 
 	certsDirectory, err := os.MkdirTemp("", "certsdir")

--- a/cmd/cdi-importer/importer_suite_test.go
+++ b/cmd/cdi-importer/importer_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImporter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Importer Test Suite")
+}

--- a/cmd/cdi-importer/importer_test.go
+++ b/cmd/cdi-importer/importer_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("waitForReadyFile", func() {
+	It("waits long enough to outlast a container image pull", func() {
+		Expect(readyFileTimeout).To(Equal(30 * time.Minute))
+	})
+
+	Context("awaitReadyFile", func() {
+		var readyFile string
+
+		BeforeEach(func() {
+			readyFile = filepath.Join(GinkgoT().TempDir(), "ready")
+		})
+
+		It("succeeds when the file is already present", func() {
+			Expect(os.WriteFile(readyFile, []byte("disk.img"), 0600)).To(Succeed())
+
+			Expect(awaitReadyFile(readyFile, time.Second, time.Millisecond)).To(BeTrue())
+		})
+
+		It("succeeds when the file appears while waiting", func() {
+			go func() {
+				defer GinkgoRecover()
+				time.Sleep(20 * time.Millisecond)
+				Expect(os.WriteFile(readyFile, []byte("disk.img"), 0600)).To(Succeed())
+			}()
+
+			Expect(awaitReadyFile(readyFile, time.Minute, time.Millisecond)).To(BeTrue())
+		})
+
+		It("gives up once the timeout elapses", func() {
+			Expect(awaitReadyFile(readyFile, 10*time.Millisecond, time.Millisecond)).To(BeFalse())
+		})
+
+		It("waits for the whole timeout before giving up", func() {
+			const timeout = 50 * time.Millisecond
+			start := time.Now()
+
+			Expect(awaitReadyFile(readyFile, timeout, time.Millisecond)).To(BeFalse())
+
+			Expect(time.Since(start)).To(BeNumerically(">=", timeout))
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

For registry imports with `pullMethod: node`, `cdi-importer` waits for the ready file written by the
`cdi-containerimage-server` sidecar. The sidecar runs the disk image as its own container image, so
that file cannot appear until kubelet has finished pulling it. The wait is a fixed 60 seconds, so
any import whose image takes longer than that to pull exits 1 with `Timeout waiting for file
/shared/ready` and reports a spurious `ErrImportFailed`, then succeeds after kubelet restarts the
importer. Details and measurements are in #4253.

This is the smallest change I could find that removes the false failure without changing how the
import is structured:

- the wait stays bounded, still writes the same termination message, and still exits 1, so the
  behaviour #2221 introduced is preserved;
- the bound is raised from 60 seconds to 30 minutes.

The reasoning behind the larger bound is that 60 seconds conflates two conditions. One is "the
sidecar image is still being pulled", which is normal, has no upper bound in principle, and is
already reported by kubelet if the pull genuinely fails. The other is "the sidecar is running but
never wrote the ready file", which is what the bound is actually useful for. Sizing the bound for
the second case makes a generous value cheap, because by the time it expires something really is
wrong.

There are two commits:

1. `cdi-importer: parse flags in main` — `flag.Parse()` ran in `init()`, which makes the package
   untestable, because the test binary's own flags are not registered yet and parsing fails before
   any spec runs. `cmd/cdi-cloner` already registers flags in `init()` and parses in `main()`; this
   matches that. No behaviour change for the binary, since the command defines no flags of its own
   beyond klog's.
2. `cdi-importer: let the ready file wait outlast the image pull` — the change itself, with unit
   tests for the wait. `cmd/cdi-importer/BUILD.bazel` gains a `go_test` target mirroring
   `cmd/cdi-cloner`, so the new tests are visible to bazel as well as to `go test`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4253

**Special notes for your reviewer**:

I have marked this as an RFC because the fix is a design choice and I did not want to presume the answer. Three things I would specifically like your opinion on:

1. **Is 30 minutes the right bound?** It is deliberately generous rather than derived. The longest
   pull I measured was about 154 seconds, but that depends entirely on image size and registry
   throughput, so I did not want to pick a value that merely covered my own environment. The
   tradeoff is that a sidecar which never becomes ready now takes longer to be reported, which I
   think is acceptable because kubelet reports pull and container failures independently and
   sooner. Happy to use a different value.

2. **Should this be configurable at all?** An earlier version of this patch read the bound from an
   environment variable, but the importer pod's environment is built by the controller, so nothing
   could actually set it and I removed it. If you would like it tunable, the natural home looks like
   a `CDIConfig` field plumbed through `importPodEnvVar` into the pod spec, and I am happy to add
   that here or in a follow-up.

3. **Would you rather fix this structurally?** The sidecar's readiness really means "kubelet
   finished pulling my image", so expressing it as a sidecar container (an init container with
   `restartPolicy: Always`) would let kubelet order startup and remove the need for a timeout at
   all, with a stuck pull surfacing as `ImagePullBackOff`. That is a bigger change with a minimum
   Kubernetes version implication, so I did not attempt it here. If you prefer that direction,
   please close this PR in favour of it; I would be glad to help.

One practical note: I found this during large-scale internal durability testing rather than from a
synthetic reproducer, so the numbers in the issue come from production-adjacent clusters rather than
a lab setup.

**Release note**:
```release-note
Fixed spurious import failures for registry imports using pullMethod node when pulling the disk image takes longer than 60 seconds.
```
