### PR TITLE
MTV-6604 | Add nfc support

### DIFF
--- a/manifests/example/vddk-configmap.yaml
+++ b/manifests/example/vddk-configmap.yaml
@@ -5,4 +5,6 @@ metadata:
 data:
         # Replace registry:5000 with the registry containing your privately-built VDDK image,
         # and replace vddk-init:latest with your image's name and tag.
+        # A traditional VDDK image uses nbdkit-vddk. Set this to the importer image
+        # (the one that contains nbdkit-nfc) to use nbdkit-nfc instead.
         vddk-init-image: registry:5000/vddk-init:latest

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -1127,7 +1127,7 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 			MountPath: common.ScratchDataDir,
 		})
 	}
-	if args.vddkImageName != nil {
+	if args.vddkImageName != nil && *args.vddkImageName != args.image {
 		containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      "vddk-vol-mount",
 			MountPath: "/opt",
@@ -1202,7 +1202,7 @@ func makeImporterVolumeSpec(args *importerPodArgs) []corev1.Volume {
 			},
 		})
 	}
-	if args.vddkImageName != nil {
+	if args.vddkImageName != nil && *args.vddkImageName != args.image {
 		volumes = append(volumes, corev1.Volume{
 			Name: "vddk-vol-mount",
 			VolumeSource: corev1.VolumeSource{
@@ -1261,7 +1261,7 @@ func makeImporterInitContainersSpec(args *importerPodArgs) []corev1.Container {
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		})
 	}
-	if args.vddkImageName != nil {
+	if args.vddkImageName != nil && *args.vddkImageName != args.image {
 		initContainers = append(initContainers, corev1.Container{
 			Name:  "vddk-side-car",
 			Image: *args.vddkImageName,

--- a/pkg/controller/import-controller_test.go
+++ b/pkg/controller/import-controller_test.go
@@ -849,6 +849,37 @@ var _ = Describe("Update PVC from POD", func() {
 		Expect(common.AwaitingVDDK).ToNot(Equal(resPvc.GetAnnotations()[cc.AnnBoundConditionReason]))
 	})
 
+	It("Should run the VDDK init image as a sidecar with its own entrypoint", func() {
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnImportPod: "testpod", cc.AnnSource: cc.SourceVDDK, cc.AnnVddkInitImageURL: "test://vddk-image"}, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc)
+		reconciler.image = testImage
+		Expect(reconciler.createImporterPod(pvc)).To(Succeed())
+
+		pod := &corev1.Pod{}
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testpod", Namespace: "default"}, pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
+		sidecar := pod.Spec.InitContainers[0]
+		Expect(sidecar.Name).To(Equal("vddk-side-car"))
+		Expect(sidecar.Image).To(Equal("test://vddk-image"))
+		Expect(sidecar.Command).To(BeEmpty())
+	})
+
+	It("Should skip the VDDK sidecar when the init image is the importer image", func() {
+		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnImportPod: "testpod", cc.AnnSource: cc.SourceVDDK, cc.AnnVddkInitImageURL: testImage}, nil, corev1.ClaimBound)
+		reconciler = createImportReconciler(pvc)
+		reconciler.image = testImage
+		Expect(reconciler.createImporterPod(pvc)).To(Succeed())
+
+		pod := &corev1.Pod{}
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: "testpod", Namespace: "default"}, pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod.Spec.InitContainers).To(BeEmpty())
+		for _, mount := range pod.Spec.Containers[0].VolumeMounts {
+			Expect(mount.Name).ToNot(Equal("vddk-vol-mount"))
+		}
+	})
+
 	It("Should copy VDDK connection information to annotations on PVC", func() {
 		pvc := cc.CreatePvcInStorageClass("testPvc1", "default", &testStorageClass, map[string]string{cc.AnnEndpoint: testEndPoint, cc.AnnPodPhase: string(corev1.PodRunning), cc.AnnSource: cc.SourceVDDK}, nil, corev1.ClaimBound)
 		scratchPvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	nbdVddkLibraryPath    = "/opt/vmware-vix-disklib-distrib"
+	nbdNfcPluginPath      = "/usr/lib64/nbdkit/plugins/nbdkit-nfc-plugin.so"
 	startupTimeoutSeconds = 15
 	defaultUserAgent      = "cdi-nbdkit-importer"
 	passwordFdEntry       = 3
@@ -42,6 +43,7 @@ const (
 	NbdkitFilePlugin     NbdkitPlugin = "file"
 	NbdkitVddkPlugin     NbdkitPlugin = "vddk"
 	NbdkitVddkMockPlugin NbdkitPlugin = "/opt/testing/libvddk-test-plugin.so"
+	NbdkitNfcPlugin      NbdkitPlugin = "nfc"
 )
 
 // Nbdkit filters
@@ -142,10 +144,15 @@ type NbdKitVddkPluginArgs struct {
 	Snapshot   string
 }
 
-// NewNbdkitVddk creates a new Nbdkit instance with the vddk plugin
+// NewNbdkitVddk creates a new Nbdkit instance with the vddk or nfc plugin,
+// depending on whether the VDDK init sidecar provided VixDiskLib.
 func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (NbdkitOperation, error) {
-	pluginArgs := []string{
-		"libdir=" + nbdVddkLibraryPath,
+	p := getVddkPluginPath()
+	var pluginArgs []string
+	if p != NbdkitNfcPlugin {
+		pluginArgs = []string{
+			"libdir=" + nbdVddkLibraryPath,
+		}
 	}
 	if args.Server != "" {
 		pluginArgs = append(pluginArgs, "server="+args.Server)
@@ -170,20 +177,23 @@ func NewNbdkitVddk(nbdkitPidFile, socket string, args NbdKitVddkPluginArgs) (Nbd
 	}
 	if args.Snapshot != "" {
 		pluginArgs = append(pluginArgs, "snapshot="+args.Snapshot)
-		pluginArgs = append(pluginArgs, "transports=file:nbdssl:nbd")
+		if p != NbdkitNfcPlugin {
+			pluginArgs = append(pluginArgs, "transports=file:nbdssl:nbd")
+		}
 	}
-	pluginArgs = append(pluginArgs, "--verbose")
-	pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")
-	pluginArgs = append(pluginArgs, "-D", "vddk.datapath=0")
-	pluginArgs = append(pluginArgs, "-D", "vddk.stats=1")
-	config, err := getVddkConfig()
-	if err != nil {
-		return nil, err
+	if p != NbdkitNfcPlugin {
+		pluginArgs = append(pluginArgs, "--verbose")
+		pluginArgs = append(pluginArgs, "-D", "nbdkit.backend.datapath=0")
+		pluginArgs = append(pluginArgs, "-D", "vddk.datapath=0")
+		pluginArgs = append(pluginArgs, "-D", "vddk.stats=1")
+		config, err := getVddkConfig()
+		if err != nil {
+			return nil, err
+		}
+		if config != "" {
+			pluginArgs = append(pluginArgs, "config="+config)
+		}
 	}
-	if config != "" {
-		pluginArgs = append(pluginArgs, "config="+config)
-	}
-	p := getVddkPluginPath()
 	n := &Nbdkit{
 		NbdPidFile: nbdkitPidFile,
 		plugin:     p,
@@ -242,6 +252,14 @@ func getVddkPluginPath() NbdkitPlugin {
 	if !os.IsNotExist(err) {
 		return NbdkitVddkMockPlugin
 	}
+	_, err = os.Stat(nbdVddkLibraryPath)
+	if !os.IsNotExist(err) {
+		return NbdkitVddkPlugin
+	}
+	_, err = os.Stat(nbdNfcPluginPath)
+	if !os.IsNotExist(err) {
+		return NbdkitNfcPlugin
+	}
 	return NbdkitVddkPlugin
 }
 
@@ -266,7 +284,7 @@ func (n *Nbdkit) getSourceArg(s string) string {
 	switch n.plugin {
 	case NbdkitCurlPlugin:
 		source = fmt.Sprintf("url=%s", s)
-	case NbdkitVddkPlugin, NbdkitVddkMockPlugin:
+	case NbdkitVddkPlugin, NbdkitVddkMockPlugin, NbdkitNfcPlugin:
 		source = fmt.Sprintf("file=%s", s)
 	default:
 		source = s
@@ -457,7 +475,9 @@ func (n *Nbdkit) validatePlugin() error {
 	args := []string{
 		"--dump-plugin",
 		string(n.plugin),
-		"libdir=" + nbdVddkLibraryPath,
+	}
+	if n.plugin != NbdkitNfcPlugin {
+		args = append(args, "libdir="+nbdVddkLibraryPath)
 	}
 	nbdkit := exec.Command("nbdkit", args...)
 	nbdkit.Env = n.Env

--- a/pkg/image/nbdkit.go
+++ b/pkg/image/nbdkit.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	nbdVddkLibraryPath    = "/opt/vmware-vix-disklib-distrib"
-	nbdNfcPluginPath      = "/usr/lib64/nbdkit/plugins/nbdkit-nfc-plugin.so"
+	nbdNfcPluginSidecar   = "/opt/nbdkit-nfc-plugin.so"
+	nbdNfcPluginBuiltin   = "/usr/lib64/nbdkit/plugins/nbdkit-nfc-plugin.so"
 	startupTimeoutSeconds = 15
 	defaultUserAgent      = "cdi-nbdkit-importer"
 	passwordFdEntry       = 3
@@ -256,7 +257,10 @@ func getVddkPluginPath() NbdkitPlugin {
 	if !os.IsNotExist(err) {
 		return NbdkitVddkPlugin
 	}
-	_, err = os.Stat(nbdNfcPluginPath)
+	_, err = os.Stat(nbdNfcPluginSidecar)
+	if os.IsNotExist(err) {
+		_, err = os.Stat(nbdNfcPluginBuiltin)
+	}
 	if !os.IsNotExist(err) {
 		return NbdkitNfcPlugin
 	}
@@ -309,8 +313,15 @@ func (n *Nbdkit) StartNbdkit(source string) error {
 	// set additional arguments
 	argsNbdkit = append(argsNbdkit, n.nbdkitArgs...)
 
+	plugin := string(n.plugin)
+	if n.plugin == NbdkitNfcPlugin {
+		plugin = nbdNfcPluginBuiltin
+		if _, err := os.Stat(nbdNfcPluginSidecar); !os.IsNotExist(err) {
+			plugin = nbdNfcPluginSidecar
+		}
+	}
 	// append nbdkit plugin arguments
-	argsNbdkit = append(argsNbdkit, string(n.plugin))
+	argsNbdkit = append(argsNbdkit, plugin)
 	argsNbdkit = append(argsNbdkit, n.pluginArgs...)
 	argsNbdkit = append(argsNbdkit, n.redactArgs...)
 	argsNbdkit = append(argsNbdkit, n.getSourceArg(source))
@@ -472,9 +483,16 @@ func (n *Nbdkit) validatePlugin() error {
 			klog.Warningf("Unable to get VDDK library directory tree: %v", err)
 		}
 	}
+	plugin := string(n.plugin)
+	if n.plugin == NbdkitNfcPlugin {
+		plugin = nbdNfcPluginBuiltin
+		if _, err := os.Stat(nbdNfcPluginSidecar); !os.IsNotExist(err) {
+			plugin = nbdNfcPluginSidecar
+		}
+	}
 	args := []string{
 		"--dump-plugin",
-		string(n.plugin),
+		plugin,
 	}
 	if n.plugin != NbdkitNfcPlugin {
 		args = append(args, "libdir="+nbdVddkLibraryPath)
@@ -483,7 +501,7 @@ func (n *Nbdkit) validatePlugin() error {
 	nbdkit.Env = n.Env
 	out, err := nbdkit.CombinedOutput()
 	if out != nil {
-		klog.Infof("Output from nbdkit --dump-plugin %s: %s", string(n.plugin), out)
+		klog.Infof("Output from nbdkit --dump-plugin %s: %s", plugin, out)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use nbdkit-nfc for vsphere disk imports when the plugin is in the importer image or copied to /opt by the init image. Skip the sidecar when the init image is already the importer.

**Special notes for your reviewer**:
Sidecar emptyDir hides /opt in the init image; the plugin must be copied into /opt at runtime.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add nbdkit-nfc support for vsphere disk imports.
```

