### PR TITLE
controller, clone, planner: fix race when PVC capacity is unavailable

### DIFF
--- a/pkg/controller/clone/planner.go
+++ b/pkg/controller/clone/planner.go
@@ -359,6 +359,10 @@ func (p *Planner) computeStrategyForSourcePVC(ctx context.Context, args *ChooseS
 	res.Strategy = strategy
 	if strategy == cdiv1.CloneStrategySnapshot ||
 		strategy == cdiv1.CloneStrategyCsiClone {
+		if _, ok := sourceClaim.Status.Capacity[corev1.ResourceStorage]; !ok {
+			args.Log.V(3).Info("Source PVC capacity not yet available, requeueing")
+			return nil, nil
+		}
 		if err := p.validateAdvancedClonePVC(ctx, args, res, sourceClaim); err != nil {
 			return nil, err
 		}
@@ -502,12 +506,9 @@ func (p *Planner) validateAdvancedClonePVC(ctx context.Context, args *ChooseStra
 		return fmt.Errorf("target storage class not found")
 	}
 
-	srcCapacity, hasSrcCapacity := sourceClaim.Status.Capacity[corev1.ResourceStorage]
-	targetRequest, hasTargetRequest := args.TargetClaim.Spec.Resources.Requests[corev1.ResourceStorage]
+	srcCapacity := sourceClaim.Status.Capacity[corev1.ResourceStorage]
+	targetRequest := args.TargetClaim.Spec.Resources.Requests[corev1.ResourceStorage]
 	allowExpansion := sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion
-	if !hasSrcCapacity || !hasTargetRequest {
-		return fmt.Errorf("source/target size info missing")
-	}
 
 	if srcCapacity.Cmp(targetRequest) < 0 && !allowExpansion {
 		p.fallbackToHostAssisted(args.TargetClaim, res, NoVolumeExpansion, MessageNoVolumeExpansion)

--- a/pkg/controller/clone/planner_test.go
+++ b/pkg/controller/clone/planner_test.go
@@ -325,6 +325,21 @@ var _ = Describe("Planner test", func() {
 				expectEvent(planner, CloneWithoutSource)
 			})
 
+			It("should return nil if source capacity not yet available", func() {
+				source := createClaim(sourceName)
+				source.Spec.VolumeName = volumeName
+				source.Status.Phase = corev1.ClaimBound
+				args := &ChooseStrategyArgs{
+					TargetClaim: createTargetClaim(),
+					DataSource:  createPVCDataSource(),
+					Log:         log,
+				}
+				planner = createPlanner(createStorageClass(), source, createVolumeSnapshotClass(), createSourceVolume())
+				csr, err := planner.ChooseStrategy(context.Background(), args)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(csr).To(BeNil())
+			})
+
 			It("should fail target smaller", func() {
 				source := createSourceClaim()
 				target := createTargetClaim()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When cloning from a source DataVolume that is still importing, the source PVC exists but its `Status.Capacity` is not yet populated. `validateAdvancedClonePVC` treats this as a hard error, setting `AnnClonePhase=Error` and triggering exponential backoff. This misclassifies a transient pending condition as an error, and the backoff can delay recovery past timeout windows.

Check whether `sourceClaim.Status.Capacity` is populated before calling `validateAdvancedClonePVC`. If not, follow the missing-source-PVC path, set `AnnClonePhase=Pending` and requeue after 5 seconds, deferring strategy selection until the source PVC is ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Some additional context on the race: whenever a clone DV is created while its source is still importing, the source PVC exists but `Status.Capacity` isn't populated until the import completes and the PVC binds. The window between PVC creation and capacity population can span minutes for large images, so this isn't necessarily a narrow edge case. We've noticed this failure when a VM was being cloned from a DV that was only 1 second into its HTTP import.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

