### PR TITLE
Fix zstd decompression buffer corruption

### DIFF
--- a/pkg/importer/format-readers.go
+++ b/pkg/importer/format-readers.go
@@ -71,6 +71,7 @@ const (
 	rdrXz
 	rdrStream
 	rdrChecksum
+	rdrZstd
 )
 
 // map scheme and format to rdrType
@@ -78,6 +79,7 @@ var rdrTypM = map[string]int{
 	"gz":     rdrGz,
 	"xz":     rdrXz,
 	"stream": rdrStream,
+	"zst":    rdrZstd,
 }
 
 // NewFormatReaders creates a new instance of FormatReaders using the input stream and content type passed in.
@@ -263,7 +265,7 @@ func (fr *FormatReaders) matchHeader(knownHdrs *image.Headers) (*image.Header, e
 		return nil, err
 	}
 	// append multi-reader so that the header data can be re-read by subsequent readers
-	fr.appendReader(rdrMulti, bytes.NewReader(fr.buf))
+	fr.appendReader(rdrMulti, bytes.NewReader(bytes.Clone(fr.buf)))
 
 	// loop through known headers until a match
 	for format, kh := range *knownHdrs {

--- a/pkg/importer/format-readers_test.go
+++ b/pkg/importer/format-readers_test.go
@@ -23,6 +23,7 @@ var (
 	tinyCoreFilePath          = filepath.Join(imageDir, tinyCoreFileName)
 	tinyCoreXzFilePath, _     = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtXz)
 	tinyCoreGzFilePath, _     = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtGz)
+	tinyCoreZstFilePath, _    = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtZst)
 	tinyCoreTarFilePath, _    = utils.FormatTestData(tinyCoreFilePath, os.TempDir(), image.ExtTar)
 	archiveFilePath, _        = utils.ArchiveFiles(archiveFileNameWithoutExt, os.TempDir(), tinyCoreFilePath, cirrosFilePath)
 	archiveFileNameWithoutExt = strings.TrimSuffix(archiveFileName, filepath.Ext(archiveFileName))
@@ -62,6 +63,7 @@ var _ = Describe("Format Readers", func() {
 	},
 		Entry("successfully construct a xz reader", tinyCoreXzFilePath, 4, false, true, false),              // [stream, multi-r, xz, multi-r] convert = false
 		Entry("successfully construct a gz reader", tinyCoreGzFilePath, 4, false, true, false),              // [stream, multi-r, gz, multi-r] convert = false
+		Entry("successfully construct a zst reader", tinyCoreZstFilePath, 4, false, true, false),            // [stream, multi-r, zst, multi-r] convert = false
 		Entry("successfully return the base reader when archived", archiveFilePath, 3, false, false, false), // [stream, multi-r, multi-r] convert = false
 		Entry("successfully construct qcow2 reader", cirrosFilePath, 2, false, false, true),                 // [stream, multi-r] convert = true
 		Entry("successfully construct .iso reader", tinyCoreFilePath, 2, false, false, false),               // [stream, multi-r] convert = false
@@ -99,6 +101,19 @@ var _ = Describe("Format Readers", func() {
 		Expect(testReader.progressReader).To(BeNil())
 		// This should not crash
 		testReader.StartProgressUpdate()
+	})
+
+	It("successfully decompresses zst stream without corruption", func() {
+		f, err := os.Open(tinyCoreZstFilePath)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+
+		fr, err = NewFormatReaders(f, uint64(0), nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		n, err := io.Copy(io.Discard, fr.TopReader())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(BeNumerically(">", 0))
 	})
 
 	Describe("with checksum validator", func() {

--- a/pkg/importer/importer_suite_test.go
+++ b/pkg/importer/importer_suite_test.go
@@ -16,12 +16,13 @@ import (
 //  2. in tinyCore.iso where the returned size is smaller than the original. Note: this is not
 //     the case for larger iso files such as windows.
 var sizeExceptions = map[string]struct{}{
-	".iso":    {},
-	".iso.gz": {},
-	".iso.xz": {},
+	".iso":     {},
+	".iso.gz":  {},
+	".iso.xz":  {},
+	".iso.zst": {},
 }
 
-var testfiles = []string{tinyCoreXzFilePath, tinyCoreGzFilePath, tinyCoreTarFilePath, archiveFilePath}
+var testfiles = []string{tinyCoreXzFilePath, tinyCoreGzFilePath, tinyCoreZstFilePath, tinyCoreTarFilePath, archiveFilePath}
 
 func TestImporter(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Fixes data corruption issue when trying to import a zst image.
Essentially the issue boils down to how cdi finds out which compressed
format the data is inside matchHeaders.

1) `matchHeader` reads 512 bytes from the raw network reader into fr.buf
2) It detects zst and pushes a zst reader to the reader stack
3) `matchHeader` uses the zst reader to read the first zstd block which
   in the case of my image was only 100b long. It then saves the decompressed data of 512 bytes back into `fr.buf` but we only read part of the original fr.buf.
   This causes us to overwrite compressed data with decompressed data.
4) The next read from the zst reader then tries reading decompressed
   data as a zst header and sees a very high window size leading to the
   error `failed to pull image: window size exceeded`

This issue can also technically arrive with xz since it has block headers that can get clobbered, but gz cannot since it uses fixed size windows.

**What this PR does / why we need it**:

- Clone header buffer (bytes.Clone) when wrapping with bytes.NewReader in matchHeader to prevent subsequent format detection passes from overwriting unconsumed compressed bytes.
- Add rdrZstd constant and mapping to rdrTypM.
- Add test coverage for .iso.zst reader construction and streaming decompression.

This PR is needed to fix a data corruption crash in the importer pod experienced when trying to import a variable window size compressed image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4277 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

