### PR TITLE
Remove redundant ImageStream entry from containerdisk env labels test

### DIFF
--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
@@ -2107,22 +2106,13 @@ var _ = Describe("Containerdisk envs to PVC labels", func() {
 		trustedRegistryURL  = func() string {
 			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName), utils.WithDocker(), utils.WithTag(f.DockerTag)).String()
 		}
-		trustedRegistryIS = func() string {
-			return utils.NewRegistryImage(utils.WithBase(f.DockerPrefix), utils.WithImage(utils.TinyCoreImageName)).String()
-		}
 	)
 
-	DescribeTable("Import should add KUBEVIRT_IO_ env vars to PVC labels when source is registry", func(pullMethod cdiv1.RegistryPullMethod, urlFn func() string, isImageStream bool) {
+	DescribeTable("Import should add KUBEVIRT_IO_ env vars to PVC labels when source is registry", func(pullMethod cdiv1.RegistryPullMethod, urlFn func() string) {
 		dataVolume := utils.NewDataVolumeWithRegistryImport("import-dv", "100Mi", urlFn())
 		// The existing key should not be overwritten
 		dataVolume.ObjectMeta.Labels = map[string]string{
 			testKubevirtIoKeyExisting: testKubevirtIoValueExisting,
-		}
-
-		if isImageStream {
-			dataVolume.Spec.Source.Registry.URL = nil
-			dataVolume.Spec.Source.Registry.ImageStream = ptr.To(urlFn())
-			dataVolume.Annotations[controller.AnnPodRetainAfterCompletion] = "true"
 		}
 
 		dataVolume.Spec.Source.Registry.PullMethod = &pullMethod
@@ -2153,9 +2143,8 @@ var _ = Describe("Containerdisk envs to PVC labels", func() {
 			HaveKeyWithValue(testKubevirtIoKeyExisting, testKubevirtIoValueExisting),
 		))
 	},
-		Entry("with pullMethod pod", cdiv1.RegistryPullPod, tinyCoreRegistryURL, false),
-		Entry("with pullMethod node", cdiv1.RegistryPullNode, trustedRegistryURL, false),
-		Entry("with pullMethod node", cdiv1.RegistryPullNode, trustedRegistryIS, true),
+		Entry("with pullMethod pod", cdiv1.RegistryPullPod, tinyCoreRegistryURL),
+		Entry("with pullMethod node", cdiv1.RegistryPullNode, trustedRegistryURL),
 	)
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The ImageStream entry exercises the same label propagation code path
as the regular node pull entry - the env extraction, termination
message, and PVC label writing are all identical regardless of
whether the source uses .Registry.URL or .Registry.ImageStream.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

