### PR TITLE
controller: constrain VDDK importer pods to amd64 nodes

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -964,8 +964,12 @@ func createImporterPod(ctx context.Context, log logr.Logger, client client.Clien
 		}
 		setRegistryNodeImportEnvVars(args)
 		if args.podEnvVar.registryImageArchitecture != "" {
-			setRegistryNodeImportNodeSelector(args)
+			setImportNodeSelectorArch(args, args.podEnvVar.registryImageArchitecture)
 		}
+	}
+	// VDDK requires amd64: the VMware VDDK library only ships x86_64 binaries.
+	if args.vddkImageName != nil {
+		setImportNodeSelectorArch(args, "amd64")
 	}
 
 	pod := makeImporterPodSpec(args)
@@ -1302,11 +1306,11 @@ func setRegistryNodeImportEnvVars(args *importerPodArgs) {
 	args.podEnvVar.doneFile = "/shared/done"
 }
 
-func setRegistryNodeImportNodeSelector(args *importerPodArgs) {
+func setImportNodeSelectorArch(args *importerPodArgs, arch string) {
 	if args.workloadNodePlacement.NodeSelector == nil {
 		args.workloadNodePlacement.NodeSelector = make(map[string]string, 0)
 	}
-	args.workloadNodePlacement.NodeSelector[v1.LabelArchStable] = args.podEnvVar.registryImageArchitecture
+	args.workloadNodePlacement.NodeSelector[v1.LabelArchStable] = arch
 }
 
 func createConfigMapVolume(certVolName, objRef string) corev1.Volume {

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -374,6 +374,25 @@ var _ = Describe("ImportConfig Controller reconcile loop", func() {
 		Expect(err.Error()).To(ContainSubstring("failed to parse"))
 	})
 
+	It("Should set amd64 node selector for VDDK import", func() {
+		annotations := map[string]string{
+			cc.AnnEndpoint:         testEndPoint,
+			cc.AnnImportPod:        "importer-testPvc1",
+			cc.AnnSource:           cc.SourceVDDK,
+			cc.AnnVddkInitImageURL: "test://vddk-image",
+		}
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, annotations, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc)
+
+		err := reconciler.createImporterPod(pvc)
+		Expect(err).ToNot(HaveOccurred())
+		pod := &corev1.Pod{}
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "importer-testPvc1", Namespace: "default"}, pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/arch", "amd64"))
+	})
+
 	It("Should create a POD if a PVC with all needed annotations is passed", func() {
 		pvc := cc.CreatePvc("testPvc1", "default", map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnImportPod: "importer-testPvc1", cc.AnnPodNetwork: "net1", "unrelatedAnnotation": "test"}, nil)
 		pvc.Status.Phase = v1.ClaimBound


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The VDDK library only ships x86_64 binaries, so VDDK importer pods can only run on amd64 nodes. Without an explicit node selector, the scheduler could place them on non-amd64 nodes in multi-arch clusters, causing runtime issues.

Set kubernetes.io/arch=amd64 on VDDK importer pods to make the requirement explicit.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

