### PR TITLE
datavolume: emit event when PVC size is raised to minimum supported size

### DIFF
--- a/pkg/controller/datavolume/import-controller_test.go
+++ b/pkg/controller/datavolume/import-controller_test.go
@@ -219,6 +219,35 @@ var _ = Describe("All DataVolume Tests", func() {
 			Expect(val).To(Equal(string(dv.UID)))
 		})
 
+		It("Should record a MinimumPVCSizeApplied event and grow the PVC when the requested size is below the storage profile minimum", func() {
+			scName := "testSC"
+			sc := CreateStorageClass(scName, nil)
+			sp := createStorageProfile(scName, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, corev1.PersistentVolumeBlock)
+			sp.Annotations = map[string]string{AnnMinimumSupportedPVCSize: "4Gi"}
+
+			storageSpec := &cdiv1.StorageSpec{
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			}
+			dv := createDataVolumeWithStorageAPI("test-dv", metav1.NamespaceDefault,
+				&cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{}}, storageSpec)
+
+			reconciler = createImportReconciler(dv, sc, sp)
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}})
+			Expect(err).ToNot(HaveOccurred())
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "test-dv", Namespace: metav1.NamespaceDefault}, pvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvc.Spec.Resources.Requests.Storage().Cmp(resource.MustParse("4Gi"))).To(Equal(0))
+
+			Eventually(reconciler.recorder.(*record.FakeRecorder).Events).Should(Receive(ContainSubstring(MinimumPVCSizeApplied)))
+		})
+
 		It("Should create a PVC on a valid import DV without delayed annotation then add on success", func() {
 			dv := NewImportDataVolume("test-dv")
 			AddAnnotation(dv, "foo", "bar")

--- a/pkg/controller/datavolume/util.go
+++ b/pkg/controller/datavolume/util.go
@@ -53,12 +53,26 @@ const (
 
 	// MessageErrStorageClassNotFound provides a const to indicate the PVC spec is missing accessMode and no storageClass to choose profile
 	MessageErrStorageClassNotFound = "PVC spec is missing accessMode and no storageClass to choose profile"
+
+	// MinimumPVCSizeApplied is the event reason emitted when a PVC is grown to the storage profile's minimum supported size
+	MinimumPVCSizeApplied = "MinimumPVCSizeApplied"
+	// MessageMinimumPVCSizeApplied is the event message emitted when a PVC is grown to the storage profile's minimum supported size
+	MessageMinimumPVCSizeApplied = "The requested storage size %s is smaller than the minimum supported PVC size for storage class %q; PVC will be created with %s"
 )
 
 var (
 	// ErrStorageClassNotFound indicates the PVC spec is missing accessMode and no storageClass to choose profile
 	ErrStorageClassNotFound = errors.New(MessageErrStorageClassNotFound)
 )
+
+// renderResult carries side-signals produced while rendering a PVC spec, so
+// callers can react (e.g. emit events) without the render logic depending on
+// the event recorder.
+type renderResult struct {
+	// minSizeApplied is true when the requested size was raised to the storage
+	// profile's minimum supported PVC size.
+	minSizeApplied bool
+}
 
 // RenderPvc renders the PVC according to StorageProfiles
 func RenderPvc(ctx context.Context, client client.Client, pvc *v1.PersistentVolumeClaim) error {
@@ -83,7 +97,8 @@ func RenderPvc(ctx context.Context, client client.Client, pvc *v1.PersistentVolu
 		return nil
 	}
 
-	return renderPvcSpecVolumeSize(client, &pvc.Spec, false, nil)
+	_, err := renderPvcSpecVolumeSize(client, &pvc.Spec, false, nil)
+	return err
 }
 
 // hasVolumeSnapshotDataSource returns true if the PVC's DataSource or DataSourceRef
@@ -138,8 +153,15 @@ func pvcFromStorage(client client.Client, recorder record.EventRecorder, log log
 
 	if shouldRender {
 		isClone := dv.Spec.Source.PVC != nil || dv.Spec.Source.Snapshot != nil
-		if err := renderPvcSpecVolumeSize(client, pvcSpec, isClone, &log); err != nil {
+		requested := pvcSpec.Resources.Requests[v1.ResourceStorage]
+		result, err := renderPvcSpecVolumeSize(client, pvcSpec, isClone, &log)
+		if err != nil {
 			return nil, err
+		}
+		if result.minSizeApplied && recorder != nil && !requested.IsZero() && pvcSpec.StorageClassName != nil {
+			effective := pvcSpec.Resources.Requests[v1.ResourceStorage]
+			recorder.Eventf(dv, v1.EventTypeNormal, MinimumPVCSizeApplied,
+				MessageMinimumPVCSizeApplied, requested.String(), *pvcSpec.StorageClassName, effective.String())
 		}
 	}
 
@@ -305,37 +327,40 @@ func hasCloneSourceRef(pvc *v1.PersistentVolumeClaim) bool {
 	return dsRef != nil && dsRef.APIGroup != nil && *dsRef.APIGroup == cc.AnnAPIGroup && dsRef.Kind == cdiv1.VolumeCloneSourceRef && dsRef.Name != ""
 }
 
-func renderPvcSpecVolumeSize(client client.Client, pvcSpec *v1.PersistentVolumeClaimSpec, isClone bool, log *logr.Logger) error {
+func renderPvcSpecVolumeSize(client client.Client, pvcSpec *v1.PersistentVolumeClaimSpec, isClone bool, log *logr.Logger) (renderResult, error) {
+	var result renderResult
 	requestedSize, found := pvcSpec.Resources.Requests[v1.ResourceStorage]
 
 	// Storage size can be empty when cloning
 	if !found {
 		if !isClone {
-			return errors.Errorf("PVC Spec is not valid - missing storage size")
+			return result, errors.Errorf("PVC Spec is not valid - missing storage size")
 		}
 		setRequestedVolumeSize(pvcSpec, resource.Quantity{})
-		return nil
+		return result, nil
 	}
 
 	// Kubevirt doesn't allow disks smaller than 1MiB. Rejecting for consistency.
 	if requestedSize.Value() < units.MiB {
-		return errors.Errorf("PVC Spec is not valid - storage size should be at least 1MiB")
+		return result, errors.Errorf("PVC Spec is not valid - storage size should be at least 1MiB")
 	}
 
 	requestedSize, err := cc.InflateSizeWithOverhead(context.TODO(), client, requestedSize.Value(), pvcSpec)
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	if scName := pvcSpec.StorageClassName; scName != nil {
+		sizeBeforeBump := requestedSize
 		if requestedSize, err = cc.GetEffectiveVolumeSize(context.TODO(), client, requestedSize, *scName, log); err != nil {
-			return err
+			return result, err
 		}
+		result.minSizeApplied = requestedSize.Cmp(sizeBeforeBump) > 0
 	}
 
 	setRequestedVolumeSize(pvcSpec, requestedSize)
 
-	return nil
+	return result, nil
 }
 
 func setRequestedVolumeSize(pvcSpec *v1.PersistentVolumeClaimSpec, volumeSize resource.Quantity) {

--- a/pkg/controller/datavolume/util_test.go
+++ b/pkg/controller/datavolume/util_test.go
@@ -33,7 +33,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 
 	It("Should return empty volume size on clone PVC with empty storage size", func() {
 		pvcSpec := &corev1.PersistentVolumeClaimSpec{}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, true, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, true, nil)
 		Expect(err).ToNot(HaveOccurred())
 		requestedVolumeSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
 		Expect(found).To(BeTrue())
@@ -42,7 +42,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 
 	It("Should return error on non-clone PVC with empty storage size", func() {
 		pvcSpec := &corev1.PersistentVolumeClaimSpec{}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("PVC Spec is not valid - missing storage size"))
 		_, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
@@ -60,7 +60,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 				},
 			},
 		}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("PVC Spec is not valid - storage size should be at least 1MiB"))
 	})
@@ -76,7 +76,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 				},
 			},
 		}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		requestedVolumeSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
@@ -95,7 +95,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 				},
 			},
 		}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
 		Expect(err).ToNot(HaveOccurred())
 		requestedVolumeSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
 		Expect(found).To(BeTrue())
@@ -131,7 +131,7 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 				},
 			},
 		}
-		err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
+		_, err := renderPvcSpecVolumeSize(client, pvcSpec, false, nil)
 		Expect(err).ToNot(HaveOccurred())
 		requestedSize, found := pvcSpec.Resources.Requests[corev1.ResourceStorage]
 		Expect(found).To(BeTrue())
@@ -143,6 +143,40 @@ var _ = Describe("renderPvcSpecVolumeSize", func() {
 		Entry("original volume size if no minimal size defined", "1Gi", "", "1Gi"),
 		Entry("original volume size if wrong minimal size defined", "1Gi", "bla", "1Gi"),
 	)
+
+	Context("minimum supported PVC size event", func() {
+		newSpec := func(storageSize string) *corev1.PersistentVolumeClaimSpec {
+			return &corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(storageSize),
+					},
+				},
+			}
+		}
+
+		sp := &cdiv1.StorageProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        scName,
+				Annotations: map[string]string{AnnMinimumSupportedPVCSize: "4Gi"},
+			},
+		}
+
+		It("Should flag minSizeApplied when the requested size is bumped up to the minimum", func() {
+			cl := createClient(sp)
+			result, err := renderPvcSpecVolumeSize(cl, newSpec("1Gi"), false, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.minSizeApplied).To(BeTrue())
+		})
+
+		It("Should not flag minSizeApplied when the requested size is at or above the minimum", func() {
+			cl := createClient(sp)
+			result, err := renderPvcSpecVolumeSize(cl, newSpec("5Gi"), false, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.minSizeApplied).To(BeFalse())
+		})
+	})
 })
 
 var _ = Describe("RenderPvc", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
  When a DataVolume/PVC is requested smaller than the storage profile's minimumSupportedPvcSize, CDI silently grows it to the minimum,    
  leaving users confused about the final size. This PR emits a Normal MinimumPVCSizeApplied event on the DataVolume explaining the change.

 **Before this PR:**
PVC is created larger than requested, with no event or explanation.

 **After this PR:**
 kubectl describe dv shows an event, e.g. "The requested storage size 1Gi is smaller than the minimum supported PVC size for storage class "my-sc"; PVC will be created with 4Gi".

**References:**
https://redhat.atlassian.net/browse/CNV-64649

  ```release-note
  A DataVolume now emits a "MinimumPVCSizeApplied" event when its requested size is raised to the storage class's minimum supported PVC   
  size.
  ```